### PR TITLE
release: `vercel` v0.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vercel"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python SDK for Vercel"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release notes
- Add MIT license file ([#77](https://github.com/vercel/vercel-py/pull/77))
- Update `Sandbox.status` to use a `StrEnum` ([#80](https://github.com/vercel/vercel-py/pull/80))
- Accept `timedelta` for time-based sandbox properties ([#78](https://github.com/vercel/vercel-py/pull/78))
- Add typed sandbox create payloads ([#81](https://github.com/vercel/vercel-py/pull/81))
- Make sandbox lists item-first ([#83](https://github.com/vercel/vercel-py/pull/83))