### PR TITLE
Add sandbox list pagination

### DIFF
--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -1,0 +1,180 @@
+"""
+Example: List sandboxes after concurrent creation.
+
+This example demonstrates how to:
+1. Create several sandboxes concurrently with ``AsyncSandbox.create()``
+2. Exercise the async pager APIs, including direct async iteration
+3. Exercise the sync page APIs
+
+The list API returns typed pages. Use a small ``limit`` to paginate through
+the recent results and inspect only the first few pages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+
+from dotenv import load_dotenv
+
+from vercel.sandbox import AsyncSandbox, Sandbox
+
+load_dotenv()
+
+SANDBOX_COUNT = 5
+PAGE_SIZE = 2
+MAX_PAGES = 3
+TIMEOUT_MS = 120_000
+MAX_ITEMS = PAGE_SIZE * MAX_PAGES
+PROJECT_ID = os.environ["VERCEL_PROJECT_ID"]
+
+
+def _print_page(prefix: str, page_number: int, sandbox_ids: list[str]) -> None:
+    print(f"{prefix} page {page_number}: {sandbox_ids}")
+
+
+def _print_page_state(prefix: str, page) -> None:
+    next_page_info = page.next_page_info()
+    next_until = None if next_page_info is None else next_page_info.until
+    print(
+        f"{prefix} has_next={page.has_next_page()} "
+        f"count={page.pagination.count} next_until={next_until}"
+    )
+
+
+def _summarize_created(prefix: str, sandbox_ids: list[str], created_ids: set[str]) -> None:
+    seen_created = sorted(set(sandbox_ids) & created_ids)
+    print(f"{prefix} created sandboxes seen: {seen_created}")
+
+
+async def _create_sandbox(index: int) -> AsyncSandbox:
+    sandbox = await AsyncSandbox.create(
+        project_id=PROJECT_ID,
+        timeout=TIMEOUT_MS,
+        env={"LIST_EXAMPLE_INDEX": str(index)},
+    )
+    print(f"Created sandbox {index}: {sandbox.sandbox_id}")
+    return sandbox
+
+
+async def async_demo(since: datetime) -> list[AsyncSandbox]:
+    print("=" * 60)
+    print("ASYNC SANDBOX LIST EXAMPLE")
+    print("=" * 60)
+
+    sandboxes = await asyncio.gather(*(_create_sandbox(index) for index in range(SANDBOX_COUNT)))
+    created_ids = {sandbox.sandbox_id for sandbox in sandboxes}
+    print(f"Created {len(created_ids)} sandboxes concurrently")
+
+    print("\n[1] Await the pager to get the first page")
+    pager = AsyncSandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since)
+    first_page = await pager
+    _print_page_state("async first page:", first_page)
+    _print_page("async", 1, [sandbox.id for sandbox in first_page.sandboxes])
+
+    print("\n[2] Fetch the next page explicitly with get_next_page()")
+    next_page = await first_page.get_next_page()
+    if next_page is None:
+        print("async next page: none")
+    else:
+        _print_page_state("async next page:", next_page)
+        _print_page("async", 2, [sandbox.id for sandbox in next_page.sandboxes])
+
+    print("\n[3] Iterate pages from the pager with iter_pages()")
+    paged_ids: list[str] = []
+    page_number = 0
+    async for page in AsyncSandbox.list(
+        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+    ).iter_pages():
+        page_number += 1
+        page_ids = [sandbox.id for sandbox in page.sandboxes]
+        _print_page("async iter_pages", page_number, page_ids)
+        paged_ids.extend(page_ids)
+        if page_number >= MAX_PAGES:
+            break
+    _summarize_created("async iter_pages", paged_ids, created_ids)
+
+    print("\n[4] Iterate items from the first page with page.iter_items()")
+    iter_item_ids: list[str] = []
+    async for sandbox in first_page.iter_items():
+        iter_item_ids.append(sandbox.id)
+        if len(iter_item_ids) >= MAX_ITEMS:
+            break
+    print(f"async iter_items: {iter_item_ids}")
+    _summarize_created("async iter_items", iter_item_ids, created_ids)
+
+    print("\n[5] Iterate items from the pager with pager.iter_items()")
+    pager_item_ids: list[str] = []
+    async for sandbox in AsyncSandbox.list(
+        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+    ).iter_items():
+        pager_item_ids.append(sandbox.id)
+        if len(pager_item_ids) >= MAX_ITEMS:
+            break
+    print(f"async pager.iter_items: {pager_item_ids}")
+    _summarize_created("async pager.iter_items", pager_item_ids, created_ids)
+
+    print("\n[6] Iterate items directly from the pager")
+    direct_item_ids: list[str] = []
+    async for sandbox in AsyncSandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since):
+        direct_item_ids.append(sandbox.id)
+        if len(direct_item_ids) >= MAX_ITEMS:
+            break
+    print(f"async direct iteration: {direct_item_ids}")
+    _summarize_created("async direct iteration", direct_item_ids, created_ids)
+
+    return sandboxes
+
+
+async def cleanup(sandboxes: list[AsyncSandbox]) -> None:
+    await asyncio.gather(*(sandbox.stop() for sandbox in sandboxes), return_exceptions=True)
+    await asyncio.gather(*(sandbox.client.aclose() for sandbox in sandboxes))
+
+
+def sync_demo(since: datetime) -> None:
+    print("\n" + "=" * 60)
+    print("SYNC SANDBOX LIST EXAMPLE")
+    print("=" * 60)
+
+    print("\n[1] Get the first page")
+    first_page = Sandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since)
+    _print_page_state("sync first page:", first_page)
+    _print_page("sync", 1, [sandbox.id for sandbox in first_page.sandboxes])
+
+    print("\n[2] Fetch the next page explicitly with get_next_page()")
+    next_page = first_page.get_next_page()
+    if next_page is None:
+        print("sync next page: none")
+    else:
+        _print_page_state("sync next page:", next_page)
+        _print_page("sync", 2, [sandbox.id for sandbox in next_page.sandboxes])
+
+    print("\n[3] Iterate pages with iter_pages()")
+    page_number = 0
+    for current_page in Sandbox.list(
+        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+    ).iter_pages():
+        page_number += 1
+        _print_page(
+            "sync iter_pages", page_number, [sandbox.id for sandbox in current_page.sandboxes]
+        )
+        if page_number >= MAX_PAGES:
+            break
+
+    print("\n[4] Iterate items with iter_items()")
+    iter_item_ids: list[str] = []
+    for sandbox in Sandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since).iter_items():
+        iter_item_ids.append(sandbox.id)
+        if len(iter_item_ids) >= MAX_ITEMS:
+            break
+    print(f"sync iter_items: {iter_item_ids}")
+
+
+if __name__ == "__main__":
+    since = datetime.now(timezone.utc) - timedelta(seconds=5)
+    sandboxes = asyncio.run(async_demo(since))
+    try:
+        sync_demo(since)
+    finally:
+        asyncio.run(cleanup(sandboxes))

--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -68,7 +68,11 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     print(f"Created {len(created_ids)} sandboxes concurrently")
 
     print("\n[1] Await the pager to get the first page")
-    pager = AsyncSandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since)
+    pager = AsyncSandbox.list(
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
+    )
     first_page = await pager
     _print_page_state("async first page:", first_page)
     _print_page("async", 1, [sandbox.id for sandbox in first_page.sandboxes])
@@ -85,7 +89,9 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     paged_ids: list[str] = []
     page_number = 0
     async for page in AsyncSandbox.list(
-        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
     ).iter_pages():
         page_number += 1
         page_ids = [sandbox.id for sandbox in page.sandboxes]
@@ -107,7 +113,9 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     print("\n[5] Iterate items from the pager with pager.iter_items()")
     pager_item_ids: list[str] = []
     async for sandbox in AsyncSandbox.list(
-        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
     ).iter_items():
         pager_item_ids.append(sandbox.id)
         if len(pager_item_ids) >= MAX_ITEMS:
@@ -117,7 +125,11 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
 
     print("\n[6] Iterate items directly from the pager")
     direct_item_ids: list[str] = []
-    async for sandbox in AsyncSandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since):
+    async for sandbox in AsyncSandbox.list(
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
+    ):
         direct_item_ids.append(sandbox.id)
         if len(direct_item_ids) >= MAX_ITEMS:
             break
@@ -138,7 +150,11 @@ def sync_demo(since: datetime) -> None:
     print("=" * 60)
 
     print("\n[1] Get the first page")
-    first_page = Sandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since)
+    first_page = Sandbox.list(
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
+    )
     _print_page_state("sync first page:", first_page)
     _print_page("sync", 1, [sandbox.id for sandbox in first_page.sandboxes])
 
@@ -153,7 +169,9 @@ def sync_demo(since: datetime) -> None:
     print("\n[3] Iterate pages with iter_pages()")
     page_number = 0
     for current_page in Sandbox.list(
-        project_id=PROJECT_ID, limit=PAGE_SIZE, since=since
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
     ).iter_pages():
         page_number += 1
         _print_page(
@@ -164,7 +182,11 @@ def sync_demo(since: datetime) -> None:
 
     print("\n[4] Iterate items with iter_items()")
     iter_item_ids: list[str] = []
-    for sandbox in Sandbox.list(project_id=PROJECT_ID, limit=PAGE_SIZE, since=since).iter_items():
+    for sandbox in Sandbox.list(
+        project_id=PROJECT_ID,
+        limit=PAGE_SIZE,
+        since=since,
+    ).iter_items():
         iter_item_ids.append(sandbox.id)
         if len(iter_item_ids) >= MAX_ITEMS:
             break

--- a/src/vercel/_internal/pagination.py
+++ b/src/vercel/_internal/pagination.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator, Sequence
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from vercel._internal.iter_coroutine import iter_coroutine
+
+PageT = TypeVar("PageT")
+ItemT = TypeVar("ItemT")
+PageInfoT = TypeVar("PageInfoT")
+
+
+@dataclass(frozen=True)
+class PageController(Generic[PageT, ItemT, PageInfoT]):
+    get_items: Callable[[PageT], Sequence[ItemT]]
+    get_next_page_info: Callable[[PageT], PageInfoT | None]
+    fetch_next_page: Callable[[PageInfoT], Awaitable[PageT]]
+
+    def has_next_page(self, page: PageT) -> bool:
+        return self.get_next_page_info(page) is not None
+
+    def next_page_info(self, page: PageT) -> PageInfoT | None:
+        return self.get_next_page_info(page)
+
+    async def get_next_page(self, page: PageT) -> PageT | None:
+        next_page_info = self.get_next_page_info(page)
+        if next_page_info is None:
+            return None
+        return await self.fetch_next_page(next_page_info)
+
+    def get_next_page_sync(self, page: PageT) -> PageT | None:
+        return iter_coroutine(self.get_next_page(page))
+
+    async def iter_pages(self, initial_page: PageT) -> AsyncGenerator[PageT, None]:
+        page = initial_page
+        while True:
+            yield page
+            next_page = await self.get_next_page(page)
+            if next_page is None:
+                return
+            page = next_page
+
+    async def iter_items(self, initial_page: PageT) -> AsyncGenerator[ItemT, None]:
+        async for page in self.iter_pages(initial_page):
+            for item in self.get_items(page):
+                yield item
+
+    def iter_pages_sync(self, initial_page: PageT) -> Iterator[PageT]:
+        iterator = self.iter_pages(initial_page)
+        try:
+            while True:
+                try:
+                    yield iter_coroutine(iterator.__anext__())
+                except StopAsyncIteration:
+                    return
+        finally:
+            try:
+                iter_coroutine(iterator.aclose())
+            except RuntimeError:
+                pass
+
+    def iter_items_sync(self, initial_page: PageT) -> Iterator[ItemT]:
+        iterator = self.iter_items(initial_page)
+        try:
+            while True:
+                try:
+                    yield iter_coroutine(iterator.__anext__())
+                except StopAsyncIteration:
+                    return
+        finally:
+            try:
+                iter_coroutine(iterator.aclose())
+            except RuntimeError:
+                pass
+
+
+__all__ = ["PageController"]

--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -236,7 +236,7 @@ class BaseSandboxOpsClient:
     async def list_sandboxes(
         self,
         *,
-        project: str | None = None,
+        project_id: str | None = None,
         limit: int | None = None,
         since: int | None = None,
         until: int | None = None,
@@ -245,7 +245,7 @@ class BaseSandboxOpsClient:
             "GET",
             "/v1/sandboxes",
             query={
-                "project": project,
+                "project": project_id,
                 "limit": limit,
                 "since": since,
                 "until": until,

--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -34,6 +34,7 @@ from vercel._internal.sandbox.models import (
     CreateSnapshotResponse,
     LogLine,
     SandboxAndRoutesResponse,
+    SandboxesResponse,
     SandboxResponse,
     SnapshotResponse,
     WriteFile,
@@ -231,6 +232,26 @@ class BaseSandboxOpsClient:
     async def get_sandbox(self, *, sandbox_id: str) -> SandboxAndRoutesResponse:
         data = await self._request_client.request_json("GET", f"/v1/sandboxes/{sandbox_id}")
         return SandboxAndRoutesResponse.model_validate(data)
+
+    async def list_sandboxes(
+        self,
+        *,
+        project: str | None = None,
+        limit: int | None = None,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> SandboxesResponse:
+        data = await self._request_client.request_json(
+            "GET",
+            "/v1/sandboxes",
+            query={
+                "project": project,
+                "limit": limit,
+                "since": since,
+                "until": until,
+            },
+        )
+        return SandboxesResponse.model_validate(data)
 
     async def update_network_policy(
         self,

--- a/src/vercel/_internal/sandbox/pagination.py
+++ b/src/vercel/_internal/sandbox/pagination.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vercel._internal.sandbox.models import Pagination
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxPageInfo:
+    until: int
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxListParams:
+    project: str | None = None
+    limit: int | None = None
+    since: int | None = None
+    until: int | None = None
+
+    def with_until(self, until: int) -> SandboxListParams:
+        return SandboxListParams(
+            project=self.project,
+            limit=self.limit,
+            since=self.since,
+            until=until,
+        )
+
+
+def next_sandbox_page_info(pagination: Pagination) -> SandboxPageInfo | None:
+    if pagination.next is None:
+        return None
+    return SandboxPageInfo(until=pagination.next)
+
+
+__all__ = ["SandboxListParams", "SandboxPageInfo", "next_sandbox_page_info"]

--- a/src/vercel/_internal/sandbox/pagination.py
+++ b/src/vercel/_internal/sandbox/pagination.py
@@ -12,14 +12,14 @@ class SandboxPageInfo:
 
 @dataclass(frozen=True, slots=True)
 class SandboxListParams:
-    project: str | None = None
+    project_id: str | None = None
     limit: int | None = None
     since: int | None = None
     until: int | None = None
 
     def with_until(self, until: int) -> SandboxListParams:
         return SandboxListParams(
-            project=self.project,
+            project_id=self.project_id,
             limit=self.limit,
             since=self.since,
             until=until,

--- a/src/vercel/sandbox/__init__.py
+++ b/src/vercel/sandbox/__init__.py
@@ -9,14 +9,17 @@ from vercel._internal.sandbox.network_policy import (
 
 from .command import AsyncCommand, AsyncCommandFinished, Command, CommandFinished
 from .models import GitSource, SnapshotSource, Source, TarballSource
+from .page import AsyncSandboxPage, SandboxPage
 from .sandbox import AsyncSandbox, Sandbox
 from .snapshot import AsyncSnapshot, Snapshot
 
 __all__ = [
     "APIError",
     "AsyncSandbox",
+    "AsyncSandboxPage",
     "AsyncSnapshot",
     "Sandbox",
+    "SandboxPage",
     "Snapshot",
     "AsyncCommand",
     "AsyncCommandFinished",

--- a/src/vercel/sandbox/page.py
+++ b/src/vercel/sandbox/page.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from vercel._internal.pagination import PageController
+from vercel._internal.sandbox.models import Pagination, Sandbox as SandboxModel
+from vercel._internal.sandbox.pagination import SandboxPageInfo, next_sandbox_page_info
+
+
+@dataclass(slots=True)
+class SandboxPage:
+    sandboxes: list[SandboxModel]
+    pagination: Pagination
+    _controller: PageController[SandboxPage, SandboxModel, SandboxPageInfo] = field(
+        init=False,
+        repr=False,
+    )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        sandboxes: list[SandboxModel],
+        pagination: Pagination,
+        fetch_next_page: Callable[[SandboxPageInfo], Awaitable[SandboxPage]],
+    ) -> SandboxPage:
+        page = cls(sandboxes=list(sandboxes), pagination=pagination)
+        page._controller = PageController(
+            get_items=lambda current_page: current_page.sandboxes,
+            get_next_page_info=lambda current_page: next_sandbox_page_info(current_page.pagination),
+            fetch_next_page=fetch_next_page,
+        )
+        return page
+
+    def has_next_page(self) -> bool:
+        return self._controller.has_next_page(self)
+
+    def next_page_info(self) -> SandboxPageInfo | None:
+        return self._controller.next_page_info(self)
+
+    def get_next_page(self) -> SandboxPage | None:
+        return self._controller.get_next_page_sync(self)
+
+    def iter_pages(self) -> Iterator[SandboxPage]:
+        return self._controller.iter_pages_sync(self)
+
+    def iter_items(self) -> Iterator[SandboxModel]:
+        return self._controller.iter_items_sync(self)
+
+
+@dataclass(slots=True)
+class AsyncSandboxPage:
+    sandboxes: list[SandboxModel]
+    pagination: Pagination
+    _controller: PageController[AsyncSandboxPage, SandboxModel, SandboxPageInfo] = field(
+        init=False,
+        repr=False,
+    )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        sandboxes: list[SandboxModel],
+        pagination: Pagination,
+        fetch_next_page: Callable[[SandboxPageInfo], Awaitable[AsyncSandboxPage]],
+    ) -> AsyncSandboxPage:
+        page = cls(sandboxes=list(sandboxes), pagination=pagination)
+        page._controller = PageController(
+            get_items=lambda current_page: current_page.sandboxes,
+            get_next_page_info=lambda current_page: next_sandbox_page_info(current_page.pagination),
+            fetch_next_page=fetch_next_page,
+        )
+        return page
+
+    def has_next_page(self) -> bool:
+        return self._controller.has_next_page(self)
+
+    def next_page_info(self) -> SandboxPageInfo | None:
+        return self._controller.next_page_info(self)
+
+    async def get_next_page(self) -> AsyncSandboxPage | None:
+        return await self._controller.get_next_page(self)
+
+    def iter_pages(self) -> AsyncIterator[AsyncSandboxPage]:
+        return self._controller.iter_pages(self)
+
+    def iter_items(self) -> AsyncIterator[SandboxModel]:
+        return self._controller.iter_items(self)
+
+
+@dataclass(slots=True)
+class AsyncSandboxPager:
+    _fetch_first_page: Callable[[], Awaitable[AsyncSandboxPage]]
+    _first_page: AsyncSandboxPage | None = field(init=False, default=None, repr=False)
+
+    async def _get_first_page(self) -> AsyncSandboxPage:
+        if self._first_page is None:
+            self._first_page = await self._fetch_first_page()
+        return self._first_page
+
+    def __await__(self) -> Generator[Any, None, AsyncSandboxPage]:
+        return self._get_first_page().__await__()
+
+    def __aiter__(self) -> AsyncIterator[SandboxModel]:
+        return self.iter_items()
+
+    async def iter_pages(self) -> AsyncIterator[AsyncSandboxPage]:
+        first_page = await self._get_first_page()
+        async for page in first_page.iter_pages():
+            yield page
+
+    async def iter_items(self) -> AsyncIterator[SandboxModel]:
+        first_page = await self._get_first_page()
+        async for item in first_page.iter_items():
+            yield item
+
+
+__all__ = [
+    "AsyncSandboxPager",
+    "AsyncSandboxPage",
+    "SandboxPage",
+    "SandboxPageInfo",
+]

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -54,7 +54,7 @@ async def _build_async_sandbox_page(
     client = AsyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
     try:
         response = await client.list_sandboxes(
-            project=params.project,
+            project_id=params.project_id,
             limit=params.limit,
             since=params.since,
             until=params.until,
@@ -83,7 +83,7 @@ async def _build_sync_sandbox_page(
     client = SyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
     try:
         response = await client.list_sandboxes(
-            project=params.project,
+            project_id=params.project_id,
             limit=params.limit,
             since=params.since,
             until=params.until,
@@ -227,7 +227,6 @@ class AsyncSandbox:
     @staticmethod
     def list(
         *,
-        project: str | None = None,
         limit: int | None = None,
         since: datetime | int | None = None,
         until: datetime | int | None = None,
@@ -238,14 +237,14 @@ class AsyncSandbox:
         """List sandboxes and return the first page.
 
         Args:
