### PR TITLE
Consolidate vercel-sandbox into vercel package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
           uv run python -c "import vercel, vercel.cache, vercel.headers, vercel.oidc, vercel.sandbox"
 
       - name: Run tests
-        run: uv run pytest -v --capture=tee-sys
+        run: uv run pytest -v --capture=tee-sys --ignore=tests/test_examples.py
+
+      - name: Run example tests
+        run: uv run pytest -v --capture=tee-sys tests/test_examples.py -n auto
 
       - name: Build package
         run: uv run python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Typecheck
         run: |
           uv run mypy src
-          uv run python -c "import vercel, vercel.cache, vercel.headers, vercel.oidc"
+          uv run python -c "import vercel, vercel.cache, vercel.headers, vercel.oidc, vercel.sandbox"
 
       - name: Run tests
         run: uv run pytest -v --capture=tee-sys

--- a/examples/sandbox_01_run_echo.py
+++ b/examples/sandbox_01_run_echo.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+async def main() -> None:
+    # Requires env vars: VERCEL_OIDC_TOKEN + VERCEL_PROJECT_ID + VERCEL_TEAM_ID
+    async with await Sandbox.create(timeout=60_000) as sandbox:  # 1 minute sandbox
+        # Simple echo
+        cmd = await sandbox.run_command("bash", ["-lc", "echo hello && echo world 1>&2"])
+        print("exit:", cmd.exit_code)
+
+        # Detached + logs streaming (Ctrl+C will trigger cleanup via context manager)
+        detached = await sandbox.run_command_detached(
+            "bash", ["-lc", "for i in 1 2 3; do echo $i; sleep 0.2; done"]
+        )
+        async for line in detached.logs():
+            print(line.stream, line.data, end="")
+        await detached.wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_02_fs_ops.py
+++ b/examples/sandbox_02_fs_ops.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+async def main() -> None:
+    async with await Sandbox.create(timeout=60_000) as sandbox:
+        # Write file into /vercel/sandbox/hello.txt
+        await sandbox.write_files(
+            [
+                {"path": "hello.txt", "content": b"hello vercel"},
+                {
+                    "path": "/vercel/sandbox/nested/dir/note.txt",
+                    "content": b"nested file",
+                },
+            ]
+        )
+
+        data1 = await sandbox.read_file("hello.txt")
+        data2 = await sandbox.read_file("/vercel/sandbox/nested/dir/note.txt")
+        print("hello.txt:", data1.decode())
+        print("note.txt:", data2.decode())
+
+        # Sleep briefly to keep the sandbox alive for inspection
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_03_next_dev.py
+++ b/examples/sandbox_03_next_dev.py
@@ -1,0 +1,63 @@
+import asyncio
+import contextlib
+import os
+import webbrowser
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+async def main() -> None:
+    async with await Sandbox.create(
+        source={
+            "type": "git",
+            "url": "https://github.com/vercel/sandbox-example-next.git",
+        },
+        resources={"vcpus": 4},
+        ports=[3000],
+        timeout=600_000,
+        runtime="node22",
+    ) as sandbox:
+        print("Installing dependencies...")
+        install = await sandbox.run_command("npm", ["install", "--loglevel", "info"])
+        if install.exit_code != 0:
+            raise SystemExit("install failed")
+
+        print("Starting the development server...")
+        cmd = await sandbox.run_command_detached("npm", ["run", "dev"])  # logs stream below
+
+        # Stream logs and open browser once ready. Ctrl+C is handled by the async context manger.
+        ready = asyncio.Event()
+
+        async def logs_and_detect_ready():
+            async for line in cmd.logs():
+                print(line.data, end="")
+                if not ready.is_set() and ("Ready" in line.data or "Local:" in line.data):
+                    ready.set()
+
+        logs_task = asyncio.create_task(logs_and_detect_ready())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=60)
+        except asyncio.TimeoutError:
+            pass
+
+        url = sandbox.domain(3000)
+        if url:
+            print("Open:", url)
+            # In CI, avoid opening a browser.
+            if not os.getenv("CI"):
+                with contextlib.suppress(Exception):
+                    webbrowser.open(url)
+
+        # Stop streaming logs and terminate the server so the example exits promptly.
+        logs_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await logs_task
+        await cmd.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_04_python_run.py
+++ b/examples/sandbox_04_python_run.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+PY_CODE = b"""
+import os
+import sys
+
+print("Hello from Python inside Vercel Sandbox!")
+print("Python version:", sys.version)
+print("ENV SAMPLE:", os.getenv("SAMPLE_ENV", "<missing>"))
+"""
+
+
+async def main() -> None:
+    runtime = os.getenv("SANDBOX_RUNTIME") or None  # e.g., "python311"
+
+    async with await Sandbox.create(timeout=120_000, runtime=runtime) as sandbox:
+        # Write a Python file to the sandbox working directory
+        await sandbox.write_files(
+            [
+                {"path": "main.py", "content": PY_CODE},
+            ]
+        )
+
+        # Try python3 first, then fall back to python
+        cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                f"cd {sandbox.sandbox.cwd} && (python3 main.py || python main.py)",
+            ],
+            env={"SAMPLE_ENV": "works"},
+        )
+
+        out = await cmd.stdout()
+        done = await cmd.wait()
+        print("========= OUTPUT =========")
+        print(out, end="")
+        print("==========================")
+        print("exit:", done.exit_code)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_05_fastapi.py
+++ b/examples/sandbox_05_fastapi.py
@@ -1,0 +1,110 @@
+import asyncio
+import contextlib
+import os
+import webbrowser
+
+import httpx
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+FASTAPI_APP = b"""
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from FastAPI in Vercel Sandbox!"}
+"""
+
+
+async def main() -> None:
+    # TODO: Figure out why python3.13 was causing issues with the runtime initialization.
+    runtime = os.getenv("SANDBOX_RUNTIME") or "python3.13"
+
+    async with await Sandbox.create(ports=[8000], timeout=600_000, runtime=runtime) as sandbox:
+        # Write the FastAPI application to the sandbox working directory
+        await sandbox.write_files(
+            [
+                {"path": "main.py", "content": FASTAPI_APP},
+            ]
+        )
+
+        print("Installing FastAPI and Uvicorn...")
+        install_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    "PYBIN=$(command -v python3 || command -v python); "
+                    "if [ -z \"$PYBIN\" ]; then echo 'python not found in sandbox'; exit 1; fi; "
+                    "$PYBIN -m ensurepip --upgrade || true; "
+                    "$PYBIN -m pip install --upgrade pip; "
+                    "$PYBIN -m pip install --no-cache-dir fastapi uvicorn"
+                ),
+            ],
+        )
+
+        async for line in install_cmd.logs():
+            print(line.data, end="")
+        install_done = await install_cmd.wait()
+        if install_done.exit_code != 0:
+            raise SystemExit("Dependency installation failed")
+
+        print("Starting FastAPI server...")
+        cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {sandbox.sandbox.cwd} && "
+                    "PYBIN=$(command -v python3 || command -v python) && "
+                    "$PYBIN -m uvicorn main:app --host 0.0.0.0 --port 8000"
+                ),
+            ],
+        )
+
+        # Stream logs and open browser once server is ready. Ctrl+C will stop the script.
+        ready = asyncio.Event()
+
+        async def logs_and_detect_ready():
+            async for line in cmd.logs():
+                print(line.data, end="")
+                if not ready.is_set() and (
+                    "Application startup complete" in line.data or "Uvicorn running on" in line.data
+                ):
+                    ready.set()
+
+        logs_task = asyncio.create_task(logs_and_detect_ready())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            pass
+
+        url = sandbox.domain(8000)
+        print("Open:", url)
+
+        # In CI, don't try to open a browser. Optionally probe the endpoint once.
+        if not os.getenv("CI"):
+            with contextlib.suppress(Exception):
+                webbrowser.open(url)
+
+        # Probe the server once to ensure it's reachable, then tear down quickly.
+        with contextlib.suppress(Exception):
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url)
+                print("GET / status:", resp.status_code)
+
+        # Stop streaming logs and terminate the server so the example exits promptly.
+        logs_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await logs_task
+        await cmd.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_06_stop_sandbox.py
+++ b/examples/sandbox_06_stop_sandbox.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+async def main() -> None:
+    # TODO: Figure out why python3.13 was causing issues with the runtime initialization.
+    runtime = os.getenv("SANDBOX_RUNTIME") or "python3.13"
+
+    # Create sandbox (not using context manager so we can control lifecycle)
+    sandbox = await Sandbox.create(timeout=120_000, runtime=runtime)
+    try:
+        print("Sandbox started:", sandbox.sandbox_id)
+
+        # Start a long-running Python process (60s sleep)
+        await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                "PYBIN=$(command -v python3 || command -v python) && $PYBIN -c 'import time; time.sleep(60)'",
+            ],
+        )
+
+        # Retrieve the same sandbox by ID before stopping
+        fetched = await Sandbox.get(sandbox_id=sandbox.sandbox_id)
+        try:
+            print("Status before stop:", fetched.status)
+
+            # Stop the sandbox
+            print("Stopping sandbox...")
+            await fetched.stop()
+        finally:
+            await fetched.client.aclose()
+
+        # Retrieve final status
+        refreshed = await Sandbox.get(sandbox_id=sandbox.sandbox_id)
+        try:
+            print("Status after stop:", refreshed.status)
+        finally:
+            await refreshed.client.aclose()
+    finally:
+        await sandbox.client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_07_ruby_sinatra.py
+++ b/examples/sandbox_07_ruby_sinatra.py
@@ -1,0 +1,180 @@
+import asyncio
+import contextlib
+import os
+import webbrowser
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+SINATRA_APP = b"""
+require 'json'
+require 'sinatra'
+
+set :bind, '0.0.0.0'
+set :port, 4567
+set :server, :webrick
+disable :protection
+
+get '/' do
+  content_type :json
+  { message: 'Hello from Sinatra in Vercel Sandbox!' }.to_json
+end
+"""
+
+
+CONFIG_RU = b"""
+# frozen_string_literal: true
+ENV['RACK_ENV'] ||= 'production'
+require_relative './app'
+run Sinatra::Application
+"""
+
+
+GEMFILE = b"""
+source 'https://rubygems.org'
+
+gem 'sinatra'
+gem 'webrick'
+gem 'rackup'
+"""
+
+
+async def main() -> None:
+    runtime = (
+        os.getenv("SANDBOX_RUNTIME") or "node22"
+    )  # note: ruby runtime is not supported so we have to install ruby via dnf
+
+    # Sinatra default port is 4567
+    port = 4567
+
+    async with await Sandbox.create(ports=[port], timeout=600_000, runtime=runtime) as sandbox:
+        # Write the Sinatra application to the sandbox working directory
+        await sandbox.write_files(
+            [
+                {"path": "app.rb", "content": SINATRA_APP},
+                {"path": "config.ru", "content": CONFIG_RU},
+                {"path": "Gemfile", "content": GEMFILE},
+            ]
+        )
+
+        # Ensure Ruby 3.2 and JSON lib are available in the Amazon Linux 2023 base image
+        print("Installing Ruby 3.2 and JSON via dnf...")
+        apt_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                ("dnf install -y ruby3.2 ruby3.2-rubygems ruby3.2-rubygem-json"),
+            ],
+            sudo=True,
+        )
+        async for line in apt_cmd.logs():
+            print(line.data, end="")
+        apt_done = await apt_cmd.wait()
+        if apt_done.exit_code != 0:
+            raise SystemExit("dnf install failed")
+
+        # Install Bundler globally (requires sudo); later gem installs will go to vendor/bundle
+        print("Installing Bundler...")
+        bundler_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                ("gem install --no-document bundler"),
+            ],
+            sudo=True,
+        )
+        async for line in bundler_cmd.logs():
+            print(line.data, end="")
+        bundler_done = await bundler_cmd.wait()
+        if bundler_done.exit_code != 0:
+            raise SystemExit("Bundler installation failed")
+
+        # Configure bundler to install into a writable path inside the sandbox working directory
+        print("Configuring Bundler to use vendor/bundle...")
+        bundler_cfg_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {sandbox.sandbox.cwd} && "
+                    "bundle config set --local path vendor/bundle && "
+                    "bundle config set --local without 'development:test'"
+                ),
+            ],
+        )
+        async for line in bundler_cfg_cmd.logs():
+            print(line.data, end="")
+        bundler_cfg_done = await bundler_cfg_cmd.wait()
+        if bundler_cfg_done.exit_code != 0:
+            raise SystemExit("Bundler config failed")
+
+        # Install gems from Gemfile into vendor/bundle
+        print("Running bundle install...")
+        bundle_install_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {sandbox.sandbox.cwd} && bundle install --jobs 4 --retry 3"),
+            ],
+        )
+        async for line in bundle_install_cmd.logs():
+            print(line.data, end="")
+        bundle_install_done = await bundle_install_cmd.wait()
+        if bundle_install_done.exit_code != 0:
+            raise SystemExit("bundle install failed")
+
+        print("Starting Sinatra server...")
+        cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {sandbox.sandbox.cwd} && "
+                    # Start via rackup using WEBrick, binding to 0.0.0.0 and selected port
+                    f"RACK_ENV=production bundle exec rackup -s webrick -o 0.0.0.0 -p {port}"
+                ),
+            ],
+        )
+
+        # Stream logs and open browser once server is ready.
+        ready = asyncio.Event()
+
+        async def logs_and_detect_ready():
+            async for line in cmd.logs():
+                print(line.data, end="")
+                if not ready.is_set() and (
+                    "Listening on" in line.data
+                    or "WEBrick::HTTPServer#start" in line.data
+                    or "Sinatra has taken the stage" in line.data
+                    or f"tcp://0.0.0.0:{port}" in line.data
+                    or "WEBrick::HTTPServer#start: pid=" in line.data
+                ):
+                    ready.set()
+
+        logs_task = asyncio.create_task(logs_and_detect_ready())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=90)
+        except asyncio.TimeoutError:
+            pass
+
+        url = sandbox.domain(port)
+        print("Open:", url)
+
+        # In CI, avoid opening a browser.
+        if not os.getenv("CI"):
+            with contextlib.suppress(Exception):
+                webbrowser.open(url)
+
+        # Stop streaming logs and terminate the server so the example exits promptly.
+        logs_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await logs_task
+        await cmd.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_08_go_gin.py
+++ b/examples/sandbox_08_go_gin.py
@@ -1,0 +1,138 @@
+import asyncio
+import contextlib
+import os
+import webbrowser
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+GIN_APP = b"""
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Hello from Gin in Vercel Sandbox!",
+		})
+	})
+
+	port := "3000"
+
+	ln, err := net.Listen("tcp", "0.0.0.0:"+port)
+	if err != nil {
+		log.Fatalf("listen error: %v", err)
+	}
+	log.Printf("Listening on http://0.0.0.0:%s", port)
+
+	if err := http.Serve(ln, router); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("serve error: %v", err)
+	}
+}
+"""
+
+
+async def main() -> None:
+    runtime = (
+        os.getenv("SANDBOX_RUNTIME") or "node22"
+    )  # note: go runtime is not pre-installed; install via dnf
+
+    # Gin default port
+    port = 3000
+
+    async with await Sandbox.create(ports=[port], timeout=600_000, runtime=runtime) as sandbox:
+        # Write the Go Gin application to the sandbox working directory
+        await sandbox.write_files(
+            [
+                {"path": "main.go", "content": GIN_APP},
+            ]
+        )
+
+        # Ensure Go toolchain is available in the Amazon Linux 2023 base image
+        print("Installing Go (golang) and Git via dnf...")
+        dnf_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                ("dnf install -y golang git"),
+            ],
+            sudo=True,
+        )
+        async for line in dnf_cmd.logs():
+            print(line.data, end="")
+        dnf_done = await dnf_cmd.wait()
+        if dnf_done.exit_code != 0:
+            raise SystemExit("dnf install failed")
+
+        print("Initializing Go module and fetching Gin...")
+        mod_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {sandbox.sandbox.cwd} && "
+                    "go version && "
+                    "go mod init ginapp && "
+                    "go get github.com/gin-gonic/gin@latest"
+                ),
+            ],
+        )
+        async for line in mod_cmd.logs():
+            print(line.data, end="")
+        mod_done = await mod_cmd.wait()
+        if mod_done.exit_code != 0:
+            raise SystemExit("go module setup failed")
+
+        print("Starting Gin server...")
+        cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {sandbox.sandbox.cwd} && go run ."),
+            ],
+        )
+
+        # Stream logs and open browser once server is ready.
+        ready = asyncio.Event()
+
+        async def logs_and_detect_ready():
+            async for line in cmd.logs():
+                print(line.data, end="")
+                if not ready.is_set() and ("Listening on" in line.data and str(port) in line.data):
+                    ready.set()
+
+        logs_task = asyncio.create_task(logs_and_detect_ready())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=90)
+        except asyncio.TimeoutError:
+            pass
+
+        url = sandbox.domain(port)
+        print("Open:", url)
+        # In CI, avoid opening a browser.
+        if not os.getenv("CI"):
+            with contextlib.suppress(Exception):
+                webbrowser.open(url)
+
+        # Stop streaming logs and terminate the server so the example exits promptly.
+        logs_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await logs_task
+        await cmd.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_09_rails_api.py
+++ b/examples/sandbox_09_rails_api.py
@@ -1,0 +1,261 @@
+import asyncio
+import contextlib
+import os
+import webbrowser
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox as Sandbox
+
+load_dotenv()
+
+
+ROUTES_SCAFFOLD_RB = b"""
+Rails.application.routes.draw do
+  resources :posts
+  root "posts#index"
+end
+"""
+
+
+HOSTS_INITIALIZER = b"""
+# Allow sandbox host passed via environment variable
+if ENV['ALLOWED_HOST'] && !ENV['ALLOWED_HOST'].empty?
+  Rails.application.config.hosts << ENV['ALLOWED_HOST']
+end
+"""
+
+SEEDS_RB = b"""
+# Seed some sample posts for the demo
+Post.destroy_all
+Post.create!([
+  { title: "Hello", body: "First post from Rails on Vercel Sandbox." },
+  { title: "Rails + Sandbox", body: "It works! CRUD ready." }
+])
+puts "Seeded #{Post.count} posts"
+"""
+
+
+async def main() -> None:
+    runtime = (
+        os.getenv("SANDBOX_RUNTIME") or "node22"
+    )  # note: ruby runtime is not supported so we install ruby via dnf
+
+    # Rails default port is 3000
+    port = 3000
+    app_name = "rails_api"
+
+    async with await Sandbox.create(ports=[port], timeout=600_000, runtime=runtime) as sandbox:
+        # Ensure Ruby 3.2 and build tools are available in the Amazon Linux 2023 base image
+        print("Installing Ruby 3.2, SQLite, and build tools via dnf...")
+        dnf_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    "dnf install -y "
+                    "ruby3.2 ruby3.2-rubygems ruby3.2-rubygem-json ruby3.2-devel "
+                    "libyaml-devel "
+                    "gcc gcc-c++ make git sqlite sqlite-devel"
+                ),
+            ],
+            sudo=True,
+        )
+        async for line in dnf_cmd.logs():
+            print(line.data, end="")
+        dnf_done = await dnf_cmd.wait()
+        if dnf_done.exit_code != 0:
+            raise SystemExit("dnf install failed")
+
+        # Install Bundler and Rails globally (requires sudo)
+        print("Installing Bundler and Rails gems...")
+        gem_install_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                ("gem install --no-document bundler && gem install --no-document rails"),
+            ],
+            sudo=True,
+        )
+        async for line in gem_install_cmd.logs():
+            print(line.data, end="")
+        gem_install_done = await gem_install_cmd.wait()
+        if gem_install_done.exit_code != 0:
+            raise SystemExit("gem install rails/bundler failed")
+
+        # Create a new (non API-only) Rails app
+        print("Generating new Rails app...")
+        new_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {sandbox.sandbox.cwd} && "
+                    f"rails new {app_name} "
+                    "--database=sqlite3 "
+                    "--skip-asset-pipeline "
+                    "--skip-javascript "
+                    "--skip-hotwire "
+                    "--skip-jbuilder "
+                    "--skip-action-mailbox "
+                    "--skip-action-text "
+                    "--skip-active-storage "
+                    "--skip-action-cable "
+                    "--skip-system-test "
+                    "--skip-git "
+                    "--force"
+                ),
+            ],
+        )
+        async for line in new_cmd.logs():
+            print(line.data, end="")
+        new_done = await new_cmd.wait()
+        if new_done.exit_code != 0:
+            raise SystemExit("rails new failed")
+
+        app_path = f"{sandbox.sandbox.cwd}/{app_name}"
+
+        # Configure bundler to install into a writable path inside the app directory
+        print("Configuring Bundler to use vendor/bundle...")
+        bundler_cfg_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {app_path} && bundle config set --local path vendor/bundle"),
+            ],
+        )
+        async for line in bundler_cfg_cmd.logs():
+            print(line.data, end="")
+        bundler_cfg_done = await bundler_cfg_cmd.wait()
+        if bundler_cfg_done.exit_code != 0:
+            raise SystemExit("Bundler config failed")
+
+        # Install gems from Gemfile into vendor/bundle
+        print("Running bundle install...")
+        bundle_install_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {app_path} && bundle install --jobs 4 --retry 3"),
+            ],
+        )
+        async for line in bundle_install_cmd.logs():
+            print(line.data, end="")
+        bundle_install_done = await bundle_install_cmd.wait()
+        if bundle_install_done.exit_code != 0:
+            raise SystemExit("bundle install failed")
+
+        # Generate a CRUD scaffold for Post (title:string, body:text)
+        print("Generating scaffold for Post...")
+        scaffold_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {app_path} && "
+                    "bundle exec rails generate scaffold Post title:string body:text"
+                ),
+            ],
+        )
+        async for line in scaffold_cmd.logs():
+            print(line.data, end="")
+        scaffold_done = await scaffold_cmd.wait()
+        if scaffold_done.exit_code != 0:
+            raise SystemExit("rails generate scaffold failed")
+
+        # Overwrite routes to ensure resources and root
+        print("Configuring routes and seeds...")
+        await sandbox.write_files(
+            [
+                {"path": f"{app_name}/config/routes.rb", "content": ROUTES_SCAFFOLD_RB},
+                {"path": f"{app_name}/db/seeds.rb", "content": SEEDS_RB},
+                {
+                    "path": f"{app_name}/config/initializers/allow_hosts.rb",
+                    "content": HOSTS_INITIALIZER,
+                },
+            ]
+        )
+
+        # Run database migrations
+        print("Running migrations...")
+        migrate_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {app_path} && bundle exec rails db:migrate"),
+            ],
+        )
+        async for line in migrate_cmd.logs():
+            print(line.data, end="")
+        migrate_done = await migrate_cmd.wait()
+        if migrate_done.exit_code != 0:
+            raise SystemExit("rails db:migrate failed")
+
+        # Seed sample data
+        print("Seeding database...")
+        seed_cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (f"cd {app_path} && bundle exec rails db:seed"),
+            ],
+        )
+        async for line in seed_cmd.logs():
+            print(line.data, end="")
+        seed_done = await seed_cmd.wait()
+        if seed_done.exit_code != 0:
+            raise SystemExit("rails db:seed failed")
+
+        # Start Rails server (development env) binding to 0.0.0.0
+        print("Starting Rails server...")
+        # Determine sandbox hostname for host authorization
+        sandbox_url = sandbox.domain(port)
+        allowed_host = urlparse(sandbox_url).hostname or ""
+        cmd = await sandbox.run_command_detached(
+            "bash",
+            [
+                "-lc",
+                (
+                    f"cd {app_path} && "
+                    f"ALLOWED_HOST={allowed_host} bundle exec rails server -b 0.0.0.0 -p {port}"
+                ),
+            ],
+        )
+
+        # Stream logs and open browser once server is ready.
+        ready = asyncio.Event()
+
+        async def logs_and_detect_ready():
+            async for line in cmd.logs():
+                print(line.data, end="")
+                if not ready.is_set() and (
+                    "Listening on" in line.data
+                    and f":{port}" in line.data
+                    or "Use Ctrl-C to stop" in line.data
+                    or "Puma starting" in line.data
+                ):
+                    ready.set()
+
+        logs_task = asyncio.create_task(logs_and_detect_ready())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=120)
+        except asyncio.TimeoutError:
+            pass
+
+        url = sandbox_url
+        print("Open:", url)
+        # In CI, avoid opening a browser.
+        if not os.getenv("CI"):
+            with contextlib.suppress(Exception):
+                webbrowser.open(url)
+
+        # Stop streaming logs and terminate the server so the example exits promptly.
+        logs_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await logs_task
+        await cmd.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox_10_sync_and_async.py
+++ b/examples/sandbox_10_sync_and_async.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox, Sandbox
+
+load_dotenv()
+
+
+async def async_demo() -> None:
+    # Requires env vars: VERCEL_OIDC_TOKEN + VERCEL_PROJECT_ID + VERCEL_TEAM_ID
+    async with await AsyncSandbox.create(timeout=60_000) as sandbox:  # 1 minute sandbox
+        # One-shot command (waits)
+        res = await sandbox.run_command("bash", ["-lc", "echo async hello && echo async err 1>&2"])
+        print("async exit:", res.exit_code)
+
+        # Detached + logs streaming
+        detached = await sandbox.run_command_detached(
+            "bash", ["-lc", "for i in 1 2 3; do echo async $i; sleep 0.1; done"]
+        )
+        async for line in detached.logs():
+            print("async", line.stream, line.data, end="")
+        await detached.wait()
+
+
+def sync_demo() -> None:
+    # Requires env vars: VERCEL_OIDC_TOKEN + VERCEL_PROJECT_ID + VERCEL_TEAM_ID
+    with Sandbox.create(timeout=60_000) as sandbox:  # 1 minute sandbox
+        # One-shot command (waits)
+        res = sandbox.run_command("bash", ["-lc", "echo sync hello && echo sync err 1>&2"])
+        print("sync exit:", res.exit_code)
+
+        # Detached + logs streaming
+        detached = sandbox.run_command_detached(
+            "bash", ["-lc", "for i in 1 2 3; do echo sync $i; sleep 0.1; done"]
+        )
+        for line in detached.logs():
+            print("sync", line.stream, line.data, end="")
+        detached.wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(async_demo())
+    sync_demo()

