### PR TITLE
sandbox: Simplify Sandbox/Snapshot pagination

### DIFF
--- a/examples/sandbox_11_snapshots.py
+++ b/examples/sandbox_11_snapshots.py
@@ -131,12 +131,14 @@ async def async_demo() -> None:
 
     paged_ids: list[list[str]] = []
     found_ids: set[str] = set()
-    async for page in pager.iter_pages():
+    page = first_page
+    while page is not None:
         page_ids = [listed.id for listed in page.snapshots]
         paged_ids.append(page_ids)
         found_ids.update(page_ids)
         if all(snapshot_id in found_ids for snapshot_id in async_snapshot_ids):
             break
+        page = await page.get_next_page()
 
     print(f"    Visited pages: {paged_ids}")
     assert all(snapshot_id in found_ids for snapshot_id in async_snapshot_ids), (
@@ -144,10 +146,12 @@ async def async_demo() -> None:
     )
 
     item_ids: list[str] = []
-    async for listed in AsyncSnapshot.list(limit=10, since=since).iter_items():
-        item_ids.append(listed.id)
+    page = await AsyncSnapshot.list(limit=10, since=since)
+    while page is not None:
+        item_ids.extend(listed.id for listed in page)
         if all(snapshot_id in item_ids for snapshot_id in async_snapshot_ids):
             break
