### PR TITLE
[ci] Ruff linter rules

### DIFF
--- a/examples/fastapi_oidc_plus_cache/index.py
+++ b/examples/fastapi_oidc_plus_cache/index.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable
-
-from fastapi import FastAPI, Request, HTTPException
 import logging
 import traceback
+from collections.abc import Callable
+
+from fastapi import FastAPI, HTTPException, Request
 
 from vercel.cache import AsyncRuntimeCache
-
 from vercel.headers import geolocation, ip_address, set_headers
 from vercel.oidc import decode_oidc_payload
 from vercel.oidc.aio import get_vercel_oidc_token
-
 
 logger = logging.getLogger(__name__)
 app = FastAPI()
@@ -35,7 +33,7 @@ async def oidc_info():
     except Exception as e:
         logger.error(f"Error getting OIDC info: {e}")
         logger.error(traceback.format_exc())
-        raise HTTPException(status_code=500, detail="Error getting OIDC info")
+        raise HTTPException(status_code=500, detail="Error getting OIDC info") from None
 
 
 @app.get("/api/cache")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,16 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle errors
-    "F",  # pyflakes
-    "UP", # pyupgrade rules (enforce modern Python syntax)
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # isort
+    "I",
 ]
 
 [tool.ruff.lint.pyupgrade]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,17 +53,18 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    # pycodestyle
-    "E",
-    # Pyflakes
-    "F",
-    # pyupgrade
-    "UP",
-    # flake8-bugbear
-    "B",
-    # isort
-    "I",
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
 ]