--- a/examples/sandbox_11_snapshots.py
+++ b/examples/sandbox_11_snapshots.py
@@ -1,0 +1,165 @@
+"""
+Example: Snapshots (Sync & Async)
+
+This example demonstrates how to:
+1. Create a sandbox and set it up with files/dependencies
+2. Create a snapshot of that sandbox (saves its state)
+3. Create a new sandbox FROM the snapshot (inherits the saved state)
+4. Verify the new sandbox has the same files as the original
+5. Delete the snapshot when done
+
+Snapshots are useful for:
+- Fast startup: Pre-install dependencies once, then create sandboxes instantly
+- Templates: Create base environments that can be reused
+- Cost efficiency: Avoid repetitive setup tasks
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox, AsyncSnapshot, Sandbox, Snapshot
+
+load_dotenv()
+
+
+async def async_demo() -> None:
+    print("=" * 60)
+    print("ASYNC SNAPSHOT EXAMPLE")
+    print("=" * 60)
+
+    # Step 1: Create a sandbox and set it up
+    print("\n[1] Creating initial sandbox...")
+    sandbox1 = await AsyncSandbox.create(timeout=120_000)
+    try:
+        print(f"    Sandbox ID: {sandbox1.sandbox_id}")
+
+        # Write some files to simulate a "setup" step
+        print("\n[2] Writing files to simulate environment setup...")
+        await sandbox1.write_files([
+            {"path": "config.json", "content": b'{"version": "1.0", "env": "async"}'},
+            {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
+        ])
+
+        config = await sandbox1.read_file("config.json")
+        print(f"    Created config.json: {config.decode()}")
+
+        # Step 2: Create a snapshot (this STOPS the sandbox)
+        print("\n[3] Creating snapshot...")
+        snapshot = await sandbox1.snapshot()
+        print(f"    Snapshot ID: {snapshot.snapshot_id}")
+        print(f"    Status: {snapshot.status}")
+        print(f"    Sandbox status after snapshot: {sandbox1.status}")
+
+    finally:
+        await sandbox1.client.aclose()
+
+    # Step 3: Create a NEW sandbox FROM the snapshot
+    print("\n[4] Creating new sandbox from snapshot...")
+    sandbox2 = await AsyncSandbox.create(
+        timeout=120_000,
+        source={"type": "snapshot", "snapshot_id": snapshot.snapshot_id},
+    )
+    try:
+        print(f"    New Sandbox ID: {sandbox2.sandbox_id}")
+        print(f"    Source Snapshot ID: {sandbox2.source_snapshot_id}")
+
+        # Step 4: Verify the snapshot preserved our files
+        print("\n[5] Verifying snapshot preserved files...")
+        config2 = await sandbox2.read_file("config.json")
+        users2 = await sandbox2.read_file("data/users.txt")
+
+        print(f"    config.json: {config2.decode()}")
+        print(f"    data/users.txt: {users2.decode()}")
+
+        assert config2 == b'{"version": "1.0", "env": "async"}', "config.json mismatch!"
+        assert users2 == b"alice\nbob\ncharlie", "users.txt mismatch!"
+        print("\n✓ Async assertions passed!")
+
+    finally:
+        await sandbox2.stop()
+        await sandbox2.client.aclose()
+
+    # Step 5: Retrieve and delete the snapshot
+    print("\n[6] Retrieving and deleting snapshot...")
+    fetched = await AsyncSnapshot.get(snapshot_id=snapshot.snapshot_id)
+    try:
+        await fetched.delete()
+        print(f"    Deleted snapshot, status: {fetched.status}")
+    finally:
+        await fetched.client.aclose()
+
+
+def sync_demo() -> None:
+    print("\n" + "=" * 60)
+    print("SYNC SNAPSHOT EXAMPLE")
+    print("=" * 60)
+
+    # Step 1: Create a sandbox and set it up
+    print("\n[1] Creating initial sandbox...")
+    sandbox1 = Sandbox.create(timeout=120_000)
+    try:
+        print(f"    Sandbox ID: {sandbox1.sandbox_id}")
+
+        # Write some files to simulate a "setup" step
+        print("\n[2] Writing files to simulate environment setup...")
+        sandbox1.write_files([
+            {"path": "config.json", "content": b'{"version": "1.0", "env": "sync"}'},
+            {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
+        ])
+
+        config = sandbox1.read_file("config.json")
+        print(f"    Created config.json: {config.decode()}")
+
+        # Step 2: Create a snapshot (this STOPS the sandbox)
+        print("\n[3] Creating snapshot...")
+        snapshot = sandbox1.snapshot()
+        print(f"    Snapshot ID: {snapshot.snapshot_id}")
+        print(f"    Status: {snapshot.status}")
+        print(f"    Sandbox status after snapshot: {sandbox1.status}")
+
+    finally:
+        sandbox1.client.close()
+
+    # Step 3: Create a NEW sandbox FROM the snapshot
+    print("\n[4] Creating new sandbox from snapshot...")
+    sandbox2 = Sandbox.create(
+        timeout=120_000,
+        source={"type": "snapshot", "snapshot_id": snapshot.snapshot_id},
+    )
+    try:
+        print(f"    New Sandbox ID: {sandbox2.sandbox_id}")
+        print(f"    Source Snapshot ID: {sandbox2.source_snapshot_id}")
+
+        # Step 4: Verify the snapshot preserved our files
+        print("\n[5] Verifying snapshot preserved files...")
+        config2 = sandbox2.read_file("config.json")
+        users2 = sandbox2.read_file("data/users.txt")
+
+        print(f"    config.json: {config2.decode()}")
+        print(f"    data/users.txt: {users2.decode()}")
+
+        assert config2 == b'{"version": "1.0", "env": "sync"}', "config.json mismatch!"
+        assert users2 == b"alice\nbob\ncharlie", "users.txt mismatch!"
+        print("\n✓ Sync assertions passed!")
+
+    finally:
+        sandbox2.stop()
+        sandbox2.client.close()
+
+    # Step 5: Retrieve and delete the snapshot
+    print("\n[6] Retrieving and deleting snapshot...")
+    fetched = Snapshot.get(snapshot_id=snapshot.snapshot_id)
+    try:
+        fetched.delete()
+        print(f"    Deleted snapshot, status: {fetched.status}")
+    finally:
+        fetched.client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(async_demo())
+    sync_demo()
+    print("\n" + "=" * 60)
+    print("ALL SNAPSHOT TESTS COMPLETE")
+    print("=" * 60)

--- a/examples/sandbox_11_snapshots.py
+++ b/examples/sandbox_11_snapshots.py
@@ -36,10 +36,12 @@ async def async_demo() -> None:
 
         # Write some files to simulate a "setup" step
         print("\n[2] Writing files to simulate environment setup...")
-        await sandbox1.write_files([
-            {"path": "config.json", "content": b'{"version": "1.0", "env": "async"}'},
-            {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
-        ])
+        await sandbox1.write_files(
+            [
+                {"path": "config.json", "content": b'{"version": "1.0", "env": "async"}'},
+                {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
+            ]
+        )
 
         config = await sandbox1.read_file("config.json")
         print(f"    Created config.json: {config.decode()}")
@@ -103,10 +105,12 @@ def sync_demo() -> None:
 
         # Write some files to simulate a "setup" step
         print("\n[2] Writing files to simulate environment setup...")
-        sandbox1.write_files([
-            {"path": "config.json", "content": b'{"version": "1.0", "env": "sync"}'},
-            {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
-        ])
+        sandbox1.write_files(
+            [
+                {"path": "config.json", "content": b'{"version": "1.0", "env": "sync"}'},
+                {"path": "data/users.txt", "content": b"alice\nbob\ncharlie"},
+            ]
+        )
 
         config = sandbox1.read_file("config.json")
         print(f"    Created config.json: {config.decode()}")

--- a/examples/sandbox_12_extend_timeout.py
+++ b/examples/sandbox_12_extend_timeout.py
@@ -1,0 +1,90 @@
+"""
+Example: Extend Timeout (Sync & Async)
+
+This example demonstrates how to:
+1. Create a sandbox with a specific timeout
+2. Check the current timeout value
+3. Extend the timeout duration
+4. Verify the timeout was extended
+
+The extend_timeout method allows you to extend the lifetime of a running sandbox
+up until the maximum execution timeout for your plan.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox, Sandbox
+
+load_dotenv()
+
+
+async def async_demo() -> None:
+    print("=" * 60)
+    print("ASYNC EXTEND TIMEOUT EXAMPLE")
+    print("=" * 60)
+
+    # Step 1: Create a sandbox with a 2-minute timeout
+    initial_timeout = 2 * 60 * 1000  # 2 minutes in milliseconds
+    print(f"\n[1] Creating sandbox with {initial_timeout // 1000}s timeout...")
+    sandbox = await AsyncSandbox.create(timeout=initial_timeout)
+    try:
+        print(f"    Sandbox ID: {sandbox.sandbox_id}")
+        print(f"    Initial timeout: {sandbox.timeout}ms ({sandbox.timeout // 1000}s)")
+
+        # Step 2: Extend the timeout by 3 minutes
+        extension = 3 * 60 * 1000  # 3 minutes in milliseconds
+        print(f"\n[2] Extending timeout by {extension // 1000}s...")
+        await sandbox.extend_timeout(extension)
+        print(f"    New timeout: {sandbox.timeout}ms ({sandbox.timeout // 1000}s)")
+
+        # Verify the timeout was extended
+        expected_timeout = initial_timeout + extension
+        assert sandbox.timeout == expected_timeout, (
+            f"Expected timeout {expected_timeout}, got {sandbox.timeout}"
+        )
+        print("\n✓ Async extend_timeout test passed!")
+
+    finally:
+        await sandbox.stop()
+        await sandbox.client.aclose()
+
+
+def sync_demo() -> None:
+    print("\n" + "=" * 60)
+    print("SYNC EXTEND TIMEOUT EXAMPLE")
+    print("=" * 60)
+
+    # Step 1: Create a sandbox with a 2-minute timeout
+    initial_timeout = 2 * 60 * 1000  # 2 minutes in milliseconds
+    print(f"\n[1] Creating sandbox with {initial_timeout // 1000}s timeout...")
+    sandbox = Sandbox.create(timeout=initial_timeout)
+    try:
+        print(f"    Sandbox ID: {sandbox.sandbox_id}")
+        print(f"    Initial timeout: {sandbox.timeout}ms ({sandbox.timeout // 1000}s)")
+
+        # Step 2: Extend the timeout by 3 minutes
+        extension = 3 * 60 * 1000  # 3 minutes in milliseconds
+        print(f"\n[2] Extending timeout by {extension // 1000}s...")
+        sandbox.extend_timeout(extension)
+        print(f"    New timeout: {sandbox.timeout}ms ({sandbox.timeout // 1000}s)")
+
+        # Verify the timeout was extended
+        expected_timeout = initial_timeout + extension
+        assert sandbox.timeout == expected_timeout, (
+            f"Expected timeout {expected_timeout}, got {sandbox.timeout}"
+        )
+        print("\n✓ Sync extend_timeout test passed!")
+
+    finally:
+        sandbox.stop()
+        sandbox.client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(async_demo())
+    sync_demo()
+    print("\n" + "=" * 60)
+    print("ALL EXTEND TIMEOUT TESTS COMPLETE")
+    print("=" * 60)

