### PR TITLE
Fix sandbox import cycle

### DIFF
--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -28,7 +28,7 @@ from vercel._internal.http import (
 )
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox.errors import APIError
-from vercel.sandbox.models import (
+from vercel._internal.sandbox.models import (
     CommandFinishedResponse,
     CommandResponse,
     CreateSnapshotResponse,

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Source types for Sandbox.create()
+
+
+class _GitSourceRequired(TypedDict):
+    """Required fields for GitSource."""
+
+    type: Literal["git"]
+    url: str
+
+
+class GitSource(_GitSourceRequired, total=False):
+    """Git repository source for creating a sandbox."""
+
+    depth: int
+    revision: str
+    username: str
+    password: str
+
+
+class TarballSource(TypedDict):
+    """Tarball URL source for creating a sandbox."""
+
+    type: Literal["tarball"]
+    url: str
+
+
+class SnapshotSource(TypedDict):
+    """Snapshot source for creating a sandbox."""
+
+    type: Literal["snapshot"]
+    snapshot_id: str
+
+
+Source = GitSource | TarballSource | SnapshotSource
+
+
+class Sandbox(BaseModel):
+    """Sandbox metadata from the API."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    memory: int
+    vcpus: int
+    region: str
+    runtime: str
+    timeout: int
+    status: Literal["pending", "running", "stopping", "stopped", "failed", "snapshotting"]
+    requested_at: int = Field(alias="requestedAt")
+    started_at: int | None = Field(default=None, alias="startedAt")
+    requested_stop_at: int | None = Field(default=None, alias="requestedStopAt")
+    stopped_at: int | None = Field(default=None, alias="stoppedAt")
+    duration: int | None = None
+    source_snapshot_id: str | None = Field(default=None, alias="sourceSnapshotId")
+    snapshotted_at: int | None = Field(default=None, alias="snapshottedAt")
+    created_at: int = Field(alias="createdAt")
+    cwd: str
+    updated_at: int = Field(alias="updatedAt")
+    interactive_port: int | None = Field(default=None, alias="interactivePort")
+
+
+class SandboxRoute(BaseModel):
+    """Route mapping for a sandbox port."""
+
+    url: str
+    subdomain: str
+    port: int
+
+
+class Pagination(BaseModel):
+    """Pagination metadata for list responses."""
+
+    count: int
+    next: int | None = None
+    prev: int | None = None
+
+
+class Command(BaseModel):
+    """Command metadata from the API."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    args: list[str]
+    cwd: str
+    sandbox_id: str = Field(alias="sandboxId")
+    exit_code: int | None = Field(default=None, alias="exitCode")
+    started_at: int = Field(alias="startedAt")
+
+
+class CommandFinished(Command):
+    """Completed command with exit code."""
+
+    exit_code: int = Field(alias="exitCode")
+
+
+class SandboxResponse(BaseModel):
+    """API response containing a sandbox."""
+
+    sandbox: Sandbox
+
+
+class SandboxAndRoutesResponse(SandboxResponse):
+    """API response containing a sandbox and its routes."""
+
+    routes: list[SandboxRoute]
+
+
+class CommandResponse(BaseModel):
+    """API response containing a command."""
+
+    command: Command
+
+
+class CommandFinishedResponse(BaseModel):
+    """API response containing a finished command."""
+
+    command: CommandFinished
+
+
+class EmptyResponse(BaseModel):
+    """Empty API response."""
+
+    pass
+
+
+class LogLine(BaseModel):
+    """Log line from command output."""
+
+    stream: Literal["stdout", "stderr"]
+    data: str
+
+
+class SandboxesResponse(BaseModel):
+    """API response containing a list of sandboxes."""
+
+    sandboxes: list[Sandbox]
+    pagination: Pagination
+
+
+class _WriteFileRequired(TypedDict):
+    """File to write to the sandbox."""
+
+    path: str
+    content: bytes
+
+
+class WriteFile(_WriteFileRequired, total=False):
+    """File to write to the sandbox."""
+
+    mode: int
+
+
+class Snapshot(BaseModel):
+    """Snapshot metadata from the API."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    source_sandbox_id: str = Field(alias="sourceSandboxId")
+    region: str
+    status: Literal["created", "deleted", "failed"]
+    size_bytes: int = Field(alias="sizeBytes")
+    expires_at: int = Field(alias="expiresAt")
+    created_at: int = Field(alias="createdAt")
+    updated_at: int = Field(alias="updatedAt")
+
+
+class SnapshotResponse(BaseModel):
+    """API response containing a snapshot."""
+
+    snapshot: Snapshot
+
+
+class CreateSnapshotResponse(BaseModel):
+    """API response containing a snapshot and the stopped sandbox."""
+
+    snapshot: Snapshot
+    sandbox: Sandbox

--- a/src/vercel/sandbox/command.py
+++ b/src/vercel/sandbox/command.py
@@ -5,8 +5,11 @@ from dataclasses import dataclass
 
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox import APIError, AsyncSandboxOpsClient, SyncSandboxOpsClient
-
-from .models import Command as CommandModel, CommandFinishedResponse, LogLine
+from vercel._internal.sandbox.models import (
+    Command as CommandModel,
+    CommandFinishedResponse,
+    LogLine,
+)
 
 
 @dataclass

--- a/src/vercel/sandbox/models.py
+++ b/src/vercel/sandbox/models.py
@@ -1,186 +1,45 @@
-from __future__ import annotations
-
-from typing import Literal, TypedDict
-
-from pydantic import BaseModel, ConfigDict, Field
-
-# Source types for Sandbox.create()
-
-
-class _GitSourceRequired(TypedDict):
-    """Required fields for GitSource."""
-
-    type: Literal["git"]
-    url: str
-
-
-class GitSource(_GitSourceRequired, total=False):
-    """Git repository source for creating a sandbox."""
-
-    depth: int
-    revision: str
-    username: str
-    password: str
-
-
-class TarballSource(TypedDict):
-    """Tarball URL source for creating a sandbox."""
-
-    type: Literal["tarball"]
-    url: str
-
-
-class SnapshotSource(TypedDict):
-    """Snapshot source for creating a sandbox."""
-
-    type: Literal["snapshot"]
-    snapshot_id: str
-
-
-Source = GitSource | TarballSource | SnapshotSource
-
-
-class Sandbox(BaseModel):
-    """Sandbox metadata from the API."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    id: str
-    memory: int
-    vcpus: int
-    region: str
-    runtime: str
-    timeout: int
-    status: Literal["pending", "running", "stopping", "stopped", "failed", "snapshotting"]
-    requested_at: int = Field(alias="requestedAt")
-    started_at: int | None = Field(default=None, alias="startedAt")
-    requested_stop_at: int | None = Field(default=None, alias="requestedStopAt")
-    stopped_at: int | None = Field(default=None, alias="stoppedAt")
-    duration: int | None = None
-    source_snapshot_id: str | None = Field(default=None, alias="sourceSnapshotId")
-    snapshotted_at: int | None = Field(default=None, alias="snapshottedAt")
-    created_at: int = Field(alias="createdAt")
-    cwd: str
-    updated_at: int = Field(alias="updatedAt")
-    interactive_port: int | None = Field(default=None, alias="interactivePort")
-
-
-class SandboxRoute(BaseModel):
-    """Route mapping for a sandbox port."""
-
-    url: str
-    subdomain: str
-    port: int
-
-
-class Pagination(BaseModel):
-    """Pagination metadata for list responses."""
-
-    count: int
-    next: int | None = None
-    prev: int | None = None
-
-
-class Command(BaseModel):
-    """Command metadata from the API."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    id: str
-    name: str
-    args: list[str]
-    cwd: str
-    sandbox_id: str = Field(alias="sandboxId")
-    exit_code: int | None = Field(default=None, alias="exitCode")
-    started_at: int = Field(alias="startedAt")
-
-
-class CommandFinished(Command):
-    """Completed command with exit code."""
-
-    exit_code: int = Field(alias="exitCode")
-
-
-class SandboxResponse(BaseModel):
-    """API response containing a sandbox."""
-
-    sandbox: Sandbox
-
-
-class SandboxAndRoutesResponse(SandboxResponse):
-    """API response containing a sandbox and its routes."""
-
-    routes: list[SandboxRoute]
-
-
-class CommandResponse(BaseModel):
-    """API response containing a command."""
-
-    command: Command
-
-
-class CommandFinishedResponse(BaseModel):
-    """API response containing a finished command."""
-
-    command: CommandFinished
-
-
-class EmptyResponse(BaseModel):
-    """Empty API response."""
-
-    pass
-
-
-class LogLine(BaseModel):
-    """Log line from command output."""
-
-    stream: Literal["stdout", "stderr"]
-    data: str
-
-
-class SandboxesResponse(BaseModel):
-    """API response containing a list of sandboxes."""
-
-    sandboxes: list[Sandbox]
-    pagination: Pagination
-
-
-class _WriteFileRequired(TypedDict):
-    """File to write to the sandbox."""
-
-    path: str
-    content: bytes
-
-
-class WriteFile(_WriteFileRequired, total=False):
-    """File to write to the sandbox."""
-
-    mode: int
-
-
-class Snapshot(BaseModel):
-    """Snapshot metadata from the API."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    id: str
-    source_sandbox_id: str = Field(alias="sourceSandboxId")
-    region: str
-    status: Literal["created", "deleted", "failed"]
-    size_bytes: int = Field(alias="sizeBytes")
-    expires_at: int = Field(alias="expiresAt")
-    created_at: int = Field(alias="createdAt")
-    updated_at: int = Field(alias="updatedAt")
-
-
-class SnapshotResponse(BaseModel):
-    """API response containing a snapshot."""
-
-    snapshot: Snapshot
-
-
-class CreateSnapshotResponse(BaseModel):
-    """API response containing a snapshot and the stopped sandbox."""
-
-    snapshot: Snapshot
-    sandbox: Sandbox
+from vercel._internal.sandbox.models import (
+    Command,
+    CommandFinished,
+    CommandFinishedResponse,
+    CommandResponse,
+    CreateSnapshotResponse,
+    EmptyResponse,
+    GitSource,
+    LogLine,
+    Pagination,
+    Sandbox,
+    SandboxAndRoutesResponse,
+    SandboxesResponse,
+    SandboxResponse,
+    SandboxRoute,
+    Snapshot,
+    SnapshotResponse,
+    SnapshotSource,
+    Source,
+    TarballSource,
+    WriteFile,
+)
+
+__all__ = [
+    "Command",
+    "CommandFinished",
+    "CommandFinishedResponse",
+    "CommandResponse",
+    "CreateSnapshotResponse",
+    "EmptyResponse",
+    "GitSource",
+    "LogLine",
+    "Pagination",
+    "Sandbox",
+    "SandboxAndRoutesResponse",
+    "SandboxResponse",
+    "SandboxRoute",
+    "SandboxesResponse",
+    "Snapshot",
+    "SnapshotResponse",
+    "SnapshotSource",
+    "Source",
+    "TarballSource",
+    "WriteFile",
+]

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -6,6 +6,13 @@ from typing import Any
 
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox import AsyncSandboxOpsClient, SyncSandboxOpsClient
+from vercel._internal.sandbox.models import (
+    CommandResponse,
+    Sandbox as SandboxModel,
+    SandboxAndRoutesResponse,
+    Source,
+    WriteFile,
+)
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -13,13 +20,6 @@ from .command import (
     AsyncCommandFinished,
     Command,
     CommandFinished,
-)
-from .models import (
-    CommandResponse,
-    Sandbox as SandboxModel,
-    SandboxAndRoutesResponse,
-    Source,
-    WriteFile,
 )
 from .pty.shell import start_interactive_shell
 from .snapshot import AsyncSnapshot, Snapshot as SnapshotClass

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -5,9 +5,9 @@ from typing import Literal
 
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox import AsyncSandboxOpsClient, SyncSandboxOpsClient
+from vercel._internal.sandbox.models import Snapshot as SnapshotModel
 
 from ..oidc import Credentials, get_credentials
-from .models import Snapshot as SnapshotModel
 
 
 @dataclass


### PR DESCRIPTION
The sandbox internals depended on public sandbox models, which pulled package initialization back through the public API and left `vercel._internal.sandbox` partially initialized.

Move sandbox model definitions into `_internal` and re-export them from the public package so the public API stays stable while internal imports no longer route through `vercel.sandbox`.