### PR TITLE
Add sandbox request config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ pip install vercel
 
 This package provides both synchronous and asynchronous clients to interact with the Vercel API.
 
+### Sandbox Request Configuration
+
+`Sandbox.create()`, `Sandbox.get()`, `Sandbox.list()`, `AsyncSandbox.create()`,
+`AsyncSandbox.get()`, and `AsyncSandbox.list()` accept
+`request_config=SandboxRequestConfig(...)` for transport-level defaults such as
+HTTP timeout and retry policy.
+
+```python
+from vercel.sandbox import RetryPolicy, Sandbox, SandboxRequestConfig
+
+request_config = SandboxRequestConfig(
+    timeout=30.0,
+    retry=RetryPolicy(retries=2),
+)
+
+sandbox = Sandbox.get(
+    sandbox_id="sbx_123",
+    request_config=request_config,
+)
+
+result = sandbox.run_command("python", ["-V"])
+```
+
+Use workflow-level controls such as `wait_for_status(timeout=...)` and
+`stop(blocking=True, timeout=...)` separately. They do not override the
+default HTTP timeout in `SandboxRequestConfig`.
+
 <br/>
 
 ---

--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -8,6 +8,10 @@ This example demonstrates how to:
 
 The list API is item-first. Use ``limit`` as the maximum number of sandboxes
 you want the iterator to yield across all internally fetched pages.
+
+This example also shows ``request_config=SandboxRequestConfig(...)`` for
+transport-level request defaults. Workflow-level controls such as
+``wait_for_status(timeout=...)`` stay separate.
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ from datetime import UTC, datetime, timedelta
 
 from dotenv import load_dotenv
 
-from vercel.sandbox import AsyncSandbox, Sandbox
+from vercel.sandbox import AsyncSandbox, RetryPolicy, Sandbox, SandboxRequestConfig
 
 load_dotenv()
 
@@ -26,6 +30,10 @@ SANDBOX_COUNT = 5
 LIST_LIMIT = 4
 TIMEOUT_MS = 120_000
 PROJECT_ID = os.environ["VERCEL_PROJECT_ID"]
+REQUEST_CONFIG = SandboxRequestConfig(
+    timeout=30.0,
+    retry=RetryPolicy(retries=2),
+)
 
 
 def _summarize_created(prefix: str, sandbox_ids: list[str], created_ids: set[str]) -> None:
@@ -58,6 +66,7 @@ async def async_demo(since: datetime) -> list[AsyncSandbox]:
         project_id=PROJECT_ID,
         limit=LIST_LIMIT,
         since=since,
+        request_config=REQUEST_CONFIG,
     ):
         async_ids.append(sandbox.id)
         print(f"async sandbox: {sandbox.id}")
@@ -83,6 +92,7 @@ def sync_demo(since: datetime) -> None:
         project_id=PROJECT_ID,
         limit=LIST_LIMIT,
         since=since,
+        request_config=REQUEST_CONFIG,
     ):
         sync_ids.append(sandbox.id)
         print(f"sync sandbox: {sandbox.id}")

--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -64,6 +64,7 @@ from vercel._internal.sandbox.models import (
 )
 from vercel._internal.sandbox.snapshot import SnapshotExpiration
 from vercel._internal.sandbox.time import normalize_duration_ms
+from vercel.sandbox.request_config import SandboxRequestConfig, resolve_sandbox_request_timeout
 
 try:
     VERSION = _pkg_version("vercel")
@@ -576,6 +577,7 @@ class SyncSandboxOpsClient(BaseSandboxOpsClient):
         host: str = "https://api.vercel.com",
         team_id: str,
         token: str,
+        request_config: SandboxRequestConfig | None = None,
         filesystem_client: FilesystemClient[Any] | None = None,
     ) -> None:
         super().__init__(filesystem_client=filesystem_client or create_filesystem_client())
@@ -583,7 +585,8 @@ class SyncSandboxOpsClient(BaseSandboxOpsClient):
             token=token,
             base_headers={"user-agent": USER_AGENT},
             base_params={"teamId": team_id},
-            timeout=180.0,
+            retry=request_config.retry if request_config is not None else None,
+            timeout=resolve_sandbox_request_timeout(request_config),
             base_url=host,
         )
         self._request_client = SandboxRequestClient(request_client=rc)
@@ -663,6 +666,7 @@ class AsyncSandboxOpsClient(BaseSandboxOpsClient):
         host: str = "https://api.vercel.com",
         team_id: str,
         token: str,