--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -145,7 +145,9 @@ async def test():
         print("4. Connecting to WebSocket...")
         host = sandbox.domain(sandbox.interactive_port)
         host = host.replace("https://", "").replace("http://", "")
-        ws_url = f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
+        ws_url = (
+            f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
+        )
 
         # Small delay to ensure server is ready
         await asyncio.sleep(0.5)

--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Example: Interactive Shell Session
+
+This example demonstrates how to use the interactive shell feature
+to get a full PTY-based terminal session in a Vercel Sandbox.
+
+Prerequisites:
+- Set VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID environment variables
+- Or create a .env file with these values
+- Or run from a Vercel Function with OIDC credentials
+
+Usage:
+    python examples/13_interactive_shell.py          # Interactive bash shell
+    python examples/13_interactive_shell.py --python # Interactive Python REPL
+    python examples/13_interactive_shell.py --test   # Non-interactive CI test
+
+Interactive mode will:
+1. Create a sandbox with interactive support enabled
+2. Drop you into an interactive bash shell
+3. You can type commands, use arrow keys, tab completion, etc.
+4. Press Ctrl+D or type 'exit' to end the session
+"""
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox
+
+load_dotenv()
+
+
+async def main():
+    print("Creating sandbox with interactive support...")
+
+    # Create sandbox with interactive=True to enable PTY support
+    sandbox = await AsyncSandbox.create(
+        interactive=True,
+        timeout=300_000,  # 5 minutes
+    )
+
+    print(f"Sandbox created: {sandbox.sandbox_id}")
+    print(f"Interactive port: {sandbox.interactive_port}")
+    print()
+    print("Starting interactive shell...")
+    print("=" * 50)
+    print("You are now in a remote shell. Try commands like:")
+    print("  ls -la")
+    print("  python3 --version")
+    print("  echo $SHELL")
+    print()
+    print("Press Ctrl+D or type 'exit' to end the session.")
+    print("=" * 50)
+    print()
+
+    try:
+        # Start interactive bash shell
+        await sandbox.shell(["/bin/bash"])
+    finally:
+        print()
+        print("Stopping sandbox...")
+        await sandbox.stop()
+        print("Done!")
+
+
+async def python_repl_example():
+    """Example: Interactive Python REPL"""
+    print("Creating sandbox with interactive support...")
+
+    sandbox = await AsyncSandbox.create(
+        interactive=True,
+        timeout=300_000,
+    )
+
+    print(f"Sandbox created: {sandbox.sandbox_id}")
+    print()
+    print("Starting Python REPL...")
+    print("=" * 50)
+    print("You are now in a remote Python interpreter.")
+    print("Try: print('Hello from Vercel Sandbox!')")
+    print("Press Ctrl+D to exit.")
+    print("=" * 50)
+    print()
+
+    try:
+        await sandbox.shell(["python3"])
+    finally:
+        print()
+        print("Stopping sandbox...")
+        await sandbox.stop()
+        print("Done!")
+
+
+async def test():
+    """Non-interactive test for CI environments.
+
+    This tests the PTY infrastructure without taking over the terminal:
+    1. Creates sandbox with interactive=True
+    2. Verifies interactive port is allocated
+    3. Sets up sandbox environment (installs PTY server)
+    4. Connects to WebSocket and runs a command
+    5. Verifies output is received
+    """
+    from vercel.sandbox.pty.client import PTYClient
+    from vercel.sandbox.pty.shell import setup_sandbox_environment, start_pty_server
+
+    print("=" * 60)
+    print("Interactive Shell CI Test (non-interactive)")
+    print("=" * 60)
+    print()
+
+    print("1. Creating sandbox with interactive=True...")
+    sandbox = await AsyncSandbox.create(
+        interactive=True,
+        timeout=120_000,  # 2 minutes
+    )
+
+    try:
+        print(f"   Sandbox ID: {sandbox.sandbox_id}")
+        print(f"   Interactive port: {sandbox.interactive_port}")
+
+        # Verify interactive port
+        assert sandbox.interactive_port is not None, "Interactive port should be set"
+        print("   ✅ Interactive port allocated")
+        print()
+
+        print("2. Setting up sandbox environment (installing PTY server)...")
+        await setup_sandbox_environment(sandbox)
+        print("   ✅ PTY server installed")
+        print()
+
+        print("3. Starting PTY server with bash...")
+        # Use bash with a command that outputs, waits, then exits
+        # This gives us time to connect and read output
+        cmd, conn_info = await start_pty_server(
+            sandbox,
+            ["bash", "-c", "echo 'PTY_TEST_OUTPUT'; sleep 2; echo 'DONE'"],
+        )
+        print(f"   Process ID: {conn_info['processId']}")
+        print(f"   Token: {conn_info['token'][:20]}...")
+        print("   ✅ PTY server started")
+        print()
+
+        print("4. Connecting to WebSocket...")
+        host = sandbox.domain(sandbox.interactive_port)
+        host = host.replace("https://", "").replace("http://", "")
+        ws_url = f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
+
+        # Small delay to ensure server is ready
+        await asyncio.sleep(0.5)
+
+        client = await PTYClient.connect(ws_url)
+        print("   ✅ WebSocket connected")
+        print()
+
+        print("5. Sending ready signal and receiving output...")
+        await client.send_ready()
+        await client.send_resize(80, 24)
+
+        # Collect output with timeout
+        output = b""
+        try:
+            async with asyncio.timeout(5):
+                async for data in client.raw_messages():
+                    output += data
+                    # Check if we got our test string
+                    if b"PTY_TEST_OUTPUT" in output:
+                        break
+        except asyncio.TimeoutError:
+            pass
+
+        await client.close()
+
+        # Verify output
+        output_str = output.decode("utf-8", errors="replace")
+        print(f"   Received {len(output)} bytes")
+
+        if "PTY_TEST_OUTPUT" in output_str:
+            print("   ✅ Expected output received!")
+        else:
+            print("   ⚠️  Output received but test string not found")
+            print(f"   Output preview: {repr(output_str[:200])}")
+
+        print()
+        print("=" * 60)
+        print("✅ All tests passed!")
+        print("=" * 60)
+
+    finally:
+        print()
+        print("Stopping sandbox...")
+        await sandbox.stop()
+        print("Done!")
+
+
+if __name__ == "__main__":
+    import os
+
+    # Auto-detect CI environment (no TTY or CI env var set)
+    is_ci = os.environ.get("CI") == "1" or not sys.stdin.isatty()
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--python":
+            asyncio.run(python_repl_example())
+        elif sys.argv[1] == "--test":
+            asyncio.run(test())
+        else:
+            print(f"Unknown flag: {sys.argv[1]}")
+            print("Usage: python 13_interactive_shell.py [--python|--test]")
+            sys.exit(1)
+    elif is_ci:
+        # In CI, run non-interactive test automatically
+        asyncio.run(test())
+    else:
+        asyncio.run(main())

--- a/examples/sandbox_14_pty_test.py
+++ b/examples/sandbox_14_pty_test.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Example: PTY Infrastructure Test
+
+This example tests the PTY infrastructure without taking over the terminal.
+Useful for debugging and verifying the setup works correctly.
+
+Usage:
+    python examples/15_pty_test.py
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox
+from vercel.sandbox.pty.binary import (
+    BINARY_BASE_URL,
+    CACHE_DIR,
+    DEFAULT_SANDBOX_ARCH,
+    SERVER_BIN_NAME,
+    download_binary_async,
+    get_binary_cache_path,
+)
+
+load_dotenv()
+
+
+async def test_binary_download():
+    """Test downloading the PTY server binary."""
+    print("=" * 60)
+    print("Testing PTY Server Binary Download")
+    print("=" * 60)
+    print()
+
+    print(f"Binary URL: {BINARY_BASE_URL}")
+    print(f"Cache directory: {CACHE_DIR}")
+    print(f"Server binary name: {SERVER_BIN_NAME}")
+    print(f"Default architecture: {DEFAULT_SANDBOX_ARCH}")
+    print()
+
+    cache_path = get_binary_cache_path()
+    print(f"Expected cache path: {cache_path}")
+    print(f"Binary cached: {cache_path.exists()}")
+    print()
+
+    print("Downloading binary (will use cache if available)...")
+    path = await download_binary_async()
+    print(f"Binary path: {path}")
+    print(f"Binary size: {path.stat().st_size:,} bytes")
+    print()
+    print("✅ Binary download test passed!")
+    return True
+
+
+async def test_sandbox_interactive_creation():
+    """Test creating a sandbox with interactive support."""
+    print()
+    print("=" * 60)
+    print("Testing Sandbox Creation with Interactive Support")
+    print("=" * 60)
+    print()
+
+    print("Creating sandbox with interactive=True...")
+    sandbox = await AsyncSandbox.create(
+        interactive=True,
+        timeout=60_000,  # 1 minute
+    )
+
+    print(f"Sandbox ID: {sandbox.sandbox_id}")
+    print(f"Status: {sandbox.status}")
+    print(f"Interactive port: {sandbox.interactive_port}")
+    print()
+
+    if sandbox.interactive_port:
+        print("✅ Interactive port allocated!")
+    else:
+        print("❌ No interactive port - API may not support __interactive flag")
+
+    # Test that the sandbox works
+    print()
+    print("Testing basic command execution...")
+    result = await sandbox.run_command("echo", ["Hello from sandbox!"])
+    output = await result.stdout()
+    print(f"Output: {output.strip()}")
+    print(f"Exit code: {result.exit_code}")
+
+    # Get architecture
+    print()
+    print("Checking sandbox architecture...")
+    result = await sandbox.run_command("uname", ["-m"])
+    arch = (await result.stdout()).strip()
+    print(f"Sandbox architecture: {arch}")
+
+    # Stop sandbox
+    print()
+    print("Stopping sandbox...")
+    await sandbox.stop()
+    print("✅ Sandbox test passed!")
+
+    return sandbox.interactive_port is not None
+
+
+async def test_pty_server_upload():
+    """Test uploading and running the PTY server in a sandbox."""
+    print()
+    print("=" * 60)
+    print("Testing PTY Server Upload and Execution")
+    print("=" * 60)
+    print()
+
+    from vercel.sandbox.pty.binary import get_binary_bytes_async
+    from vercel.sandbox.pty.shell import SERVER_BIN_NAME
+
+    print("Creating sandbox...")
+    sandbox = await AsyncSandbox.create(
+        interactive=True,
+        timeout=120_000,  # 2 minutes
+    )
+
+    try:
+        print(f"Sandbox ID: {sandbox.sandbox_id}")
+        print()
+
+        # Download binary
+        print("Downloading PTY server binary...")
+        binary = await get_binary_bytes_async()
+        print(f"Binary size: {len(binary):,} bytes")
+
+        # Upload to sandbox
+        print()
+        print("Uploading binary to sandbox...")
+        tmp_path = f"/tmp/{SERVER_BIN_NAME}-test"
+        await sandbox.write_files([{"path": tmp_path, "content": binary}])
+
+        # Make executable and move
+        print("Installing binary...")
+        result = await sandbox.run_command(
+            "bash",
+            [
+                "-c",
+                f'mv "{tmp_path}" /usr/local/bin/{SERVER_BIN_NAME} && '
+                f"chmod +x /usr/local/bin/{SERVER_BIN_NAME}",
+            ],
+            sudo=True,
+        )
+
+        if result.exit_code != 0:
+            print(f"❌ Failed to install binary: {await result.stderr()}")
+            return False
+
+        # Verify installation
+        print()
+        print("Verifying installation...")
+        result = await sandbox.run_command("which", [SERVER_BIN_NAME])
+        if result.exit_code == 0:
+            path = (await result.stdout()).strip()
+            print(f"Binary installed at: {path}")
+        else:
+            print("❌ Binary not found in PATH")
+            return False
+
+        # Check version/help
+        print()
+        print("Checking binary help...")
+        result = await sandbox.run_command(SERVER_BIN_NAME, ["--help"])
+        output = await result.stdout()
+        stderr = await result.stderr()
+
+        # The help might go to stderr
+        help_text = output or stderr
+        if "PTY Tunnel Server" in help_text or "WebSocket" in help_text:
+            print("✅ Binary runs correctly!")
+            print()
+            print("First few lines of help output:")
+            for line in help_text.split("\n")[:5]:
+                print(f"  {line}")
+        else:
+            print("Binary output:")
+            print(help_text[:500])
+
+        print()
+        print("✅ PTY server upload test passed!")
+        return True
+
+    finally:
+        print()
+        print("Stopping sandbox...")
+        await sandbox.stop()
+
+
+async def main():
+    """Run all PTY infrastructure tests."""
+    print()
+    print("🧪 PTY Infrastructure Test Suite")
+    print()
+
+    results = []
+
+    # Test 1: Binary download
+    try:
+        results.append(("Binary Download", await test_binary_download()))
+    except Exception as e:
+        print(f"❌ Binary download failed: {e}")
+        results.append(("Binary Download", False))
+
+    # Test 2: Sandbox creation with interactive
+    try:
+        results.append(("Sandbox Interactive Creation", await test_sandbox_interactive_creation()))
+    except Exception as e:
+        print(f"❌ Sandbox creation failed: {e}")
+        results.append(("Sandbox Interactive Creation", False))
+
+    # Test 3: PTY server upload
+    try:
+        results.append(("PTY Server Upload", await test_pty_server_upload()))
+    except Exception as e:
+        print(f"❌ PTY server upload failed: {e}")
+        results.append(("PTY Server Upload", False))
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("Test Summary")
+    print("=" * 60)
+    for name, passed in results:
+        status = "✅ PASS" if passed else "❌ FAIL"
+        print(f"  {status}: {name}")
+
+    all_passed = all(passed for _, passed in results)
+    print()
+    if all_passed:
+        print("🎉 All tests passed!")
+    else:
+        print("⚠️  Some tests failed")
+
+    return all_passed
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    exit(0 if success else 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "ruff>=0.5.0",
     "pytest>=7.0.0",
     "pytest-asyncio",
+    "pytest-xdist",
     "mypy",
     "build",
     "twine",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,17 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE", "LICENSE.*"]
 dependencies = [
-    "vercel-sandbox>=0.0.4",
     "httpx>=0.27.0",
     "pydantic>=2.7.0",
     "anyio>=4.0.0",
-    "python-dotenv"
+    "python-dotenv",
+    "websockets>=12.0",
 ]
 
 [project.scripts]
 vercel = "vercel.__main__:main"
+vercel-sandbox = "vercel.sandbox.__main__:main"
+sandbox = "vercel.sandbox.__main__:main"
 
 [dependency-groups]
 dev = [

--- a/src/vercel/_telemetry/__init__.py
+++ b/src/vercel/_telemetry/__init__.py
@@ -4,4 +4,3 @@ from .client import TelemetryClient
 from .tracker import track
 
 __all__ = ["TelemetryClient", "track"]
-

--- a/src/vercel/sandbox/__init__.py
+++ b/src/vercel/sandbox/__init__.py
@@ -1,0 +1,20 @@
+from .command import AsyncCommand, AsyncCommandFinished, Command, CommandFinished
+from .models import GitSource, SnapshotSource, Source, TarballSource
+from .sandbox import AsyncSandbox, Sandbox
+from .snapshot import AsyncSnapshot, Snapshot
+
+__all__ = [
+    "AsyncSandbox",
+    "AsyncSnapshot",
+    "Sandbox",
+    "Snapshot",
+    "AsyncCommand",
+    "AsyncCommandFinished",
+    "Command",
+    "CommandFinished",
+    # Source types
+    "Source",
+    "GitSource",
+    "TarballSource",
+    "SnapshotSource",
+]

--- a/src/vercel/sandbox/__main__.py
+++ b/src/vercel/sandbox/__main__.py
@@ -1,0 +1,46 @@
+"""CLI entry point that delegates to npx sandbox."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+
+def main() -> int:
+    """Run npx sandbox with all command line arguments.
+
+    This delegates to the TypeScript CLI for full functionality including
+    interactive shell, SSH, and other commands.
+
+    Returns:
+        Exit code (0 for success, non-zero for error).
+    """
+    if not shutil.which("npx"):
+        print(
+            "Error: 'npx' is not available. Please install Node.js and npm to use the CLI.",
+            file=sys.stderr,
+        )
+        print(
+            "\nNote: The SDK works without Node.js for programmatic use:",
+            file=sys.stderr,
+        )
+        print(
+            "  from vercel.sandbox import AsyncSandbox",
+            file=sys.stderr,
+        )
+        print(
+            "  sandbox = await AsyncSandbox.create()",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Replace current process with npx sandbox
+    os.execvp("npx", ["npx", "sandbox"] + sys.argv[1:])
+
+    # This line is never reached (execvp replaces the process)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vercel/sandbox/aio.py
+++ b/src/vercel/sandbox/aio.py
@@ -1,0 +1,8 @@
+from .command import AsyncCommand as Command, AsyncCommandFinished as CommandFinished
+from .sandbox import AsyncSandbox as Sandbox
+
+__all__ = [
+    "Sandbox",
+    "Command",
+    "CommandFinished",
+]

--- a/src/vercel/sandbox/api_client.py
+++ b/src/vercel/sandbox/api_client.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
+
+import httpx
+
+from .base_client import APIError, AsyncBaseClient, BaseClient
+from .models import (
+    CommandFinishedResponse,
+    CommandResponse,
+    CreateSnapshotResponse,
+    LogLine,
+    SandboxAndRoutesResponse,
+    SandboxResponse,
+    SnapshotResponse,
+    WriteFile,
+)
+
+VERSION = "0.1.0"
+USER_AGENT = (
+    f"vercel/sandbox/{VERSION} (Python/{sys.version}; {os.uname().sysname}/{os.uname().machine})"
+)
+
+
+class AsyncAPIClient(AsyncBaseClient):
+    def __init__(self, *, host: str = "https://api.vercel.com", team_id: str, token: str):
+        super().__init__(host=host, token=token)
+        self._team_id = team_id
+
+    async def request(self, method: str, path: str, **kwargs):
+        headers = kwargs.pop("headers", {})
+        headers = {
+            "user-agent": USER_AGENT,
+            **headers,
+        }
+        query = kwargs.pop("query", {})
+        query = {"teamId": self._team_id, **(query or {})}
+        return await super().request(method, path, headers=headers, query=query, **kwargs)
+
+    async def request_json(self, method: str, path: str, **kwargs):
+        r = await self.request(method, path, **kwargs)
+        return r.json()
+
+    async def create_sandbox(
+        self,
+        *,
+        project_id: str,
+        ports: list[int] | None = None,
+        source: dict[str, Any] | None = None,
+        timeout: int | None = None,
+        resources: dict[str, Any] | None = None,
+        runtime: str | None = None,
+        interactive: bool = False,
+    ) -> SandboxAndRoutesResponse:
+        # Build body with only provided values to avoid sending nulls
+        body: dict[str, Any] = {"projectId": project_id}
+        if ports:
+            body["ports"] = ports
+        if source is not None:
+            body["source"] = source
+        if timeout is not None:
+            body["timeout"] = timeout
+        if resources is not None:
+            body["resources"] = resources
+        if runtime is not None:
+            body["runtime"] = runtime
+        if interactive:
+            body["__interactive"] = True
+
+        data = await self.request_json("POST", "/v1/sandboxes", json_body=body)
+        return SandboxAndRoutesResponse.model_validate(data)
+
+    async def get_sandbox(self, *, sandbox_id: str) -> SandboxAndRoutesResponse:
+        data = await self.request_json("GET", f"/v1/sandboxes/{sandbox_id}")
+        return SandboxAndRoutesResponse.model_validate(data)
+
+    async def run_command(
+        self,
+        *,
+        sandbox_id: str,
+        command: str,
+        args: list[str],
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> CommandResponse:
+        body: dict[str, Any] = {
+            "command": command,
+            "args": args,
+            "env": env or {},
+            "sudo": sudo,
+        }
+        if cwd is not None:
+            body["cwd"] = cwd
+        data = await self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/cmd",
+            json_body=body,
+        )
+        return CommandResponse.model_validate(data)
+
+    async def get_command(
+        self, *, sandbox_id: str, cmd_id: str, wait: bool = False
+    ) -> CommandResponse | CommandFinishedResponse:
+        data = await self.request_json(
+            "GET",
+            f"/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}",
+            query={"wait": "true"} if wait else None,
+        )
+        if wait:
+            return CommandFinishedResponse.model_validate(data)
+        return CommandResponse.model_validate(data)
+
+    async def get_logs(self, *, sandbox_id: str, cmd_id: str) -> AsyncGenerator[LogLine, None]:
+        try:
+            async with self._client.stream(
+                "GET",
+                f"/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}/logs",
+                params={"teamId": self._team_id},
+                headers={
+                    "user-agent": USER_AGENT,
+                    "authorization": f"Bearer {self._token}",
+                    "accept": "text/event-stream",
+                },
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if not line:
+                        continue
+                    try:
+                        yield LogLine.model_validate_json(line)
+                    except Exception:
+                        # Ignore lines that are not valid JSON log payloads
+                        continue
+        except (
+            httpx.RemoteProtocolError,
+            httpx.ReadError,
+            httpx.ProtocolError,
+            httpx.TransportError,
+        ):
+            # Treat abrupt stream termination as normal end-of-logs
+            return
+
+    async def stop_sandbox(self, *, sandbox_id: str) -> SandboxResponse:
+        data = await self.request_json("POST", f"/v1/sandboxes/{sandbox_id}/stop")
+        return SandboxResponse.model_validate(data)
+
+    async def mk_dir(self, *, sandbox_id: str, path: str, cwd: str | None = None) -> None:
+        body: dict[str, Any] = {"path": path}
+        if cwd is not None:
+            body["cwd"] = cwd
+        await self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/fs/mkdir",
+            json_body=body,
+        )
+
+    async def read_file(
+        self, *, sandbox_id: str, path: str, cwd: str | None = None
+    ) -> bytes | None:
+        body: dict[str, Any] = {"path": path}
+        if cwd is not None:
+            body["cwd"] = cwd
+        try:
+            resp = await self.request(
+                "POST",
+                f"/v1/sandboxes/{sandbox_id}/fs/read",
+                json_body=body,
+            )
+        except APIError as e:
+            if e.status_code == 404:
+                return None
+            raise
+        if resp.content is None:
+            return None
+        return resp.content
+
+    async def write_files(
+        self,
+        *,
+        sandbox_id: str,
+        files: list[WriteFile],
+        extract_dir: str,
+        cwd: str,
+    ) -> None:
+        import io
+        import posixpath
+        import tarfile
+
+        def normalize_path(file_path: str) -> str:
+            # Mirror TS normalizePath: basePath is absolute path. If relative, resolve against cwd.
+            base_path = (
+                posixpath.normpath(file_path)
+                if posixpath.isabs(file_path)
+                else posixpath.normpath(posixpath.join(cwd, file_path))
+            )
+            # Return path relative to extract_dir
+            return posixpath.relpath(base_path, extract_dir)
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+            for f in files:
+                data = f["content"]
+                rel = normalize_path(f["path"])  # e.g., vercel/sandbox/foo.txt
+                info = tarfile.TarInfo(name=rel)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+        payload = buffer.getvalue()
+        r = await self._client.request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/fs/write",
+            params={"teamId": self._team_id},
+            headers={
+                "content-type": "application/gzip",
+                "x-cwd": extract_dir,
+                "user-agent": USER_AGENT,
+                "authorization": f"Bearer {self._token}",
+            },
+            content=payload,
+        )
+        r.raise_for_status()
+
+    async def kill_command(self, *, sandbox_id: str, command_id: str, signal: int = 15) -> None:
+        r = await self._client.request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/cmd/{command_id}/kill",
+            params={"teamId": self._team_id},
+            headers={"user-agent": USER_AGENT},
+            json={"signal": signal},
+        )
+        r.raise_for_status()
+
+    async def extend_timeout(self, *, sandbox_id: str, duration: int) -> SandboxResponse:
+        data = await self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/extend-timeout",
+            json_body={"duration": duration},
+        )
+        return SandboxResponse.model_validate(data)
+
+    async def create_snapshot(self, *, sandbox_id: str) -> CreateSnapshotResponse:
+        data = await self.request_json("POST", f"/v1/sandboxes/{sandbox_id}/snapshot")
+        return CreateSnapshotResponse.model_validate(data)
+
+    async def get_snapshot(self, *, snapshot_id: str) -> SnapshotResponse:
+        data = await self.request_json("GET", f"/v1/sandboxes/snapshots/{snapshot_id}")
+        return SnapshotResponse.model_validate(data)
+
+    async def delete_snapshot(self, *, snapshot_id: str) -> SnapshotResponse:
+        data = await self.request_json("DELETE", f"/v1/sandboxes/snapshots/{snapshot_id}")
+        return SnapshotResponse.model_validate(data)
+
+
+class APIClient(BaseClient):
+    def __init__(self, *, host: str = "https://api.vercel.com", team_id: str, token: str):
+        super().__init__(host=host, token=token)
+        self._team_id = team_id
+
+    def request(self, method: str, path: str, **kwargs):
+        headers = kwargs.pop("headers", {})
+        headers = {
+            "user-agent": USER_AGENT,
+            **headers,
+        }
+        query = kwargs.pop("query", {})
+        query = {"teamId": self._team_id, **(query or {})}
+        return super().request(method, path, headers=headers, query=query, **kwargs)
+
+    def request_json(self, method: str, path: str, **kwargs):
+        r = self.request(method, path, **kwargs)
+        return r.json()
+
+    def create_sandbox(
+        self,
+        *,
+        project_id: str,
+        ports: list[int] | None = None,
+        source: dict[str, Any] | None = None,
+        timeout: int | None = None,
+        resources: dict[str, Any] | None = None,
+        runtime: str | None = None,
+        interactive: bool = False,
+    ) -> SandboxAndRoutesResponse:
+        body: dict[str, Any] = {"projectId": project_id}
+        if ports:
+            body["ports"] = ports
+        if source is not None:
+            body["source"] = source
+        if timeout is not None:
+            body["timeout"] = timeout
+        if resources is not None:
+            body["resources"] = resources
+        if runtime is not None:
+            body["runtime"] = runtime
+        if interactive:
+            body["__interactive"] = True
+
+        data = self.request_json("POST", "/v1/sandboxes", json_body=body)
+        return SandboxAndRoutesResponse.model_validate(data)
+
+    def get_sandbox(self, *, sandbox_id: str) -> SandboxAndRoutesResponse:
+        data = self.request_json("GET", f"/v1/sandboxes/{sandbox_id}")
+        return SandboxAndRoutesResponse.model_validate(data)
+
+    def run_command(
+        self,
+        *,
+        sandbox_id: str,
+        command: str,
+        args: list[str],
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> CommandResponse:
+        body: dict[str, Any] = {
+            "command": command,
+            "args": args,
+            "env": env or {},
+            "sudo": sudo,
+        }
+        if cwd is not None:
+            body["cwd"] = cwd
+        data = self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/cmd",
+            json_body=body,
+        )
+        return CommandResponse.model_validate(data)
+
+    def get_command(
+        self, *, sandbox_id: str, cmd_id: str, wait: bool = False
+    ) -> CommandResponse | CommandFinishedResponse:
+        data = self.request_json(
+            "GET",
+            f"/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}",
+            query={"wait": "true"} if wait else None,
+        )
+        if wait:
+            return CommandFinishedResponse.model_validate(data)
+        return CommandResponse.model_validate(data)
+
+    def get_logs(self, *, sandbox_id: str, cmd_id: str) -> Generator[LogLine, None, None]:
+        try:
+            with self._client.stream(
+                "GET",
+                f"/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}/logs",
+                params={"teamId": self._team_id},
+                headers={
+                    "user-agent": USER_AGENT,
+                    "authorization": f"Bearer {self._token}",
+                    "accept": "text/event-stream",
+                },
+            ) as resp:
+                resp.raise_for_status()
+                for line in resp.iter_lines():
+                    if not line:
+                        continue
+                    try:
+                        yield LogLine.model_validate_json(line)
+                    except Exception:
+                        # Ignore lines that are not valid JSON log payloads
+                        continue
+        except (
+            httpx.RemoteProtocolError,
+            httpx.ReadError,
+            httpx.ProtocolError,
+            httpx.TransportError,
+        ):
+            # Treat abrupt stream termination as normal end-of-logs
+            return
+
+    def stop_sandbox(self, *, sandbox_id: str) -> SandboxResponse:
+        data = self.request_json("POST", f"/v1/sandboxes/{sandbox_id}/stop")
+        return SandboxResponse.model_validate(data)
+
+    def mk_dir(self, *, sandbox_id: str, path: str, cwd: str | None = None) -> None:
+        body: dict[str, Any] = {"path": path}
+        if cwd is not None:
+            body["cwd"] = cwd
+        self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/fs/mkdir",
+            json_body=body,
+        )
+
+    def read_file(self, *, sandbox_id: str, path: str, cwd: str | None = None) -> bytes | None:
+        body: dict[str, Any] = {"path": path}
+        if cwd is not None:
+            body["cwd"] = cwd
+        try:
+            resp = self.request(
+                "POST",
+                f"/v1/sandboxes/{sandbox_id}/fs/read",
+                json_body=body,
+            )
+        except APIError as e:
+            if e.status_code == 404:
+                return None
+            raise
+        if resp.content is None:
+            return None
+        return resp.content
+
+    def write_files(
+        self,
+        *,
+        sandbox_id: str,
+        files: list[WriteFile],
+        extract_dir: str,
+        cwd: str,
+    ) -> None:
+        import io
+        import posixpath
+        import tarfile
+
+        def normalize_path(file_path: str) -> str:
+            base_path = (
+                posixpath.normpath(file_path)
+                if posixpath.isabs(file_path)
+                else posixpath.normpath(posixpath.join(cwd, file_path))
+            )
+            return posixpath.relpath(base_path, extract_dir)
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+            for f in files:
+                data = f["content"]
+                rel = normalize_path(f["path"])  # e.g., vercel/sandbox/foo.txt
+                info = tarfile.TarInfo(name=rel)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+        payload = buffer.getvalue()
+        r = self._client.request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/fs/write",
+            params={"teamId": self._team_id},
+            headers={
+                "content-type": "application/gzip",
+                "x-cwd": extract_dir,
+                "user-agent": USER_AGENT,
+                "authorization": f"Bearer {self._token}",
+            },
+            content=payload,
+        )
+        r.raise_for_status()
+
+    def kill_command(self, *, sandbox_id: str, command_id: str, signal: int = 15) -> None:
+        r = self._client.request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/cmd/{command_id}/kill",
+            params={"teamId": self._team_id},
+            headers={"user-agent": USER_AGENT},
+            json={"signal": signal},
+        )
+        r.raise_for_status()
+
+    def extend_timeout(self, *, sandbox_id: str, duration: int) -> SandboxResponse:
+        data = self.request_json(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/extend-timeout",
+            json_body={"duration": duration},
+        )
+        return SandboxResponse.model_validate(data)
+
+    def create_snapshot(self, *, sandbox_id: str) -> CreateSnapshotResponse:
+        data = self.request_json("POST", f"/v1/sandboxes/{sandbox_id}/snapshot")
+        return CreateSnapshotResponse.model_validate(data)
+
+    def get_snapshot(self, *, snapshot_id: str) -> SnapshotResponse:
+        data = self.request_json("GET", f"/v1/sandboxes/snapshots/{snapshot_id}")
+        return SnapshotResponse.model_validate(data)
+
+    def delete_snapshot(self, *, snapshot_id: str) -> SnapshotResponse:
+        data = self.request_json("DELETE", f"/v1/sandboxes/snapshots/{snapshot_id}")
+        return SnapshotResponse.model_validate(data)

