### PR TITLE
sandbox: Take `timedelta` for expiration

### DIFF
--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -17,6 +17,7 @@ import sys
 import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator, Generator
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from importlib.metadata import version as _pkg_version
 from typing import Any, TypeAlias, cast
 
@@ -60,6 +61,8 @@ from vercel._internal.sandbox.network_policy import (
     ApiNetworkPolicy,
     NetworkPolicy,
 )
+from vercel._internal.sandbox.snapshot import SnapshotExpiration
+from vercel._internal.sandbox.time import normalize_duration_ms
 
 try:
     VERSION = _pkg_version("vercel")
@@ -272,7 +275,7 @@ class BaseSandboxOpsClient:
         project_id: str,
         ports: list[int] | None = None,
         source: dict[str, Any] | None = None,
-        timeout: int | None = None,
+        timeout: int | timedelta | None = None,
         resources: dict[str, Any] | None = None,
         runtime: str | None = None,
         network_policy: NetworkPolicy | None = None,
@@ -285,7 +288,7 @@ class BaseSandboxOpsClient:
         if source is not None:
             body["source"] = source
         if timeout is not None:
-            body["timeout"] = timeout
+            body["timeout"] = normalize_duration_ms(timeout)
         if resources is not None:
             body["resources"] = resources
         if runtime is not None:
@@ -505,18 +508,20 @@ class BaseSandboxOpsClient:
             body=JSONBody({"signal": signal}),
         )
 
-    async def extend_timeout(self, *, sandbox_id: str, duration: int) -> SandboxResponse:
+    async def extend_timeout(
+        self, *, sandbox_id: str, duration: int | timedelta
+    ) -> SandboxResponse:
         data = await self._request_client.request_json(
             "POST",
             f"/v1/sandboxes/{sandbox_id}/extend-timeout",
-            body=JSONBody({"duration": duration}),
+            body=JSONBody({"duration": normalize_duration_ms(duration)}),
         )
         return SandboxResponse.model_validate(data)
 
     async def create_snapshot(
-        self, *, sandbox_id: str, expiration: int | None = None
+        self, *, sandbox_id: str, expiration: SnapshotExpiration | None = None
     ) -> CreateSnapshotResponse:
