### PR TITLE
Investigate CI by pinning uv 0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint-test-and-build:
-    name: lint-test-and-build
+  lint-and-tests:
+    name: lint-and-tests
     runs-on: ubuntu-latest
     environment: ci
     env:
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
+        with:
+          version: 0.11.0
 
       - name: Set up virtualenv (Python 3.12)
         run: uv venv --python 3.12
@@ -32,8 +34,56 @@ jobs:
       - name: Run tests
         run: ./scripts/test.sh
 
+  example-tests:
+    name: example-tests
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: 0.11.0
+
+      - name: Set up virtualenv (Python 3.12)
+        run: uv venv --python 3.12
+
+      - name: Install dependencies
+        run: uv pip install -e .[dev]
+
       - name: Run example tests
         run: ./scripts/test-examples.sh
+
+  build-package:
+    name: build-package
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: 0.11.0
+
+      - name: Set up virtualenv (Python 3.12)
+        run: uv venv --python 3.12
+
+      - name: Install dependencies
+        run: uv pip install -e .[dev]
 
       - name: Build package
         run: ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint-and-tests:
-    name: lint-and-tests
+  lint-test-and-build:
+    name: lint-test-and-build
     runs-on: ubuntu-latest
     environment: ci
     env:
@@ -34,56 +34,8 @@ jobs:
       - name: Run tests
         run: ./scripts/test.sh
 
-  example-tests:
-    name: example-tests
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: 0.11.0
-
-      - name: Set up virtualenv (Python 3.12)
-        run: uv venv --python 3.12
-
-      - name: Install dependencies
-        run: uv pip install -e .[dev]
-
       - name: Run example tests
         run: ./scripts/test-examples.sh
-
-  build-package:
-    name: build-package
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: 0.11.0
-
-      - name: Set up virtualenv (Python 3.12)
-        run: uv venv --python 3.12
-
-      - name: Install dependencies
-        run: uv pip install -e .[dev]
 
       - name: Build package
         run: ./scripts/build.sh


### PR DESCRIPTION
## Goal
Pin `uv` back to `0.11.0` and leave Bundler unpinned to test whether the Python build failure tracks the `uv` upgrade.

## What changed
- pin `astral-sh/setup-uv@v3` to `version: 0.11.0`
- split CI into separate `lint-and-tests`, `example-tests`, and `build-package` jobs so the Ruby example failure cannot mask the build result

## Expected interpretation
- if `build-package` passes and `example-tests` still fails, that supports `uv` drift as the Python-side cause and an independent Ruby-side issue
- if both still fail, the `uv` upgrade alone is probably not sufficient to explain the Python regression