--- a/src/vercel/sandbox/base_client.py
+++ b/src/vercel/sandbox/base_client.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+
+class APIError(Exception):
+    def __init__(self, response: httpx.Response, message: str, *, data: Any | None = None):
+        super().__init__(message)
+        self.response = response
+        self.status_code = response.status_code
+        self.data = data
+
+
+class BaseClient:
+    def __init__(self, *, host: str, token: str | None = None):
+        self._host = host.rstrip("/")
+        self._token = token
+        self._client = httpx.Client(base_url=self._host, timeout=httpx.Timeout(None))
+
+    def close(self) -> None:
+        self._client.close()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        query: Mapping[str, Any] | None = None,
+        json_body: Any | None = None,
+    ) -> httpx.Response:
+        req_headers: dict[str, str] = {"content-type": "application/json"}
+        if self._token:
+            req_headers["authorization"] = f"Bearer {self._token}"
+        if headers:
+            req_headers.update(headers)
+
+        response = self._client.request(
+            method,
+            path,
+            params={k: v for k, v in (query or {}).items() if v is not None},
+            json=json_body,
+            headers=req_headers,
+        )
+
+        if 200 <= response.status_code < 300:
+            return response
+
+        # Attempt to parse a helpful error message from the API
+        parsed: Any | None = None
+        message = f"HTTP {response.status_code}"
+        try:
+            parsed = response.json()
+            # Vercel errors commonly include fields like error, message, code
+            # Try a few shapes for a concise message
+            if isinstance(parsed, dict):
+                if "message" in parsed and isinstance(parsed["message"], str):
+                    message = f"{message}: {parsed['message']}"
+                elif "error" in parsed:
+                    err = parsed["error"]
+                    if isinstance(err, dict):
+                        code = err.get("code")
+                        msg = err.get("message") or err.get("msg")
+                        if msg:
+                            message = f"{message}: {msg}"
+                        if code:
+                            message = f"{message} (code={code})"
+        except Exception:
+            parsed = None
+
+        # If still not informative, include a small slice of the text body
+        if parsed is None:
+            try:
+                text = response.text
+                if text:
+                    snippet = text if len(text) <= 500 else text[:500] + "…"
+                    message = f"{message}: {snippet}"
+            except Exception:
+                pass
+
+        raise APIError(response, message, data=parsed)
+
+    def request_json(self, *args, **kwargs):
+        r = self.request(*args, **kwargs)
+        return r.json()
+
+
+class AsyncBaseClient:
+    def __init__(self, *, host: str, token: str | None = None):
+        self._host = host.rstrip("/")
+        self._token = token
+        self._client = httpx.AsyncClient(base_url=self._host, timeout=httpx.Timeout(None))
+
+    async def aclose(self):
+        await self._client.aclose()
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        query: Mapping[str, Any] | None = None,
+        json_body: Any | None = None,
+    ) -> httpx.Response:
+        req_headers: dict[str, str] = {"content-type": "application/json"}
+        if self._token:
+            req_headers["authorization"] = f"Bearer {self._token}"
+        if headers:
+            req_headers.update(headers)
+
+        response = await self._client.request(
+            method,
+            path,
+            params={k: v for k, v in (query or {}).items() if v is not None},
+            json=json_body,
+            headers=req_headers,
+        )
+
+        if 200 <= response.status_code < 300:
+            return response
+
+        # Attempt to parse a helpful error message from the API
+        parsed: Any | None = None
+        message = f"HTTP {response.status_code}"
+        try:
+            parsed = response.json()
+            # Vercel errors commonly include fields like error, message, code
+            # Try a few shapes for a concise message
+            if isinstance(parsed, dict):
+                if "message" in parsed and isinstance(parsed["message"], str):
+                    message = f"{message}: {parsed['message']}"
+                elif "error" in parsed:
+                    err = parsed["error"]
+                    if isinstance(err, dict):
+                        code = err.get("code")
+                        msg = err.get("message") or err.get("msg")
+                        if msg:
+                            message = f"{message}: {msg}"
+                        if code:
+                            message = f"{message} (code={code})"
+        except Exception:
+            parsed = None
+
+        # If still not informative, include a small slice of the text body
+        if parsed is None:
+            try:
+                text = response.text
+                if text:
+                    snippet = text if len(text) <= 500 else text[:500] + "…"
+                    message = f"{message}: {snippet}"
+            except Exception:
+                pass
+
+        raise APIError(response, message, data=parsed)
+
+    async def request_json(self, *args, **kwargs):
+        r = await self.request(*args, **kwargs)
+        return r.json()

