### PR TITLE
Release `vercel` v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vercel"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python SDK for Vercel"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release notes

### Features

- **Private blob storage support** ([#50](https://github.com/vercel/vercel-py/pull/50)) — All blob operations (`put`, `copy`, `get`, multipart) now accept `access="private"` in addition to `"public"`. Private blobs use `*.private.blob.vercel-storage.com` domains and authenticate via Bearer token.
- New `GetBlobResult` type with `.content`, `.etag`, `.size`, `.content_type`, etc.
- New params on `get`: `use_cache`, `if_none_match` (for conditional 304 requests)

### Breaking changes

- **`get()` / `get_async()`** now return `GetBlobResult` instead of `bytes`. Migrate: `get(url)` → `get(url).content`
- **`get()` / `get_async()`** now require `access` param (defaults to `"public"`, backward-compatible for public stores)
- `download_file` / `download_file_async` gain an `access` param (defaults to `"public"`)

### Bug fixes

- Handle RFC 7231 date format in `Last-Modified` header (blob storage CDN returns HTTP date format, not ISO 8601)