### PR TITLE
Add support for default environment variables

### DIFF
--- a/examples/sandbox_04_python_run.py
+++ b/examples/sandbox_04_python_run.py
@@ -14,37 +14,47 @@ import sys
 
 print("Hello from Python inside Vercel Sandbox!")
 print("Python version:", sys.version)
-print("ENV SAMPLE:", os.getenv("SAMPLE_ENV", "<missing>"))
+print("SAMPLE_ENV:", os.getenv("SAMPLE_ENV", "<missing>"))
+print("EXTRA_ENV:", os.getenv("EXTRA_ENV", "<missing>"))
 """
 
 
 async def main() -> None:
     runtime = os.getenv("SANDBOX_RUNTIME") or None  # e.g., "python311"
 
-    async with await Sandbox.create(timeout=120_000, runtime=runtime) as sandbox:
-        # Write a Python file to the sandbox working directory
+    # Default env vars are inherited by all commands in the sandbox
+    async with await Sandbox.create(
+        timeout=120_000, runtime=runtime, env={"SAMPLE_ENV": "default"}
+    ) as sandbox:
         await sandbox.write_files(
             [
                 {"path": "main.py", "content": PY_CODE},
             ]
         )
 
-        # Try python3 first, then fall back to python
-        cmd = await sandbox.run_command_detached(
-            "bash",
-            [
-                "-lc",
-                f"cd {sandbox.sandbox.cwd} && (python3 main.py || python main.py)",
-            ],
-            env={"SAMPLE_ENV": "works"},
-        )
+        run_py = f"cd {sandbox.sandbox.cwd} && (python3 main.py || python main.py)"
 
-        out = await cmd.stdout()
-        done = await cmd.wait()
-        print("========= OUTPUT =========")
-        print(out, end="")
-        print("==========================")
-        print("exit:", done.exit_code)
+        # Run 1: add EXTRA_ENV per-command; SAMPLE_ENV keeps its default
+        cmd1 = await sandbox.run_command_detached(
+            "bash",
+            ["-lc", run_py],
+            env={"EXTRA_ENV": "added"},
+        )
+        done1 = await cmd1.wait()
+        print("=== Run 1: add EXTRA_ENV, keep default SAMPLE_ENV ===")
+        print(await cmd1.stdout(), end="")
+        print(f"exit: {done1.exit_code}\n")
+
+        # Run 2: override SAMPLE_ENV per-command
+        cmd2 = await sandbox.run_command_detached(
+            "bash",
+            ["-lc", run_py],
+            env={"SAMPLE_ENV": "overridden", "EXTRA_ENV": "added"},
+        )
+        done2 = await cmd2.wait()
+        print("=== Run 2: override SAMPLE_ENV, add EXTRA_ENV ===")
+        print(await cmd2.stdout(), end="")
+        print(f"exit: {done2.exit_code}")
 
 
 if __name__ == "__main__":

--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -183,6 +183,7 @@ class BaseSandboxOpsClient:
         resources: dict[str, Any] | None = None,
         runtime: str | None = None,
         interactive: bool = False,
+        env: dict[str, str] | None = None,
     ) -> SandboxAndRoutesResponse:
         body: dict[str, Any] = {"projectId": project_id}
         if ports:
@@ -197,6 +198,8 @@ class BaseSandboxOpsClient:
             body["runtime"] = runtime
         if interactive:
             body["__interactive"] = True
+        if env is not None:
+            body["env"] = env
 
         data = await self._request_client.request_json("POST", "/v1/sandboxes", body=JSONBody(body))
         return SandboxAndRoutesResponse.model_validate(data)

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -82,6 +82,7 @@ class AsyncSandbox:
         project_id: str | None = None,
         team_id: str | None = None,
         interactive: bool = False,
+        env: dict[str, str] | None = None,
     ) -> AsyncSandbox:
         """Create a new sandbox.
 
@@ -96,6 +97,8 @@ class AsyncSandbox:
             team_id: Team ID (uses OIDC if not provided).
             interactive: Enable interactive shell support. When True, the sandbox
                 will have an interactive port for PTY connections.
+            env: Default environment variables for the sandbox. These are inherited
+                by all commands unless overridden per-command.
 
         Returns:
             Created AsyncSandbox instance.
@@ -110,6 +113,7 @@ class AsyncSandbox:
             resources=resources,
             runtime=runtime,
             interactive=interactive,
+            env=env,
         )
         return AsyncSandbox(
             client=client,
@@ -353,6 +357,7 @@ class Sandbox:
         project_id: str | None = None,
         team_id: str | None = None,
         interactive: bool = False,
+        env: dict[str, str] | None = None,
     ) -> Sandbox:
         """Create a new sandbox.
 
@@ -368,6 +373,8 @@ class Sandbox:
             interactive: Enable interactive shell support. When True, the sandbox
                 will have an interactive port for PTY connections.
                 Note: For interactive shell sessions, use AsyncSandbox instead.
+            env: Default environment variables for the sandbox. These are inherited
+                by all commands unless overridden per-command.
 
         Returns:
             Created Sandbox instance.
@@ -383,6 +390,7 @@ class Sandbox:
                 resources=resources,
                 runtime=runtime,
                 interactive=interactive,
+                env=env,
             )
         )
         return Sandbox(

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -120,6 +120,69 @@ class TestSandboxCreate:
 
         sandbox.client.close()
 
+    @respx.mock
+    def test_create_sandbox_with_env_sync(self, mock_env_clear, mock_sandbox_create_response):
+        """Test sandbox creation with env dict."""
+        from vercel.sandbox import Sandbox
+
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_create_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        sandbox = Sandbox.create(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            env={"NODE_ENV": "production"},
+        )
+
+        assert route.called
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["env"] == {"NODE_ENV": "production"}
+
+        sandbox.client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_sandbox_with_env_async(
+        self, mock_env_clear, mock_sandbox_create_response
+    ):
+        """Test async sandbox creation with env dict."""
+        from vercel.sandbox import AsyncSandbox
+
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_create_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        sandbox = await AsyncSandbox.create(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            env={"NODE_ENV": "production"},
+        )
+
+        assert route.called
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["env"] == {"NODE_ENV": "production"}
+
+        await sandbox.client.aclose()
+
 
 class TestSandboxGet:
     """Test sandbox get operations."""


### PR DESCRIPTION
Similar to the TS implementation in vercel/sandbox#70, we conditionally attach an `env` key to the create request.