-            project: Filter results to a project name.
             limit: Maximum number of sandboxes to request per page.
             since: Lower timestamp bound as a timezone-aware ``datetime`` or
                 integer milliseconds since the Unix epoch.
             until: Upper timestamp bound as a timezone-aware ``datetime`` or
                 integer milliseconds since the Unix epoch.
             token: API token. Uses configured credentials when omitted.
-            project_id: Project ID used for credential resolution when needed.
+            project_id: Project ID used for credential resolution and as the
+                sandbox list scope. Uses configured credentials when omitted.
             team_id: Team ID scope for the sandbox API.
 
         Returns:
@@ -255,7 +254,7 @@ class AsyncSandbox:
         """
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         params = SandboxListParams(
-            project=project,
+            project_id=creds.project_id,
             limit=limit,
             since=_normalize_list_timestamp(since),
             until=_normalize_list_timestamp(until),
@@ -564,7 +563,6 @@ class Sandbox:
     @staticmethod
     def list(
         *,
-        project: str | None = None,
         limit: int | None = None,
         since: datetime | int | None = None,
         until: datetime | int | None = None,
@@ -575,14 +573,14 @@ class Sandbox:
         """List sandboxes and return the first page.
 
         Args:
-            project: Filter results to a project name.
             limit: Maximum number of sandboxes to request per page.
             since: Lower timestamp bound as a timezone-aware ``datetime`` or
                 integer milliseconds since the Unix epoch.
             until: Upper timestamp bound as a timezone-aware ``datetime`` or
                 integer milliseconds since the Unix epoch.
             token: API token. Uses configured credentials when omitted.