+isort = { combine-as-imports = true, known-first-party = ["vercel"] }
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = false
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**/*.py" = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,21 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "UP"]
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = false
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "F",  # pyflakes
+    "UP", # pyupgrade rules (enforce modern Python syntax)
+]
+
+[tool.ruff.lint.pyupgrade]
+# Target Python 3.10 to prefer builtins (list, dict, tuple) and PEP 604 unions (X | Y)
+target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 100
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [
@@ -58,5 +59,4 @@ select = [
 ]
 
 [tool.ruff.lint.pyupgrade]
-# Target Python 3.10 to prefer builtins (list, dict, tuple) and PEP 604 unions (X | Y)
-target-version = "py310"
+keep-runtime-typing = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,6 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
-
-[tool.ruff.lint]
-select = ["E", "F", "UP"]
-
-[tool.ruff.lint.pyupgrade]
-keep-runtime-typing = false
 
 [tool.ruff.lint]
 select = [

--- a/src/vercel/blob/client.py
+++ b/src/vercel/blob/client.py
@@ -1,41 +1,50 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Awaitable, Iterable, Iterator
 from os import PathLike
-from typing import Any, Callable, Awaitable, Iterable, Iterator
+from typing import Any, Callable
 
 from .errors import BlobError
-from .utils import UploadProgressEvent
-from .types import (
-    PutBlobResult as PutBlobResultType,
-    HeadBlobResult as HeadBlobResultType,
-    ListBlobResult as ListBlobResultType,
-    ListBlobItem,
-    CreateFolderResult as CreateFolderResultType,
-)
+from .multipart.api import create_multipart_uploader, create_multipart_uploader_async
 from .ops import (
-    put,
-    put_async,
-    delete,
-    delete_async,
-    head,
-    head_async,
-    get,
-    get_async,
-    list_objects,
-    list_objects_async,
     copy,
     copy_async,
     create_folder,
     create_folder_async,
+    delete,
+    delete_async,
     download_file,
     download_file_async,
-    upload_file,
-    upload_file_async,
+    get,
+    get_async,
+    head,
+    head_async,
     iter_objects,
     iter_objects_async,
+    list_objects,
+    list_objects_async,
+    put,
+    put_async,
+    upload_file,
+    upload_file_async,
 )
-from .multipart.api import create_multipart_uploader, create_multipart_uploader_async
+from .types import (
+    CreateFolderResult as CreateFolderResultType,
+)
+from .types import (
+    HeadBlobResult as HeadBlobResultType,
+)
+from .types import (
+    ListBlobItem,
+)
+from .types import (
+    ListBlobResult as ListBlobResultType,
+)
+from .types import (
+    PutBlobResult as PutBlobResultType,
+)
+from .utils import UploadProgressEvent
 
 
 class BlobClient:
@@ -43,7 +52,8 @@ class BlobClient:
         self.token = token or os.getenv("BLOB_READ_WRITE_TOKEN")
         if not self.token:
             raise BlobError(
-                "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` environment variable, or pass a `token` option to your calls."
+                "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` "
+                "environment variable, or pass a `token` option to your calls."
             )
 
     def put(
@@ -207,7 +217,8 @@ class AsyncBlobClient:
         self.token = token or os.getenv("BLOB_READ_WRITE_TOKEN")
         if not self.token:
             raise BlobError(
-                "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` environment variable, or pass a `token` option to your calls."
+                "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` "
+                "environment variable, or pass a `token` option to your calls."
             )
 
     async def put(

--- a/src/vercel/blob/errors.py
+++ b/src/vercel/blob/errors.py
@@ -18,7 +18,9 @@ class BlobContentTypeNotAllowedError(BlobError):
 class BlobPathnameMismatchError(BlobError):
     def __init__(self, message: str) -> None:
         super().__init__(
-            f"Pathname mismatch, {message}. Check the pathname used in upload() or put() matches the one from the client token."
+            f"Pathname mismatch, {message}. "
+            "Check the pathname used in upload() or put() "
+            "matches the one from the client token."
         )
 
 

--- a/src/vercel/blob/ops.py
+++ b/src/vercel/blob/ops.py
@@ -54,7 +54,8 @@ def put(
 
     if isinstance(body, dict):
         raise BlobError(
-            "Body must be a string, buffer or stream. You sent a plain object, double check what you're trying to upload."
+            "Body must be a string, buffer or stream. "
+            "You sent a plain object, double check what you're trying to upload."
         )
 
     options: dict[str, Any] = {
@@ -132,7 +133,8 @@ async def put_async(
     # Reject plain dict (JS plain object equivalent) to match TS error semantics
     if isinstance(body, dict):
         raise BlobError(
-            "Body must be a string, buffer or stream. You sent a plain object, double check what you're trying to upload."
+            "Body must be a string, buffer or stream. "
+            "You sent a plain object, double check what you're trying to upload."
         )
 
     options: dict[str, Any] = {

--- a/src/vercel/blob/ops.py
+++ b/src/vercel/blob/ops.py
@@ -4,7 +4,7 @@ import inspect
 from os import PathLike
 import os
 import httpx
-from typing import Any, Callable, Awaitable, Iterable, Iterator, AsyncIterator
+from typing import Any, Callable, Awaitable, Iterable, Iterator, AsyncIterator, List
 
 from .utils import (
     UploadProgressEvent,
@@ -348,7 +348,7 @@ def list_objects(
         options={"token": token} if token else {},
         params=params,
     )
-    blobs_list: list[ListBlobItem] = []
+    blobs_list: List[ListBlobItem] = []
     for b in resp.get("blobs", []):
         uploaded_at = (
             parse_datetime(b["uploadedAt"])

--- a/src/vercel/blob/ops.py
+++ b/src/vercel/blob/ops.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import inspect
 import os
-from collections.abc import AsyncIterator, Awaitable, Iterable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from os import PathLike
-from typing import Any, Callable
+from typing import Any
 
 import httpx
 
@@ -13,17 +13,9 @@ from .errors import BlobError, BlobNotFoundError
 from .multipart import auto_multipart_upload, auto_multipart_upload_async
 from .types import (
     CreateFolderResult as CreateFolderResultType,
-)
-from .types import (
     HeadBlobResult as HeadBlobResultType,
-)
-from .types import (
     ListBlobItem,
-)
-from .types import (
     ListBlobResult as ListBlobResultType,
-)
-from .types import (
     PutBlobResult as PutBlobResultType,
 )
 from .utils import (

--- a/src/vercel/blob/utils.py
+++ b/src/vercel/blob/utils.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 import uuid
-from os import PathLike
+from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
-import asyncio
-from typing import Any, Callable, Iterable, Protocol, Awaitable
+from os import PathLike
+from typing import Any, Callable, Protocol
 
 from .errors import BlobError
-
 
 DEFAULT_VERCEL_BLOB_API_URL = "https://vercel.com/api/blob"
 MAXIMUM_PATHNAME_LENGTH = 950
@@ -103,7 +103,8 @@ def get_token_from_options_or_env(options: dict[str, Any] | None = None) -> str:
     if env_token:
         return env_token
     raise BlobError(
-        "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` environment variable, or pass a `token` option to your calls."
+        "No token found. Either configure the `BLOB_READ_WRITE_TOKEN` "
+        "environment variable, or pass a `token` option to your calls."
     )
 
 
@@ -318,7 +319,7 @@ def parse_datetime(value: str) -> datetime:
 
 def get_download_url(blob_url: str) -> str:
     try:
-        from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
+        from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
         parsed = urlparse(blob_url)
         q = dict(parse_qsl(parsed.query))

--- a/src/vercel/deployments/deployments.py
+++ b/src/vercel/deployments/deployments.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
-import httpx
-from typing import Any, Iterable
+from typing import Any
 
+import httpx
 
 DEFAULT_API_BASE_URL = "https://api.vercel.com"
 DEFAULT_TIMEOUT = 60.0
@@ -83,8 +83,11 @@ def create_deployment(
 ) -> dict[str, Any]:
     """Create a new deployment.
 
-    body: matches the Deployments Create request body (name, project, files|gitSource, target, projectSettings, etc.)
-    Optional query params: team_id -> teamId, slug -> slug, force_new -> forceNew, skip_auto_detection_confirmation -> skipAutoDetectionConfirmation
+    body: matches the Deployments Create request body (name, project,
+    files|gitSource, target, projectSettings, etc.)
+    Optional query params: team_id -> teamId, slug -> slug, force_new ->
+    forceNew, skip_auto_detection_confirmation ->
+    skipAutoDetectionConfirmation
     """
     params: dict[str, Any] = {}
     if team_id:
@@ -231,8 +234,11 @@ async def create_deployment_async(
 ) -> dict[str, Any]:
     """Create a new deployment.
 
-    body: matches the Deployments Create request body (name, project, files|gitSource, target, projectSettings, etc.)
-    Optional query params: team_id -> teamId, slug -> slug, force_new -> forceNew, skip_auto_detection_confirmation -> skipAutoDetectionConfirmation
+    body: matches the Deployments Create request body (name, project,
+    files|gitSource, target, projectSettings, etc.)
+    Optional query params: team_id -> teamId, slug -> slug, force_new ->
+    forceNew, skip_auto_detection_confirmation ->
+    skipAutoDetectionConfirmation
     """
     params: dict[str, Any] = {}
     if team_id:

--- a/src/vercel/oidc/credentials.py
+++ b/src/vercel/oidc/credentials.py
@@ -40,5 +40,6 @@ def get_credentials(
         return Credentials(token=token, project_id=project_id, team_id=team_id)
 
     raise RuntimeError(
-        "Missing credentials. Provide VERCEL_OIDC_TOKEN with VERCEL_PROJECT_ID and VERCEL_TEAM_ID, or VERCEL_TOKEN, VERCEL_PROJECT_ID, VERCEL_TEAM_ID."
+        "Missing credentials. Provide VERCEL_OIDC_TOKEN with VERCEL_PROJECT_ID "
+        "and VERCEL_TEAM_ID, or VERCEL_TOKEN, VERCEL_PROJECT_ID, VERCEL_TEAM_ID."
     )

--- a/src/vercel/oidc/token.py
+++ b/src/vercel/oidc/token.py
@@ -125,13 +125,13 @@ def get_vercel_oidc_token() -> str:
                 raise VercelOidcTokenError(
                     "Missing OIDC request header and no local project context (.vercel) available",
                     e,
-                )
+                ) from e
             refresh_token()
             token = get_vercel_oidc_token_from_context()
     except Exception as e:
         if err and isinstance(e, Exception) and getattr(err, "message", None):
             e.args = (f"{err}\n{e}",)
-        raise VercelOidcTokenError("Failed to refresh OIDC token", e)
+        raise VercelOidcTokenError("Failed to refresh OIDC token", e) from e
     return token
 
 
@@ -153,13 +153,13 @@ async def get_vercel_oidc_token_async() -> str:
                 raise VercelOidcTokenError(
                     "Missing OIDC request header and no local project context (.vercel) available",
                     e,
-                )
+                ) from e
             await refresh_token_async()
             token = get_vercel_oidc_token_from_context()
     except Exception as e:
         if err and isinstance(e, Exception) and getattr(err, "message", None):
             e.args = (f"{err}\n{e}",)
-        raise VercelOidcTokenError("Failed to refresh OIDC token", e)
+        raise VercelOidcTokenError("Failed to refresh OIDC token", e) from e
     return token
 
 

--- a/src/vercel/oidc/token.py
+++ b/src/vercel/oidc/token.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
-import httpx
 from collections.abc import Mapping
 
+import httpx
+
 from ..cache.context import get_headers
+from .types import VercelTokenResponse
 from .utils import (
     find_project_info,
     get_token_payload,
@@ -13,8 +15,6 @@ from .utils import (
     load_token,
     save_token,
 )
-from .types import VercelTokenResponse
-
 
 BASE_URL = "https://api.vercel.com/v1"
 
@@ -54,7 +54,8 @@ def get_vercel_oidc_token_from_context() -> str:
     token_from_env = os.getenv("VERCEL_OIDC_TOKEN")
     if not token_from_env:
         raise VercelOidcTokenError(
-            "The 'x-vercel-oidc-token' header is missing from the request. Do you have the OIDC option enabled in the Vercel project settings?"
+            "The 'x-vercel-oidc-token' header is missing from the request. "
+            "Do you have the OIDC option enabled in the Vercel project settings?"
         )
     return token_from_env
 

--- a/tests/integration/test_projects_real_api.py
+++ b/tests/integration/test_projects_real_api.py
@@ -6,12 +6,13 @@ They require VERCEL_TOKEN and VERCEL_TEAM_ID environment variables.
 """
 
 import os
-import pytest
 import time
 
+import pytest
+
 # Import the actual functions (not mocked)
-from vercel.projects import get_projects, create_project, update_project, delete_project
-from vercel.projects.projects import get_projects_async, create_project_async, delete_project_async
+from vercel.projects import create_project, delete_project, get_projects, update_project
+from vercel.projects.projects import create_project_async, delete_project_async, get_projects_async
 
 
 @pytest.mark.skipif(
@@ -149,7 +150,9 @@ class TestProjectsRealAPI:
                 f"Updated timestamp too old: {result['updatedAt']}"
             )
 
-            print(f"✅ Real API test passed: Created project {result['name']} with ID {result['id']}")
+            print(
+                f"✅ Real API test passed: Created project {result['name']} with ID {result['id']}"
+            )
 
         finally:
             # Clean up - delete the project
@@ -304,7 +307,8 @@ class TestProjectsRealAPI:
         )
 
         print(
-            f"✅ Real async API test passed: Created project {result['name']} with ID {result['id']}"
+            "✅ Real async API test passed: Created project "
+            f"{result['name']} with ID {result['id']}"
         )
 
         # Clean up - delete the project

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -26,7 +26,9 @@ def test_examples_run(capsys=None) -> None:
             timeout=45,
         )
         assert result.returncode == 0, (
-            f"{script_path.name} failed with code {result.returncode}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            f"{script_path.name} failed with code {result.returncode}\n"
+            f"STDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
         )
 
     print("All examples ran successfully")


### PR DESCRIPTION
Adds [ruff linter rules](https://docs.astral.sh/ruff/linter/#rule-selection) to `pyproject.toml` to enforce python 3.10+ syntax:
* E (pycodestyle): Style errors (spacing, indentation, line breaks, whitespace around operators, etc.).
* W (pycodestyle warnings): Similar to E but for less critical style issues, like deprecated features or conventions that should be followed but won't break code.
* F (Pyflakes): Logical issues like undefined names, unused variables/imports, redefinitions, and syntax mistakes Ruff can infer.
* UP (pyupgrade): Modernizes syntax. Examples: built-in generics (list/dict/tuple) over typing.List/Dict/Tuple, prefer | unions (when target >= py310), f-strings, super() without args, removing obsolete compat code.
* B (flake8-bugbear): Flags likely bugs and footguns: mutable default arguments, problematic iteration patterns, unsafe comparisons, dubious exception handling, etc.
* I (isort): Enforces deterministic import ordering and grouping (standard library, third-party, local), and removes duplicates; Ruff can autofix.
* C4 (flake8-comprehensions): Suggests better ways to write comprehensions and builtin functions (e.g., using dict(x) instead of {k: v for k, v in x} when appropriate).

Can autofix with `uv run ruff check --fix .`