### PR TITLE
Add __bytes__ to GetBlobResult

### DIFF
--- a/examples/blob_storage.py
+++ b/examples/blob_storage.py
@@ -54,7 +54,7 @@ async def main() -> None:
 
     # 3b) Get object via get() (async client)
     result = await client.get(uploaded.url, access="public")
-    print("get():", len(result.content), "bytes, etag:", result.etag)
+    print("get():", len(bytes(result)), "bytes, etag:", result.etag)
 
     # 4) Copy (async client)
     copied = await client.copy(

--- a/src/vercel/blob/types.py
+++ b/src/vercel/blob/types.py
@@ -68,6 +68,9 @@ class GetBlobResult:
     content: bytes
     status_code: int
 
+    def __bytes__(self) -> bytes:
+        return self.content
+
 
 @dataclass(slots=True)
 class MultipartPart:


### PR DESCRIPTION
The `get()` method recently changed from returning raw bytes to returning a `GetBlobResult` envelope. Adding `__bytes__` lets consumers use `bytes(result)` idiomatically instead of reaching into the `.content` property, easing the migration.