+        request_config: SandboxRequestConfig | None = None,
         filesystem_client: FilesystemClient[Any] | None = None,
     ) -> None:
         super().__init__(filesystem_client=filesystem_client or create_async_filesystem_client())
@@ -670,7 +674,8 @@ class AsyncSandboxOpsClient(BaseSandboxOpsClient):
             token=token,
             base_headers={"user-agent": USER_AGENT},
             base_params={"teamId": team_id},
-            timeout=180.0,
+            retry=request_config.retry if request_config is not None else None,
+            timeout=resolve_sandbox_request_timeout(request_config),
             base_url=host,
         )
         self._request_client = SandboxRequestClient(request_client=rc)

--- a/src/vercel/sandbox/__init__.py
+++ b/src/vercel/sandbox/__init__.py
@@ -1,3 +1,4 @@
+from vercel._internal.http import RetryPolicy
 from vercel._internal.sandbox import (
     APIError,
     SandboxAuthError,
@@ -24,6 +25,7 @@ from .models import (
     Source,
     TarballSource,
 )
+from .request_config import SandboxRequestConfig
 from .sandbox import AsyncSandbox, Sandbox
 from .snapshot import (
     MIN_SNAPSHOT_EXPIRATION_MS,
@@ -43,6 +45,7 @@ __all__ = [
     "AsyncSandbox",
     "AsyncSnapshot",
     "Sandbox",
+    "SandboxRequestConfig",
     "Snapshot",
     "SnapshotExpiration",
     "MIN_SNAPSHOT_EXPIRATION_MS",
@@ -65,4 +68,5 @@ __all__ = [
     "NetworkPolicySubnets",
     "NetworkPolicyCustom",
     "NetworkPolicy",
+    "RetryPolicy",
 ]

--- a/src/vercel/sandbox/request_config.py
+++ b/src/vercel/sandbox/request_config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vercel._internal.http import RetryPolicy
+
+DEFAULT_SANDBOX_REQUEST_TIMEOUT = 180.0
+
+
+@dataclass(frozen=True)
+class SandboxRequestConfig:
+    """Transport-level request defaults for sandbox API calls.
+
+    This config applies to the HTTP requests issued by the sandbox ops client.
+    Workflow-level controls such as ``wait_for_status(timeout=...)`` and
+    ``stop(blocking=True, timeout=...)`` remain separate per-call settings.
+    """
+
+    timeout: float | None = None
+    retry: RetryPolicy | None = None
+
+
+def resolve_sandbox_request_timeout(request_config: SandboxRequestConfig | None) -> float:
+    if request_config is None or request_config.timeout is None:
+        return DEFAULT_SANDBOX_REQUEST_TIMEOUT
+    return request_config.timeout
+
+
+__all__ = [
+    "DEFAULT_SANDBOX_REQUEST_TIMEOUT",
+    "SandboxRequestConfig",
+    "resolve_sandbox_request_timeout",
+]

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -40,6 +40,7 @@ from .command import (
     CommandFinished,
 )
 from .pty.shell import start_interactive_shell
+from .request_config import SandboxRequestConfig
 from .snapshot import (
     AsyncSnapshot,
     Snapshot as SnapshotClass,
@@ -131,6 +132,7 @@ class AsyncSandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
         interactive: bool = False,
         env: dict[str, str] | None = None,
         network_policy: NetworkPolicy | None = None,
@@ -146,6 +148,9 @@ class AsyncSandbox:
             token: API token (uses OIDC if not provided).
             project_id: Project ID (uses OIDC if not provided).
             team_id: Team ID (uses OIDC if not provided).
+            request_config: Default HTTP timeout and retry policy for sandbox API
+                requests. This does not affect workflow-level wait or poll
+                settings on methods like ``wait_for_status()``.
             interactive: Enable interactive shell support. When True, the sandbox
                 will have an interactive port for PTY connections.
             env: Default environment variables for the sandbox. These are inherited
@@ -158,7 +163,11 @@ class AsyncSandbox:
         """
         parsed_source, parsed_resources = _parse_create_inputs(source=source, resources=resources)
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
-        client = AsyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+        client = AsyncSandboxOpsClient(
+            team_id=creds.team_id,
+            token=creds.token,
+            request_config=request_config,
+        )
         resp: SandboxAndRoutesResponse = await client.create_sandbox(
             project_id=creds.project_id,
             source=parsed_source,
@@ -183,9 +192,14 @@ class AsyncSandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
     ) -> AsyncSandbox:
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
-        client = AsyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+        client = AsyncSandboxOpsClient(
+            team_id=creds.team_id,
+            token=creds.token,
+            request_config=request_config,
+        )
         resp: SandboxAndRoutesResponse = await client.get_sandbox(sandbox_id=sandbox_id)
         return AsyncSandbox(
             client=client,
@@ -203,6 +217,7 @@ class AsyncSandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
     ) -> AsyncIterator[SandboxModel]:
         """List sandboxes as an async iterable of sandbox models.
 
@@ -220,6 +235,8 @@ class AsyncSandbox:
             project_id: Project ID used for credential resolution and as the
                 sandbox list scope. Uses configured credentials when omitted.
             team_id: Team ID scope for the sandbox API.
+            request_config: Default HTTP timeout and retry policy for sandbox API
+                requests made while traversing the iterator.
 
         Returns:
             An async iterable of typed sandbox results.
@@ -235,7 +252,11 @@ class AsyncSandbox:
 
         async def iter_sandboxes() -> AsyncIterator[SandboxModel]:
             current_params = params
-            async with AsyncSandboxOpsClient(team_id=creds.team_id, token=creds.token) as client:
+            async with AsyncSandboxOpsClient(
+                team_id=creds.team_id,
+                token=creds.token,
+                request_config=request_config,
+            ) as client:
                 while True:
                     response = await client.list_sandboxes(
                         project_id=current_params.project_id,
@@ -559,6 +580,7 @@ class Sandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
         interactive: bool = False,
         env: dict[str, str] | None = None,
         network_policy: NetworkPolicy | None = None,
@@ -574,6 +596,9 @@ class Sandbox:
             token: API token (uses OIDC if not provided).
             project_id: Project ID (uses OIDC if not provided).
             team_id: Team ID (uses OIDC if not provided).
+            request_config: Default HTTP timeout and retry policy for sandbox API
+                requests. This does not affect workflow-level wait or poll
+                settings on methods like ``wait_for_status()``.
             interactive: Enable interactive shell support. When True, the sandbox
                 will have an interactive port for PTY connections.
                 Note: For interactive shell sessions, use AsyncSandbox instead.
@@ -587,7 +612,11 @@ class Sandbox:
         """
         parsed_source, parsed_resources = _parse_create_inputs(source=source, resources=resources)
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
-        client = SyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+        client = SyncSandboxOpsClient(
+            team_id=creds.team_id,
+            token=creds.token,
+            request_config=request_config,
+        )
         resp: SandboxAndRoutesResponse = iter_coroutine(
             client.create_sandbox(
                 project_id=creds.project_id,
@@ -614,9 +643,14 @@ class Sandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
     ) -> Sandbox:
         creds: Credentials = get_credentials(token=token, project_id=project_id, team_id=team_id)
-        client = SyncSandboxOpsClient(team_id=creds.team_id, token=creds.token)
+        client = SyncSandboxOpsClient(
+            team_id=creds.team_id,
+            token=creds.token,
+            request_config=request_config,
+        )
         resp: SandboxAndRoutesResponse = iter_coroutine(client.get_sandbox(sandbox_id=sandbox_id))
         return Sandbox(
             client=client,
@@ -634,6 +668,7 @@ class Sandbox:
         token: str | None = None,
         project_id: str | None = None,
         team_id: str | None = None,
+        request_config: SandboxRequestConfig | None = None,
     ) -> Iterator[SandboxModel]:
         """List sandboxes as an iterable of sandbox models.
 
@@ -651,6 +686,8 @@ class Sandbox:
             project_id: Project ID used for credential resolution and as the
                 sandbox list scope. Uses configured credentials when omitted.
             team_id: Team ID scope for the sandbox API.
+            request_config: Default HTTP timeout and retry policy for sandbox API
+                requests made while traversing the iterator.
 
         Returns:
             An iterable of typed sandbox results.
@@ -666,7 +703,11 @@ class Sandbox:
 
         def iter_sandboxes() -> Iterator[SandboxModel]:
             current_params = params
-            with SyncSandboxOpsClient(team_id=creds.team_id, token=creds.token) as client:
+            with SyncSandboxOpsClient(
+                team_id=creds.team_id,
+                token=creds.token,
+                request_config=request_config,
+            ) as client:
                 while True:
                     response = iter_coroutine(
                         client.list_sandboxes(

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -23,8 +23,10 @@ from vercel.sandbox import (
     NetworkPolicySubnets,
     NetworkTransformer,
     Resources,
+    RetryPolicy,
     Sandbox,
     SandboxNotFoundError,
+    SandboxRequestConfig,
     SandboxServerError,
     SandboxValidationError,
 )
@@ -1801,6 +1803,99 @@ class TestSandboxUpdateNetworkPolicy:
 
 class TestSandboxRunCommand:
     """Test sandbox command execution."""
+
+    @staticmethod
+    def _assert_request_timeout(route: respx.Route, expected_timeout: float) -> None:
+        for call in route.calls:
+            assert call.request.extensions["timeout"] == {
+                "connect": expected_timeout,
+                "read": expected_timeout,
+                "write": expected_timeout,
+                "pool": expected_timeout,
+            }
+
+    @respx.mock
+    def test_create_request_config_applies_to_command_workflow_and_logs(
+        self, mock_env_clear, mock_sandbox_create_response, mock_sandbox_command_response
+    ):
+        """Configured request defaults stay in use for downstream sync command flows."""
+        sandbox_id = mock_sandbox_create_response["id"]
+        cmd_id = mock_sandbox_command_response["commandId"]
+        request_config = SandboxRequestConfig(
+            timeout=12.5,
+            retry=RetryPolicy(retries=2),
+        )
+
+        create_route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sandbox": mock_sandbox_create_response,
+                    "routes": [],
+                },
+            )
+        )
+        run_route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/cmd").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "command": {
+                        "id": cmd_id,
+                        "name": "echo",
+                        "args": ["Hello, World!"],
+                        "cwd": "/app",
+                        "sandboxId": sandbox_id,
+                        "exitCode": None,
+                        "startedAt": 1705320600000,
+                    }
+                },
+            )
+        )
+        wait_route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "command": {
+                        "id": cmd_id,
+                        "name": "echo",
+                        "args": ["Hello, World!"],
+                        "cwd": "/app",
+                        "sandboxId": sandbox_id,
+                        "exitCode": 0,
+                        "startedAt": 1705320600000,
+                        "stdout": "Hello, World!\n",
+                        "stderr": "",
+                    }
+                },
+            )
+        )
+        logs_route = respx.get(
+            f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/cmd/{cmd_id}/logs"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                text='{"time":1705320600000,"stream":"stdout","data":"Hello, World!\\n"}\n',
+            )
+        )
+
+        sandbox = Sandbox.create(
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            request_config=request_config,
+        )
+
+        command = sandbox.run_command("echo", ["Hello, World!"])
+
+        assert command.exit_code == 0
+        assert command.stdout() == "Hello, World!\n"
+        assert sandbox.client._rc._retry is request_config.retry
+        self._assert_request_timeout(create_route, 12.5)
+        self._assert_request_timeout(run_route, 12.5)
+        self._assert_request_timeout(wait_route, 12.5)
+        self._assert_request_timeout(logs_route, 12.5)
+
+        sandbox.client.close()
 
     @respx.mock
     def test_run_command_sync(
@@ -4081,6 +4176,60 @@ class TestSandboxRefresh:
 
 class TestSandboxWaitForStatus:
     """Test sandbox wait_for_status operations."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_wait_for_status_keeps_request_config_separate_from_wait_timeout(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        """Async wait loops reuse request defaults while keeping semantic timeout separate."""
+        from vercel.sandbox import SandboxStatus
+
+        sandbox_id = "sbx_test123456"
+        pending_response = {**mock_sandbox_get_response, "status": "pending"}
+        request_config = SandboxRequestConfig(
+            timeout=9.0,
+            retry=RetryPolicy(retries=1),
+        )
+
+        route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": mock_sandbox_get_response, "routes": []},
+                ),
+            ]
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+            request_config=request_config,
+        )
+
+        await sandbox.wait_for_status("running", timeout=0.05, poll_interval=0.01)
+
+        assert sandbox.status is SandboxStatus.RUNNING
+        assert sandbox.client._rc._retry is request_config.retry
+        for call in route.calls:
+            assert call.request.extensions["timeout"] == {
+                "connect": 9.0,
+                "read": 9.0,
+                "write": 9.0,
+                "pool": 9.0,
+            }
+
+        await sandbox.client.aclose()
 
     @respx.mock
     def test_wait_for_status_already_matched(self, mock_env_clear, mock_sandbox_get_response):

--- a/tests/unit/test_sandbox_request_config.py
+++ b/tests/unit/test_sandbox_request_config.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+import vercel.sandbox.sandbox as sandbox_module
+from vercel._internal.fs import FilesystemClient
+from vercel._internal.http import RetryPolicy
+from vercel._internal.sandbox import core as sandbox_core
+from vercel._internal.sandbox.models import (
+    Sandbox as SandboxModel,
+    SandboxAndRoutesResponse,
+    SandboxStatus,
+)
+from vercel.oidc.types import Credentials
+from vercel.sandbox import AsyncSandbox, Sandbox, SandboxRequestConfig
+
+
+def _sandbox_model(sandbox_id: str = "sbx_123") -> SandboxModel:
+    return SandboxModel(
+        id=sandbox_id,
+        memory=4096,
+        vcpus=2,
+        region="iad1",
+        runtime="node22",
+        timeout=60_000,
+        status=SandboxStatus.RUNNING,
+        requestedAt=0,
+        createdAt=0,
+        cwd="/",
+        updatedAt=0,
+    )
+
+
+def _sandbox_response(sandbox_id: str = "sbx_123") -> SandboxAndRoutesResponse:
+    return SandboxAndRoutesResponse(sandbox=_sandbox_model(sandbox_id), routes=[])
+
+
+class _RecordingSyncSandboxOpsClient:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+        self.list_calls: list[dict[str, object]] = []
+
+    async def create_sandbox(self, **kwargs: object) -> SandboxAndRoutesResponse:
+        self.create_calls.append(kwargs)
+        return _sandbox_response()
+
+    async def get_sandbox(self, **kwargs: object) -> SandboxAndRoutesResponse:
+        self.get_calls.append(kwargs)
+        return _sandbox_response(cast(str, kwargs["sandbox_id"]))
+
+    async def list_sandboxes(self, **kwargs: object) -> SimpleNamespace:
+        self.list_calls.append(kwargs)
+        return SimpleNamespace(
+            sandboxes=[_sandbox_model("sbx_list_1")],
+            pagination=SimpleNamespace(next=None),
+        )
+
+    def close(self) -> None:
+        return None
+
+    def __enter__(self) -> _RecordingSyncSandboxOpsClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class _RecordingAsyncSandboxOpsClient:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+        self.list_calls: list[dict[str, object]] = []
+
+    async def create_sandbox(self, **kwargs: object) -> SandboxAndRoutesResponse:
+        self.create_calls.append(kwargs)
+        return _sandbox_response()
+
+    async def get_sandbox(self, **kwargs: object) -> SandboxAndRoutesResponse:
+        self.get_calls.append(kwargs)
+        return _sandbox_response(cast(str, kwargs["sandbox_id"]))
+
+    async def list_sandboxes(self, **kwargs: object) -> SimpleNamespace:
+        self.list_calls.append(kwargs)
+        return SimpleNamespace(
+            sandboxes=[_sandbox_model("sbx_list_1")],
+            pagination=SimpleNamespace(next=None),
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+    async def __aenter__(self) -> _RecordingAsyncSandboxOpsClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class _StubRequestClient:
+    def close(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _patch_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sandbox_module,
+        "get_credentials",
+        lambda **_: Credentials(
+            token="token_123",
+            project_id="project_123",
+            team_id="team_123",
+        ),
+    )
+
+
+def test_sandbox_request_config_is_forwarded_from_sync_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_credentials(monkeypatch)
+    client = _RecordingSyncSandboxOpsClient()
+    init_kwargs: list[dict[str, object]] = []
+
+    def build_client(**kwargs: object) -> _RecordingSyncSandboxOpsClient:
+        init_kwargs.append(kwargs)
+        return client
+
+    monkeypatch.setattr(sandbox_module, "SyncSandboxOpsClient", build_client)
+
+    retry = RetryPolicy(retries=2, retry_on_network_error=False)
+    request_config = SandboxRequestConfig(timeout=12.5, retry=retry)
+
+    created = Sandbox.create(request_config=request_config)
+    fetched = Sandbox.get(sandbox_id="sbx_get", request_config=request_config)
+    listed = list(Sandbox.list(request_config=request_config))
+
+    assert created.sandbox_id == "sbx_123"
+    assert fetched.sandbox_id == "sbx_get"
+    assert [sandbox.id for sandbox in listed] == ["sbx_list_1"]
+    assert init_kwargs == [
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_request_config_is_forwarded_from_async_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_credentials(monkeypatch)
+    client = _RecordingAsyncSandboxOpsClient()
+    init_kwargs: list[dict[str, object]] = []
+
+    def build_client(**kwargs: object) -> _RecordingAsyncSandboxOpsClient:
+        init_kwargs.append(kwargs)
+        return client
+
+    monkeypatch.setattr(sandbox_module, "AsyncSandboxOpsClient", build_client)
+
+    retry = RetryPolicy(retries=1, retry_on_network_error=True)
+    request_config = SandboxRequestConfig(timeout=9.0, retry=retry)
+
+    created = await AsyncSandbox.create(request_config=request_config)
+    fetched = await AsyncSandbox.get(sandbox_id="sbx_get", request_config=request_config)
+    listed = [sandbox async for sandbox in AsyncSandbox.list(request_config=request_config)]
+
+    assert created.sandbox_id == "sbx_123"
+    assert fetched.sandbox_id == "sbx_get"
+    assert [sandbox.id for sandbox in listed] == ["sbx_list_1"]
+    assert init_kwargs == [
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+        {"team_id": "team_123", "token": "token_123", "request_config": request_config},
+    ]
+
+
+def test_sync_sandbox_ops_client_uses_default_request_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_request_client(**kwargs: object) -> _StubRequestClient:
+        captured.update(kwargs)
+        return _StubRequestClient()
+
+    monkeypatch.setattr(sandbox_core, "create_request_client", fake_create_request_client)
+
+    sandbox_core.SyncSandboxOpsClient(
+        team_id="team_123",
+        token="token_123",
+        filesystem_client=cast(FilesystemClient[Any], SimpleNamespace()),
+    )
+
+    assert captured["timeout"] == 180.0
+    assert captured["retry"] is None
+
+
+def test_sync_sandbox_ops_client_uses_custom_request_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_request_client(**kwargs: object) -> _StubRequestClient:
+        captured.update(kwargs)
+        return _StubRequestClient()
+
+    monkeypatch.setattr(sandbox_core, "create_request_client", fake_create_request_client)
+    retry = RetryPolicy(retries=3, retry_on_network_error=False)
+    request_config = SandboxRequestConfig(timeout=42.0, retry=retry)
+
+    sandbox_core.SyncSandboxOpsClient(
+        team_id="team_123",
+        token="token_123",
+        request_config=request_config,
+        filesystem_client=cast(FilesystemClient[Any], SimpleNamespace()),
+    )
+
+    assert captured["timeout"] == 42.0
+    assert captured["retry"] is retry
+
+
+@pytest.mark.asyncio
+async def test_async_sandbox_ops_client_uses_default_request_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_async_request_client(**kwargs: object) -> _StubRequestClient:
+        captured.update(kwargs)
+        return _StubRequestClient()
+
+    monkeypatch.setattr(
+        sandbox_core, "create_async_request_client", fake_create_async_request_client
+    )
+
+    client = sandbox_core.AsyncSandboxOpsClient(
+        team_id="team_123",
+        token="token_123",
+        filesystem_client=cast(FilesystemClient[Any], SimpleNamespace()),
+    )
+
+    assert captured["timeout"] == 180.0
+    assert captured["retry"] is None
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_sandbox_ops_client_uses_custom_request_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_async_request_client(**kwargs: object) -> _StubRequestClient:
+        captured.update(kwargs)
+        return _StubRequestClient()
+
+    monkeypatch.setattr(
+        sandbox_core, "create_async_request_client", fake_create_async_request_client
+    )
+    retry = RetryPolicy(retries=4, retry_on_network_error=True)
+    request_config = SandboxRequestConfig(timeout=21.0, retry=retry)
+
+    client = sandbox_core.AsyncSandboxOpsClient(
+        team_id="team_123",
+        token="token_123",
+        request_config=request_config,
+        filesystem_client=cast(FilesystemClient[Any], SimpleNamespace()),
+    )
+
+    assert captured["timeout"] == 21.0
+    assert captured["retry"] is retry
+    await client.aclose()


### PR DESCRIPTION
## Summary
- add a public SandboxRequestConfig surface for sandbox create/get/list APIs
- thread timeout and retry settings into sync and async sandbox ops clients
- document the contract and add workflow coverage showing request defaults persist without changing wait semantics

## Motivation
Sandbox callers could not tune transport-level timeout or retry behavior without wrapping the public API. This exposes that configuration directly while keeping workflow-level wait controls separate.