+        page = await page.get_next_page()
 
     print(f"    Iterated snapshot IDs: {item_ids}")
     assert all(snapshot_id in item_ids for snapshot_id in async_snapshot_ids), (
@@ -252,12 +256,14 @@ def sync_demo() -> None:
 
     paged_ids: list[list[str]] = []
     found_ids: set[str] = set()
-    for page in first_page.iter_pages():
+    page = first_page
+    while page is not None:
         page_ids = [listed.id for listed in page.snapshots]
         paged_ids.append(page_ids)
         found_ids.update(page_ids)
         if all(snapshot_id in found_ids for snapshot_id in sync_snapshot_ids):
             break
+        page = page.get_next_page()
 
     print(f"    Visited pages: {paged_ids}")
     assert all(snapshot_id in found_ids for snapshot_id in sync_snapshot_ids), (
@@ -265,10 +271,12 @@ def sync_demo() -> None:
     )
 
     item_ids: list[str] = []
-    for listed in Snapshot.list(limit=10, since=since).iter_items():
-        item_ids.append(listed.id)
+    page = Snapshot.list(limit=10, since=since)
+    while page is not None:
+        item_ids.extend(listed.id for listed in page)
         if all(snapshot_id in item_ids for snapshot_id in sync_snapshot_ids):
             break
+        page = page.get_next_page()
 
     print(f"    Iterated snapshot IDs: {item_ids}")
     assert all(snapshot_id in item_ids for snapshot_id in sync_snapshot_ids), (

--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -110,7 +110,14 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     print(f"async iter_items: {iter_item_ids}")
     _summarize_created("async iter_items", iter_item_ids, created_ids)
 
-    print("\n[5] Iterate items from the pager with pager.iter_items()")
+    print("\n[5] Iterate items directly from the first page")
+    current_page_ids: list[str] = []
+    async for sandbox in first_page:
+        current_page_ids.append(sandbox.id)
+    print(f"async current page iteration: {current_page_ids}")
+    _summarize_created("async current page iteration", current_page_ids, created_ids)
+
+    print("\n[6] Iterate items from the pager with pager.iter_items()")
     pager_item_ids: list[str] = []
     async for sandbox in AsyncSandbox.list(
         project_id=PROJECT_ID,
@@ -123,7 +130,7 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     print(f"async pager.iter_items: {pager_item_ids}")
     _summarize_created("async pager.iter_items", pager_item_ids, created_ids)
 
-    print("\n[6] Iterate items directly from the pager")
+    print("\n[7] Iterate items directly from the pager")
     direct_item_ids: list[str] = []
     async for sandbox in AsyncSandbox.list(
         project_id=PROJECT_ID,

--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -3,11 +3,11 @@ Example: List sandboxes after concurrent creation.
 
 This example demonstrates how to:
 1. Create several sandboxes concurrently with ``AsyncSandbox.create()``
-2. Exercise the async pager APIs, including direct async iteration
-3. Exercise the sync page APIs
+2. Fetch sandbox pages explicitly with ``list()`` and ``get_next_page()``
+3. Iterate directly over the sandboxes owned by each page
 
 The list API returns typed pages. Use a small ``limit`` to paginate through
-the recent results and inspect only the first few pages.
+the recent results one page at a time.
 """
 
 from __future__ import annotations
@@ -26,7 +26,6 @@ SANDBOX_COUNT = 5
 PAGE_SIZE = 2
 MAX_PAGES = 3
 TIMEOUT_MS = 120_000
-MAX_ITEMS = PAGE_SIZE * MAX_PAGES
 PROJECT_ID = os.environ["VERCEL_PROJECT_ID"]
 
 
@@ -35,12 +34,7 @@ def _print_page(prefix: str, page_number: int, sandbox_ids: list[str]) -> None:
 
 
 def _print_page_state(prefix: str, page) -> None:
-    next_page_info = page.next_page_info()
-    next_until = None if next_page_info is None else next_page_info.until
-    print(
-        f"{prefix} has_next={page.has_next_page()} "
-        f"count={page.pagination.count} next_until={next_until}"
-    )
+    print(f"{prefix} count={page.pagination.count} next_until={page.pagination.next}")
 
 
 def _summarize_created(prefix: str, sandbox_ids: list[str], created_ids: set[str]) -> None:
@@ -67,81 +61,36 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
     created_ids = {sandbox.sandbox_id for sandbox in sandboxes}
     print(f"Created {len(created_ids)} sandboxes concurrently")
 
-    print("\n[1] Await the pager to get the first page")
-    pager = AsyncSandbox.list(
+    print("\n[1] Await the first page")
+    first_page = await AsyncSandbox.list(
         project_id=PROJECT_ID,
         limit=PAGE_SIZE,
         since=since,
     )
-    first_page = await pager
     _print_page_state("async first page:", first_page)
     _print_page("async", 1, [sandbox.id for sandbox in first_page.sandboxes])
 
-    print("\n[2] Fetch the next page explicitly with get_next_page()")
-    next_page = await first_page.get_next_page()
-    if next_page is None:
-        print("async next page: none")
-    else:
-        _print_page_state("async next page:", next_page)
-        _print_page("async", 2, [sandbox.id for sandbox in next_page.sandboxes])
-
-    print("\n[3] Iterate pages from the pager with iter_pages()")
-    paged_ids: list[str] = []
-    page_number = 0
-    async for page in AsyncSandbox.list(
-        project_id=PROJECT_ID,
-        limit=PAGE_SIZE,
-        since=since,
-    ).iter_pages():
-        page_number += 1
-        page_ids = [sandbox.id for sandbox in page.sandboxes]
-        _print_page("async iter_pages", page_number, page_ids)
-        paged_ids.extend(page_ids)
-        if page_number >= MAX_PAGES:
-            break
-    _summarize_created("async iter_pages", paged_ids, created_ids)
-
-    print("\n[4] Iterate items from the first page with page.iter_items()")
-    iter_item_ids: list[str] = []
-    async for sandbox in first_page.iter_items():
-        iter_item_ids.append(sandbox.id)
-        if len(iter_item_ids) >= MAX_ITEMS:
-            break
-    print(f"async iter_items: {iter_item_ids}")
-    _summarize_created("async iter_items", iter_item_ids, created_ids)
-
-    print("\n[5] Iterate items directly from the first page")
-    current_page_ids: list[str] = []
-    async for sandbox in first_page:
-        current_page_ids.append(sandbox.id)
+    print("\n[2] Iterate the sandboxes in the first page")
+    current_page_ids = [sandbox.id for sandbox in first_page]
     print(f"async current page iteration: {current_page_ids}")
     _summarize_created("async current page iteration", current_page_ids, created_ids)
 
-    print("\n[6] Iterate items from the pager with pager.iter_items()")
-    pager_item_ids: list[str] = []
-    async for sandbox in AsyncSandbox.list(
-        project_id=PROJECT_ID,
-        limit=PAGE_SIZE,
-        since=since,
-    ).iter_items():
-        pager_item_ids.append(sandbox.id)
-        if len(pager_item_ids) >= MAX_ITEMS:
+    print("\n[3] Walk forward with get_next_page()")
+    paged_ids: list[str] = []
+    page_number = 1
+    page = first_page
+    while True:
+        page_ids = [sandbox.id for sandbox in page]
+        _print_page("async paged", page_number, page_ids)
+        paged_ids.extend(page_ids)
+        if page_number >= MAX_PAGES:
             break
-    print(f"async pager.iter_items: {pager_item_ids}")
-    _summarize_created("async pager.iter_items", pager_item_ids, created_ids)
-
-    print("\n[7] Iterate items directly from the pager")
-    direct_item_ids: list[str] = []
-    async for sandbox in AsyncSandbox.list(
-        project_id=PROJECT_ID,
-        limit=PAGE_SIZE,
-        since=since,
-    ):
-        direct_item_ids.append(sandbox.id)
-        if len(direct_item_ids) >= MAX_ITEMS:
+        next_page = await page.get_next_page()
+        if next_page is None:
             break
-    print(f"async direct iteration: {direct_item_ids}")
-    _summarize_created("async direct iteration", direct_item_ids, created_ids)
+        page_number += 1
+        page = next_page
+    _summarize_created("async paged", paged_ids, created_ids)
 
     return sandboxes
 
@@ -165,39 +114,22 @@ def sync_demo(since: datetime) -> None:
     _print_page_state("sync first page:", first_page)
     _print_page("sync", 1, [sandbox.id for sandbox in first_page.sandboxes])
 
-    print("\n[2] Fetch the next page explicitly with get_next_page()")
-    next_page = first_page.get_next_page()
-    if next_page is None:
-        print("sync next page: none")
-    else:
-        _print_page_state("sync next page:", next_page)
-        _print_page("sync", 2, [sandbox.id for sandbox in next_page.sandboxes])
+    print("\n[2] Iterate the sandboxes in the first page")
+    current_page_ids = [sandbox.id for sandbox in first_page]
+    print(f"sync current page iteration: {current_page_ids}")
 
-    print("\n[3] Iterate pages with iter_pages()")
-    page_number = 0
-    for current_page in Sandbox.list(
-        project_id=PROJECT_ID,
-        limit=PAGE_SIZE,
-        since=since,
-    ).iter_pages():
-        page_number += 1
-        _print_page(
-            "sync iter_pages", page_number, [sandbox.id for sandbox in current_page.sandboxes]
-        )
+    print("\n[3] Walk forward with get_next_page()")
+    page_number = 1
+    page = first_page
+    while True:
+        _print_page("sync paged", page_number, [sandbox.id for sandbox in page])
         if page_number >= MAX_PAGES:
             break
-
-    print("\n[4] Iterate items with iter_items()")
-    iter_item_ids: list[str] = []
-    for sandbox in Sandbox.list(
-        project_id=PROJECT_ID,
-        limit=PAGE_SIZE,
-        since=since,
-    ).iter_items():
-        iter_item_ids.append(sandbox.id)
-        if len(iter_item_ids) >= MAX_ITEMS:
+        next_page = page.get_next_page()
+        if next_page is None:
             break
-    print(f"sync iter_items: {iter_item_ids}")
+        page_number += 1
+        page = next_page
 
 
 if __name__ == "__main__":

--- a/src/vercel/_internal/pagination.py
+++ b/src/vercel/_internal/pagination.py
@@ -1,78 +1,21 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator, Sequence
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
-from vercel._internal.iter_coroutine import iter_coroutine
+from vercel._internal.sandbox.models import Pagination
 
-PageT = TypeVar("PageT")
 ItemT = TypeVar("ItemT")
-PageInfoT = TypeVar("PageInfoT")
 
 
-@dataclass(frozen=True)
-class PageController(Generic[PageT, ItemT, PageInfoT]):
-    get_items: Callable[[PageT], Sequence[ItemT]]
-    get_next_page_info: Callable[[PageT], PageInfoT | None]
-    fetch_next_page: Callable[[PageInfoT], Awaitable[PageT]]
+@dataclass(slots=True)
+class Page(Generic[ItemT]):
+    items: list[ItemT]
+    pagination: Pagination
 
-    def has_next_page(self, page: PageT) -> bool:
-        return self.get_next_page_info(page) is not None
-
-    def next_page_info(self, page: PageT) -> PageInfoT | None:
-        return self.get_next_page_info(page)
-
-    async def get_next_page(self, page: PageT) -> PageT | None:
-        next_page_info = self.get_next_page_info(page)
-        if next_page_info is None:
-            return None
-        return await self.fetch_next_page(next_page_info)
-
-    def get_next_page_sync(self, page: PageT) -> PageT | None:
-        return iter_coroutine(self.get_next_page(page))
-
-    async def iter_pages(self, initial_page: PageT) -> AsyncGenerator[PageT, None]:
-        page = initial_page
-        while True:
-            yield page
-            next_page = await self.get_next_page(page)
-            if next_page is None:
-                return
-            page = next_page
-
-    async def iter_items(self, initial_page: PageT) -> AsyncGenerator[ItemT, None]:
-        async for page in self.iter_pages(initial_page):
-            for item in self.get_items(page):
-                yield item
-
-    def iter_pages_sync(self, initial_page: PageT) -> Iterator[PageT]:
-        iterator = self.iter_pages(initial_page)
-        try:
-            while True:
-                try:
-                    yield iter_coroutine(iterator.__anext__())
-                except StopAsyncIteration:
-                    return
-        finally:
-            try:
-                iter_coroutine(iterator.aclose())
-            except RuntimeError:
-                pass
-
-    def iter_items_sync(self, initial_page: PageT) -> Iterator[ItemT]:
-        iterator = self.iter_items(initial_page)
-        try:
-            while True:
-                try:
-                    yield iter_coroutine(iterator.__anext__())
-                except StopAsyncIteration:
-                    return
-        finally:
-            try:
-                iter_coroutine(iterator.aclose())
-            except RuntimeError:
-                pass
+    def __iter__(self) -> Iterator[ItemT]:
+        return iter(self.items)
 
 
-__all__ = ["PageController"]
+__all__ = ["Page"]

--- a/src/vercel/_internal/sandbox/pagination.py
+++ b/src/vercel/_internal/sandbox/pagination.py
@@ -3,13 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from vercel._internal.sandbox.models import Pagination
-
-
-@dataclass(frozen=True, slots=True)
-class SandboxPageInfo:
-    until: int
-
 
 @dataclass(frozen=True, slots=True, init=False)
 class _BaseListParams:
@@ -42,17 +35,6 @@ class SandboxListParams(_BaseListParams):
         )
 
 
-def next_sandbox_page_info(pagination: Pagination) -> SandboxPageInfo | None:
-    if pagination.next is None:
-        return None
-    return SandboxPageInfo(until=pagination.next)
-
-
-@dataclass(frozen=True, slots=True)
-class SnapshotPageInfo:
-    until: int
-
-
 @dataclass(frozen=True, slots=True, init=False)
 class SnapshotListParams(_BaseListParams):
     def with_until(self, until: int) -> SnapshotListParams:
@@ -62,12 +44,6 @@ class SnapshotListParams(_BaseListParams):
             since=self.since,
             until=until,
         )
-
-
-def next_snapshot_page_info(pagination: Pagination) -> SnapshotPageInfo | None:
-    if pagination.next is None:
-        return None
-    return SnapshotPageInfo(until=pagination.next)
 
 
 def normalize_list_timestamp(value: datetime | int | None) -> int | None:
@@ -84,10 +60,6 @@ def normalize_list_timestamp(value: datetime | int | None) -> int | None:
 
 __all__ = [
     "SandboxListParams",
-    "SandboxPageInfo",
     "SnapshotListParams",
-    "SnapshotPageInfo",
-    "next_sandbox_page_info",
-    "next_snapshot_page_info",
     "normalize_list_timestamp",
 ]

--- a/src/vercel/sandbox/page.py
+++ b/src/vercel/sandbox/page.py
@@ -1,266 +1,103 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Iterator
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import Any
 
-from vercel._internal.pagination import PageController
+from vercel._internal.iter_coroutine import iter_coroutine
+from vercel._internal.pagination import Page
 from vercel._internal.sandbox.models import (
-    Pagination,
     Sandbox as SandboxModel,
     Snapshot as SnapshotModel,
 )
-from vercel._internal.sandbox.pagination import (
-    SandboxPageInfo,
-    SnapshotPageInfo,
-    next_sandbox_page_info,
-    next_snapshot_page_info,
-)
 
 
 @dataclass(slots=True)
-class SandboxPage:
-    sandboxes: list[SandboxModel]
-    pagination: Pagination
-    _controller: PageController[SandboxPage, SandboxModel, SandboxPageInfo] = field(
-        init=False,
+class SandboxPage(Page[SandboxModel]):
+    _fetch_next_page: Callable[[int], Coroutine[None, None, SandboxPage]] | None = field(
         repr=False,
+        default=None,
     )
 
-    @classmethod
-    def create(
-        cls,
-        *,
-        sandboxes: list[SandboxModel],
-        pagination: Pagination,
-        fetch_next_page: Callable[[SandboxPageInfo], Awaitable[SandboxPage]],
-    ) -> SandboxPage:
-        page = cls(sandboxes=list(sandboxes), pagination=pagination)
-        page._controller = PageController(
-            get_items=lambda current_page: current_page.sandboxes,
-            get_next_page_info=lambda current_page: next_sandbox_page_info(current_page.pagination),
-            fetch_next_page=fetch_next_page,
-        )
-        return page
-
-    def has_next_page(self) -> bool:
-        return self._controller.has_next_page(self)
-
-    def next_page_info(self) -> SandboxPageInfo | None:
-        return self._controller.next_page_info(self)
+    @property
+    def sandboxes(self) -> list[SandboxModel]:
+        return self.items
 
     def get_next_page(self) -> SandboxPage | None:
-        return self._controller.get_next_page_sync(self)
-
-    def iter_pages(self) -> Iterator[SandboxPage]:
-        return self._controller.iter_pages_sync(self)
-
-    def iter_items(self) -> Iterator[SandboxModel]:
-        return self._controller.iter_items_sync(self)
-
-    def __iter__(self) -> Iterator[SandboxModel]:
-        return iter(self.sandboxes)
+        next_until = self.pagination.next
+        if next_until is None:
+            return None
+        fetch_next_page = self._fetch_next_page
+        if fetch_next_page is None:
+            return None
+        return iter_coroutine(fetch_next_page(next_until))
 
 
 @dataclass(slots=True)
-class AsyncSandboxPage:
-    sandboxes: list[SandboxModel]
-    pagination: Pagination
-    _controller: PageController[AsyncSandboxPage, SandboxModel, SandboxPageInfo] = field(
-        init=False,
+class AsyncSandboxPage(Page[SandboxModel]):
+    _fetch_next_page: Callable[[int], Awaitable[AsyncSandboxPage]] | None = field(
         repr=False,
+        default=None,
     )
 
-    @classmethod
-    def create(
-        cls,
-        *,
-        sandboxes: list[SandboxModel],
-        pagination: Pagination,
-        fetch_next_page: Callable[[SandboxPageInfo], Awaitable[AsyncSandboxPage]],
-    ) -> AsyncSandboxPage:
-        page = cls(sandboxes=list(sandboxes), pagination=pagination)
-        page._controller = PageController(
-            get_items=lambda current_page: current_page.sandboxes,
-            get_next_page_info=lambda current_page: next_sandbox_page_info(current_page.pagination),
-            fetch_next_page=fetch_next_page,
-        )
-        return page
-
-    def has_next_page(self) -> bool:
-        return self._controller.has_next_page(self)
-
-    def next_page_info(self) -> SandboxPageInfo | None:
-        return self._controller.next_page_info(self)
+    @property
+    def sandboxes(self) -> list[SandboxModel]:
+        return self.items
 
     async def get_next_page(self) -> AsyncSandboxPage | None:
-        return await self._controller.get_next_page(self)
-
-    def iter_pages(self) -> AsyncIterator[AsyncSandboxPage]:
-        return self._controller.iter_pages(self)
-
-    def iter_items(self) -> AsyncIterator[SandboxModel]:
-        return self._controller.iter_items(self)
-
-    async def __aiter__(self) -> AsyncIterator[SandboxModel]:
-        for sandbox in self.sandboxes:
-            yield sandbox
+        next_until = self.pagination.next
+        if next_until is None:
+            return None
+        fetch_next_page = self._fetch_next_page
+        if fetch_next_page is None:
+            return None
+        return await fetch_next_page(next_until)
 
 
 @dataclass(slots=True)
-class AsyncSandboxPager:
-    _fetch_first_page: Callable[[], Awaitable[AsyncSandboxPage]]
-    _first_page: AsyncSandboxPage | None = field(init=False, default=None, repr=False)
-
-    async def _get_first_page(self) -> AsyncSandboxPage:
-        if self._first_page is None:
-            self._first_page = await self._fetch_first_page()
-        return self._first_page
-
-    def __await__(self) -> Generator[Any, None, AsyncSandboxPage]:
-        return self._get_first_page().__await__()
-
-    def __aiter__(self) -> AsyncIterator[SandboxModel]:
-        return self.iter_items()
-
-    async def iter_pages(self) -> AsyncIterator[AsyncSandboxPage]:
-        first_page = await self._get_first_page()
-        async for page in first_page.iter_pages():
-            yield page
-
-    async def iter_items(self) -> AsyncIterator[SandboxModel]:
-        first_page = await self._get_first_page()
-        async for item in first_page.iter_items():
-            yield item
-
-
-@dataclass(slots=True)
-class SnapshotPage:
-    snapshots: list[SnapshotModel]
-    pagination: Pagination
-    _controller: PageController[SnapshotPage, SnapshotModel, SnapshotPageInfo] = field(
-        init=False,
+class SnapshotPage(Page[SnapshotModel]):
+    _fetch_next_page: Callable[[int], Coroutine[None, None, SnapshotPage]] | None = field(
         repr=False,
+        default=None,
     )
 
-    @classmethod
-    def create(
-        cls,
-        *,
-        snapshots: list[SnapshotModel],
-        pagination: Pagination,
-        fetch_next_page: Callable[[SnapshotPageInfo], Awaitable[SnapshotPage]],
-    ) -> SnapshotPage:
-        page = cls(snapshots=list(snapshots), pagination=pagination)
-        page._controller = PageController(
-            get_items=lambda current_page: current_page.snapshots,
-            get_next_page_info=lambda current_page: next_snapshot_page_info(
-                current_page.pagination
-            ),
-            fetch_next_page=fetch_next_page,
-        )
-        return page
-
-    def has_next_page(self) -> bool:
-        return self._controller.has_next_page(self)
-
-    def next_page_info(self) -> SnapshotPageInfo | None:
-        return self._controller.next_page_info(self)
+    @property
+    def snapshots(self) -> list[SnapshotModel]:
+        return self.items
 
     def get_next_page(self) -> SnapshotPage | None:
-        return self._controller.get_next_page_sync(self)
-
-    def iter_pages(self) -> Iterator[SnapshotPage]:
-        return self._controller.iter_pages_sync(self)
-
-    def iter_items(self) -> Iterator[SnapshotModel]:
-        return self._controller.iter_items_sync(self)
-
-    def __iter__(self) -> Iterator[SnapshotModel]:
-        return iter(self.snapshots)
+        next_until = self.pagination.next
+        if next_until is None:
+            return None
+        fetch_next_page = self._fetch_next_page
+        if fetch_next_page is None:
+            return None
+        return iter_coroutine(fetch_next_page(next_until))
 
 
 @dataclass(slots=True)
-class AsyncSnapshotPage:
-    snapshots: list[SnapshotModel]
-    pagination: Pagination
-    _controller: PageController[AsyncSnapshotPage, SnapshotModel, SnapshotPageInfo] = field(
-        init=False,
+class AsyncSnapshotPage(Page[SnapshotModel]):
+    _fetch_next_page: Callable[[int], Awaitable[AsyncSnapshotPage]] | None = field(
         repr=False,
+        default=None,
     )
 
-    @classmethod
-    def create(
-        cls,
-        *,
-        snapshots: list[SnapshotModel],
-        pagination: Pagination,
-        fetch_next_page: Callable[[SnapshotPageInfo], Awaitable[AsyncSnapshotPage]],
-    ) -> AsyncSnapshotPage:
-        page = cls(snapshots=list(snapshots), pagination=pagination)
-        page._controller = PageController(
-            get_items=lambda current_page: current_page.snapshots,
-            get_next_page_info=lambda current_page: next_snapshot_page_info(
-                current_page.pagination
-            ),
-            fetch_next_page=fetch_next_page,
-        )
-        return page
-
-    def has_next_page(self) -> bool:
-        return self._controller.has_next_page(self)
-
-    def next_page_info(self) -> SnapshotPageInfo | None:
-        return self._controller.next_page_info(self)
+    @property
+    def snapshots(self) -> list[SnapshotModel]:
+        return self.items
 
     async def get_next_page(self) -> AsyncSnapshotPage | None:
-        return await self._controller.get_next_page(self)
-
-    def iter_pages(self) -> AsyncIterator[AsyncSnapshotPage]:
-        return self._controller.iter_pages(self)
-
-    def iter_items(self) -> AsyncIterator[SnapshotModel]:
-        return self._controller.iter_items(self)
-
-    async def __aiter__(self) -> AsyncIterator[SnapshotModel]:
-        for snapshot in self.snapshots:
-            yield snapshot
-
-
-@dataclass(slots=True)
-class AsyncSnapshotPager:
-    _fetch_first_page: Callable[[], Awaitable[AsyncSnapshotPage]]
-    _first_page: AsyncSnapshotPage | None = field(init=False, default=None, repr=False)
-
-    async def _get_first_page(self) -> AsyncSnapshotPage:
-        if self._first_page is None:
-            self._first_page = await self._fetch_first_page()
-        return self._first_page
-
-    def __await__(self) -> Generator[Any, None, AsyncSnapshotPage]:
-        return self._get_first_page().__await__()
-
-    def __aiter__(self) -> AsyncIterator[SnapshotModel]:
-        return self.iter_items()
-
-    async def iter_pages(self) -> AsyncIterator[AsyncSnapshotPage]:
-        first_page = await self._get_first_page()
-        async for page in first_page.iter_pages():
-            yield page
-
-    async def iter_items(self) -> AsyncIterator[SnapshotModel]:
-        first_page = await self._get_first_page()
-        async for item in first_page.iter_items():
-            yield item
+        next_until = self.pagination.next
+        if next_until is None:
+            return None
+        fetch_next_page = self._fetch_next_page
+        if fetch_next_page is None:
+            return None
+        return await fetch_next_page(next_until)
 
 
 __all__ = [
-    "AsyncSnapshotPager",
     "AsyncSnapshotPage",
-    "AsyncSandboxPager",
     "AsyncSandboxPage",
     "SandboxPage",
     "SnapshotPage",
-    "SandboxPageInfo",
-    "SnapshotPageInfo",
 ]

--- a/src/vercel/sandbox/page.py
+++ b/src/vercel/sandbox/page.py
@@ -58,6 +58,9 @@ class SandboxPage:
     def iter_items(self) -> Iterator[SandboxModel]:
         return self._controller.iter_items_sync(self)
 
+    def __iter__(self) -> Iterator[SandboxModel]:
+        return iter(self.sandboxes)
+
 
 @dataclass(slots=True)
 class AsyncSandboxPage:
@@ -98,6 +101,10 @@ class AsyncSandboxPage:
 
     def iter_items(self) -> AsyncIterator[SandboxModel]:
         return self._controller.iter_items(self)
+
+    async def __aiter__(self) -> AsyncIterator[SandboxModel]:
+        for sandbox in self.sandboxes:
+            yield sandbox
 
 
 @dataclass(slots=True)
@@ -169,6 +176,9 @@ class SnapshotPage:
     def iter_items(self) -> Iterator[SnapshotModel]:
         return self._controller.iter_items_sync(self)
 
+    def __iter__(self) -> Iterator[SnapshotModel]:
+        return iter(self.snapshots)
+
 
 @dataclass(slots=True)
 class AsyncSnapshotPage:
@@ -211,6 +221,10 @@ class AsyncSnapshotPage:
 
     def iter_items(self) -> AsyncIterator[SnapshotModel]:
         return self._controller.iter_items(self)
+
+    async def __aiter__(self) -> AsyncIterator[SnapshotModel]:
+        for snapshot in self.snapshots:
+            yield snapshot
 
 
 @dataclass(slots=True)

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -31,7 +31,7 @@ from .command import (
     Command,
     CommandFinished,
 )
-from .page import AsyncSandboxPage, AsyncSandboxPager, SandboxPage
+from .page import AsyncSandboxPage, SandboxPage
 from .pty.shell import start_interactive_shell
 from .snapshot import (
     AsyncSnapshot,
@@ -70,16 +70,16 @@ async def _build_async_sandbox_page(
     finally:
         await client.aclose()
 
-    async def fetch_next_page(page_info) -> AsyncSandboxPage:
+    async def fetch_next_page(next_until: int) -> AsyncSandboxPage:
         return await _build_async_sandbox_page(
             creds=creds,
-            params=params.with_until(page_info.until),
+            params=params.with_until(next_until),
         )
 
-    return AsyncSandboxPage.create(
-        sandboxes=response.sandboxes,
+    return AsyncSandboxPage(
+        items=list(response.sandboxes),
         pagination=response.pagination,
-        fetch_next_page=fetch_next_page,
+        _fetch_next_page=fetch_next_page,
     )
 
 
@@ -99,16 +99,16 @@ async def _build_sync_sandbox_page(
     finally:
         client.close()
 
-    async def fetch_next_page(page_info) -> SandboxPage:
+    async def fetch_next_page(next_until: int) -> SandboxPage:
         return await _build_sync_sandbox_page(
             creds=creds,
-            params=params.with_until(page_info.until),
+            params=params.with_until(next_until),
         )
 
-    return SandboxPage.create(
-        sandboxes=response.sandboxes,
+    return SandboxPage(
+        items=list(response.sandboxes),
         pagination=response.pagination,
-        fetch_next_page=fetch_next_page,
+        _fetch_next_page=fetch_next_page,
     )
 
 
@@ -221,7 +221,7 @@ class AsyncSandbox:
         )
 
     @staticmethod
-    def list(
+    async def list(
         *,
         limit: int | None = None,
         since: datetime | int | None = None,
@@ -229,7 +229,7 @@ class AsyncSandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
-    ) -> AsyncSandboxPager:
+    ) -> AsyncSandboxPage:
         """List sandboxes and return the first page.
 
         Args:
@@ -244,9 +244,9 @@ class AsyncSandbox:
             team_id: Team ID scope for the sandbox API.
 
         Returns:
-            An awaitable pager whose first awaited value is the first page of
-            typed sandbox results. Continue pagination with ``iter_pages()``
-            or ``iter_items()`` on the page or pager.
+            The first page of typed sandbox results. Iterate the returned page
+            directly for its sandboxes. Call ``get_next_page()`` to fetch the
+            next page when ``page.pagination.next`` is present.
         """
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         params = SandboxListParams(
@@ -255,9 +255,7 @@ class AsyncSandbox:
             since=since,
             until=until,
         )
-        return AsyncSandboxPager(
-            _fetch_first_page=lambda: _build_async_sandbox_page(creds=creds, params=params)
-        )
+        return await _build_async_sandbox_page(creds=creds, params=params)
 
     async def refresh(self) -> None:
         """Re-fetch this sandbox's state from the API, updating in place."""
@@ -640,8 +638,9 @@ class Sandbox:
             team_id: Team ID scope for the sandbox API.
 
         Returns:
-            The first page of typed sandbox results. Continue pagination with
-            ``iter_pages()`` or ``iter_items()`` on the returned page.
+            The first page of typed sandbox results. Iterate the returned page
+            directly for its sandboxes. Call ``get_next_page()`` to fetch the
+            next page when ``page.pagination.next`` is present.
         """
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         params = SandboxListParams(

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -10,7 +10,7 @@ from vercel._internal.sandbox.models import Snapshot as SnapshotModel
 from vercel._internal.sandbox.pagination import SnapshotListParams
 
 from ..oidc import Credentials, get_credentials
-from .page import AsyncSnapshotPage, AsyncSnapshotPager, SnapshotPage
+from .page import AsyncSnapshotPage, SnapshotPage
 
 MIN_SNAPSHOT_EXPIRATION_MS: Final[int] = 86_400_000
 
@@ -57,16 +57,16 @@ async def _build_async_snapshot_page(
     finally:
         await client.aclose()
 
-    async def fetch_next_page(page_info) -> AsyncSnapshotPage:
+    async def fetch_next_page(next_until: int) -> AsyncSnapshotPage:
         return await _build_async_snapshot_page(
             creds=creds,
-            params=params.with_until(page_info.until),
+            params=params.with_until(next_until),
         )
 
-    return AsyncSnapshotPage.create(
-        snapshots=response.snapshots,
+    return AsyncSnapshotPage(
+        items=list(response.snapshots),
         pagination=response.pagination,
-        fetch_next_page=fetch_next_page,
+        _fetch_next_page=fetch_next_page,
     )
 
 
@@ -86,16 +86,16 @@ async def _build_sync_snapshot_page(
     finally:
         client.close()
 
-    async def fetch_next_page(page_info) -> SnapshotPage:
+    async def fetch_next_page(next_until: int) -> SnapshotPage:
         return await _build_sync_snapshot_page(
             creds=creds,
-            params=params.with_until(page_info.until),
+            params=params.with_until(next_until),
         )
 
-    return SnapshotPage.create(
-        snapshots=response.snapshots,
+    return SnapshotPage(
+        items=list(response.snapshots),
         pagination=response.pagination,
-        fetch_next_page=fetch_next_page,
+        _fetch_next_page=fetch_next_page,
     )
 
 
@@ -151,7 +151,7 @@ class AsyncSnapshot:
         return AsyncSnapshot(client=client, snapshot=resp.snapshot)
 
     @staticmethod
-    def list(
+    async def list(
         *,
         limit: int | None = None,
         since: datetime | int | None = None,
@@ -159,7 +159,7 @@ class AsyncSnapshot:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
-    ) -> AsyncSnapshotPager:
+    ) -> AsyncSnapshotPage:
         """List snapshots and return the first page."""
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
         params = SnapshotListParams(
@@ -168,9 +168,7 @@ class AsyncSnapshot:
             since=since,
             until=until,
         )
-        return AsyncSnapshotPager(
-            _fetch_first_page=lambda: _build_async_snapshot_page(creds=creds, params=params)
-        )
+        return await _build_async_snapshot_page(creds=creds, params=params)
 
     async def delete(self) -> None:
         """Delete this snapshot."""

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -56,14 +56,6 @@ def _snapshot_with_id(
     return snapshot
 
 
-async def _collect_async_pages(page) -> list:
-    return [current_page async for current_page in page.iter_pages()]
-
-
-async def _collect_async_items(page) -> list:
-    return [sandbox async for sandbox in page.iter_items()]
-
-
 class TestSandboxCreate:
     """Test sandbox creation operations."""
 
@@ -592,14 +584,12 @@ class TestSandboxList:
         assert page.sandboxes[0].created_at == 1705311000000
         assert page.sandboxes[0].requested_at == 1705311000000
         assert page.pagination.count == 3
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == int(next_until)
+        assert page.pagination.next == int(next_until)
+        assert [sandbox.id for sandbox in page] == ["sbx_filtered_1", "sbx_filtered_2"]
 
-        assert [sandbox.id for sandbox in page.iter_items()] == [
-            "sbx_filtered_1",
-            "sbx_filtered_2",
-            "sbx_filtered_3",
-        ]
+        next_page = page.get_next_page()
+        assert next_page is not None
+        assert [sandbox.id for sandbox in next_page] == ["sbx_filtered_3"]
         assert requests == [
             {
                 "teamId": "team_test123",
@@ -698,15 +688,12 @@ class TestSandboxList:
         assert page.sandboxes[0].created_at == 1705313400000
         assert page.sandboxes[0].requested_at == 1705313400000
         assert page.pagination.count == 3
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == int(next_until)
+        assert page.pagination.next == int(next_until)
+        assert [sandbox.id for sandbox in page] == ["sbx_async_filtered_1", "sbx_async_filtered_2"]
 
-        items = await _collect_async_items(page)
-        assert [sandbox.id for sandbox in items] == [
-            "sbx_async_filtered_1",
-            "sbx_async_filtered_2",
-            "sbx_async_filtered_3",
-        ]
+        next_page = await page.get_next_page()
+        assert next_page is not None
+        assert [sandbox.id for sandbox in next_page] == ["sbx_async_filtered_3"]
         assert requests == [
             {
                 "teamId": "team_test123",
@@ -725,7 +712,7 @@ class TestSandboxList:
         ]
 
     @respx.mock
-    def test_list_sandbox_sync_iterates_pages_and_items(
+    def test_list_sandbox_sync_iterates_current_page_and_fetches_next_page(
         self, mock_env_clear, mock_sandbox_get_response
     ):
         from vercel.sandbox import Sandbox
@@ -784,39 +771,21 @@ class TestSandboxList:
         assert [sandbox.id for sandbox in page.sandboxes] == ["sbx_page_1", "sbx_page_2"]
         assert page.pagination.count == 3
         assert page.pagination.next == 1705319400000
-        assert page.has_next_page() is True
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == 1705319400000
-
-        pages = list(page.iter_pages())
-        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
-            ["sbx_page_1", "sbx_page_2"],
-            ["sbx_page_3"],
-        ]
-        assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123"},
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
-        ]
+        assert [sandbox.id for sandbox in page] == ["sbx_page_1", "sbx_page_2"]
+        assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
         requests.clear()
-        items_page = Sandbox.list(
-            token="test_token",
-            team_id="team_test123",
-            project_id="prj_test123",
-        )
-        assert [sandbox.id for sandbox in items_page.iter_items()] == [
-            "sbx_page_1",
-            "sbx_page_2",
-            "sbx_page_3",
-        ]
+        next_page = page.get_next_page()
+        assert next_page is not None
+        assert [sandbox.id for sandbox in next_page] == ["sbx_page_3"]
+        assert next_page.pagination.next is None
         assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123"},
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
+            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"}
         ]
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_list_sandbox_async_iterates_pages_and_items(
+    async def test_list_sandbox_async_iterates_current_page_and_fetches_next_page(
         self, mock_env_clear, mock_sandbox_get_response
     ):
         from vercel.sandbox import AsyncSandbox
@@ -875,126 +844,16 @@ class TestSandboxList:
         assert [sandbox.id for sandbox in page.sandboxes] == ["sbx_async_1", "sbx_async_2"]
         assert page.pagination.count == 3
         assert page.pagination.next == 1705319400000
-        assert page.has_next_page() is True
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == 1705319400000
+        assert [sandbox.id for sandbox in page] == ["sbx_async_1", "sbx_async_2"]
         assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
         requests.clear()
         next_page = await page.get_next_page()
         assert next_page is not None
-        assert [sandbox.id for sandbox in next_page.sandboxes] == ["sbx_async_3"]
+        assert [sandbox.id for sandbox in next_page] == ["sbx_async_3"]
+        assert next_page.pagination.next is None
         assert requests == [
             {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"}
-        ]
-
-        requests.clear()
-        pages = await _collect_async_pages(page)
-        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
-            ["sbx_async_1", "sbx_async_2"],
-            ["sbx_async_3"],
-        ]
-        assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"}
-        ]
-
-        requests.clear()
-        items_page = await AsyncSandbox.list(
-            token="test_token",
-            team_id="team_test123",
-            project_id="prj_test123",
-        )
-        items = await _collect_async_items(items_page)
-        assert [sandbox.id for sandbox in items] == [
-            "sbx_async_1",
-            "sbx_async_2",
-            "sbx_async_3",
-        ]
-        assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123"},
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
-        ]
-
-    @respx.mock
-    @pytest.mark.asyncio
-    async def test_list_sandbox_async_builder_supports_direct_iteration(
-        self, mock_env_clear, mock_sandbox_get_response
-    ):
-        from vercel.sandbox import AsyncSandbox
-
-        first_page = {
-            "sandboxes": [
-                _sandbox_with_id(
-                    mock_sandbox_get_response,
-                    "sbx_builder_1",
-                    created_at=1705320600000,
-                ),
-                _sandbox_with_id(
-                    mock_sandbox_get_response,
-                    "sbx_builder_2",
-                    created_at=1705320000000,
-                ),
-            ],
-            "pagination": {
-                "count": 3,
-                "next": 1705319400000,
-                "prev": None,
-            },
-        }
-        second_page = {
-            "sandboxes": [
-                _sandbox_with_id(
-                    mock_sandbox_get_response,
-                    "sbx_builder_3",
-                    created_at=1705319400000,
-                ),
-            ],
-            "pagination": {
-                "count": 3,
-                "next": None,
-                "prev": 1705320600000,
-            },
-        }
-        requests: list[dict[str, str]] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            params = dict(request.url.params)
-            requests.append(params)
-            if params.get("until") == "1705319400000":
-                return httpx.Response(200, json=second_page)
-            return httpx.Response(200, json=first_page)
-
-        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(side_effect=handler)
-
-        item_ids = [
-            sandbox.id
-            async for sandbox in AsyncSandbox.list(
-                token="test_token",
-                team_id="team_test123",
-                project_id="prj_test123",
-            )
-        ]
-        assert item_ids == ["sbx_builder_1", "sbx_builder_2", "sbx_builder_3"]
-        assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123"},
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
-        ]
-
-        requests.clear()
-        pages = await _collect_async_pages(
-            AsyncSandbox.list(
-                token="test_token",
-                team_id="team_test123",
-                project_id="prj_test123",
-            )
-        )
-        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
-            ["sbx_builder_1", "sbx_builder_2"],
-            ["sbx_builder_3"],
-        ]
-        assert requests == [
-            {"teamId": "team_test123", "project": "prj_test123"},
-            {"teamId": "team_test123", "project": "prj_test123", "until": "1705319400000"},
         ]
 
     @respx.mock
@@ -1031,15 +890,9 @@ class TestSandboxList:
             project_id="prj_test123",
         )
 
-        assert page.has_next_page() is False
-        assert page.next_page_info() is None
+        assert page.pagination.next is None
         assert page.get_next_page() is None
-        assert [
-            [sandbox.id for sandbox in current_page.sandboxes] for current_page in page.iter_pages()
-        ] == [
-            ["sbx_single_page"],
-        ]
-        assert [sandbox.id for sandbox in page.iter_items()] == ["sbx_single_page"]
+        assert [sandbox.id for sandbox in page] == ["sbx_single_page"]
         assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
     @respx.mock
@@ -1077,15 +930,9 @@ class TestSandboxList:
             project_id="prj_test123",
         )
 
-        assert page.has_next_page() is False
-        assert page.next_page_info() is None
+        assert page.pagination.next is None
         assert await page.get_next_page() is None
-        pages = await _collect_async_pages(page)
-        assert [[sandbox.id for sandbox in current_page.sandboxes] for current_page in pages] == [
-            ["sbx_async_terminal"],
-        ]
-        items = await _collect_async_items(page)
-        assert [sandbox.id for sandbox in items] == ["sbx_async_terminal"]
+        assert [sandbox.id for sandbox in page] == ["sbx_async_terminal"]
         assert requests == [{"teamId": "team_test123", "project": "prj_test123"}]
 
 
@@ -1183,8 +1030,11 @@ class TestSnapshotList:
             ),
         ]
         assert page.pagination.count == 3
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == int(next_until)
+        assert page.pagination.next == int(next_until)
+
+        next_page = page.get_next_page()
+        assert next_page is not None
+        assert [snapshot.id for snapshot in next_page] == ["snap_list_3"]
 
     @respx.mock
     @pytest.mark.asyncio
@@ -1276,8 +1126,11 @@ class TestSnapshotList:
             ),
         ]
         assert page.pagination.count == 3
-        assert page.next_page_info() is not None
-        assert page.next_page_info().until == int(next_until)
+        assert page.pagination.next == int(next_until)
+
+        next_page = await page.get_next_page()
+        assert next_page is not None
+        assert [snapshot.id for snapshot in next_page] == ["snap_async_3"]
 
     @respx.mock
     def test_get_sandbox_sync_exposes_mode_network_policy(

--- a/tests/live/test_sandbox_live.py
+++ b/tests/live/test_sandbox_live.py
@@ -250,7 +250,13 @@ class TestSandboxLive:
                     limit=20,
                     since=since,
                 )
-                found_ids = [item.id for item in page.iter_items()]
+                found_ids = []
+                current_page = page
+                while current_page is not None:
+                    found_ids.extend(item.id for item in current_page)
+                    if sandbox.sandbox_id in found_ids:
+                        break
+                    current_page = current_page.get_next_page()
                 if sandbox.sandbox_id in found_ids:
                     break
                 time.sleep(1)

--- a/tests/unit/test_sandbox_page.py
+++ b/tests/unit/test_sandbox_page.py
@@ -23,123 +23,83 @@ def _snapshot_model(snapshot_id: str, *, created_at: int) -> SnapshotModel:
     )
 
 
-async def _collect_async_pages(page: AsyncSnapshotPage) -> list[AsyncSnapshotPage]:
-    return [current_page async for current_page in page.iter_pages()]
-
-
-async def _collect_async_items(page: AsyncSnapshotPage) -> list:
-    return [snapshot async for snapshot in page.iter_items()]
-
-
-async def _collect_async_current_page_items(page: AsyncSnapshotPage) -> list:
-    return [snapshot async for snapshot in page]
-
-
 class TestSnapshotPage:
-    def test_iterates_pages_and_items(self) -> None:
-        second_page = SnapshotPage.create(
-            snapshots=[_snapshot_model("snap_2", created_at=1705320000000)],
+    def test_iterates_current_page_and_fetches_next_page(self) -> None:
+        second_page = SnapshotPage(
+            items=[_snapshot_model("snap_2", created_at=1705320000000)],
             pagination=Pagination(count=2, next=None, prev=1705320600000),
-            fetch_next_page=self._fetch_unreachable_page,
+            _fetch_next_page=self._fetch_unreachable_page,
         )
 
-        async def fetch_next_page(_page_info):
+        async def fetch_next_page(_next_until: int) -> SnapshotPage:
             return second_page
 
-        first_page = SnapshotPage.create(
-            snapshots=[_snapshot_model("snap_1", created_at=1705320600000)],
+        first_page = SnapshotPage(
+            items=[_snapshot_model("snap_1", created_at=1705320600000)],
             pagination=Pagination(count=2, next=1705320000000, prev=None),
-            fetch_next_page=fetch_next_page,
+            _fetch_next_page=fetch_next_page,
         )
 
-        assert first_page.has_next_page() is True
-        next_page_info = first_page.next_page_info()
-        assert next_page_info is not None
-        assert next_page_info.until == 1705320000000
-        assert [
-            [snapshot.id for snapshot in page.snapshots] for page in first_page.iter_pages()
-        ] == [
-            ["snap_1"],
-            ["snap_2"],
-        ]
+        assert first_page.pagination.next == 1705320000000
         assert [snapshot.id for snapshot in first_page] == ["snap_1"]
-        assert [snapshot.id for snapshot in first_page.iter_items()] == ["snap_1", "snap_2"]
+
+        next_page = first_page.get_next_page()
+        assert next_page is second_page
+        assert [snapshot.id for snapshot in next_page] == ["snap_2"]
 
     def test_terminal_page_does_not_fetch_more(self) -> None:
-        page = SnapshotPage.create(
-            snapshots=[_snapshot_model("snap_terminal", created_at=1705320600000)],
+        page = SnapshotPage(
+            items=[_snapshot_model("snap_terminal", created_at=1705320600000)],
             pagination=Pagination(count=1, next=None, prev=None),
-            fetch_next_page=self._fetch_unreachable_page,
+            _fetch_next_page=self._fetch_unreachable_page,
         )
 
-        assert page.has_next_page() is False
-        assert page.next_page_info() is None
+        assert page.pagination.next is None
         assert page.get_next_page() is None
-        assert [
-            [snapshot.id for snapshot in current.snapshots] for current in page.iter_pages()
-        ] == [
-            ["snap_terminal"],
-        ]
         assert [snapshot.id for snapshot in page] == ["snap_terminal"]
-        assert [snapshot.id for snapshot in page.iter_items()] == ["snap_terminal"]
 
     @staticmethod
-    async def _fetch_unreachable_page(_page_info) -> SnapshotPage:
+    async def _fetch_unreachable_page(_next_until: int) -> SnapshotPage:
         raise AssertionError("fetch_next_page should not be called")
 
 
 class TestAsyncSnapshotPage:
     @pytest.mark.asyncio
-    async def test_iterates_pages_and_items(self) -> None:
-        second_page = AsyncSnapshotPage.create(
-            snapshots=[_snapshot_model("snap_async_2", created_at=1705320000000)],
+    async def test_iterates_current_page_and_fetches_next_page(self) -> None:
+        second_page = AsyncSnapshotPage(
+            items=[_snapshot_model("snap_async_2", created_at=1705320000000)],
             pagination=Pagination(count=2, next=None, prev=1705320600000),
-            fetch_next_page=self._fetch_unreachable_page,
+            _fetch_next_page=self._fetch_unreachable_page,
         )
 
-        async def fetch_next_page(_page_info):
+        async def fetch_next_page(_next_until: int) -> AsyncSnapshotPage:
             return second_page
 
-        first_page = AsyncSnapshotPage.create(
-            snapshots=[_snapshot_model("snap_async_1", created_at=1705320600000)],
+        first_page = AsyncSnapshotPage(
+            items=[_snapshot_model("snap_async_1", created_at=1705320600000)],
             pagination=Pagination(count=2, next=1705320000000, prev=None),
-            fetch_next_page=fetch_next_page,
+            _fetch_next_page=fetch_next_page,
         )
 
-        assert first_page.has_next_page() is True
-        next_page_info = first_page.next_page_info()
-        assert next_page_info is not None
-        assert next_page_info.until == 1705320000000
-        pages = await _collect_async_pages(first_page)
-        assert [[snapshot.id for snapshot in page.snapshots] for page in pages] == [
-            ["snap_async_1"],
-            ["snap_async_2"],
-        ]
-        current_page_items = await _collect_async_current_page_items(first_page)
-        assert [snapshot.id for snapshot in current_page_items] == ["snap_async_1"]
-        items = await _collect_async_items(first_page)
-        assert [snapshot.id for snapshot in items] == ["snap_async_1", "snap_async_2"]
+        assert first_page.pagination.next == 1705320000000
+        assert [snapshot.id for snapshot in first_page] == ["snap_async_1"]
+
+        next_page = await first_page.get_next_page()
+        assert next_page is second_page
+        assert [snapshot.id for snapshot in next_page] == ["snap_async_2"]
 
     @pytest.mark.asyncio
     async def test_terminal_page_does_not_fetch_more(self) -> None:
-        page = AsyncSnapshotPage.create(
-            snapshots=[_snapshot_model("snap_async_terminal", created_at=1705320600000)],
+        page = AsyncSnapshotPage(
+            items=[_snapshot_model("snap_async_terminal", created_at=1705320600000)],
             pagination=Pagination(count=1, next=None, prev=None),
-            fetch_next_page=self._fetch_unreachable_page,
+            _fetch_next_page=self._fetch_unreachable_page,
         )
 
-        assert page.has_next_page() is False
-        assert page.next_page_info() is None
+        assert page.pagination.next is None
         assert await page.get_next_page() is None
-        pages = await _collect_async_pages(page)
-        assert [[snapshot.id for snapshot in current.snapshots] for current in pages] == [
-            ["snap_async_terminal"],
-        ]
-        current_page_items = await _collect_async_current_page_items(page)
-        assert [snapshot.id for snapshot in current_page_items] == ["snap_async_terminal"]
-        items = await _collect_async_items(page)
-        assert [snapshot.id for snapshot in items] == ["snap_async_terminal"]
+        assert [snapshot.id for snapshot in page] == ["snap_async_terminal"]
 
     @staticmethod
-    async def _fetch_unreachable_page(_page_info) -> AsyncSnapshotPage:
+    async def _fetch_unreachable_page(_next_until: int) -> AsyncSnapshotPage:
         raise AssertionError("fetch_next_page should not be called")

--- a/tests/unit/test_sandbox_page.py
+++ b/tests/unit/test_sandbox_page.py
@@ -31,6 +31,10 @@ async def _collect_async_items(page: AsyncSnapshotPage) -> list:
     return [snapshot async for snapshot in page.iter_items()]
 
 
+async def _collect_async_current_page_items(page: AsyncSnapshotPage) -> list:
+    return [snapshot async for snapshot in page]
+
+
 class TestSnapshotPage:
     def test_iterates_pages_and_items(self) -> None:
         second_page = SnapshotPage.create(
@@ -58,6 +62,7 @@ class TestSnapshotPage:
             ["snap_1"],
             ["snap_2"],
         ]
+        assert [snapshot.id for snapshot in first_page] == ["snap_1"]
         assert [snapshot.id for snapshot in first_page.iter_items()] == ["snap_1", "snap_2"]
 
     def test_terminal_page_does_not_fetch_more(self) -> None:
@@ -75,6 +80,7 @@ class TestSnapshotPage:
         ] == [
             ["snap_terminal"],
         ]
+        assert [snapshot.id for snapshot in page] == ["snap_terminal"]
         assert [snapshot.id for snapshot in page.iter_items()] == ["snap_terminal"]
 
     @staticmethod
@@ -109,6 +115,8 @@ class TestAsyncSnapshotPage:
             ["snap_async_1"],
             ["snap_async_2"],
         ]
+        current_page_items = await _collect_async_current_page_items(first_page)
+        assert [snapshot.id for snapshot in current_page_items] == ["snap_async_1"]
         items = await _collect_async_items(first_page)
         assert [snapshot.id for snapshot in items] == ["snap_async_1", "snap_async_2"]
 
@@ -127,6 +135,8 @@ class TestAsyncSnapshotPage:
         assert [[snapshot.id for snapshot in current.snapshots] for current in pages] == [
             ["snap_async_terminal"],
         ]
+        current_page_items = await _collect_async_current_page_items(page)
+        assert [snapshot.id for snapshot in current_page_items] == ["snap_async_terminal"]
         items = await _collect_async_items(page)
         assert [snapshot.id for snapshot in items] == ["snap_async_terminal"]
 


### PR DESCRIPTION
Add direct iteration support to sandbox and snapshot page objects. This iterates only the items already loaded on that page. Leave iter_items() behavior unchanged for now so cross-page iteration still uses the existing explicit API.