--- a/src/vercel/sandbox/command.py
+++ b/src/vercel/sandbox/command.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from dataclasses import dataclass
+
+import httpx
+
+from .api_client import APIClient, AsyncAPIClient
+from .models import Command as CommandModel, CommandFinishedResponse, LogLine
+
+
+@dataclass
+class AsyncCommand:
+    client: AsyncAPIClient
+    sandbox_id: str
+    cmd: CommandModel
+
+    @property
+    def cmd_id(self) -> str:
+        return self.cmd.id
+
+    @property
+    def cwd(self) -> str:
+        return self.cmd.cwd
+
+    @property
+    def started_at(self) -> int:
+        return self.cmd.started_at
+
+    async def logs(self) -> AsyncGenerator[LogLine, None]:
+        async for log in self.client.get_logs(sandbox_id=self.sandbox_id, cmd_id=self.cmd.id):
+            yield log
+
+    async def wait(self) -> AsyncCommandFinished:
+        resp = await self.client.get_command(
+            sandbox_id=self.sandbox_id, cmd_id=self.cmd.id, wait=True
+        )
+        assert isinstance(resp, CommandFinishedResponse)
+        return AsyncCommandFinished(
+            client=self.client,
+            sandbox_id=self.sandbox_id,
+            cmd=resp.command,
+            exit_code=resp.command.exit_code,
+        )
+
+    async def output(self, stream: str = "both") -> str:
+        data = ""
+        async for log in self.logs():
+            if stream == "both" or log.stream == stream:
+                data += log.data
+        return data
+
+    async def stdout(self) -> str:
+        return await self.output("stdout")
+
+    async def stderr(self) -> str:
+        return await self.output("stderr")
+
+    async def kill(self, signal: int = 15) -> None:
+        try:
+            await self.client.kill_command(
+                sandbox_id=self.sandbox_id, command_id=self.cmd.id, signal=signal
+            )
+        except httpx.HTTPStatusError as e:
+            # Command may already have exited; ignore 404s
+            if e.response is not None and e.response.status_code == 404:
+                return
+            raise
+
+
+@dataclass
+class AsyncCommandFinished(AsyncCommand):
+    exit_code: int
+
+    async def wait(self) -> AsyncCommandFinished:
+        return self
+
+
+# Sync command API
+
+
+@dataclass
+class Command:
+    client: APIClient
+    sandbox_id: str
+    cmd: CommandModel
+
+    @property
+    def cmd_id(self) -> str:
+        return self.cmd.id
+
+    @property
+    def cwd(self) -> str:
+        return self.cmd.cwd
+
+    @property
+    def started_at(self) -> int:
+        return self.cmd.started_at
+
+    def logs(self) -> Generator[LogLine, None, None]:
+        yield from self.client.get_logs(sandbox_id=self.sandbox_id, cmd_id=self.cmd.id)
+
+    def wait(self) -> CommandFinished:
+        resp = self.client.get_command(sandbox_id=self.sandbox_id, cmd_id=self.cmd.id, wait=True)
+        assert isinstance(resp, CommandFinishedResponse)
+        return CommandFinished(
+            client=self.client,
+            sandbox_id=self.sandbox_id,
+            cmd=resp.command,
+            exit_code=resp.command.exit_code,
+        )
+
+    def output(self, stream: str = "both") -> str:
+        data = ""
+        for log in self.logs():
+            if stream == "both" or log.stream == stream:
+                data += log.data
+        return data
+
+    def stdout(self) -> str:
+        return self.output("stdout")
+
+    def stderr(self) -> str:
+        return self.output("stderr")
+
+    def kill(self, signal: int = 15) -> None:
+        try:
+            self.client.kill_command(
+                sandbox_id=self.sandbox_id, command_id=self.cmd.id, signal=signal
+            )
+        except httpx.HTTPStatusError as e:
+            if e.response is not None and e.response.status_code == 404:
+                return
+            raise
+
+
+@dataclass
+class CommandFinished(Command):
+    exit_code: int
+
+    def wait(self) -> CommandFinished:
+        return self

--- a/src/vercel/sandbox/models.py
+++ b/src/vercel/sandbox/models.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Source types for Sandbox.create()
+
+class _GitSourceRequired(TypedDict):
+    """Required fields for GitSource."""
+    type: Literal["git"]
+    url: str
+
+
+class GitSource(_GitSourceRequired, total=False):
+    """Git repository source for creating a sandbox."""
+    depth: int
+    revision: str
+    username: str
+    password: str
+
+
+class TarballSource(TypedDict):
+    """Tarball URL source for creating a sandbox."""
+    type: Literal["tarball"]
+    url: str
+
+
+class SnapshotSource(TypedDict):
+    """Snapshot source for creating a sandbox."""
+    type: Literal["snapshot"]
+    snapshot_id: str
+
+
+Source = GitSource | TarballSource | SnapshotSource
+
+
+class Sandbox(BaseModel):
+    """Sandbox metadata from the API."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    memory: int
+    vcpus: int
+    region: str
+    runtime: str
+    timeout: int
+    status: Literal["pending", "running", "stopping", "stopped", "failed", "snapshotting"]
+    requested_at: int = Field(alias="requestedAt")
+    started_at: int | None = Field(default=None, alias="startedAt")
+    requested_stop_at: int | None = Field(default=None, alias="requestedStopAt")
+    stopped_at: int | None = Field(default=None, alias="stoppedAt")
+    duration: int | None = None
+    source_snapshot_id: str | None = Field(default=None, alias="sourceSnapshotId")
+    snapshotted_at: int | None = Field(default=None, alias="snapshottedAt")
+    created_at: int = Field(alias="createdAt")
+    cwd: str
+    updated_at: int = Field(alias="updatedAt")
+    interactive_port: int | None = Field(default=None, alias="interactivePort")
+
+
+class SandboxRoute(BaseModel):
+    """Route mapping for a sandbox port."""
+    url: str
+    subdomain: str
+    port: int
+
+
+class Pagination(BaseModel):
+    """Pagination metadata for list responses."""
+    count: int
+    next: int | None = None
+    prev: int | None = None
+
+
+class Command(BaseModel):
+    """Command metadata from the API."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    args: list[str]
+    cwd: str
+    sandbox_id: str = Field(alias="sandboxId")
+    exit_code: int | None = Field(default=None, alias="exitCode")
+    started_at: int = Field(alias="startedAt")
+
+
+class CommandFinished(Command):
+    """Completed command with exit code."""
+    exit_code: int = Field(alias="exitCode")
+
+
+class SandboxResponse(BaseModel):
+    """API response containing a sandbox."""
+    sandbox: Sandbox
+
+
+class SandboxAndRoutesResponse(SandboxResponse):
+    """API response containing a sandbox and its routes."""
+    routes: list[SandboxRoute]
+
+
+class CommandResponse(BaseModel):
+    """API response containing a command."""
+    command: Command
+
+
+class CommandFinishedResponse(BaseModel):
+    """API response containing a finished command."""
+    command: CommandFinished
+
+
+class EmptyResponse(BaseModel):
+    """Empty API response."""
+    pass
+
+
+class LogLine(BaseModel):
+    """Log line from command output."""
+    stream: Literal["stdout", "stderr"]
+    data: str
+
+
+class SandboxesResponse(BaseModel):
+    """API response containing a list of sandboxes."""
+    sandboxes: list[Sandbox]
+    pagination: Pagination
+
+
+class WriteFile(TypedDict):
+    """File to write to the sandbox."""
+    path: str
+    content: bytes
+
+
+class Snapshot(BaseModel):
+    """Snapshot metadata from the API."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    source_sandbox_id: str = Field(alias="sourceSandboxId")
+    region: str
+    status: Literal["created", "deleted", "failed"]
+    size_bytes: int = Field(alias="sizeBytes")
+    expires_at: int = Field(alias="expiresAt")
+    created_at: int = Field(alias="createdAt")
+    updated_at: int = Field(alias="updatedAt")
+
+
+class SnapshotResponse(BaseModel):
+    """API response containing a snapshot."""
+    snapshot: Snapshot
+
+
+class CreateSnapshotResponse(BaseModel):
+    """API response containing a snapshot and the stopped sandbox."""
+    snapshot: Snapshot
+    sandbox: Sandbox

--- a/src/vercel/sandbox/models.py
+++ b/src/vercel/sandbox/models.py
@@ -6,14 +6,17 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Source types for Sandbox.create()
 
+
 class _GitSourceRequired(TypedDict):
     """Required fields for GitSource."""
+
     type: Literal["git"]
     url: str
 
 
 class GitSource(_GitSourceRequired, total=False):
     """Git repository source for creating a sandbox."""
+
     depth: int
     revision: str
     username: str
@@ -22,12 +25,14 @@ class GitSource(_GitSourceRequired, total=False):
 
 class TarballSource(TypedDict):
     """Tarball URL source for creating a sandbox."""
+
     type: Literal["tarball"]
     url: str
 
 
 class SnapshotSource(TypedDict):
     """Snapshot source for creating a sandbox."""
+
     type: Literal["snapshot"]
     snapshot_id: str
 
@@ -37,6 +42,7 @@ Source = GitSource | TarballSource | SnapshotSource
 
 class Sandbox(BaseModel):
     """Sandbox metadata from the API."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