-            project_id: Project ID used for credential resolution when needed.
+            project_id: Project ID used for credential resolution and as the
+                sandbox list scope. Uses configured credentials when omitted.
             team_id: Team ID scope for the sandbox API.
 
         Returns:
@@ -591,7 +589,7 @@ class Sandbox:
         """
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         params = SandboxListParams(
-            project=project,
+            project_id=creds.project_id,
             limit=limit,
             since=_normalize_list_timestamp(since),
             until=_normalize_list_timestamp(until),

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import builtins
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from vercel._internal.iter_coroutine import iter_coroutine
@@ -17,6 +19,7 @@ from vercel._internal.sandbox.network_policy import (
     ApiNetworkPolicy,
     NetworkPolicy,
 )
+from vercel._internal.sandbox.pagination import SandboxListParams
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -25,6 +28,7 @@ from .command import (
     Command,
     CommandFinished,
 )
+from .page import AsyncSandboxPage, AsyncSandboxPager, SandboxPage
 from .pty.shell import start_interactive_shell
 from .snapshot import AsyncSnapshot, Snapshot as SnapshotClass
 
@@ -40,6 +44,76 @@ def _normalize_source(source: Source | None) -> dict[str, Any] | None:
     }
 
     return {key_map.get(k, k): v for k, v in source.items()}
+
+
+async def _build_async_sandbox_page(
+    *,
+    creds: Credentials,
+    params: SandboxListParams,
+) -> AsyncSandboxPage:
+    client = AsyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+    try:
+        response = await client.list_sandboxes(
+            project=params.project,
+            limit=params.limit,
+            since=params.since,
+            until=params.until,
+        )
+    finally:
+        await client.aclose()
+
+    async def fetch_next_page(page_info) -> AsyncSandboxPage:
+        return await _build_async_sandbox_page(
+            creds=creds,
+            params=params.with_until(page_info.until),
+        )
+
+    return AsyncSandboxPage.create(
+        sandboxes=response.sandboxes,
+        pagination=response.pagination,
+        fetch_next_page=fetch_next_page,
+    )
+
+
+async def _build_sync_sandbox_page(
+    *,
+    creds: Credentials,
+    params: SandboxListParams,
+) -> SandboxPage:
+    client = SyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+    try:
+        response = await client.list_sandboxes(
+            project=params.project,
+            limit=params.limit,
+            since=params.since,
+            until=params.until,
+        )
+    finally:
+        client.close()
+
+    async def fetch_next_page(page_info) -> SandboxPage:
+        return await _build_sync_sandbox_page(
+            creds=creds,
+            params=params.with_until(page_info.until),
+        )
+
+    return SandboxPage.create(
+        sandboxes=response.sandboxes,
+        pagination=response.pagination,
+        fetch_next_page=fetch_next_page,
+    )
+
+
+def _normalize_list_timestamp(value: datetime | int | None) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp() * 1000)
+    raise TypeError("Sandbox list timestamps must be datetime or integer milliseconds")
 
 
 @dataclass
@@ -150,6 +224,46 @@ class AsyncSandbox:
             routes=[r.model_dump() for r in resp.routes],
         )
 
+    @staticmethod
+    def list(
+        *,
+        project: str | None = None,
+        limit: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> AsyncSandboxPager:
+        """List sandboxes and return the first page.
+
+        Args:
+            project: Filter results to a project name.
+            limit: Maximum number of sandboxes to request per page.
+            since: Lower timestamp bound as a timezone-aware ``datetime`` or
+                integer milliseconds since the Unix epoch.
+            until: Upper timestamp bound as a timezone-aware ``datetime`` or
+                integer milliseconds since the Unix epoch.
+            token: API token. Uses configured credentials when omitted.
+            project_id: Project ID used for credential resolution when needed.
+            team_id: Team ID scope for the sandbox API.
+
+        Returns:
+            An awaitable pager whose first awaited value is the first page of
+            typed sandbox results. Continue pagination with ``iter_pages()``
+            or ``iter_items()`` on the page or pager.
+        """
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        params = SandboxListParams(
+            project=project,
+            limit=limit,
+            since=_normalize_list_timestamp(since),
+            until=_normalize_list_timestamp(until),
+        )
+        return AsyncSandboxPager(
+            _fetch_first_page=lambda: _build_async_sandbox_page(creds=creds, params=params)
+        )
+
     async def refresh(self) -> None:
         """Re-fetch this sandbox's state from the API, updating in place."""
         resp = await self.client.get_sandbox(sandbox_id=self.sandbox.id)
