### PR TITLE
Investigate CI by pinning Bundler 4.0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint-and-tests:
-    name: lint-and-tests
+  lint-test-and-build:
+    name: lint-test-and-build
     runs-on: ubuntu-latest
     environment: ci
     env:
@@ -32,52 +32,8 @@ jobs:
       - name: Run tests
         run: ./scripts/test.sh
 
-  example-tests:
-    name: example-tests
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: Set up virtualenv (Python 3.12)
-        run: uv venv --python 3.12
-
-      - name: Install dependencies
-        run: uv pip install -e .[dev]
-
       - name: Run example tests
         run: ./scripts/test-examples.sh
-
-  build-package:
-    name: build-package
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: Set up virtualenv (Python 3.12)
-        run: uv venv --python 3.12
-
-      - name: Install dependencies
-        run: uv pip install -e .[dev]
 
       - name: Build package
         run: ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint-test-and-build:
-    name: lint-test-and-build
+  lint-and-tests:
+    name: lint-and-tests
     runs-on: ubuntu-latest
     environment: ci
     env:
@@ -32,8 +32,52 @@ jobs:
       - name: Run tests
         run: ./scripts/test.sh
 
+  example-tests:
+    name: example-tests
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up virtualenv (Python 3.12)
+        run: uv venv --python 3.12
+
+      - name: Install dependencies
+        run: uv pip install -e .[dev]
+
       - name: Run example tests
         run: ./scripts/test-examples.sh
+
+  build-package:
+    name: build-package
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up virtualenv (Python 3.12)
+        run: uv venv --python 3.12
+
+      - name: Install dependencies
+        run: uv pip install -e .[dev]
 
       - name: Build package
         run: ./scripts/build.sh

--- a/examples/sandbox_07_ruby_sinatra.py
+++ b/examples/sandbox_07_ruby_sinatra.py
@@ -83,7 +83,7 @@ async def main() -> None:
             "bash",
             [
                 "-lc",
-                ("gem install --no-document bundler"),
+                ("gem install --no-document bundler -v 4.0.8"),
             ],
             sudo=True,
         )

--- a/examples/sandbox_09_rails_api.py
+++ b/examples/sandbox_09_rails_api.py
@@ -74,7 +74,10 @@ async def main() -> None:
             "bash",
             [
                 "-lc",
-                ("gem install --no-document bundler && gem install --no-document rails"),
+                (
+                    "gem install --no-document bundler -v 4.0.8 "
+                    "&& gem install --no-document rails"
+                ),
             ],
             sudo=True,
         )

--- a/examples/sandbox_09_rails_api.py
+++ b/examples/sandbox_09_rails_api.py
@@ -74,10 +74,7 @@ async def main() -> None:
             "bash",
             [
                 "-lc",
-                (
-                    "gem install --no-document bundler -v 4.0.8 "
-                    "&& gem install --no-document rails"
-                ),
+                ("gem install --no-document bundler -v 4.0.8 && gem install --no-document rails"),
             ],
             sudo=True,
         )


### PR DESCRIPTION
## Goal
Pin Bundler back to `4.0.8` in the Ruby sandbox examples and leave `uv` unpinned to test whether the Ruby example failure tracks the Bundler upgrade.

## What changed
- pin Bundler to `4.0.8` in the Ruby sandbox examples
- split CI into separate `lint-and-tests`, `example-tests`, and `build-package` jobs so the Ruby example result does not mask the build result

## Expected interpretation
- if `example-tests` passes and `build-package` still fails, that supports Bundler drift as the Ruby-side cause and an independent Python-side issue
- if both still fail, the Bundler upgrade alone is probably not sufficient to explain the Ruby regression