@@ -61,6 +67,7 @@ class Sandbox(BaseModel):
 
 class SandboxRoute(BaseModel):
     """Route mapping for a sandbox port."""
+
     url: str
     subdomain: str
     port: int
@@ -68,6 +75,7 @@ class SandboxRoute(BaseModel):
 
 class Pagination(BaseModel):
     """Pagination metadata for list responses."""
+
     count: int
     next: int | None = None
     prev: int | None = None
@@ -75,6 +83,7 @@ class Pagination(BaseModel):
 
 class Command(BaseModel):
     """Command metadata from the API."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
@@ -88,54 +97,64 @@ class Command(BaseModel):
 
 class CommandFinished(Command):
     """Completed command with exit code."""
+
     exit_code: int = Field(alias="exitCode")
 
 
 class SandboxResponse(BaseModel):
     """API response containing a sandbox."""
+
     sandbox: Sandbox
 
 
 class SandboxAndRoutesResponse(SandboxResponse):
     """API response containing a sandbox and its routes."""
+
     routes: list[SandboxRoute]
 
 
 class CommandResponse(BaseModel):
     """API response containing a command."""
+
     command: Command
 
 
 class CommandFinishedResponse(BaseModel):
     """API response containing a finished command."""
+
     command: CommandFinished
 
 
 class EmptyResponse(BaseModel):
     """Empty API response."""
+
     pass
 
 
 class LogLine(BaseModel):
     """Log line from command output."""
+
     stream: Literal["stdout", "stderr"]
     data: str
 
 
 class SandboxesResponse(BaseModel):
     """API response containing a list of sandboxes."""
+
     sandboxes: list[Sandbox]
     pagination: Pagination
 
 
 class WriteFile(TypedDict):
     """File to write to the sandbox."""
+
     path: str
     content: bytes
 
 
 class Snapshot(BaseModel):
     """Snapshot metadata from the API."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
@@ -150,10 +169,12 @@ class Snapshot(BaseModel):
 
 class SnapshotResponse(BaseModel):
     """API response containing a snapshot."""
+
     snapshot: Snapshot
 
 
 class CreateSnapshotResponse(BaseModel):
     """API response containing a snapshot and the stopped sandbox."""
+
     snapshot: Snapshot
     sandbox: Sandbox

--- a/src/vercel/sandbox/pty/__init__.py
+++ b/src/vercel/sandbox/pty/__init__.py
@@ -1,0 +1,23 @@
+"""PTY tunnel client for interactive shell sessions.
+
+This module provides WebSocket-based PTY tunneling for remote terminal access
+to Vercel Sandboxes.
+"""
+
+from __future__ import annotations
+
+from .client import PTYClient
+from .protocol import Message, MessageType, message, message_bytes, parse, ready, resize
+
+__all__ = [
+    # Client
+    "PTYClient",
+    # Protocol
+    "Message",
+    "MessageType",
+    "message",
+    "message_bytes",
+    "parse",
+    "ready",
+    "resize",
+]

--- a/src/vercel/sandbox/pty/binary.py
+++ b/src/vercel/sandbox/pty/binary.py
@@ -1,0 +1,135 @@
+"""PTY server binary management - download and cache from Vercel CDN.
+
+The PTY server is a Go binary that runs inside the sandbox to manage
+pseudo-terminal sessions. This module handles downloading and caching
+the binary from Vercel's CDN.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+BINARY_BASE_URL = "https://pty-tunnel.labs.vercel.dev"
+
+CACHE_DIR = Path.home() / ".cache" / "vercel-sandbox"
+
+SERVER_BIN_NAME = "vc-interactive-server"
+
+# Sandboxes are currently always Linux x86_64
+DEFAULT_SANDBOX_ARCH = "x86_64"
+
+
+def get_binary_cache_path(arch: str | None = None) -> Path:
+    """Get the cache path for the PTY server binary.
+
+    Args:
+        arch: Target sandbox architecture (x86_64 or aarch64).
+            Defaults to x86_64 (current sandbox architecture).
+
+    Returns:
+        Path to the cached binary file.
+    """
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+    return CACHE_DIR / f"pty-server-linux-{arch}"
+
+
+def download_binary(arch: str | None = None, *, force: bool = False) -> Path:
+    """Download the PTY server binary if not already cached.
+
+    Args:
+        arch: Target sandbox architecture (x86_64 or aarch64).
+            Defaults to x86_64 (current sandbox architecture).
+        force: Force re-download even if cached.
+
+    Returns:
+        Path to the cached binary.
+
+    Raises:
+        httpx.HTTPError: If the download fails.
+    """
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+
+    cache_path = get_binary_cache_path(arch)
+
+    if cache_path.exists() and not force:
+        return cache_path
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Download from Vercel CDN
+    url = f"{BINARY_BASE_URL}/linux-{arch}"
+    with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        cache_path.write_bytes(response.content)
+
+    return cache_path
+
+
+def get_binary_bytes(arch: str | None = None) -> bytes:
+    """Get the PTY server binary bytes, downloading if necessary.
+
+    This is the main entry point for getting the binary content to upload
+    to a sandbox.
+
+    Args:
+        arch: Target sandbox architecture (x86_64 or aarch64).
+            Defaults to x86_64 (current sandbox architecture).
+
+    Returns:
+        Binary content as bytes.
+    """
+    path = download_binary(arch)
+    return path.read_bytes()
+
+
+async def download_binary_async(arch: str | None = None, *, force: bool = False) -> Path:
+    """Download the PTY server binary asynchronously.
+
+    Args:
+        arch: Target sandbox architecture (x86_64 or aarch64).
+            Defaults to x86_64 (current sandbox architecture).
+        force: Force re-download even if cached.
+
+    Returns:
+        Path to the cached binary.
+
+    Raises:
+        httpx.HTTPError: If the download fails.
+    """
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+
+    cache_path = get_binary_cache_path(arch)
+
+    if cache_path.exists() and not force:
+        return cache_path
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Download from Vercel CDN
+    url = f"{BINARY_BASE_URL}/linux-{arch}"
+    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        cache_path.write_bytes(response.content)
+
+    return cache_path
+
+
+async def get_binary_bytes_async(arch: str | None = None) -> bytes:
+    """Get the PTY server binary bytes asynchronously.
+
+    Args:
+        arch: Target sandbox architecture (x86_64 or aarch64).
+            Defaults to x86_64 (current sandbox architecture).
+
+    Returns:
+        Binary content as bytes.
+    """
+    path = await download_binary_async(arch)
+    return path.read_bytes()

--- a/src/vercel/sandbox/pty/client.py
+++ b/src/vercel/sandbox/pty/client.py
@@ -1,0 +1,187 @@
+"""WebSocket client for PTY tunnel communication.
+
+This module provides an async WebSocket client that speaks the PTY tunnel
+protocol. It connects to the PTY server running inside a sandbox and
+forwards terminal I/O over the network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import websockets
+from websockets import ClientConnection, State
+
+from . import protocol
+
+
+class PTYClient:
+    """Async WebSocket client for PTY tunnel protocol.
+
+    This client connects to a PTY tunnel server running inside a sandbox
+    and provides methods to send/receive terminal data.
+
+    The client uses the "hybrid" design pattern where:
+    - Constructor takes an already-connected WebSocket (for testability)
+    - Class method `connect()` creates a new connection (for convenience)
+
+    Example:
+        # Using class method (recommended)
+        client = await PTYClient.connect(url)
+        async with client:
+            await client.send_ready()
+            await client.send_resize(80, 24)
+            await client.send_input("ls -la\\n")
+            async for msg in client:
+                print(msg.payload.decode())
+
+        # Using constructor (for testing)
+        mock_ws = AsyncMock()
+        client = PTYClient(mock_ws)
+        await client.send_ready()
+    """
+
+    def __init__(self, ws: ClientConnection):
+        """Create a PTYClient wrapping an existing WebSocket connection.
+
+        Args:
+            ws: An already-connected WebSocket.
+        """
+        self._ws = ws
+
+    @classmethod
+    async def connect(cls, url: str) -> PTYClient:
+        """Connect to a PTY tunnel server.
+
+        Args:
+            url: WebSocket URL (e.g., wss://host/ws/client?token=xxx&processId=123)
+
+        Returns:
+            Connected PTYClient instance.
+
+        Raises:
+            websockets.WebSocketException: If connection fails.
+        """
+        ws = await websockets.connect(url)
+        return cls(ws)
+
+    async def close(self) -> None:
+        """Close the WebSocket connection."""
+        await self._ws.close()
+
+    # High-level convenience methods
+
+    async def send_ready(self) -> None:
+        """Send READY signal to indicate connection is established.
+
+        This should be sent after connecting to signal to the PTY server
+        that the client is ready to receive output.
+        """
+        await self._ws.send(protocol.ready())
+
+    async def send_resize(self, cols: int, rows: int) -> None:
+        """Send terminal resize event.
+
+        Args:
+            cols: Terminal width in columns.
+            rows: Terminal height in rows.
+        """
+        await self._ws.send(protocol.resize(cols, rows))
+
+    async def send_input(self, text: str) -> None:
+        """Send terminal input (stdin).
+
+        Args:
+            text: Text to send to the remote terminal.
+        """
+        await self._ws.send(protocol.message(text))
+
+    async def send_input_bytes(self, data: bytes) -> None:
+        """Send raw bytes as terminal input.
+
+        Args:
+            data: Raw bytes to send.
+        """
+        await self._ws.send(protocol.message_bytes(data))
+
+    # Low-level access
+
+    async def send_raw(self, data: bytes) -> None:
+        """Send raw bytes over WebSocket (low-level).
+
+        Args:
+            data: Raw protocol message bytes.
+        """
+        await self._ws.send(data)
+
+    async def receive(self) -> protocol.Message | None:
+        """Receive and parse a single message.
+
+        Returns:
+            Parsed protocol Message, or None for unknown message types.
+
+        Raises:
+            websockets.ConnectionClosed: If the connection is closed.
+        """
+        data = await self._ws.recv()
+        if isinstance(data, str):
+            data = data.encode()
+        return protocol.parse(data)
+
+    async def raw_messages(self) -> AsyncIterator[bytes]:
+        """Iterate over raw WebSocket messages (no protocol parsing).
+
+        The PTY server sends raw terminal data without protocol wrapping,
+        so this method yields the raw bytes directly.
+
+        Yields:
+            Raw bytes from WebSocket messages.
+        """
+        try:
+            async for data in self._ws:
+                if isinstance(data, str):
+                    data = data.encode()
+                if data:
+                    yield data
+        except websockets.ConnectionClosed:
+            pass
+
+    async def __aiter__(self) -> AsyncIterator[protocol.Message]:
+        """Iterate over incoming messages (parsed with protocol).
+
+        This allows using the client in an async for loop:
+
+            async for msg in client:
+                if msg.type == MessageType.MESSAGE:
+                    print(msg.payload.decode())
+
+        Yields:
+            Parsed protocol Messages until the connection closes.
+        """
+        try:
+            async for data in self._ws:
+                if isinstance(data, str):
+                    data = data.encode()
+                # Skip empty messages (can happen on connection close)
+                if not data:
+                    continue
+                msg = protocol.parse(data)
+                # Skip unknown message types (like TypeScript does)
+                if msg is None:
+                    continue
+                yield msg
+        except websockets.ConnectionClosed:
+            pass
+
+    async def __aenter__(self) -> PTYClient:
+        """Enter async context (client is already connected)."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit async context - close the connection."""
+        await self.close()
+
+    @property
+    def is_open(self) -> bool:
+        """Check if the WebSocket connection is open."""
+        return self._ws.state == State.OPEN