@@ -209,7 +323,7 @@ class AsyncSandbox:
     async def run_command(
         self,
         cmd: str,
-        args: list[str] | None = None,
+        args: builtins.list[str] | None = None,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
@@ -232,7 +346,7 @@ class AsyncSandbox:
     async def run_command_detached(
         self,
         cmd: str,
-        args: list[str] | None = None,
+        args: builtins.list[str] | None = None,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
@@ -256,7 +370,7 @@ class AsyncSandbox:
     async def read_file(self, path: str, *, cwd: str | None = None) -> bytes | None:
         return await self.client.read_file(sandbox_id=self.sandbox.id, path=path, cwd=cwd)
 
-    async def write_files(self, files: list[WriteFile]) -> None:
+    async def write_files(self, files: builtins.list[WriteFile]) -> None:
         await self.client.write_files(
             sandbox_id=self.sandbox.id,
             cwd=self.sandbox.cwd,
@@ -293,7 +407,7 @@ class AsyncSandbox:
 
     async def shell(
         self,
-        command: list[str] | None = None,
+        command: builtins.list[str] | None = None,
         *,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
@@ -447,6 +561,43 @@ class Sandbox:
             routes=[r.model_dump() for r in resp.routes],
         )
 
+    @staticmethod
+    def list(
+        *,
+        project: str | None = None,
+        limit: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        token: str | None = None,
+        project_id: str | None = None,
+        team_id: str | None = None,
+    ) -> SandboxPage:
+        """List sandboxes and return the first page.
+
+        Args:
+            project: Filter results to a project name.
+            limit: Maximum number of sandboxes to request per page.
+            since: Lower timestamp bound as a timezone-aware ``datetime`` or
+                integer milliseconds since the Unix epoch.
+            until: Upper timestamp bound as a timezone-aware ``datetime`` or
+                integer milliseconds since the Unix epoch.
+            token: API token. Uses configured credentials when omitted.
+            project_id: Project ID used for credential resolution when needed.
+            team_id: Team ID scope for the sandbox API.
+
+        Returns:
+            The first page of typed sandbox results. Continue pagination with
+            ``iter_pages()`` or ``iter_items()`` on the returned page.
+        """
+        creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
+        params = SandboxListParams(
+            project=project,
+            limit=limit,
+            since=_normalize_list_timestamp(since),
+            until=_normalize_list_timestamp(until),
+        )
+        return iter_coroutine(_build_sync_sandbox_page(creds=creds, params=params))
+
     def refresh(self) -> None:
         """Re-fetch this sandbox's state from the API, updating in place."""
         resp = iter_coroutine(self.client.get_sandbox(sandbox_id=self.sandbox.id))
@@ -505,7 +656,7 @@ class Sandbox:
     def run_command(
         self,
         cmd: str,
-        args: list[str] | None = None,
+        args: builtins.list[str] | None = None,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
@@ -529,7 +680,7 @@ class Sandbox:
     def run_command_detached(
         self,
         cmd: str,
-        args: list[str] | None = None,
+        args: builtins.list[str] | None = None,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
@@ -553,7 +704,7 @@ class Sandbox:
     def read_file(self, path: str, *, cwd: str | None = None) -> bytes | None:
         return iter_coroutine(self.client.read_file(sandbox_id=self.sandbox.id, path=path, cwd=cwd))
 
-    def write_files(self, files: list[WriteFile]) -> None:
+    def write_files(self, files: builtins.list[WriteFile]) -> None:
         iter_coroutine(
             self.client.write_files(
                 sandbox_id=self.sandbox.id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,9 @@ def has_blob_credentials() -> bool:
 
 def has_sandbox_credentials() -> bool:
     """Check if Sandbox credentials are available."""
-    return has_vercel_credentials()
+    return bool(
+        os.getenv("VERCEL_TOKEN") and os.getenv("VERCEL_TEAM_ID") and os.getenv("VERCEL_PROJECT_ID")
+    )
 
 
 # Skip markers for live tests
@@ -98,5 +100,5 @@ requires_blob_credentials = pytest.mark.skipif(
 
 requires_sandbox_credentials = pytest.mark.skipif(
     not has_sandbox_credentials(),
-    reason="Requires VERCEL_TOKEN and VERCEL_TEAM_ID environment variables for sandbox",
+    reason="Requires VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID for sandbox",
 )

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -554,8 +554,7 @@ class TestSandboxList:
         page = Sandbox.list(
             token="test_token",
             team_id="team_test123",
-            project_id="prj_test123",
-            project=project,
+            project_id=project,
             limit=limit,
             since=since,
             until=until,
@@ -661,8 +660,7 @@ class TestSandboxList:
         page = await AsyncSandbox.list(
             token="test_token",
             team_id="team_test123",
-            project_id="prj_test123",
-            project=project,
+            project_id=project,
             limit=limit,
             since=since,
             until=until,
@@ -778,8 +776,8 @@ class TestSandboxList:
             ["sbx_page_3"],
         ]
         assert requests == [
-            {"teamId": "team_test123"},
-            {"teamId": "team_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
         requests.clear()
@@ -794,8 +792,8 @@ class TestSandboxList:
             "sbx_page_3",
         ]
         assert requests == [
-            {"teamId": "team_test123"},
-            {"teamId": "team_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
     @respx.mock
@@ -862,13 +860,15 @@ class TestSandboxList:
         assert page.has_next_page() is True
         assert page.next_page_info() is not None
         assert page.next_page_info().until == 1705319400000
-        assert requests == [{"teamId": "team_test123"}]
+        assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
         requests.clear()
         next_page = await page.get_next_page()
         assert next_page is not None
         assert [sandbox.id for sandbox in next_page.sandboxes] == ["sbx_async_3"]
-        assert requests == [{"teamId": "team_test123", "until": "1705319400000"}]
+        assert requests == [
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"}
+        ]
 
         requests.clear()
         pages = await _collect_async_pages(page)
@@ -876,7 +876,9 @@ class TestSandboxList:
             ["sbx_async_1", "sbx_async_2"],
             ["sbx_async_3"],
         ]
-        assert requests == [{"teamId": "team_test123", "until": "1705319400000"}]
+        assert requests == [
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"}
+        ]
 
         requests.clear()
         items_page = await AsyncSandbox.list(
@@ -891,8 +893,8 @@ class TestSandboxList:
             "sbx_async_3",
         ]
         assert requests == [
-            {"teamId": "team_test123"},
-            {"teamId": "team_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
     @respx.mock
@@ -956,8 +958,8 @@ class TestSandboxList:
         ]
         assert item_ids == ["sbx_builder_1", "sbx_builder_2", "sbx_builder_3"]
         assert requests == [
-            {"teamId": "team_test123"},
-            {"teamId": "team_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
         requests.clear()
@@ -973,8 +975,8 @@ class TestSandboxList:
             ["sbx_builder_3"],
         ]
         assert requests == [
-            {"teamId": "team_test123"},
-            {"teamId": "team_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
     @respx.mock
@@ -1020,7 +1022,7 @@ class TestSandboxList:
             ["sbx_single_page"],
         ]
         assert [sandbox.id for sandbox in page.iter_items()] == ["sbx_single_page"]
-        assert requests == [{"teamId": "team_test123"}]
+        assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
     @respx.mock
     @pytest.mark.asyncio
@@ -1066,7 +1068,7 @@ class TestSandboxList:
         ]
         items = await _collect_async_items(page)
         assert [sandbox.id for sandbox in items] == ["sbx_async_terminal"]
-        assert requests == [{"teamId": "team_test123"}]
+        assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
     @respx.mock
     def test_get_sandbox_sync_exposes_mode_network_policy(

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -5,6 +5,7 @@ Tests both sync and async variants (Sandbox and AsyncSandbox).
 
 import json
 import tarfile
+from datetime import datetime, timezone
 from io import BytesIO
 
 import httpx
@@ -20,6 +21,29 @@ from vercel.sandbox import (
 
 # Base URL for Vercel Sandbox API
 SANDBOX_API_BASE = "https://api.vercel.com"
+
+
+def _sandbox_with_id(
+    base_sandbox: dict,
+    sandbox_id: str,
+    *,
+    created_at: int,
+) -> dict:
+    sandbox = dict(base_sandbox)
+    sandbox["id"] = sandbox_id
+    sandbox["createdAt"] = created_at
+    sandbox["requestedAt"] = created_at
+    sandbox["updatedAt"] = created_at
+    sandbox["startedAt"] = created_at + 1000
+    return sandbox
+
+
+async def _collect_async_pages(page) -> list:
+    return [current_page async for current_page in page.iter_pages()]
+
+
+async def _collect_async_items(page) -> list:
+    return [sandbox async for sandbox in page.iter_items()]
 
 
 class TestSandboxCreate:
@@ -463,6 +487,586 @@ class TestSandboxGet:
         assert sandbox.sandbox_id == sandbox_id
 
         await sandbox.client.aclose()
+
+
+class TestSandboxList:
+    """Test sandbox listing pagination behavior."""
+
+    @respx.mock
+    def test_list_sandbox_sync_serializes_datetime_filters_and_typed_pages(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel._internal.sandbox.models import Sandbox as SandboxModel
+        from vercel.sandbox import Sandbox
+
+        project = "sandbox-project"
+        limit = 2
+        since = datetime(2024, 1, 15, 9, 0, tzinfo=timezone.utc)
+        until = datetime(2024, 1, 15, 9, 30, tzinfo=timezone.utc)
+        expected_since = str(int(since.timestamp() * 1000))
+        expected_until = str(int(until.timestamp() * 1000))
+        next_until = "1705310400000"
+
+        first_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_filtered_1",
+                    created_at=1705311000000,
+                ),
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_filtered_2",
+                    created_at=1705310700000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": int(next_until),
+                "prev": None,
+            },
+        }
+        second_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_filtered_3",
+                    created_at=1705310400000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": None,
+                "prev": 1705311000000,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append(params)
+            if params.get("until") == next_until:
+                return httpx.Response(200, json=second_page)
+            return httpx.Response(200, json=first_page)
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = Sandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            project=project,
+            limit=limit,
+            since=since,
+            until=until,
+        )
+
+        assert requests == [
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": expected_since,
+                "until": expected_until,
+            }
+        ]
+        assert isinstance(page.sandboxes[0], SandboxModel)
+        assert page.sandboxes[0].id == "sbx_filtered_1"
+        assert page.sandboxes[0].created_at == 1705311000000
+        assert page.sandboxes[0].requested_at == 1705311000000
+        assert page.pagination.count == 3
+        assert page.next_page_info() is not None
+        assert page.next_page_info().until == int(next_until)
+
+        assert [sandbox.id for sandbox in page.iter_items()] == [
+            "sbx_filtered_1",
+            "sbx_filtered_2",
+            "sbx_filtered_3",
+        ]
+        assert requests == [
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": expected_since,
+                "until": expected_until,
+            },
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": expected_since,
+                "until": next_until,
+            },
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_sandbox_async_serializes_integer_filters_and_typed_pages(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel._internal.sandbox.models import Sandbox as SandboxModel
+        from vercel.sandbox import AsyncSandbox
+
+        project = "sandbox-project"
+        limit = 2
+        since = 1705312800000
+        until = 1705314600000
+        next_until = "1705312500000"
+
+        first_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_filtered_1",
+                    created_at=1705313400000,
+                ),
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_filtered_2",
+                    created_at=1705313100000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": int(next_until),
+                "prev": None,
+            },
+        }
+        second_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_filtered_3",
+                    created_at=1705312500000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": None,
+                "prev": 1705313400000,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append(params)
+            if params.get("until") == next_until:
+                return httpx.Response(200, json=second_page)
+            return httpx.Response(200, json=first_page)
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = await AsyncSandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            project=project,
+            limit=limit,
+            since=since,
+            until=until,
+        )
+
+        assert requests == [
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": str(since),
+                "until": str(until),
+            }
+        ]
+        assert isinstance(page.sandboxes[0], SandboxModel)
+        assert page.sandboxes[0].id == "sbx_async_filtered_1"
+        assert page.sandboxes[0].created_at == 1705313400000
+        assert page.sandboxes[0].requested_at == 1705313400000
+        assert page.pagination.count == 3
+        assert page.next_page_info() is not None
+        assert page.next_page_info().until == int(next_until)
+
+        items = await _collect_async_items(page)
+        assert [sandbox.id for sandbox in items] == [
+            "sbx_async_filtered_1",
+            "sbx_async_filtered_2",
+            "sbx_async_filtered_3",
+        ]
+        assert requests == [
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": str(since),
+                "until": str(until),
+            },
+            {
+                "teamId": "team_test123",
+                "project": project,
+                "limit": str(limit),
+                "since": str(since),
+                "until": next_until,
+            },
+        ]
+
+    @respx.mock
+    def test_list_sandbox_sync_iterates_pages_and_items(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import Sandbox
+
+        first_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_page_1",
+                    created_at=1705320600000,
+                ),
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_page_2",
+                    created_at=1705320000000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": 1705319400000,
+                "prev": None,
+            },
+        }
+        second_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_page_3",
+                    created_at=1705319400000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": None,
+                "prev": 1705320600000,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append(params)
+            if params.get("until") == "1705319400000":
+                return httpx.Response(200, json=second_page)
+            return httpx.Response(200, json=first_page)
+
+        route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = Sandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        assert route.called
+        assert [sandbox.id for sandbox in page.sandboxes] == ["sbx_page_1", "sbx_page_2"]
+        assert page.pagination.count == 3
+        assert page.pagination.next == 1705319400000
+        assert page.has_next_page() is True
+        assert page.next_page_info() is not None
+        assert page.next_page_info().until == 1705319400000
+
+        pages = list(page.iter_pages())
+        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
+            ["sbx_page_1", "sbx_page_2"],
+            ["sbx_page_3"],
+        ]
+        assert requests == [
+            {"teamId": "team_test123"},
+            {"teamId": "team_test123", "until": "1705319400000"},
+        ]
+
+        requests.clear()
+        items_page = Sandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+        assert [sandbox.id for sandbox in items_page.iter_items()] == [
+            "sbx_page_1",
+            "sbx_page_2",
+            "sbx_page_3",
+        ]
+        assert requests == [
+            {"teamId": "team_test123"},
+            {"teamId": "team_test123", "until": "1705319400000"},
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_sandbox_async_iterates_pages_and_items(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import AsyncSandbox
+
+        first_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_1",
+                    created_at=1705320600000,
+                ),
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_2",
+                    created_at=1705320000000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": 1705319400000,
+                "prev": None,
+            },
+        }
+        second_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_3",
+                    created_at=1705319400000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": None,
+                "prev": 1705320600000,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append(params)
+            if params.get("until") == "1705319400000":
+                return httpx.Response(200, json=second_page)
+            return httpx.Response(200, json=first_page)
+
+        route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = await AsyncSandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        assert route.called
+        assert [sandbox.id for sandbox in page.sandboxes] == ["sbx_async_1", "sbx_async_2"]
+        assert page.pagination.count == 3
+        assert page.pagination.next == 1705319400000
+        assert page.has_next_page() is True
+        assert page.next_page_info() is not None
+        assert page.next_page_info().until == 1705319400000
+        assert requests == [{"teamId": "team_test123"}]
+
+        requests.clear()
+        next_page = await page.get_next_page()
+        assert next_page is not None
+        assert [sandbox.id for sandbox in next_page.sandboxes] == ["sbx_async_3"]
+        assert requests == [{"teamId": "team_test123", "until": "1705319400000"}]
+
+        requests.clear()
+        pages = await _collect_async_pages(page)
+        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
+            ["sbx_async_1", "sbx_async_2"],
+            ["sbx_async_3"],
+        ]
+        assert requests == [{"teamId": "team_test123", "until": "1705319400000"}]
+
+        requests.clear()
+        items_page = await AsyncSandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+        items = await _collect_async_items(items_page)
+        assert [sandbox.id for sandbox in items] == [
+            "sbx_async_1",
+            "sbx_async_2",
+            "sbx_async_3",
+        ]
+        assert requests == [
+            {"teamId": "team_test123"},
+            {"teamId": "team_test123", "until": "1705319400000"},
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_sandbox_async_builder_supports_direct_iteration(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import AsyncSandbox
+
+        first_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_builder_1",
+                    created_at=1705320600000,
+                ),
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_builder_2",
+                    created_at=1705320000000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": 1705319400000,
+                "prev": None,
+            },
+        }
+        second_page = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_builder_3",
+                    created_at=1705319400000,
+                ),
+            ],
+            "pagination": {
+                "count": 3,
+                "next": None,
+                "prev": 1705320600000,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append(params)
+            if params.get("until") == "1705319400000":
+                return httpx.Response(200, json=second_page)
+            return httpx.Response(200, json=first_page)
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        item_ids = [
+            sandbox.id
+            async for sandbox in AsyncSandbox.list(
+                token="test_token",
+                team_id="team_test123",
+                project_id="prj_test123",
+            )
+        ]
+        assert item_ids == ["sbx_builder_1", "sbx_builder_2", "sbx_builder_3"]
+        assert requests == [
+            {"teamId": "team_test123"},
+            {"teamId": "team_test123", "until": "1705319400000"},
+        ]
+
+        requests.clear()
+        pages = await _collect_async_pages(
+            AsyncSandbox.list(
+                token="test_token",
+                team_id="team_test123",
+                project_id="prj_test123",
+            )
+        )
+        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
+            ["sbx_builder_1", "sbx_builder_2"],
+            ["sbx_builder_3"],
+        ]
+        assert requests == [
+            {"teamId": "team_test123"},
+            {"teamId": "team_test123", "until": "1705319400000"},
+        ]
+
+    @respx.mock
+    def test_list_sandbox_sync_single_page_does_not_fetch_more(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import Sandbox
+
+        response = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_single_page",
+                    created_at=1705320600000,
+                ),
+            ],
+            "pagination": {
+                "count": 1,
+                "next": None,
+                "prev": None,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(dict(request.url.params))
+            return httpx.Response(200, json=response)
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = Sandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        assert page.has_next_page() is False
+        assert page.next_page_info() is None
+        assert page.get_next_page() is None
+        assert [
+            [sandbox.id for sandbox in current_page.sandboxes] for current_page in page.iter_pages()
+        ] == [
+            ["sbx_single_page"],
+        ]
+        assert [sandbox.id for sandbox in page.iter_items()] == ["sbx_single_page"]
+        assert requests == [{"teamId": "team_test123"}]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_sandbox_async_terminal_page_does_not_fetch_more(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import AsyncSandbox
+
+        response = {
+            "sandboxes": [
+                _sandbox_with_id(
+                    mock_sandbox_get_response,
+                    "sbx_async_terminal",
+                    created_at=1705320600000,
+                ),
+            ],
+            "pagination": {
+                "count": 1,
+                "next": None,
+                "prev": None,
+            },
+        }
+        requests: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(dict(request.url.params))
+            return httpx.Response(200, json=response)
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
+
+        page = await AsyncSandbox.list(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        assert page.has_next_page() is False
+        assert page.next_page_info() is None
+        assert await page.get_next_page() is None
+        pages = await _collect_async_pages(page)
+        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
+            ["sbx_async_terminal"],
+        ]
+        items = await _collect_async_items(page)
+        assert [sandbox.id for sandbox in items] == ["sbx_async_terminal"]
+        assert requests == [{"teamId": "team_test123"}]
 
     @respx.mock
     def test_get_sandbox_sync_exposes_mode_network_policy(

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -27,7 +27,9 @@ def has_blob_credentials() -> bool:
 
 def has_sandbox_credentials() -> bool:
     """Check if Sandbox credentials are available."""
-    return has_vercel_credentials()
+    return bool(
+        os.getenv("VERCEL_TOKEN") and os.getenv("VERCEL_TEAM_ID") and os.getenv("VERCEL_PROJECT_ID")
+    )
 
 
 # Skip markers for live tests
@@ -43,7 +45,7 @@ requires_blob_credentials = pytest.mark.skipif(
 
 requires_sandbox_credentials = pytest.mark.skipif(
     not has_sandbox_credentials(),
-    reason="Requires VERCEL_TOKEN and VERCEL_TEAM_ID environment variables for sandbox",
+    reason="Requires VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID for sandbox",
 )
 
 
@@ -63,6 +65,15 @@ def vercel_team_id() -> str:
     if not team_id:
         pytest.skip("VERCEL_TEAM_ID environment variable not set")
     return team_id
+
+
+@pytest.fixture
+def vercel_project_id() -> str:
+    """Get Vercel project ID from environment."""
+    project_id = os.getenv("VERCEL_PROJECT_ID")
+    if not project_id:
+        pytest.skip("VERCEL_PROJECT_ID environment variable not set")
+    return project_id
 
 
 @pytest.fixture

--- a/tests/live/test_sandbox_live.py
+++ b/tests/live/test_sandbox_live.py
@@ -4,6 +4,8 @@ These tests make real API calls and require VERCEL_TOKEN and VERCEL_TEAM_ID envi
 Run with: pytest tests/live/test_sandbox_live.py -v
 """
 
+import time
+
 import pytest
 
 from .conftest import requires_sandbox_credentials
@@ -215,6 +217,44 @@ class TestSandboxLive:
                 # Sandbox may already be stopped or unreachable
                 pass
             original.client.close()
+
+    def test_list_sandboxes_includes_created_sandbox(
+        self, vercel_token, vercel_team_id, cleanup_registry
+    ):
+        """Test listing sandboxes returns a newly created sandbox."""
+        from vercel.sandbox import Sandbox
+
+        sandbox = Sandbox.create(
+            token=vercel_token,
+            team_id=vercel_team_id,
+        )
+        cleanup_registry.register("sandbox", sandbox.sandbox_id)
+
+        try:
+            sandbox.wait_for_status("running")
+            since = max(sandbox.sandbox.created_at - 60_000, 0)
+            found_ids: list[str] = []
+
+            for _ in range(10):
+                page = Sandbox.list(
+                    token=vercel_token,
+                    team_id=vercel_team_id,
+                    limit=20,
+                    since=since,
+                )
+                found_ids = [item.id for item in page.iter_items()]
+                if sandbox.sandbox_id in found_ids:
+                    break
+                time.sleep(1)
+
+            assert sandbox.sandbox_id in found_ids
+        finally:
+            try:
+                sandbox.stop()
+            except Exception:
+                # Sandbox may already be stopped or unreachable
+                pass
+            sandbox.client.close()
 
     def test_mk_dir(self, vercel_token, vercel_team_id, cleanup_registry):
         """Test creating a directory in the sandbox."""

--- a/tests/live/test_sandbox_live.py
+++ b/tests/live/test_sandbox_live.py
@@ -1,6 +1,7 @@
 """Live API tests for Vercel Sandbox.
 
-These tests make real API calls and require VERCEL_TOKEN and VERCEL_TEAM_ID environment variables.
+These tests make real API calls and require VERCEL_TOKEN, VERCEL_TEAM_ID, and
+VERCEL_PROJECT_ID environment variables.
 Run with: pytest tests/live/test_sandbox_live.py -v
 """
 
@@ -219,7 +220,7 @@ class TestSandboxLive:
             original.client.close()
 
     def test_list_sandboxes_includes_created_sandbox(
-        self, vercel_token, vercel_team_id, cleanup_registry
+        self, vercel_token, vercel_team_id, vercel_project_id, cleanup_registry
     ):
         """Test listing sandboxes returns a newly created sandbox."""
         from vercel.sandbox import Sandbox
@@ -239,6 +240,7 @@ class TestSandboxLive:
                 page = Sandbox.list(
                     token=vercel_token,
                     team_id=vercel_team_id,
+                    project_id=vercel_project_id,
                     limit=20,
                     since=since,
                 )


### PR DESCRIPTION
Implement Sandbox.list() and AsyncSandbox.list() with first-page
paginator wrappers backed by a shared async-first pagination controller.

Add integration coverage for sync and async multi-page traversal,
ordered item iteration, and terminal-page behavior.