### PR TITLE
adds py.typed to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vercel-sdk"
-version = "0.0.6"
+version = "0.0.7"
 description = "Python SDK for Vercel"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -34,6 +34,9 @@ namespaces = true
 
 [tool.setuptools]
 include-package-data = false
+
+[tool.setuptools.package-data]
+vercel = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
fixes this issue on the sandboxes sdk ci:

```
Run uv run ruff format
17 files left unchanged
All checks passed!
src/vercel/sandbox/sandbox.py:6: error: Skipping analyzing "vercel.oidc": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/vercel/sandbox/sandbox.py:6: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 7 source files)
Error: Process completed with exit code 1.
```