### PR TITLE
migrating to vercel on pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/vercel-sdk
+      url: https://pypi.org/p/vercel
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "vercel-sdk"
-version = "0.0.8"
+name = "vercel"
+version = "0.3.0"
 description = "Python SDK for Vercel"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
migrates from `vercel-sdk` on pypi to `vercel`
bumps version to `0.3.0` (previous owner's version was at `0.2.1`)