-        body = None if expiration is None else JSONBody({"expiration": expiration})
+        body = None if expiration is None else JSONBody({"expiration": int(expiration)})
         data = await self._request_client.request_json(
             "POST",
             f"/v1/sandboxes/{sandbox_id}/snapshot",

--- a/src/vercel/_internal/sandbox/snapshot.py
+++ b/src/vercel/_internal/sandbox/snapshot.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Final
+
+from vercel._internal.sandbox.time import normalize_duration_ms
+
+MIN_SNAPSHOT_EXPIRATION_MS: Final[int] = 86_400_000
+
+
+class SnapshotExpiration(int):
+    """Snapshot expiration in milliseconds.
+
+    Valid values are ``0`` for no expiration or any value greater than or equal
+    to ``86_400_000`` (24 hours).
+    """
+
+    def __new__(cls, value: int | timedelta) -> SnapshotExpiration:
+        normalized_value = normalize_duration_ms(value)
+        if normalized_value is None:
+            raise TypeError("Snapshot expiration cannot be None")
+        if normalized_value != 0 and normalized_value < MIN_SNAPSHOT_EXPIRATION_MS:
+            raise ValueError(
+                "Snapshot expiration must be 0 for no expiration or >= 86400000 milliseconds"
+            )
+        return int.__new__(cls, normalized_value)

--- a/src/vercel/_internal/sandbox/time.py
+++ b/src/vercel/_internal/sandbox/time.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+
+def normalize_duration_ms(value: int | timedelta | None) -> int | None:
+    match value:
+        case None:
+            return None
+        case timedelta():
+            return int(value.total_seconds() * 1000)
+        case _:
+            return int(value)

--- a/src/vercel/_internal/sandbox/time.py
+++ b/src/vercel/_internal/sandbox/time.py
@@ -7,7 +7,9 @@ def normalize_duration_ms(value: int | timedelta | None) -> int | None:
     match value:
         case None:
             return None
+        case int():
+            return value
         case timedelta():
-            return int(value.total_seconds() * 1000)
+            return value // timedelta(milliseconds=1)
         case _:
-            return int(value)
+            raise TypeError("duration must be an int, timedelta, or None")

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -4,7 +4,7 @@ import builtins
 import time
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from os import PathLike
 from typing import Any
 
@@ -24,6 +24,7 @@ from vercel._internal.sandbox.network_policy import (
     NetworkPolicy,
 )
 from vercel._internal.sandbox.pagination import SandboxListParams
+from vercel._internal.sandbox.time import normalize_duration_ms
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -38,7 +39,6 @@ from .snapshot import (
     AsyncSnapshot,
     Snapshot as SnapshotClass,
     SnapshotExpiration,
-    normalize_snapshot_expiration,
 )
 
 
@@ -154,7 +154,7 @@ class AsyncSandbox:
         *,
         source: Source | None = None,
         ports: list[int] | None = None,
-        timeout: int | None = None,
+        timeout: int | timedelta | None = None,
         resources: dict[str, Any] | None = None,
         runtime: str | None = None,
         token: str | None = None,
@@ -169,7 +169,7 @@ class AsyncSandbox:
         Args:
             source: Source to initialize the sandbox from (git, tarball, or snapshot).
             ports: List of ports to expose.
-            timeout: Sandbox timeout in milliseconds.
+            timeout: Sandbox timeout in milliseconds or as a ``timedelta``.
             resources: Resource configuration.
             runtime: Runtime to use.
             token: API token (uses OIDC if not provided).
@@ -191,7 +191,7 @@ class AsyncSandbox:
             project_id=creds.project_id,
             source=_normalize_source(source),
             ports=ports,
-            timeout=timeout,
+            timeout=normalize_duration_ms(timeout),
             resources=resources,
             runtime=runtime,
             interactive=interactive,
@@ -436,7 +436,7 @@ class AsyncSandbox:
             return
         await self.wait_for_status("stopped", timeout=timeout, poll_interval=poll_interval)
 
-    async def extend_timeout(self, duration: int) -> None:
+    async def extend_timeout(self, duration: int | timedelta) -> None:
         """
         Extend the timeout of the sandbox by the specified duration.
 
@@ -444,13 +444,14 @@ class AsyncSandbox:
         execution timeout for your plan.
 
         Args:
-            duration: The duration in milliseconds to extend the timeout by.
+            duration: The duration in milliseconds or as a ``timedelta`` to
+                extend the timeout by.
         """
         response = await self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
         self.sandbox = response.sandbox
 
     async def snapshot(
-        self, *, expiration: int | SnapshotExpiration | None = None
+        self, *, expiration: int | timedelta | SnapshotExpiration | None = None
     ) -> AsyncSnapshot:
         """
         Create a snapshot from this currently running sandbox.
@@ -458,7 +459,7 @@ class AsyncSandbox:
 
         Note: this sandbox will be stopped as part of the snapshot creation process.
         """
-        normalized_expiration = normalize_snapshot_expiration(expiration)
+        normalized_expiration = None if expiration is None else SnapshotExpiration(expiration)
         response = await self.client.create_snapshot(
             sandbox_id=self.sandbox.id,
             expiration=normalized_expiration,
@@ -552,7 +553,7 @@ class Sandbox:
         *,
         source: Source | None = None,
         ports: list[int] | None = None,
-        timeout: int | None = None,
+        timeout: int | timedelta | None = None,
         resources: dict[str, Any] | None = None,
         runtime: str | None = None,
         token: str | None = None,
@@ -567,7 +568,7 @@ class Sandbox:
         Args:
             source: Source to initialize the sandbox from (git, tarball, or snapshot).
             ports: List of ports to expose.
-            timeout: Sandbox timeout in milliseconds.
+            timeout: Sandbox timeout in milliseconds or as a ``timedelta``.
             resources: Resource configuration.
             runtime: Runtime to use.
             token: API token (uses OIDC if not provided).
@@ -591,7 +592,7 @@ class Sandbox:
                 project_id=creds.project_id,
                 source=_normalize_source(source),
                 ports=ports,
-                timeout=timeout,
+                timeout=normalize_duration_ms(timeout),
                 resources=resources,
                 runtime=runtime,
                 interactive=interactive,
@@ -840,7 +841,7 @@ class Sandbox:
             return
         self.wait_for_status("stopped", timeout=timeout, poll_interval=poll_interval)
 
-    def extend_timeout(self, duration: int) -> None:
+    def extend_timeout(self, duration: int | timedelta) -> None:
         """
         Extend the timeout of the sandbox by the specified duration.
 
@@ -848,21 +849,24 @@ class Sandbox:
         execution timeout for your plan.
 
         Args:
-            duration: The duration in milliseconds to extend the timeout by.
+            duration: The duration in milliseconds or as a ``timedelta`` to
+                extend the timeout by.
         """
         response = iter_coroutine(
             self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
         )
         self.sandbox = response.sandbox
 
-    def snapshot(self, *, expiration: int | SnapshotExpiration | None = None) -> SnapshotClass:
+    def snapshot(
+        self, *, expiration: int | timedelta | SnapshotExpiration | None = None
+    ) -> SnapshotClass:
         """
         Create a snapshot from this currently running sandbox.
         New sandboxes can then be created from this snapshot.
 
         Note: this sandbox will be stopped as part of the snapshot creation process.
         """
-        normalized_expiration = normalize_snapshot_expiration(expiration)
+        normalized_expiration = None if expiration is None else SnapshotExpiration(expiration)
         response = iter_coroutine(
             self.client.create_snapshot(
                 sandbox_id=self.sandbox.id,

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -2,43 +2,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final, Literal
+from typing import Literal
 
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox import AsyncSandboxOpsClient, SyncSandboxOpsClient
 from vercel._internal.sandbox.models import Snapshot as SnapshotModel
 from vercel._internal.sandbox.pagination import SnapshotListParams
+from vercel._internal.sandbox.snapshot import (
+    MIN_SNAPSHOT_EXPIRATION_MS as _MIN_SNAPSHOT_EXPIRATION_MS,
+    SnapshotExpiration as _SnapshotExpiration,
+)
 
 from ..oidc import Credentials, get_credentials
 from .page import AsyncSnapshotPage, AsyncSnapshotPager, SnapshotPage
 
-MIN_SNAPSHOT_EXPIRATION_MS: Final[int] = 86_400_000
-
-
-class SnapshotExpiration(int):
-    """Snapshot expiration in milliseconds.
-
-    Valid values are ``0`` for no expiration or any value greater than or equal
-    to ``86_400_000`` (24 hours).
-    """
-
-    def __new__(cls, value: int) -> SnapshotExpiration:
-        value = int(value)
-        if value != 0 and value < MIN_SNAPSHOT_EXPIRATION_MS:
-            raise ValueError(
-                "Snapshot expiration must be 0 for no expiration or >= 86400000 milliseconds"
-            )
-        return int.__new__(cls, value)
-
-
-def normalize_snapshot_expiration(
-    expiration: int | SnapshotExpiration | None,
-) -> SnapshotExpiration | None:
-    if expiration is None:
-        return None
-    if isinstance(expiration, SnapshotExpiration):
-        return expiration
-    return SnapshotExpiration(expiration)
+MIN_SNAPSHOT_EXPIRATION_MS = _MIN_SNAPSHOT_EXPIRATION_MS
+SnapshotExpiration = _SnapshotExpiration
 
 
 async def _build_async_snapshot_page(

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -174,6 +174,35 @@ class TestSandboxCreate:
         sandbox.client.close()
 
     @respx.mock
+    def test_create_sandbox_sync_serializes_timedelta_timeout(
+        self, mock_env_clear, mock_sandbox_create_response
+    ):
+        from vercel.sandbox import Sandbox
+
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_create_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        sandbox = Sandbox.create(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            timeout=timedelta(minutes=10),
+        )
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body["timeout"] == 600000
+
+        sandbox.client.close()
+
+    @respx.mock
     def test_create_sandbox_with_env_sync(self, mock_env_clear, mock_sandbox_create_response):
         """Test sandbox creation with env dict."""
         from vercel.sandbox import Sandbox
@@ -233,6 +262,36 @@ class TestSandboxCreate:
 
         body = json.loads(route.calls.last.request.content)
         assert body["env"] == {"NODE_ENV": "production"}
+
+        await sandbox.client.aclose()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_sandbox_async_serializes_timedelta_timeout(
+        self, mock_env_clear, mock_sandbox_create_response
+    ):
+        from vercel.sandbox import AsyncSandbox
+
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_create_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        sandbox = await AsyncSandbox.create(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            timeout=timedelta(minutes=10),
+        )
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body["timeout"] == 600000
 
         await sandbox.client.aclose()
 
@@ -3670,6 +3729,87 @@ class TestSandboxExtendTimeout:
         assert sandbox.timeout == 600
 
         sandbox.client.close()
+
+    @respx.mock
+    def test_extend_timeout_sync_serializes_timedelta(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import Sandbox
+
+        sandbox_id = "sbx_test123456"
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_get_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        extended_response = dict(mock_sandbox_get_response)
+        extended_response["timeout"] = 600
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/extend-timeout").mock(
+            return_value=httpx.Response(200, json={"sandbox": extended_response})
+        )
+
+        sandbox = Sandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        sandbox.extend_timeout(timedelta(minutes=5))
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body["duration"] == 300000
+        assert sandbox.timeout == 600
+
+        sandbox.client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extend_timeout_async_serializes_timedelta(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        from vercel.sandbox import AsyncSandbox
+
+        sandbox_id = "sbx_test123456"
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_get_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        extended_response = dict(mock_sandbox_get_response)
+        extended_response["timeout"] = 600
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/extend-timeout").mock(
+            return_value=httpx.Response(200, json={"sandbox": extended_response})
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        await sandbox.extend_timeout(timedelta(minutes=5))
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body["duration"] == 300000
+        assert sandbox.timeout == 600
+
+        await sandbox.client.aclose()
 
 
 class TestSandboxDomain:

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -6,7 +6,7 @@ Tests both sync and async variants (Sandbox and AsyncSandbox).
 import json
 import tarfile
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -3331,6 +3331,54 @@ class TestSandboxSnapshot:
         sandbox.client.close()
 
     @respx.mock
+    def test_create_snapshot_sync_with_timedelta_expiration(
+        self, mock_env_clear, mock_sandbox_get_response, mock_sandbox_snapshot_response
+    ):
+        """Test sync snapshot creation serializes timedelta expiration to milliseconds."""
+        from vercel.sandbox import Sandbox
+
+        sandbox_id = "sbx_test123456"
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_get_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        stopped_response = dict(mock_sandbox_get_response)
+        stopped_response["status"] = "stopped"
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/snapshot").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": stopped_response,
+                    "snapshot": mock_sandbox_snapshot_response,
+                },
+            )
+        )
+
+        sandbox = Sandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        snapshot = sandbox.snapshot(expiration=timedelta(days=1))
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"expiration": 86_400_000}
+        assert snapshot.created_at == mock_sandbox_snapshot_response["createdAt"]
+        assert sandbox.status == "stopped"
+
+        sandbox.client.close()
+
+    @respx.mock
     def test_create_snapshot_sync_with_zero_expiration(
         self, mock_env_clear, mock_sandbox_get_response, mock_sandbox_snapshot_response
     ):
@@ -3466,6 +3514,55 @@ class TestSandboxSnapshot:
         )
 
         snapshot = await sandbox.snapshot(expiration=86_400_000)
+
+        assert route.called
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"expiration": 86_400_000}
+        assert snapshot.created_at == mock_sandbox_snapshot_response["createdAt"]
+        assert sandbox.status == "stopped"
+
+        await sandbox.client.aclose()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_snapshot_async_with_timedelta_expiration(
+        self, mock_env_clear, mock_sandbox_get_response, mock_sandbox_snapshot_response
+    ):
+        """Test async snapshot creation serializes timedelta expiration to milliseconds."""
+        from vercel.sandbox import AsyncSandbox
+
+        sandbox_id = "sbx_test123456"
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_get_response,
+                    "routes": [],
+                },
+            )
+        )
+
+        stopped_response = dict(mock_sandbox_get_response)
+        stopped_response["status"] = "stopped"
+        route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/snapshot").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": stopped_response,
+                    "snapshot": mock_sandbox_snapshot_response,
+                },
+            )
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        snapshot = await sandbox.snapshot(expiration=timedelta(days=1))
 
         assert route.called
         body = json.loads(route.calls.last.request.content)

