### PR TITLE
Fix network policy header conversion

### DIFF
--- a/src/vercel/_internal/sandbox/network_policy.py
+++ b/src/vercel/_internal/sandbox/network_policy.py
@@ -184,10 +184,7 @@ class ApiNetworkPolicy:
         allow: dict[str, list[NetworkPolicyRule]] = {domain: [] for domain in allowed_domains}
         for rule in injection_rules:
             allow.setdefault(rule.domain, [])
-            header_names = list(rule.header_names or [])
-            if not header_names and rule.headers is not None:
-                header_names = list(rule.headers.keys())
-            headers = _redacted_headers_from_names(header_names)
+            headers = _redacted_headers(rule)
             if not headers:
                 continue
             allow[rule.domain].append(
@@ -200,24 +197,55 @@ class ApiNetworkPolicy:
 def _merge_headers_case_insensitively(
     headers: Sequence[Mapping[str, str] | None],
 ) -> dict[str, str]:
-    merged: dict[str, tuple[str, str]] = {}
+    merged: dict[str, str] = {}
+    lower_to_names: dict[str, set[str]] = {}
     for header_map in headers:
-        for name, value in (header_map or {}).items():
-            merged[name.lower()] = (name, value)
-    return dict(merged.values())
+        if not header_map:
+            continue
+
+        current_lower_to_names: dict[str, set[str]] = {}
+        for name, value in header_map.items():
+            merged[name] = value
+            current_lower_to_names.setdefault(name.lower(), set()).add(name)
+
+        for lower_name, current_names in current_lower_to_names.items():
+            for previous_name in lower_to_names.get(lower_name, set()) - current_names:
+                merged.pop(previous_name, None)
+            lower_to_names[lower_name] = current_names
+
+    return merged
 
 
 def _redacted_headers_from_names(header_names: Sequence[str]) -> dict[str, str]:
-    return dict.fromkeys(
-        _merge_headers_case_insensitively([dict.fromkeys(header_names, "")]),
-        _REDACTED_HEADER_VALUE,
-    )
+    redacted: dict[str, str] = {}
+    lower_to_name: dict[str, str] = {}
+    for name in header_names:
+        lower_name = name.lower()
+        previous_name = lower_to_name.get(lower_name)
+        if previous_name is not None and previous_name != name:
+            redacted.pop(previous_name, None)
+        lower_to_name[lower_name] = name
+        redacted[name] = _REDACTED_HEADER_VALUE
+    return redacted
+
+
+def _redacted_headers(rule: ApiNetworkInjectionRule) -> dict[str, str]:
+    if rule.header_names is not None:
+        return _redacted_headers_from_names(rule.header_names)
+    return dict.fromkeys(rule.headers or {}, _REDACTED_HEADER_VALUE)
 
 
 def _merge_rule_headers(rules: Sequence[NetworkPolicyRule]) -> dict[str, str]:
     return _merge_headers_case_insensitively(
-        [transform.headers for rule in rules for transform in rule.transform or []]
+        [_merge_rule_transform_headers(rule) for rule in rules]
     )
+
+
+def _merge_rule_transform_headers(rule: NetworkPolicyRule) -> dict[str, str]:
+    merged: dict[str, str] = {}
+    for transform in rule.transform or []:
+        merged.update(transform.headers or {})
+    return merged
 
 
 def _subnets_from_api(network_policy: ApiNetworkPolicy) -> NetworkPolicySubnets | None:

--- a/src/vercel/_internal/sandbox/network_policy.py
+++ b/src/vercel/_internal/sandbox/network_policy.py
@@ -69,6 +69,20 @@ class ApiNetworkInjectionRule:
             payload["headerNames"] = self.header_names
         return payload
 
+    def to_redacted_headers(self) -> dict[str, str]:
+        if self.header_names:
+            redacted: dict[str, str] = {}
+            lower_to_name: dict[str, str] = {}
+            for name in self.header_names:
+                lower_name = name.lower()
+                previous_name = lower_to_name.get(lower_name)
+                if previous_name is not None and previous_name != name:
+                    redacted.pop(previous_name, None)
+                lower_to_name[lower_name] = name
+                redacted[name] = _REDACTED_HEADER_VALUE
+            return redacted
+        return dict.fromkeys(self.headers or {}, _REDACTED_HEADER_VALUE)
+
 
 @dataclass(frozen=True, slots=True)
 class ApiNetworkPolicy:
@@ -184,7 +198,7 @@ class ApiNetworkPolicy:
         allow: dict[str, list[NetworkPolicyRule]] = {domain: [] for domain in allowed_domains}
         for rule in injection_rules:
             allow.setdefault(rule.domain, [])
-            headers = _redacted_headers(rule)
+            headers = rule.to_redacted_headers()
             if not headers:
                 continue
             allow[rule.domain].append(
@@ -214,25 +228,6 @@ def _merge_headers_case_insensitively(
             lower_to_names[lower_name] = current_names
 
     return merged
-
-
-def _redacted_headers_from_names(header_names: Sequence[str]) -> dict[str, str]:
-    redacted: dict[str, str] = {}
-    lower_to_name: dict[str, str] = {}
-    for name in header_names:
-        lower_name = name.lower()
-        previous_name = lower_to_name.get(lower_name)
-        if previous_name is not None and previous_name != name:
-            redacted.pop(previous_name, None)
-        lower_to_name[lower_name] = name
-        redacted[name] = _REDACTED_HEADER_VALUE
-    return redacted
-
-
-def _redacted_headers(rule: ApiNetworkInjectionRule) -> dict[str, str]:
-    if rule.header_names is not None:
-        return _redacted_headers_from_names(rule.header_names)
-    return dict.fromkeys(rule.headers or {}, _REDACTED_HEADER_VALUE)
 
 
 def _merge_rule_headers(rules: Sequence[NetworkPolicyRule]) -> dict[str, str]:

--- a/tests/unit/test_sandbox_network_policy_conversion.py
+++ b/tests/unit/test_sandbox_network_policy_conversion.py
@@ -34,7 +34,7 @@ def _record_policy_domains(policy: NetworkPolicy) -> dict[str, set[str]]:
 
     domains: dict[str, set[str]] = {}
     for domain, rules in policy.allow.items():
-        domains[domain] = _rule_header_names(rules)
+        domains[domain] = _merged_rule_header_names(rules)
     return domains
 
 
@@ -44,6 +44,28 @@ def _rule_header_names(rules: Iterable[NetworkPolicyRule]) -> set[str]:
         for transform in rule.transform or []:
             header_names.update((transform.headers or {}).keys())
     return header_names
+
+
+def _merged_rule_header_names(rules: Iterable[NetworkPolicyRule]) -> set[str]:
+    merged: dict[str, None] = {}
+    lower_to_names: dict[str, set[str]] = {}
+    for rule in rules:
+        rule_header_names: dict[str, None] = {}
+        for transform in rule.transform or []:
+            for name in (transform.headers or {}).keys():
+                rule_header_names[name] = None
+
+        current_lower_to_names: dict[str, set[str]] = {}
+        for name in rule_header_names:
+            merged[name] = None
+            current_lower_to_names.setdefault(name.lower(), set()).add(name)
+
+        for lower_name, current_names in current_lower_to_names.items():
+            for previous_name in lower_to_names.get(lower_name, set()) - current_names:
+                merged.pop(previous_name, None)
+            lower_to_names[lower_name] = current_names
+
+    return set(merged)
 
 
 def _case_insensitive_headers(items: Iterable[tuple[str, str]]) -> dict[str, str]:

--- a/tests/unit/test_sandbox_network_policy_conversion.py
+++ b/tests/unit/test_sandbox_network_policy_conversion.py
@@ -542,6 +542,27 @@ class TestNetworkPolicyEdgeCases:
             }
         )
 
+    def test_empty_api_header_names_fall_back_to_headers(self) -> None:
+        assert ApiNetworkPolicy(
+            mode="custom",
+            allowed_domains=["example.com"],
+            injection_rules=[
+                ApiNetworkInjectionRule(
+                    domain="example.com",
+                    headers={"X-Trace": "trace-value"},
+                    header_names=[],
+                )
+            ],
+        ).to_network_policy() == NetworkPolicyCustom(
+            allow={
+                "example.com": [
+                    NetworkPolicyRule(
+                        transform=[NetworkTransformer(headers={"X-Trace": "<redacted>"})]
+                    )
+                ]
+            }
+        )
+
     def test_api_network_policy_to_dict_uses_wire_keys(self) -> None:
         policy = ApiNetworkPolicy(
             mode="custom",

--- a/tests/unit/test_sandbox_network_policy_conversion.py
+++ b/tests/unit/test_sandbox_network_policy_conversion.py
@@ -34,7 +34,7 @@ def _record_policy_domains(policy: NetworkPolicy) -> dict[str, set[str]]:
 
     domains: dict[str, set[str]] = {}
     for domain, rules in policy.allow.items():
-        domains[domain] = _merged_rule_header_names(rules)
+        domains[domain] = _rule_header_names(rules)
     return domains
 
 
@@ -46,35 +46,6 @@ def _rule_header_names(rules: Iterable[NetworkPolicyRule]) -> set[str]:
     return header_names
 
 
-def _merged_rule_header_names(rules: Iterable[NetworkPolicyRule]) -> set[str]:
-    merged: dict[str, None] = {}
-    lower_to_names: dict[str, set[str]] = {}
-    for rule in rules:
-        rule_header_names: dict[str, None] = {}
-        for transform in rule.transform or []:
-            for name in (transform.headers or {}).keys():
-                rule_header_names[name] = None
-
-        current_lower_to_names: dict[str, set[str]] = {}
-        for name in rule_header_names:
-            merged[name] = None
-            current_lower_to_names.setdefault(name.lower(), set()).add(name)
-
-        for lower_name, current_names in current_lower_to_names.items():
-            for previous_name in lower_to_names.get(lower_name, set()) - current_names:
-                merged.pop(previous_name, None)
-            lower_to_names[lower_name] = current_names
-
-    return set(merged)
-
-
-def _case_insensitive_headers(items: Iterable[tuple[str, str]]) -> dict[str, str]:
-    merged: dict[str, tuple[str, str]] = {}
-    for name, value in items:
-        merged[name.lower()] = (name, value)
-    return dict(merged.values())
-
-
 def _domain_strategy() -> st.SearchStrategy[str]:
     label = st.from_regex(r"[a-z][a-z0-9-]{0,5}", fullmatch=True)
     wildcard = st.just("*")
@@ -84,18 +55,6 @@ def _domain_strategy() -> st.SearchStrategy[str]:
 
 def _header_name_strategy() -> st.SearchStrategy[str]:
     return st.from_regex(r"X-[A-Z][A-Za-z0-9-]{0,10}", fullmatch=True)
-
-
-@st.composite
-def _header_name_case_variant_strategy(draw: st.DrawFn) -> str:
-    canonical = draw(st.from_regex(r"x-[a-z][a-z0-9-]{0,10}", fullmatch=True))
-    chars: list[str] = []
-    for char in canonical:
-        if char.isalpha():
-            chars.append(char.upper() if draw(st.booleans()) else char.lower())
-        else:
-            chars.append(char)
-    return "".join(chars)
 
 
 def _header_value_strategy() -> st.SearchStrategy[str]:
@@ -192,35 +151,41 @@ def _policy_semantics(policy: NetworkPolicy) -> Any:
     return ("record", domain_semantics, subnet_semantics)
 
 
-@st.composite
-def _duplicate_header_assignments_strategy(
-    draw: st.DrawFn,
-) -> list[tuple[str, str]]:
-    canonical_names = draw(
-        st.lists(
-            st.from_regex(r"x-[a-z][a-z0-9-]{0,10}", fullmatch=True),
-            min_size=1,
-            max_size=4,
-            unique=True,
+def _subnet_semantics(policy: NetworkPolicy) -> tuple[tuple[str, ...], tuple[str, ...]] | None:
+    if isinstance(policy, str) or policy.subnets is None:
+        return None
+
+    return (
+        tuple(sorted(policy.subnets.allow or [])),
+        tuple(sorted(policy.subnets.deny or [])),
+    )
+
+
+def _normalized_custom_policy_semantics(
+    policy: NetworkPolicy,
+) -> tuple[tuple[tuple[str, frozenset[str]], ...], tuple[tuple[str, ...], tuple[str, ...]] | None]:
+    if isinstance(policy, str):
+        raise TypeError("expected custom policy")
+
+    domain_semantics = tuple(
+        sorted(
+            (domain, frozenset(name.lower() for name in names))
+            for domain, names in _record_policy_domains(policy).items()
         )
     )
-    assignments: list[tuple[str, str]] = []
-    for canonical_name in canonical_names:
-        variant_count = draw(st.integers(min_value=1, max_value=3))
-        for _ in range(variant_count):
-            variant_chars: list[str] = []
-            for char in canonical_name:
-                if char.isalpha():
-                    variant_chars.append(char.upper() if draw(st.booleans()) else char.lower())
-                else:
-                    variant_chars.append(char)
-            assignments.append(
-                (
-                    "".join(variant_chars),
-                    draw(_header_value_strategy()),
-                )
-            )
-    return draw(st.permutations(assignments).map(list))
+    return (domain_semantics, _subnet_semantics(policy))
+
+
+def _header_values(policy: NetworkPolicyCustom) -> set[str]:
+    if isinstance(policy.allow, list):
+        return set()
+
+    values: set[str] = set()
+    for rules in policy.allow.values():
+        for rule in rules:
+            for transform in rule.transform or []:
+                values.update((transform.headers or {}).values())
+    return values
 
 
 class TestNetworkPolicyModes:
@@ -485,6 +450,54 @@ class TestNetworkPolicyEdgeCases:
             ],
         )
 
+    def test_single_rule_preserves_distinct_case_variants_in_api_headers(self) -> None:
+        policy = NetworkPolicyCustom(
+            allow={
+                "example.com": [
+                    NetworkPolicyRule(
+                        transform=[
+                            NetworkTransformer(headers={"X-Trace": "first", "x-trace": "second"})
+                        ]
+                    )
+                ]
+            }
+        )
+
+        assert ApiNetworkPolicy.from_network_policy(policy) == ApiNetworkPolicy(
+            mode="custom",
+            allowed_domains=["example.com"],
+            injection_rules=[
+                ApiNetworkInjectionRule(
+                    domain="example.com",
+                    headers={"X-Trace": "first", "x-trace": "second"},
+                )
+            ],
+        )
+
+    def test_later_rules_replace_earlier_case_variants_for_same_header(self) -> None:
+        policy = NetworkPolicyCustom(
+            allow={
+                "example.com": [
+                    NetworkPolicyRule(transform=[NetworkTransformer(headers={"X-Trace": "first"})]),
+                    NetworkPolicyRule(
+                        transform=[NetworkTransformer(headers={"x-trace": "second"})]
+                    ),
+                    NetworkPolicyRule(transform=[NetworkTransformer(headers={"X-Other": "other"})]),
+                ]
+            }
+        )
+
+        assert ApiNetworkPolicy.from_network_policy(policy) == ApiNetworkPolicy(
+            mode="custom",
+            allowed_domains=["example.com"],
+            injection_rules=[
+                ApiNetworkInjectionRule(
+                    domain="example.com",
+                    headers={"x-trace": "second", "X-Other": "other"},
+                )
+            ],
+        )
+
     def test_api_response_header_names_merge_case_insensitively(self) -> None:
         assert ApiNetworkPolicy(
             mode="custom",
@@ -504,6 +517,26 @@ class TestNetworkPolicyEdgeCases:
                                 headers={"x-trace": "<redacted>", "X-Other": "<redacted>"}
                             )
                         ]
+                    )
+                ]
+            }
+        )
+
+    def test_api_response_header_names_keep_last_case_variant(self) -> None:
+        assert ApiNetworkPolicy(
+            mode="custom",
+            allowed_domains=["example.com"],
+            injection_rules=[
+                ApiNetworkInjectionRule(
+                    domain="example.com",
+                    header_names=["X-Trace", "x-trace", "X-TRACE"],
+                )
+            ],
+        ).to_network_policy() == NetworkPolicyCustom(
+            allow={
+                "example.com": [
+                    NetworkPolicyRule(
+                        transform=[NetworkTransformer(headers={"X-TRACE": "<redacted>"})]
                     )
                 ]
             }
@@ -579,63 +612,22 @@ class TestNetworkPolicyGeneratedCases:
 
     @given(_record_policy_strategy())
     @settings(max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-    def test_generated_record_form_policies_preserve_domains_and_header_names(
+    def test_generated_record_form_policies_preserve_normalized_semantics(
         self, policy: NetworkPolicyCustom
     ) -> None:
-        assert _record_policy_domains(
-            ApiNetworkPolicy.from_network_policy(policy).to_network_policy()
-        ) == (_record_policy_domains(policy))
+        round_tripped = ApiNetworkPolicy.from_network_policy(policy).to_network_policy()
 
-    @given(_duplicate_header_assignments_strategy())
+        assert isinstance(round_tripped, NetworkPolicyCustom)
+        assert _normalized_custom_policy_semantics(
+            round_tripped
+        ) == _normalized_custom_policy_semantics(policy)
+
+    @given(_record_policy_strategy())
     @settings(max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-    def test_generated_record_form_merges_duplicate_headers_case_insensitively(
-        self, assignments: list[tuple[str, str]]
+    def test_generated_record_form_policies_decode_to_redacted_headers(
+        self, policy: NetworkPolicyCustom
     ) -> None:
-        policy = NetworkPolicyCustom(
-            allow={
-                "example.com": [
-                    NetworkPolicyRule(transform=[NetworkTransformer(headers={name: value})])
-                    for name, value in assignments
-                ]
-            }
-        )
+        round_tripped = ApiNetworkPolicy.from_network_policy(policy).to_network_policy()
 
-        api_policy = ApiNetworkPolicy.from_network_policy(policy)
-
-        assert api_policy == ApiNetworkPolicy(
-            mode="custom",
-            allowed_domains=["example.com"],
-            injection_rules=[
-                ApiNetworkInjectionRule(
-                    domain="example.com",
-                    headers=_case_insensitive_headers(assignments),
-                )
-            ],
-        )
-
-    @given(st.lists(_header_name_case_variant_strategy(), min_size=1, max_size=8))
-    @settings(max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-    def test_generated_api_header_names_collapse_case_insensitive_duplicates(
-        self, header_names: list[str]
-    ) -> None:
-        expected_headers = dict.fromkeys(
-            _case_insensitive_headers((name, "<redacted>") for name in header_names),
-            "<redacted>",
-        )
-
-        assert ApiNetworkPolicy(
-            mode="custom",
-            allowed_domains=["example.com"],
-            injection_rules=[
-                ApiNetworkInjectionRule(
-                    domain="example.com",
-                    header_names=header_names,
-                )
-            ],
-        ).to_network_policy() == NetworkPolicyCustom(
-            allow={
-                "example.com": [
-                    NetworkPolicyRule(transform=[NetworkTransformer(headers=expected_headers)])
-                ]
-            }
-        )
+        assert isinstance(round_tripped, NetworkPolicyCustom)
+        assert _header_values(round_tripped) <= {"<redacted>"}


### PR DESCRIPTION
Round-trip network policy conversion was collapsing header names too early. Header names are case-insensitive, but our conversion logic merged case variants at the wrong stage, so a rule that explicitly contained both `X-Trace` and `x-trace` could come back with only one of them.

Before, a policy like this:

```python
NetworkPolicyCustom(
    allow={
        "example.com": [
            NetworkPolicyRule(
                transform=[
                    NetworkTransformer(
                        headers={"X-Trace": "first", "x-trace": "second"}
                    )
                ]
            )
        ]
    }
)
```

could round-trip into:

```python
NetworkPolicyCustom(
    allow={
        "example.com": [
            NetworkPolicyRule(
                transform=[
                    NetworkTransformer(
                        headers={"x-trace": "<redacted>"}
                    )
                ]
            )
        ]
    }
)
```

That was incorrect because the original rule explicitly preserved both keys. It should instead come back as:

```python
NetworkPolicyCustom(
    allow={
        "example.com": [
            NetworkPolicyRule(
                transform=[
                    NetworkTransformer(
                        headers={
                            "X-Trace": "<redacted>",
                            "x-trace": "<redacted>",
                        }
                    )
                ]
            )
        ]
    }
)
```

The fix was to preserve exact header keys when converting concrete API `headers`, and only collapse case variants where that is actually part of the API contract: when decoding `header_names`, or when merging separate rules.

I also simplified the tests: the tricky merge behavior now has direct unit tests, while the generated tests focus on simpler structural invariants instead of reimplementing the conversion logic.