### PR TITLE
[fix] Circular import bug

### DIFF
--- a/src/vercel/_telemetry/credentials.py
+++ b/src/vercel/_telemetry/credentials.py
@@ -1,9 +1,7 @@
 """Utilities for extracting credentials (user_id, team_id, project_id) from various sources."""
 
 import os
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
-
-from ..oidc.token import decode_oidc_payload
+from typing import TYPE_CHECKING, Optional, Tuple
 
 if TYPE_CHECKING:
     from ..oidc.types import ProjectInfo
@@ -18,13 +16,13 @@ def extract_credentials(
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """
     Extract user_id, team_id, and project_id from various sources.
-    
+
     Priority order:
     1. Explicitly provided parameters
     2. Environment variables (VERCEL_PROJECT_ID, VERCEL_TEAM_ID)
     3. OIDC token payload (if available)
     4. .vercel/project.json (for local dev)
-    
+
     Returns:
         Tuple of (user_id, team_id, project_id). Each may be None if not found.
     """
@@ -32,16 +30,18 @@ def extract_credentials(
     resolved_user_id = user_id
     resolved_team_id = team_id
     resolved_project_id = project_id
-    
+
     # Check environment variables
     if not resolved_project_id:
         resolved_project_id = os.getenv("VERCEL_PROJECT_ID")
     if not resolved_team_id:
         resolved_team_id = os.getenv("VERCEL_TEAM_ID")
-    
+
     # Try to extract from OIDC token if available
     if token:
         try:
+            from ..oidc.token import decode_oidc_payload
+
             payload = decode_oidc_payload(token)
             if not resolved_project_id:
                 resolved_project_id = payload.get("project_id")
@@ -51,9 +51,9 @@ def extract_credentials(
         except Exception:
             # Silently fail - OIDC may not be available or token may be invalid
             pass
-    
+
     # Try to extract from .vercel/project.json for local dev
-    if (not resolved_project_id or not resolved_team_id):
+    if not resolved_project_id or not resolved_team_id:
         try:
             # Import lazily to avoid hard dependency in all environments
             from ..oidc.utils import find_project_info as _find_project_info  # type: ignore
@@ -66,10 +66,9 @@ def extract_credentials(
         except Exception:
             # Silently fail - .vercel directory may not exist (production context)
             pass
-    
+
     # Note: user_id typically requires API call to determine from token
     # For now, we leave it as None unless explicitly provided
     # This is acceptable as user_id may not always be available in all contexts
-    
-    return (resolved_user_id, resolved_team_id, resolved_project_id)
 
+    return (resolved_user_id, resolved_team_id, resolved_project_id)


### PR DESCRIPTION
Causing issues in `vercel-sandbox-py`
```
Run uv run ruff format
1 file reformatted, 19 files left unchanged
All checks passed!
Success: no issues found in 8 source files
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/src/vercel/sandbox/__init__.py", line 2, in <module>
    from .sandbox import AsyncSandbox, Sandbox
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/src/vercel/sandbox/sandbox.py", line 6, in <module>
    from vercel.oidc import Credentials, get_credentials
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/oidc/__init__.py", line 1, in <module>
    from .token import (
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/oidc/token.py", line 8, in <module>
    from ..cache.context import get_headers
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/cache/__init__.py", line 1, in <module>
    from .runtime_cache import get_cache, RuntimeCache, AsyncRuntimeCache
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/cache/runtime_cache.py", line 6, in <module>
    from .cache_in_memory import InMemoryCache, AsyncInMemoryCache
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/cache/cache_in_memory.py", line 6, in <module>
    from .._telemetry.tracker import track
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/_telemetry/__init__.py", line 3, in <module>
    from .client import TelemetryClient
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/_telemetry/client.py", line 11, in <module>
    from .credentials import extract_credentials
  File "/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/_telemetry/credentials.py", line 6, in <module>
    from ..oidc.token import decode_oidc_payload
ImportError: cannot import name 'decode_oidc_payload' from partially initialized module 'vercel.oidc.token' (most likely due to a circular import) (/home/runner/work/sandbox-sdk-py/sandbox-sdk-py/.venv/lib/python3.12/site-packages/vercel/oidc/token.py)
Error: Process completed with exit code 1.
```