--- a/tests/unit/test_sandbox_snapshot.py
+++ b/tests/unit/test_sandbox_snapshot.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
+from hypothesis import given, strategies as st
 
 from vercel.sandbox import MIN_SNAPSHOT_EXPIRATION_MS, SnapshotExpiration
-from vercel.sandbox.snapshot import normalize_snapshot_expiration
 
 
 class TestSnapshotExpiration:
@@ -23,8 +25,37 @@ class TestSnapshotExpiration:
         with pytest.raises(ValueError, match="0 for no expiration or >= 86400000"):
             SnapshotExpiration(MIN_SNAPSHOT_EXPIRATION_MS - 1)
 
-    def test_normalize_coerces_int(self) -> None:
-        expiration = normalize_snapshot_expiration(MIN_SNAPSHOT_EXPIRATION_MS)
+    def test_rejects_timedelta_below_minimum(self) -> None:
+        with pytest.raises(ValueError, match="0 for no expiration or >= 86400000"):
+            SnapshotExpiration(timedelta(milliseconds=MIN_SNAPSHOT_EXPIRATION_MS - 1))
 
-        assert expiration == SnapshotExpiration(MIN_SNAPSHOT_EXPIRATION_MS)
-        assert isinstance(expiration, SnapshotExpiration)
+    @given(
+        st.one_of(
+            st.just(0),
+            st.integers(
+                min_value=MIN_SNAPSHOT_EXPIRATION_MS,
+                max_value=365 * MIN_SNAPSHOT_EXPIRATION_MS,
+            ),
+        )
+    )
+    def test_roundtrips_valid_inputs(self, milliseconds: int) -> None:
+        int_expiration = SnapshotExpiration(milliseconds)
+        timedelta_expiration = SnapshotExpiration(timedelta(milliseconds=milliseconds))
+
+        assert int_expiration == SnapshotExpiration(milliseconds)
+        assert isinstance(int_expiration, SnapshotExpiration)
+        assert timedelta_expiration == SnapshotExpiration(milliseconds)
+        assert isinstance(timedelta_expiration, SnapshotExpiration)
+
+    @given(
+        st.integers(
+            min_value=-(365 * MIN_SNAPSHOT_EXPIRATION_MS),
+            max_value=MIN_SNAPSHOT_EXPIRATION_MS - 1,
+        ).filter(lambda value: value != 0)
+    )
+    def test_rejects_invalid_inputs(self, milliseconds: int) -> None:
+        with pytest.raises(ValueError, match="0 for no expiration or >= 86400000"):
+            SnapshotExpiration(milliseconds)
+
+        with pytest.raises(ValueError, match="0 for no expiration or >= 86400000"):
+            SnapshotExpiration(timedelta(milliseconds=milliseconds))