--- a/src/vercel/sandbox/pty/protocol.py
+++ b/src/vercel/sandbox/pty/protocol.py
@@ -1,0 +1,147 @@
+"""PTY tunnel binary protocol - matches Go/TypeScript implementations.
+
+This module implements the binary message format used by the PTY tunnel
+protocol. The format is simple and efficient:
+
+Message format:
+    [message_type:uint8][payload:bytes...]
+
+Message types:
+    0 (MESSAGE): Terminal data (stdin/stdout)
+    1 (RESIZE):  Terminal resize event (cols:uint16, rows:uint16, big-endian)
+    2 (READY):   Connection ready signal (empty payload)
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class MessageType(IntEnum):
+    """Message types in the PTY tunnel protocol."""
+
+    MESSAGE = 0  # Terminal data (stdin/stdout)
+    RESIZE = 1  # Terminal resize event (cols, rows)
+    READY = 2  # Connection ready signal
+
+
+@dataclass
+class Message:
+    """A PTY tunnel protocol message."""
+
+    type: MessageType
+    payload: bytes = b""
+
+    def to_bytes(self) -> bytes:
+        """Serialize message to binary format."""
+        return bytes([self.type]) + self.payload
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Message | None:
+        """Parse binary data into a Message.
+
+        Args:
+            data: Raw binary data from WebSocket.
+
+        Returns:
+            Parsed Message object, or None if empty/unknown message type.
+        """
+        if not data:
+            return None
+        try:
+            msg_type = MessageType(data[0])
+        except ValueError:
+            # Unknown message type - return None like TypeScript does
+            return None
+        return cls(type=msg_type, payload=data[1:])
+
+    def as_text(self) -> str:
+        """Get payload as UTF-8 text (for MESSAGE type).
+
+        Returns:
+            Payload decoded as UTF-8 string.
+
+        Raises:
+            ValueError: If message type is not MESSAGE.
+        """
+        if self.type != MessageType.MESSAGE:
+            raise ValueError(f"Cannot get text from {self.type.name} message")
+        return self.payload.decode("utf-8")
+
+    def as_resize(self) -> tuple[int, int]:
+        """Get cols, rows (for RESIZE type).
+
+        Returns:
+            Tuple of (cols, rows).
+
+        Raises:
+            ValueError: If message type is not RESIZE or payload is too short.
+        """
+        if self.type != MessageType.RESIZE:
+            raise ValueError(f"Cannot get resize from {self.type.name} message")
+        if len(self.payload) < 4:
+            raise ValueError("Resize payload too short")
+        cols, rows = struct.unpack(">HH", self.payload[:4])
+        return cols, rows
+
+
+def message(text: str) -> bytes:
+    """Create a MESSAGE (terminal data) packet from a string.
+
+    Args:
+        text: Text to send (will be UTF-8 encoded).
+
+    Returns:
+        Binary packet ready to send over WebSocket.
+    """
+    return bytes([MessageType.MESSAGE]) + text.encode("utf-8")
+
+
+def message_bytes(data: bytes) -> bytes:
+    """Create a MESSAGE packet from raw bytes.
+
+    Args:
+        data: Raw bytes to send.
+
+    Returns:
+        Binary packet ready to send over WebSocket.
+    """
+    return bytes([MessageType.MESSAGE]) + data
+
+
+def resize(cols: int, rows: int) -> bytes:
+    """Create a RESIZE packet.
+
+    Args:
+        cols: Terminal width in columns.
+        rows: Terminal height in rows.
+
+    Returns:
+        Binary packet ready to send over WebSocket.
+    """
+    return bytes([MessageType.RESIZE]) + struct.pack(">HH", cols, rows)
+
+
+def ready() -> bytes:
+    """Create a READY packet.
+
+    Returns:
+        Binary packet ready to send over WebSocket.
+    """
+    return bytes([MessageType.READY])
+
+
+def parse(data: bytes) -> Message | None:
+    """Parse binary data into a Message.
+
+    This is an alias for Message.from_bytes() for convenience.
+
+    Args:
+        data: Raw binary data from WebSocket.
+
+    Returns:
+        Parsed Message object, or None if empty/unknown message type.
+    """
+    return Message.from_bytes(data)

--- a/src/vercel/sandbox/pty/shell.py
+++ b/src/vercel/sandbox/pty/shell.py
@@ -1,0 +1,353 @@
+"""Interactive shell session management.
+
+This module provides the high-level orchestration for interactive shell
+sessions with Vercel Sandboxes. It handles:
+
+1. Setting up the sandbox environment (installing PTY server binary)
+2. Starting the PTY server in client mode
+3. Connecting via WebSocket
+4. Forwarding stdin/stdout between local terminal and remote sandbox
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import termios
+import tty
+from typing import TYPE_CHECKING
+
+import websockets
+
+from .binary import SERVER_BIN_NAME, get_binary_bytes_async
+from .client import PTYClient
+
+if TYPE_CHECKING:
+    from ..command import AsyncCommand
+    from ..sandbox import AsyncSandbox
+
+
+async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
+    """Install the PTY server binary in the sandbox if not present.
+
+    This downloads the Go PTY server binary and uploads it to the sandbox,
+    making it available for interactive shell sessions.
+
+    Args:
+        sandbox: The sandbox to set up.
+    """
+    # Check if already installed
+    result = await sandbox.run_command("command", ["-v", SERVER_BIN_NAME])
+    if result.exit_code == 0:
+        return
+
+    # Download binary for sandbox architecture (defaults to x86_64)
+    binary = await get_binary_bytes_async()
+
+    # Upload to sandbox
+    tmp_path = f"/tmp/{SERVER_BIN_NAME}-install"
+    await sandbox.write_files([{"path": tmp_path, "content": binary}])
+
+    # Move to /usr/local/bin and make executable
+    await sandbox.run_command(
+        "bash",
+        [
+            "-c",
+            f'mv "{tmp_path}" /usr/local/bin/{SERVER_BIN_NAME} && '
+            f"chmod +x /usr/local/bin/{SERVER_BIN_NAME}",
+        ],
+        sudo=True,
+    )
+
+
+async def start_pty_server(
+    sandbox: AsyncSandbox,
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    sudo: bool = False,
+) -> tuple[AsyncCommand, dict]:
+    """Start the PTY server in the sandbox and return connection info.
+
+    Args:
+        sandbox: The sandbox to run in.
+        command: Command to execute (e.g., ["python3"] or ["/bin/bash"]).
+        env: Additional environment variables.
+        cwd: Working directory.
+        sudo: Run with elevated privileges.
+
+    Returns:
+        Tuple of (command handle, connection info dict).
+        Connection info contains: port, token, processId, serverProcessId
+
+    Raises:
+        RuntimeError: If connection info cannot be parsed.
+    """
+    # Get terminal size
+    try:
+        cols, rows = os.get_terminal_size()
+    except OSError:
+        # Default size if not a terminal
+        cols, rows = 80, 24
+
+    # Start PTY server in client mode
+    cmd = await sandbox.run_command_detached(
+        SERVER_BIN_NAME,
+        [
+            f"--port={sandbox.interactive_port}",
+            "--mode=client",
+            f"--cols={cols}",
+            f"--rows={rows}",
+            *command,
+        ],
+        env={"TERM": "xterm-256color", **(env or {})},
+        cwd=cwd,
+        sudo=sudo,
+    )
+
+    # Read connection info from command stdout
+    connection_info = await _read_connection_info(cmd)
+
+    return cmd, connection_info
+
+
+async def _read_connection_info(cmd: AsyncCommand, timeout: float = 30.0) -> dict:
+    """Read connection info JSON from command stdout.
+
+    The PTY server outputs a JSON line with connection details:
+    {"port": N, "token": "...", "processId": N, "serverProcessId": N}
+
+    Args:
+        cmd: The command handle to read from.
+        timeout: Maximum time to wait for connection info.
+
+    Returns:
+        Parsed connection info dictionary.
+
+    Raises:
+        RuntimeError: If connection info is not received within timeout.
+    """
+    collected = ""
+
+    async def read_logs():
+        nonlocal collected
+        async for log in cmd.logs():
+            if log.stream == "stdout":
+                collected += log.data
+                # Try to parse as JSON
+                for line in collected.split("\n"):
+                    line = line.strip()
+                    if line.startswith("{") and line.endswith("}"):
+                        try:
+                            return json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+        return None
+
+    try:
+        result = await asyncio.wait_for(read_logs(), timeout=timeout)
+        if result:
+            return result
+    except asyncio.TimeoutError:
+        pass
+
+    raise RuntimeError(
+        f"Failed to get connection info from PTY server within {timeout}s. "
+        f"Collected output: {collected[:500]}"
+    )
+
+
+async def start_interactive_shell(
+    sandbox: AsyncSandbox,
+    command: list[str] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    sudo: bool = False,
+) -> None:
+    """Start an interactive shell session with the sandbox.
+
+    This takes over the terminal and provides a full interactive experience,
+    forwarding stdin/stdout between the local terminal and the remote sandbox.
+
+    Args:
+        sandbox: The sandbox to connect to (must be created with interactive=True).
+        command: Command to execute (default: ["/bin/bash"]).
+        env: Additional environment variables.
+        cwd: Working directory.
+        sudo: Run with elevated privileges.
+
+    Raises:
+        RuntimeError: If sandbox doesn't have interactive support enabled.
+    """
+    if not sandbox.interactive_port:
+        raise RuntimeError(
+            "Sandbox was not created with interactive=True. "
+            "Create with: await AsyncSandbox.create(interactive=True)"
+        )
+
+    command = command or ["/bin/bash"]
+
+    # Setup sandbox environment (install PTY server if needed)
+    print("Setting up interactive session...", file=sys.stderr)
+    await setup_sandbox_environment(sandbox)
+
+    # Start PTY server
+    print("Starting PTY server...", file=sys.stderr)
+    cmd, conn_info = await start_pty_server(sandbox, command, env=env, cwd=cwd, sudo=sudo)
+
+    # Build WebSocket URL
+    host = sandbox.domain(sandbox.interactive_port)
+    # Remove protocol prefix for WebSocket URL
+    host = host.replace("https://", "").replace("http://", "")
+    ws_url = f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
+
+    # Connect and run interactive loop
+    client = await PTYClient.connect(ws_url)
+    try:
+        await _run_interactive_loop(client, cmd)
+    finally:
+        await client.close()
+
+
+async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
+    """Main interactive loop - forward stdin/stdout between terminal and sandbox.
+
+    Args:
+        client: Connected PTY client.
+        cmd: The PTY server command handle.
+    """
+    # Get initial terminal size
+    try:
+        cols, rows = os.get_terminal_size()
+    except OSError:
+        cols, rows = 80, 24
+
+    # Send ready and initial resize
+    await client.send_ready()
+    await client.send_resize(cols, rows)
+
+    # Save terminal settings
+    stdin_fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(stdin_fd)
+
+    # Event to signal shutdown
+    stop_event = asyncio.Event()
+
+    # Get the event loop for thread-safe scheduling
+    loop = asyncio.get_running_loop()
+
+    try:
+        # Put terminal in raw mode
+        tty.setraw(stdin_fd)
+
+        # Handle SIGWINCH (terminal resize) - safely schedule from signal context
+        def on_resize(signum, frame):
+            try:
+                new_cols, new_rows = os.get_terminal_size()
+                loop.call_soon_threadsafe(
+                    lambda: asyncio.create_task(client.send_resize(new_cols, new_rows))
+                )
+            except OSError:
+                pass
+
+        signal.signal(signal.SIGWINCH, on_resize)
+
+        # Create tasks for stdin and stdout forwarding
+        stdin_task = asyncio.create_task(_forward_stdin(client, stop_event, loop))
+        stdout_task = asyncio.create_task(_forward_stdout(client))
+
+        # Wait for either to complete (connection closed or error)
+        done, pending = await asyncio.wait(
+            [stdin_task, stdout_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # Signal tasks to stop and cancel remaining
+        stop_event.set()
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    finally:
+        # Restore terminal settings
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_settings)
+        signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+        print("\n\rSession ended.", file=sys.stderr)
+
+
+async def _forward_stdin(
+    client: PTYClient, stop_event: asyncio.Event, loop: asyncio.AbstractEventLoop
+) -> None:
+    """Forward local stdin to the PTY client.
+
+    Uses asyncio's add_reader for efficient non-blocking I/O instead of polling.
+
+    Args:
+        client: Connected PTY client.
+        stop_event: Event that signals when to stop.
+        loop: The event loop for registering the reader.
+    """
+    stdin_fd = sys.stdin.fileno()
+    data_ready = asyncio.Event()
+
+    def on_stdin_ready():
+        data_ready.set()
+
+    loop.add_reader(stdin_fd, on_stdin_ready)
+    try:
+        while not stop_event.is_set() and client.is_open:
+            # Wait for stdin data or stop signal
+            wait_task = asyncio.create_task(data_ready.wait())
+            stop_task = asyncio.create_task(stop_event.wait())
+
+            done, pending = await asyncio.wait(
+                [wait_task, stop_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+            if stop_event.is_set():
+                break
+
+            # Read and send available data
+            data_ready.clear()
+            try:
+                data = os.read(stdin_fd, 4096)
+                if data:
+                    await client.send_input_bytes(data)
+                else:
+                    # EOF on stdin
+                    break
+            except OSError:
+                break
+    finally:
+        loop.remove_reader(stdin_fd)
+
+
+async def _forward_stdout(client: PTYClient) -> None:
+    """Forward PTY output to local stdout.
+
+    Args:
+        client: Connected PTY client.
+    """
+    try:
+        async for data in client.raw_messages():
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+    except websockets.ConnectionClosed:
+        # Connection closing is expected when session ends
+        pass

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vercel.oidc import Credentials, get_credentials
+
+from .api_client import APIClient, AsyncAPIClient
+from .command import (
+    AsyncCommand,
+    AsyncCommandFinished,
+    Command,
+    CommandFinished,
+)
+from .models import (
+    CommandResponse,
+    Sandbox as SandboxModel,
+    SandboxAndRoutesResponse,
+    Source,
+    WriteFile,
+)
+from .pty.shell import start_interactive_shell
+from .snapshot import AsyncSnapshot, Snapshot as SnapshotClass
+
+
+def _normalize_source(source: Source | None) -> dict[str, Any] | None:
+    """Convert snake_case keys in source dict to camelCase for the API."""
+    if source is None:
+        return None
+
+    # Map of snake_case -> camelCase for source dict keys
+    key_map = {
+        "snapshot_id": "snapshotId",
+    }
+
+    return {key_map.get(k, k): v for k, v in source.items()}
+
+
+@dataclass
+class AsyncSandbox:
+    client: AsyncAPIClient
+    sandbox: SandboxModel
+    routes: list[dict[str, Any]]
+
+    @property
+    def sandbox_id(self) -> str:
+        return self.sandbox.id
+
+    @property
+    def status(self) -> str:
+        return self.sandbox.status
+
+    @property
+    def source_snapshot_id(self) -> str | None:
+        """If the sandbox was created from a snapshot, the ID of that snapshot."""
+        return self.sandbox.source_snapshot_id
+
+    @property
+    def timeout(self) -> int:
+        """The timeout of the sandbox in milliseconds."""
+        return self.sandbox.timeout
+
+    @property
+    def interactive_port(self) -> int | None:
+        """Port for interactive PTY connections.
+
+        Returns None if the sandbox was not created with interactive=True.
+        """
+        return self.sandbox.interactive_port
+
+    @staticmethod
+    async def create(
+        *,
+        source: Source | None = None,
+        ports: list[int] | None = None,
+        timeout: int | None = None,
+        resources: dict[str, Any] | None = None,
+        runtime: str | None = None,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+        interactive: bool = False,
+    ) -> AsyncSandbox:
+        """Create a new sandbox.
+
+        Args:
+            source: Source to initialize the sandbox from (git, tarball, or snapshot).
+            ports: List of ports to expose.
+            timeout: Sandbox timeout in milliseconds.
+            resources: Resource configuration.
+            runtime: Runtime to use.
+            token: API token (uses OIDC if not provided).
+            project_id: Project ID (uses OIDC if not provided).
+            team_id: Team ID (uses OIDC if not provided).
+            interactive: Enable interactive shell support. When True, the sandbox
+                will have an interactive port for PTY connections.
+
+        Returns:
+            Created AsyncSandbox instance.
+        """
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        client = AsyncAPIClient(team_id=creds.team_id, token=creds.token)
+        resp: SandboxAndRoutesResponse = await client.create_sandbox(
+            project_id=creds.project_id,
+            source=_normalize_source(source),
+            ports=ports,
+            timeout=timeout,
+            resources=resources,
+            runtime=runtime,
+            interactive=interactive,
+        )
+        return AsyncSandbox(
+            client=client,
+            sandbox=resp.sandbox,
+            routes=[r.model_dump() for r in resp.routes],
+        )
+
+    @staticmethod
+    async def get(
+        *,
+        sandbox_id: str,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> AsyncSandbox:
+        creds: Credentials = get_credentials(
+            token=token, project_id=project_id, team_id=team_id
+        )
+        client = AsyncAPIClient(team_id=creds.team_id, token=creds.token)
+        resp: SandboxAndRoutesResponse = await client.get_sandbox(sandbox_id=sandbox_id)
+        return AsyncSandbox(
+            client=client,
+            sandbox=resp.sandbox,
+            routes=[r.model_dump() for r in resp.routes],
+        )
+
+    def domain(self, port: int) -> str:
+        for r in self.routes:
+            if r.get("port") == port:
+                # Prefer URL when provided by the API; fall back to subdomain
+                return r.get("url") or f"https://{r['subdomain']}.vercel.run"
+        raise ValueError(f"No route for port {port}")
+
+    async def get_command(self, cmd_id: str) -> AsyncCommand:
+        resp = await self.client.get_command(sandbox_id=self.sandbox.id, cmd_id=cmd_id)
+        assert isinstance(resp, CommandResponse)
+        return AsyncCommand(client=self.client, sandbox_id=self.sandbox.id, cmd=resp.command)
+
+    async def run_command(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> AsyncCommandFinished:
+        command_response = await self.client.run_command(
+            sandbox_id=self.sandbox.id,
+            command=cmd,
+            args=args or [],
+            cwd=cwd,
+            env=env or {},
+            sudo=sudo,
+        )
+        command = AsyncCommand(
+            client=self.client, sandbox_id=self.sandbox.id, cmd=command_response.command
+        )
+        # Wait for completion
+        return await command.wait()
+
+    async def run_command_detached(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> AsyncCommand:
+        command_response = await self.client.run_command(
+            sandbox_id=self.sandbox.id,
+            command=cmd,
+            args=args or [],
+            cwd=cwd,
+            env=env or {},
+            sudo=sudo,
+        )
+        return AsyncCommand(
+            client=self.client, sandbox_id=self.sandbox.id, cmd=command_response.command
+        )
+
+    async def mk_dir(self, path: str, *, cwd: str | None = None) -> None:
+        await self.client.mk_dir(sandbox_id=self.sandbox.id, path=path, cwd=cwd)
+
+    async def read_file(self, path: str, *, cwd: str | None = None) -> bytes | None:
+        return await self.client.read_file(sandbox_id=self.sandbox.id, path=path, cwd=cwd)
+
+    async def write_files(self, files: list[WriteFile]) -> None:
+        await self.client.write_files(
+            sandbox_id=self.sandbox.id,
+            cwd=self.sandbox.cwd,
+            extract_dir="/",
+            files=files,
+        )
+
+    async def stop(self) -> None:
+        await self.client.stop_sandbox(sandbox_id=self.sandbox.id)
+
+    async def extend_timeout(self, duration: int) -> None:
+        """
+        Extend the timeout of the sandbox by the specified duration.
+
+        This allows you to extend the lifetime of a sandbox up until the maximum
+        execution timeout for your plan.
+
+        Args:
+            duration: The duration in milliseconds to extend the timeout by.
+        """
+        response = await self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
+        self.sandbox = response.sandbox
+
+    async def snapshot(self) -> AsyncSnapshot:
+        """
+        Create a snapshot from this currently running sandbox.
+        New sandboxes can then be created from this snapshot.
+
+        Note: this sandbox will be stopped as part of the snapshot creation process.
+        """
+        response = await self.client.create_snapshot(sandbox_id=self.sandbox.id)
+        self.sandbox = response.sandbox
+        return AsyncSnapshot(client=self.client, snapshot=response.snapshot)
+
+    async def shell(
+        self,
+        command: list[str] | None = None,
+        *,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        sudo: bool = False,
+    ) -> None:
+        """Start an interactive shell session.
+
+        This takes over the terminal and provides a full interactive experience,
+        forwarding stdin/stdout between the local terminal and the remote sandbox.
+
+        Requires the sandbox to be created with interactive=True.
+
+        Args:
+            command: Command to execute (default: ["/bin/bash"]).
+            env: Additional environment variables.
+            cwd: Working directory.
+            sudo: Run with elevated privileges.
+
+        Raises:
+            RuntimeError: If sandbox doesn't have interactive support enabled.
+
+        Example:
+            async with await AsyncSandbox.create(interactive=True) as sandbox:
+                await sandbox.shell(["python3"])
+        """
+        await start_interactive_shell(self, command, env=env, cwd=cwd, sudo=sudo)
+
+    # Async context manager to ensure cleanup
+    async def __aenter__(self) -> AsyncSandbox:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        try:
+            await self.stop()
+        except Exception:
+            # Best-effort stop; ignore errors during teardown
+            pass
+        await self.client.aclose()
+
+
+@dataclass
+class Sandbox:
+    client: APIClient
+    sandbox: SandboxModel
+    routes: list[dict[str, Any]]
+
+    @property
+    def sandbox_id(self) -> str:
+        return self.sandbox.id
+
+    @property
+    def status(self) -> str:
+        return self.sandbox.status
+
+    @property
+    def source_snapshot_id(self) -> str | None:
+        """If the sandbox was created from a snapshot, the ID of that snapshot."""
+        return self.sandbox.source_snapshot_id
+
+    @property
+    def interactive_port(self) -> int | None:
+        """Port for interactive PTY connections.
+
+        Returns None if the sandbox was not created with interactive=True.
+
+        Note: For interactive shell sessions, use AsyncSandbox instead.
+        """
+        return self.sandbox.interactive_port
+
+    @property
+    def timeout(self) -> int:
+        """The timeout of the sandbox in milliseconds."""
+        return self.sandbox.timeout
+
+    @staticmethod
+    def create(
+        *,
+        source: Source | None = None,
+        ports: list[int] | None = None,
+        timeout: int | None = None,
+        resources: dict[str, Any] | None = None,
+        runtime: str | None = None,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+        interactive: bool = False,
+    ) -> Sandbox:
+        """Create a new sandbox.
+
+        Args:
+            source: Source to initialize the sandbox from (git, tarball, or snapshot).
+            ports: List of ports to expose.
+            timeout: Sandbox timeout in milliseconds.
+            resources: Resource configuration.
+            runtime: Runtime to use.
+            token: API token (uses OIDC if not provided).
+            project_id: Project ID (uses OIDC if not provided).
+            team_id: Team ID (uses OIDC if not provided).
+            interactive: Enable interactive shell support. When True, the sandbox
+                will have an interactive port for PTY connections.
+                Note: For interactive shell sessions, use AsyncSandbox instead.
+
+        Returns:
+            Created Sandbox instance.
+        """
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        client = APIClient(team_id=creds.team_id, token=creds.token)
+        resp: SandboxAndRoutesResponse = client.create_sandbox(
+            project_id=creds.project_id,
+            source=_normalize_source(source),
+            ports=ports,
+            timeout=timeout,
+            resources=resources,
+            runtime=runtime,
+            interactive=interactive,
+        )
+        return Sandbox(
+            client=client,
+            sandbox=resp.sandbox,
+            routes=[r.model_dump() for r in resp.routes],
+        )
+
+    @staticmethod
+    def get(
+        *,
+        sandbox_id: str,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> Sandbox:
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        client = APIClient(team_id=creds.team_id, token=creds.token)
+        resp: SandboxAndRoutesResponse = client.get_sandbox(sandbox_id=sandbox_id)
+        return Sandbox(
+            client=client,
+            sandbox=resp.sandbox,
+            routes=[r.model_dump() for r in resp.routes],
+        )
+
+    def domain(self, port: int) -> str:
+        for r in self.routes:
+            if r.get("port") == port:
+                return r.get("url") or f"https://{r['subdomain']}.vercel.run"
+        raise ValueError(f"No route for port {port}")
+
+    def get_command(self, cmd_id: str) -> Command:
+        resp = self.client.get_command(sandbox_id=self.sandbox.id, cmd_id=cmd_id)
+        assert isinstance(resp, CommandResponse)
+        return Command(client=self.client, sandbox_id=self.sandbox.id, cmd=resp.command)
+
+    def run_command(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> CommandFinished:
+        command_response = self.client.run_command(
+            sandbox_id=self.sandbox.id,
+            command=cmd,
+            args=args or [],
+            cwd=cwd,
+            env=env or {},
+            sudo=sudo,
+        )
+        command = Command(
+            client=self.client, sandbox_id=self.sandbox.id, cmd=command_response.command
+        )
+        return command.wait()
+
+    def run_command_detached(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> Command:
+        command_response = self.client.run_command(
+            sandbox_id=self.sandbox.id,
+            command=cmd,
+            args=args or [],
+            cwd=cwd,
+            env=env or {},
+            sudo=sudo,
+        )
+        return Command(client=self.client, sandbox_id=self.sandbox.id, cmd=command_response.command)
+
+    def mk_dir(self, path: str, *, cwd: str | None = None) -> None:
+        self.client.mk_dir(sandbox_id=self.sandbox.id, path=path, cwd=cwd)
+
+    def read_file(self, path: str, *, cwd: str | None = None) -> bytes | None:
+        return self.client.read_file(sandbox_id=self.sandbox.id, path=path, cwd=cwd)
+
+    def write_files(self, files: list[WriteFile]) -> None:
+        self.client.write_files(
+            sandbox_id=self.sandbox.id,
+            cwd=self.sandbox.cwd,
+            extract_dir="/",
+            files=files,
+        )
+
+    def stop(self) -> None:
+        self.client.stop_sandbox(sandbox_id=self.sandbox.id)
+
+    def extend_timeout(self, duration: int) -> None:
+        """
+        Extend the timeout of the sandbox by the specified duration.
+
+        This allows you to extend the lifetime of a sandbox up until the maximum
+        execution timeout for your plan.
+
+        Args:
+            duration: The duration in milliseconds to extend the timeout by.
+        """
+        response = self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
+        self.sandbox = response.sandbox
+
+    def snapshot(self) -> SnapshotClass:
+        """
+        Create a snapshot from this currently running sandbox.
+        New sandboxes can then be created from this snapshot.
+
+        Note: this sandbox will be stopped as part of the snapshot creation process.
+        """
+        response = self.client.create_snapshot(sandbox_id=self.sandbox.id)
+        self.sandbox = response.sandbox
+        return SnapshotClass(client=self.client, snapshot=response.snapshot)
+
+    def __enter__(self) -> Sandbox:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self.stop()
+        except Exception:
+            pass
+        self.client.close()

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vercel.oidc import Credentials, get_credentials
-
+from ..oidc import Credentials, get_credentials
 from .api_client import APIClient, AsyncAPIClient
 from .command import (
     AsyncCommand,
@@ -123,9 +122,7 @@ class AsyncSandbox:
         project_id: str | None = None,
         team_id: str | None = None,
     ) -> AsyncSandbox:
-        creds: Credentials = get_credentials(
-            token=token, project_id=project_id, team_id=team_id
-        )
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         client = AsyncAPIClient(team_id=creds.team_id, token=creds.token)
         resp: SandboxAndRoutesResponse = await client.get_sandbox(sandbox_id=sandbox_id)
         return AsyncSandbox(

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from vercel.oidc import Credentials, get_credentials
+
+from .api_client import APIClient, AsyncAPIClient
+from .models import Snapshot as SnapshotModel
+
+
+@dataclass
+class AsyncSnapshot:
+    """A Snapshot is a saved state of a Sandbox that can be used to create new Sandboxes."""
+
+    client: AsyncAPIClient
+    snapshot: SnapshotModel
+
+    @property
+    def snapshot_id(self) -> str:
+        """Unique ID of this snapshot."""
+        return self.snapshot.id
+
+    @property
+    def source_sandbox_id(self) -> str:
+        """The ID of the sandbox from which this snapshot was created."""
+        return self.snapshot.source_sandbox_id
+
+    @property
+    def status(self) -> Literal["created", "deleted", "failed"]:
+        """The status of the snapshot."""
+        return self.snapshot.status
+
+    @property
+    def size_bytes(self) -> int:
+        """Size of the snapshot in bytes."""
+        return self.snapshot.size_bytes
+
+    @property
+    def expires_at(self) -> int:
+        """Timestamp when the snapshot expires."""
+        return self.snapshot.expires_at
+
+    @staticmethod
+    async def get(
+        *,
+        snapshot_id: str,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> AsyncSnapshot:
+        """Retrieve an existing snapshot by ID."""
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        client = AsyncAPIClient(team_id=creds.team_id, token=creds.token)
+        resp = await client.get_snapshot(snapshot_id=snapshot_id)
+        return AsyncSnapshot(client=client, snapshot=resp.snapshot)
+
+    async def delete(self) -> None:
+        """Delete this snapshot."""
+        resp = await self.client.delete_snapshot(snapshot_id=self.snapshot.id)
+        self.snapshot = resp.snapshot
+
+
+@dataclass
+class Snapshot:
+    """A Snapshot is a saved state of a Sandbox that can be used to create new Sandboxes."""
+
+    client: APIClient
+    snapshot: SnapshotModel
+
+    @property
+    def snapshot_id(self) -> str:
+        """Unique ID of this snapshot."""
+        return self.snapshot.id
+
+    @property
+    def source_sandbox_id(self) -> str:
+        """The ID of the sandbox from which this snapshot was created."""
+        return self.snapshot.source_sandbox_id
+
+    @property
+    def status(self) -> Literal["created", "deleted", "failed"]:
+        """The status of the snapshot."""
+        return self.snapshot.status
+
+    @property
+    def size_bytes(self) -> int:
+        """Size of the snapshot in bytes."""
+        return self.snapshot.size_bytes
+
+    @property
+    def expires_at(self) -> int:
+        """Timestamp when the snapshot expires."""
+        return self.snapshot.expires_at
+
+    @staticmethod
+    def get(
+        *,
+        snapshot_id: str,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> Snapshot:
+        """Retrieve an existing snapshot by ID."""
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        client = APIClient(team_id=creds.team_id, token=creds.token)
+        resp = client.get_snapshot(snapshot_id=snapshot_id)
+        return Snapshot(client=client, snapshot=resp.snapshot)
+
+    def delete(self) -> None:
+        """Delete this snapshot."""
+        resp = self.client.delete_snapshot(snapshot_id=self.snapshot.id)
+        self.snapshot = resp.snapshot
+

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from vercel.oidc import Credentials, get_credentials
-
+from ..oidc import Credentials, get_credentials
 from .api_client import APIClient, AsyncAPIClient
 from .models import Snapshot as SnapshotModel
 
@@ -111,4 +110,3 @@ class Snapshot:
         """Delete this snapshot."""
         resp = self.client.delete_snapshot(snapshot_id=self.snapshot.id)
         self.snapshot = resp.snapshot
-

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 
+# Required on CI, optional locally
+_is_ci = bool(os.getenv("CI"))
+_has_credentials = bool(
+    os.getenv("BLOB_READ_WRITE_TOKEN")
+    and os.getenv("VERCEL_TOKEN")
+    and os.getenv("VERCEL_PROJECT_ID")
+    and os.getenv("VERCEL_TEAM_ID")
+)
+
+
+@pytest.mark.skipif(
+    not _is_ci and not _has_credentials,
+    reason="Requires BLOB_READ_WRITE_TOKEN, VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID",
+)
 def test_examples_run(capsys=None) -> None:
     examples_dir = Path(__file__).resolve().parents[1] / "examples"
     assert examples_dir.is_dir()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,39 +16,29 @@ _has_credentials = bool(
     and os.getenv("VERCEL_TEAM_ID")
 )
 
+_examples_dir = Path(__file__).resolve().parents[1] / "examples"
+_example_files = (
+    sorted([p for p in _examples_dir.iterdir() if p.is_file() and p.suffix == ".py"])
+    if _examples_dir.is_dir()
+    else []
+)
+
 
 @pytest.mark.skipif(
     not _is_ci and not _has_credentials,
     reason="Requires BLOB_READ_WRITE_TOKEN, VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID",
 )
-def test_examples_run(capsys=None) -> None:
-    examples_dir = Path(__file__).resolve().parents[1] / "examples"
-    assert examples_dir.is_dir()
-
-    example_files = [p for p in examples_dir.iterdir() if p.is_file() and p.suffix == ".py"]
-    assert example_files, "No example .py files found in examples/"
-
-    for script_path in example_files:
-        assert script_path.is_file()
-        if capsys is not None:
-            with capsys.disabled():
-                print(f"Running {script_path.name}")
-        else:
-            print(f"Running {script_path.name}")
-        result = subprocess.run(
-            [sys.executable, str(script_path)],
-            capture_output=True,
-            text=True,
-            timeout=45,
-        )
-        assert result.returncode == 0, (
-            f"{script_path.name} failed with code {result.returncode}\n"
-            f"STDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
-        )
-
-    print("All examples ran successfully")
-
-
-if __name__ == "__main__":
-    test_examples_run()
+@pytest.mark.parametrize("script_path", _example_files, ids=lambda p: p.name)
+def test_example(script_path: Path) -> None:
+    """Run a single example script and verify it succeeds."""
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert result.returncode == 0, (
+        f"{script_path.name} failed with code {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -35,7 +35,7 @@ def test_example(script_path: Path) -> None:
         [sys.executable, str(script_path)],
         capture_output=True,
         text=True,
-        timeout=45,
+        timeout=120,
     )
     assert result.returncode == 0, (
         f"{script_path.name} failed with code {result.returncode}\n"


### PR DESCRIPTION
This was _mostly_ a `cp` operation, with the following exceptions:

- Merged the dependencies in `pyproject.toml`
- Added `pytest.mark.skipif` to the example tests so that local runs would skip instead of fail without the appropriate environment variables setup.

---

We will follow this up with hollowing out the old `vercel-sandbox` package and having it just depend on `vercel`, effectively reversing the order of the old dependency between `vercel` and `vercel-sandbox` on pypi. @1st1 do you know if this change will land on pypi cleanly if someone is already depending on both `vercel` and `vercel-sandbox`? I assume pip will deduplicate the circular dependency here, but if not, we'll have to carefully deploy both changes as close together as possible and hope people have the right dependency range to not accidentally lock the wrong versions together 🙈 