### PR TITLE
fixes vercel namespace

### DIFF
--- a/src/vercel/__init__.py
+++ b/src/vercel/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from .client import Vercel, AsyncVercel
-
-__all__ = ["Vercel", "AsyncVercel"]


### PR DESCRIPTION
can't have `__init__.py` at /vercel so we can keep it as a namespace package for the sandboxes sdk to also be discoverable under `vercel.sandbox`