--- a/tests/unit/test_sandbox_time.py
+++ b/tests/unit/test_sandbox_time.py
@@ -1,0 +1,38 @@
+"""Tests for sandbox time helpers."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from hypothesis import given, strategies as st
+
+from vercel._internal.sandbox.time import normalize_duration_ms
+
+MAX_DURATION_MS = timedelta.max // timedelta(milliseconds=1)
+MIN_DURATION_MS = timedelta.min // timedelta(milliseconds=1)
+
+
+@given(st.one_of(st.none(), st.integers()))
+def test_normalize_duration_ms_preserves_none_and_ints(value: int | None) -> None:
+    assert normalize_duration_ms(value) == value
+
+
+@given(st.integers(min_value=MIN_DURATION_MS, max_value=MAX_DURATION_MS))
+def test_normalize_duration_ms_matches_equivalent_milliseconds(value: int) -> None:
+    assert normalize_duration_ms(timedelta(milliseconds=value)) == normalize_duration_ms(value)
+
+
+@given(
+    st.one_of(
+        st.floats(),
+        st.text(),
+        st.binary(),
+        st.lists(st.integers()),
+        st.dictionaries(st.text(), st.integers()),
+        st.tuples(st.integers(), st.integers()),
+    )
+)
+def test_normalize_duration_ms_rejects_unsupported_values(value: object) -> None:
+    with pytest.raises(TypeError, match="duration must be an int, timedelta, or None"):
+        normalize_duration_ms(value)  # type: ignore[arg-type]


### PR DESCRIPTION
Accept `timedelta` for sandbox snapshot expiration and timeout-related APIs