### PR TITLE
Add support for wait_until for python functions.

### DIFF
--- a/src/vercel/cache/context.py
+++ b/src/vercel/cache/context.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass
 
 from .types import PurgeAPI
 
-_cv_wait_until: ContextVar[Callable[[Awaitable[object]], None] | None] = ContextVar(
-    "vercel_wait_until", default=None
-)
 _cv_cache: ContextVar[object | None] = ContextVar("vercel_cache", default=None)
 _cv_purge: ContextVar[PurgeAPI | None] = ContextVar("vercel_purge", default=None)
 _cv_headers: ContextVar[Mapping[str, str] | None] = ContextVar("vercel_headers", default=None)
@@ -16,7 +13,6 @@ _cv_headers: ContextVar[Mapping[str, str] | None] = ContextVar("vercel_headers",
 
 @dataclass
 class _ContextSnapshot:
-    wait_until: Callable[[Awaitable[object]], None] | None
     cache: object | None
     purge: PurgeAPI | None
     headers: Mapping[str, str] | None
@@ -24,7 +20,6 @@ class _ContextSnapshot:
 
 def get_context() -> _ContextSnapshot:
     return _ContextSnapshot(
-        wait_until=_cv_wait_until.get(),
         cache=_cv_cache.get(),
         purge=_cv_purge.get(),
         headers=_cv_headers.get(),
@@ -33,13 +28,10 @@ def get_context() -> _ContextSnapshot:
 
 def set_context(
     *,
-    wait_until: Callable[[Awaitable[object]], None] | None = None,
     cache: object | None = None,
     purge: PurgeAPI | None = None,
     headers: Mapping[str, str] | None = None,
 ) -> None:
-    if wait_until is not None:
-        _cv_wait_until.set(wait_until)
     if cache is not None:
         _cv_cache.set(cache)
     if purge is not None:

--- a/src/vercel/functions/__init__.py
+++ b/src/vercel/functions/__init__.py
@@ -1,6 +1,7 @@
 from ..cache import AsyncRuntimeCache, RuntimeCache, get_cache
 from ..env import Env, get_env
 from ..headers import Geo, geolocation, get_headers, ip_address, set_headers
+from ..wait_until import wait_until
 
 __all__ = [
     "get_env",
@@ -13,4 +14,5 @@ __all__ = [
     "get_cache",
     "RuntimeCache",
     "AsyncRuntimeCache",
+    "wait_until",
 ]

--- a/src/vercel/wait_until.py
+++ b/src/vercel/wait_until.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import Any, TypeAlias
+
+WaitUntilWork: TypeAlias = Awaitable[Any] | Callable[[], Any]
+WaitUntilTarget: TypeAlias = Awaitable[Any] | Callable[..., Any]
+
+_cv_wait_until: ContextVar[Callable[[WaitUntilWork], None] | None] = ContextVar(
+    "vercel_wait_until", default=None
+)
+
+
+def wait_until(work: WaitUntilTarget) -> None:
+    """Enqueue background work that runs after the response is sent."""
+    if not inspect.isawaitable(work) and not callable(work):
+        raise TypeError("wait_until() expects an awaitable or zero-argument callable")
+
+    callback = _cv_wait_until.get()
+    if callback is None:
+        return
+    callback(work)
+
+
+@contextmanager
+def callback_context(
+    callback: Callable[[WaitUntilWork], None],
+) -> Iterator[None]:
+    """Set the wait_until callback for the current context.
+
+    Intended for use by the Vercel runtime to inject the background
+    work implementation before user code runs.
+    """
+    token: Token[Callable[[WaitUntilWork], None] | None] = _cv_wait_until.set(callback)
+    try:
+        yield
+    finally:
+        _cv_wait_until.reset(token)
+
+
+__all__ = [
+    "WaitUntilWork",
+    "WaitUntilTarget",
+    "callback_context",
+    "wait_until",
+]

--- a/tests/unit/test_wait_until.py
+++ b/tests/unit/test_wait_until.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from vercel.wait_until import callback_context, wait_until
+
+
+def test_returns_none_when_no_callback_is_set() -> None:
+    def my_task() -> None:
+        pass
+
+    wait_until(my_task)
+
+
+def test_delegates_awaitable_to_callback() -> None:
+    received: list[object] = []
+
+    def fake_callback(work: object) -> None:
+        received.append(work)
+
+    async def my_coro() -> None:
+        pass
+
+    coro = my_coro()
+    with callback_context(fake_callback):
+        wait_until(coro)
+
+    coro.close()
+    assert len(received) == 1
+
+
+def test_delegates_callable_to_callback() -> None:
+    received: list[object] = []
+
+    def fake_callback(work: object) -> None:
+        received.append(work)
+
+    def my_task() -> None:
+        pass
+
+    with callback_context(fake_callback):
+        wait_until(my_task)
+
+    assert received == [my_task]
+
+
+def test_rejects_non_work_values() -> None:
+    with pytest.raises(TypeError, match="awaitable or zero-argument callable"):
+        wait_until(42)  # type: ignore[arg-type]
+
+
+def test_callback_context_resets_after_exit() -> None:
+    received: list[object] = []
+
+    def fake_callback(work: object) -> None:
+        received.append(work)
+
+    def task_a() -> None:
+        pass
+
+    def task_b() -> None:
+        pass
+
+    with callback_context(fake_callback):
+        wait_until(task_a)
+
+    assert len(received) == 1
+
+    # After exiting the context, callback should be None again.
+    wait_until(task_b)
+    assert len(received) == 1
+
+
+def test_importable_from_vercel_functions() -> None:
+    from vercel.functions import wait_until as fn_wait_until
+
+    assert fn_wait_until is wait_until


### PR DESCRIPTION
```python
import logging
from flask import Flask
from vercel.wait_until import wait_until

app = Flask(__name__)

logger = logging.getLogger(__name__)

async def log_analytics(path: str) -> None:
    """Background work that runs after the response is sent."""
    logger.info("User visited %s", path)
    # e.g. send to an analytics service, update a cache, etc.

@app.route("/")
def home():
    wait_until(log_analytics("/"))
    return "Hello, World!"
```