### PR TITLE
Add support for python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ on:
 
 jobs:
   lint-test-and-build:
-    name: lint-test-and-build
+    name: test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     environment: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -24,9 +28,9 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Sync dependencies
-        run: uv sync --python 3.12
+        run: uv sync --python ${{ matrix.python-version }}
 
-      - name: Run tests
+      - name: Run tests, including lint and typecheck
         run: ./scripts/test.sh
 
       - name: Run example tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pip install vercel
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.10+
 
 ## Usage
 

--- a/examples/projects_async.py
+++ b/examples/projects_async.py
@@ -15,7 +15,7 @@ Usage:
 
 import asyncio
 import os
-from datetime import datetime
+import uuid
 
 from dotenv import load_dotenv
 
@@ -59,7 +59,7 @@ async def main() -> None:
 
         # 2. Create a new test project
         print("\n2️⃣ Creating a new test project...")
-        test_project_name = f"vercel-py-async-test-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        test_project_name = f"vercel-py-async-test-{str(uuid.uuid4())}"
 
         create_response = await create_project(
             body={

--- a/examples/projects_async.py
+++ b/examples/projects_async.py
@@ -59,7 +59,7 @@ async def main() -> None:
 
         # 2. Create a new test project
         print("\n2️⃣ Creating a new test project...")
-        test_project_name = f"vercel-py-async-test-{str(uuid.uuid4())}"
+        test_project_name = f"vercel-py-async-test-{uuid.uuid4().hex}"
 
         create_response = await create_project(
             body={

--- a/examples/sandbox_07_ruby_sinatra.py
+++ b/examples/sandbox_07_ruby_sinatra.py
@@ -160,6 +160,7 @@ async def main() -> None:
                 if not ready.is_set() and (
                     "Listening on" in line.data
                     or "WEBrick::HTTPServer#start" in line.data
+                    or "Rackup::Handler::WEBrick::Server#start" in line.data
                     or "Sinatra has taken the stage" in line.data
                     or f"tcp://0.0.0.0:{port}" in line.data
                     or "WEBrick::HTTPServer#start: pid=" in line.data
@@ -169,7 +170,7 @@ async def main() -> None:
         logs_task = asyncio.create_task(logs_and_detect_ready())
         try:
             await asyncio.wait_for(ready.wait(), timeout=90)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             pass
 
         url = sandbox.domain(port)

--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -160,17 +160,19 @@ async def test():
         await client.send_ready()
         await client.send_resize(80, 24)
 
-        # Collect output with timeout
-        output = b""
+        # Collect output with timeout. asyncio.timeout() is only available in 3.11+.
+        async def collect_output() -> bytes:
+            output = b""
+            async for data in client.raw_messages():
+                output += data
+                if b"PTY_TEST_OUTPUT" in output:
+                    break
+            return output
+
         try:
-            async with asyncio.timeout(5):
-                async for data in client.raw_messages():
-                    output += data
-                    # Check if we got our test string
-                    if b"PTY_TEST_OUTPUT" in output:
-                        break
-        except TimeoutError:
-            pass
+            output = await asyncio.wait_for(collect_output(), timeout=5)
+        except asyncio.TimeoutError:
+            output = b""
 
         await client.close()
 

--- a/examples/sandbox_15_list.py
+++ b/examples/sandbox_15_list.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from dotenv import load_dotenv
 
@@ -90,7 +90,7 @@ def sync_demo(since: datetime) -> None:
 
 
 if __name__ == "__main__":
-    since = datetime.now(UTC) - timedelta(seconds=5)
+    since = datetime.now(timezone.utc) - timedelta(seconds=5)
     sandboxes = asyncio.run(async_demo(since))
     try:
         sync_demo(since)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,14 @@ name = "vercel"
 version = "0.5.4"
 description = "Python SDK for Vercel"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE", "LICENSE.*"]
 dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.7.0",
     "anyio>=4.0.0",
+    "typing-extensions>=4.0.0 ; python_version < '3.11'",
     "python-dotenv",
     "websockets>=12.0",
     "cbor2>=5.8.0",
@@ -68,7 +69,7 @@ mypy_path = ["src"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/src/vercel/_internal/blob/core.py
+++ b/src/vercel/_internal/blob/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
-from datetime import datetime, timezone
+from datetime import datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, Literal, cast
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -77,6 +77,7 @@ from vercel._internal.http import (
 )
 from vercel._internal.http.request_client import RetryPolicy
 from vercel._internal.iter_coroutine import iter_coroutine
+from vercel._internal.polyfills import UTC
 from vercel._internal.telemetry.tracker import track
 
 BlobProgressCallback = (
@@ -390,7 +391,7 @@ def _build_cache_bypass_url(blob_url: str) -> str:
 
 def parse_last_modified(value: str | None) -> datetime:
     if not value:
-        return datetime.now(tz=timezone.utc)
+        return datetime.now(tz=UTC)
     try:
         return parsedate_to_datetime(value)
     except (ValueError, TypeError):
@@ -398,7 +399,7 @@ def parse_last_modified(value: str | None) -> datetime:
     try:
         return parse_datetime(value)
     except (ValueError, TypeError):
-        return datetime.now(tz=timezone.utc)
+        return datetime.now(tz=UTC)
 
 
 class BlobRequestClient:

--- a/src/vercel/_internal/blob/core.py
+++ b/src/vercel/_internal/blob/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any, Literal, cast
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -390,7 +390,7 @@ def _build_cache_bypass_url(blob_url: str) -> str:
 
 def parse_last_modified(value: str | None) -> datetime:
     if not value:
-        return datetime.now(tz=UTC)
+        return datetime.now(tz=timezone.utc)
     try:
         return parsedate_to_datetime(value)
     except (ValueError, TypeError):
@@ -398,7 +398,7 @@ def parse_last_modified(value: str | None) -> datetime:
     try:
         return parse_datetime(value)
     except (ValueError, TypeError):
-        return datetime.now(tz=UTC)
+        return datetime.now(tz=timezone.utc)
 
 
 class BlobRequestClient:

--- a/src/vercel/_internal/polyfills/__init__.py
+++ b/src/vercel/_internal/polyfills/__init__.py
@@ -1,0 +1,9 @@
+"""
+Polyfills for modern Python features used internally.
+"""
+
+from ._datetime import UTC
+from ._strenum import StrEnum
+from ._typing import Self
+
+__all__ = ("Self", "StrEnum", "UTC")

--- a/src/vercel/_internal/polyfills/_datetime.py
+++ b/src/vercel/_internal/polyfills/_datetime.py
@@ -1,0 +1,5 @@
+from datetime import timezone
+
+UTC = timezone.utc
+
+__all__ = ("UTC",)

--- a/src/vercel/_internal/polyfills/_strenum.py
+++ b/src/vercel/_internal/polyfills/_strenum.py
@@ -1,0 +1,10 @@
+"""enum.StrEnum polyfill."""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from ._strenum_impl import StrEnum
+
+__all__ = ("StrEnum",)

--- a/src/vercel/_internal/polyfills/_strenum_impl.py
+++ b/src/vercel/_internal/polyfills/_strenum_impl.py
@@ -1,0 +1,14 @@
+import enum as _enum
+from typing import Any
+
+
+class StrEnum(str, _enum.Enum):
+    __str__ = str.__str__
+    __format__ = str.__format__  # type: ignore[assignment]
+
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list[Any]) -> str:
+        return name.lower()
+
+
+__all__ = ("StrEnum",)

--- a/src/vercel/_internal/polyfills/_typing.py
+++ b/src/vercel/_internal/polyfills/_typing.py
@@ -1,0 +1,8 @@
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+__all__ = ("Self",)

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from enum import StrEnum
+from enum import Enum
 from typing import Annotated, Any, Literal, TypeAlias, TypedDict, cast
 
 from pydantic import (
@@ -26,8 +27,18 @@ from vercel._internal.sandbox.time import normalize_duration_ms
 # Source types for Sandbox.create()
 _REDACTED_HEADER_VALUE = "<redacted>"
 
+if sys.version_info >= (3, 11):
+    from enum import StrEnum as _StrEnum
+else:
 
-class SandboxStatus(StrEnum):
+    class _StrEnum(str, Enum):  # noqa: UP042
+        """Python 3.10-compatible subset of enum.StrEnum."""
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+
+class SandboxStatus(_StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     STOPPING = "stopping"

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from enum import Enum
 from typing import Annotated, Any, Literal, TypeAlias, TypedDict, cast
 
 from pydantic import (
@@ -21,24 +19,15 @@ from pydantic import (
 )
 from pydantic_core import InitErrorDetails
 
+from vercel._internal.polyfills import StrEnum
 from vercel._internal.sandbox.errors import SandboxError
 from vercel._internal.sandbox.time import normalize_duration_ms
 
 # Source types for Sandbox.create()
 _REDACTED_HEADER_VALUE = "<redacted>"
 
-if sys.version_info >= (3, 11):
-    from enum import StrEnum as _StrEnum
-else:
 
-    class _StrEnum(str, Enum):  # noqa: UP042
-        """Python 3.10-compatible subset of enum.StrEnum."""
-
-        def __str__(self) -> str:
-            return str(self.value)
-
-
-class SandboxStatus(_StrEnum):
+class SandboxStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     STOPPING = "stopping"

--- a/src/vercel/_internal/sandbox/pagination.py
+++ b/src/vercel/_internal/sandbox/pagination.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 
+from vercel._internal.polyfills import UTC
 from vercel._internal.sandbox.models import Pagination
 
 
@@ -101,7 +102,7 @@ def normalize_list_timestamp(value: datetime | int | None) -> int | None:
         return value
     if isinstance(value, datetime):
         if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
+            value = value.replace(tzinfo=UTC)
         return int(value.timestamp() * 1000)
     raise TypeError("List timestamps must be datetime or integer milliseconds")
 

--- a/src/vercel/_internal/sandbox/pagination.py
+++ b/src/vercel/_internal/sandbox/pagination.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from vercel._internal.sandbox.models import Pagination
 
@@ -101,7 +101,7 @@ def normalize_list_timestamp(value: datetime | int | None) -> int | None:
         return value
     if isinstance(value, datetime):
         if value.tzinfo is None:
-            value = value.replace(tzinfo=UTC)
+            value = value.replace(tzinfo=timezone.utc)
         return int(value.timestamp() * 1000)
     raise TypeError("List timestamps must be datetime or integer milliseconds")
 

--- a/src/vercel/workflow/runtime.py
+++ b/src/vercel/workflow/runtime.py
@@ -6,15 +6,12 @@ import json
 import random
 import re
 import traceback
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Generic, Literal, ParamSpec, TypeVar
 
-try:
-    from typing import Self
-except ImportError:
-    from typing_extensions import Self
-
 import anyio
+
+from vercel._internal.polyfills import UTC, Self
 
 from . import core, ulid, world as w
 
@@ -157,7 +154,7 @@ async def workflow_handler(
     events = await get_all_workflow_run_events(run_id)
 
     # Check for any elapsed waits and create wait_completed events
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     # Pre-compute completed correlation IDs for O(n) lookup instead of O(n²)
     completed_wait_ids = {e.correlation_id for e in events if e.event_type == "wait_completed"}
@@ -219,14 +216,14 @@ async def workflow_handler(
                         workflowRunId=run_id,
                         workflowStartedAt=workflow_started_at,
                         stepId=sus.correlation_id,
-                        requestedAt=datetime.now(timezone.utc),
+                        requestedAt=datetime.now(UTC),
                     ),
                 )
             elif isinstance(sus, Wait):
                 wait_data = w.WaitCreatedEventData(resumeAt=sus.resume_at)
                 tg.start_soon(world.events_create, run_id, wait_data.into_event(sus.correlation_id))
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     min_timeout_seconds = -1.0
     for sus in context.suspensions.values():
         if isinstance(sus, Wait):
@@ -253,7 +250,7 @@ async def step_handler(
     step = core.get_step(step_run.step_name)
 
     # Check if retry_after timestamp hasn't been reached yet
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     if step_run.retry_after and step_run.retry_after > now:
         timeout_seconds = max(1, int((step_run.retry_after - now).total_seconds()))
         return timeout_seconds
@@ -282,7 +279,7 @@ async def step_handler(
             f"__wkf_workflow_{req.workflow_name}",
             w.WorkflowInvokePayload(
                 runId=req.workflow_run_id,
-                requestedAt=datetime.now(timezone.utc),
+                requestedAt=datetime.now(UTC),
             ),
         )
         return None
@@ -393,7 +390,7 @@ async def step_handler(
         f"__wkf_workflow_{req.workflow_name}",
         w.WorkflowInvokePayload(
             runId=req.workflow_run_id,
-            requestedAt=datetime.now(timezone.utc),
+            requestedAt=datetime.now(UTC),
         ),
     )
     return None
@@ -465,12 +462,12 @@ def parse_duration_to_date(param: int | float | datetime | str) -> datetime:
         ms = sum(items)
         if ms < 0:
             raise RuntimeError(f"Duration parameter must be non-negative: {param}")
-        return datetime.now(timezone.utc) + timedelta(milliseconds=ms)
+        return datetime.now(UTC) + timedelta(milliseconds=ms)
 
     elif isinstance(param, (int, float)):
         if param < 0:
             raise RuntimeError(f"Duration parameter must be non-negative: {param}")
-        return datetime.now(timezone.utc) + timedelta(milliseconds=param)
+        return datetime.now(UTC) + timedelta(milliseconds=param)
 
     elif isinstance(param, datetime):
         if param.tzinfo is None:

--- a/src/vercel/workflow/runtime.py
+++ b/src/vercel/workflow/runtime.py
@@ -6,8 +6,13 @@ import json
 import random
 import re
 import traceback
-from datetime import UTC, datetime, timedelta
-from typing import Any, Generic, Literal, ParamSpec, Self, TypeVar
+from datetime import datetime, timedelta, timezone
+from typing import Any, Generic, Literal, ParamSpec, TypeVar
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import anyio
 
@@ -152,7 +157,7 @@ async def workflow_handler(
     events = await get_all_workflow_run_events(run_id)
 
     # Check for any elapsed waits and create wait_completed events
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
 
     # Pre-compute completed correlation IDs for O(n) lookup instead of O(n²)
     completed_wait_ids = {e.correlation_id for e in events if e.event_type == "wait_completed"}
@@ -214,14 +219,14 @@ async def workflow_handler(
                         workflowRunId=run_id,
                         workflowStartedAt=workflow_started_at,
                         stepId=sus.correlation_id,
-                        requestedAt=datetime.now(UTC),
+                        requestedAt=datetime.now(timezone.utc),
                     ),
                 )
             elif isinstance(sus, Wait):
                 wait_data = w.WaitCreatedEventData(resumeAt=sus.resume_at)
                 tg.start_soon(world.events_create, run_id, wait_data.into_event(sus.correlation_id))
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     min_timeout_seconds = -1.0
     for sus in context.suspensions.values():
         if isinstance(sus, Wait):
@@ -248,7 +253,7 @@ async def step_handler(
     step = core.get_step(step_run.step_name)
 
     # Check if retry_after timestamp hasn't been reached yet
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     if step_run.retry_after and step_run.retry_after > now:
         timeout_seconds = max(1, int((step_run.retry_after - now).total_seconds()))
         return timeout_seconds
@@ -275,7 +280,10 @@ async def step_handler(
         # Re-invoke the workflow to handle the failed step
         await world.queue(
             f"__wkf_workflow_{req.workflow_name}",
-            w.WorkflowInvokePayload(runId=req.workflow_run_id, requestedAt=datetime.now(UTC)),
+            w.WorkflowInvokePayload(
+                runId=req.workflow_run_id,
+                requestedAt=datetime.now(timezone.utc),
+            ),
         )
         return None
 
@@ -383,7 +391,10 @@ async def step_handler(
     # Re-invoke the workflow to continue execution
     await world.queue(
         f"__wkf_workflow_{req.workflow_name}",
-        w.WorkflowInvokePayload(runId=req.workflow_run_id, requestedAt=datetime.now(UTC)),
+        w.WorkflowInvokePayload(
+            runId=req.workflow_run_id,
+            requestedAt=datetime.now(timezone.utc),
+        ),
     )
     return None
 
@@ -454,12 +465,12 @@ def parse_duration_to_date(param: int | float | datetime | str) -> datetime:
         ms = sum(items)
         if ms < 0:
             raise RuntimeError(f"Duration parameter must be non-negative: {param}")
-        return datetime.now(UTC) + timedelta(milliseconds=ms)
+        return datetime.now(timezone.utc) + timedelta(milliseconds=ms)
 
     elif isinstance(param, (int, float)):
         if param < 0:
             raise RuntimeError(f"Duration parameter must be non-negative: {param}")
-        return datetime.now(UTC) + timedelta(milliseconds=param)
+        return datetime.now(timezone.utc) + timedelta(milliseconds=param)
 
     elif isinstance(param, datetime):
         if param.tzinfo is None:

--- a/src/vercel/workflow/world.py
+++ b/src/vercel/workflow/world.py
@@ -16,10 +16,7 @@ from typing import (
 
 import pydantic
 
-try:
-    from typing import Self
-except ImportError:
-    from typing_extensions import Self
+from vercel._internal.polyfills import Self
 
 T = TypeVar("T")
 QueuePrefix: TypeAlias = Literal["__wkf_step_", "__wkf_workflow_"]

--- a/src/vercel/workflow/world.py
+++ b/src/vercel/workflow/world.py
@@ -9,13 +9,17 @@ from typing import (
     Generic,
     Literal,
     Protocol,
-    Self,
     TypeAlias,
     TypeVar,
     overload,
 )
 
 import pydantic
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 T = TypeVar("T")
 QueuePrefix: TypeAlias = Literal["__wkf_step_", "__wkf_workflow_"]

--- a/src/vercel/workflow/worlds/local.py
+++ b/src/vercel/workflow/worlds/local.py
@@ -2,7 +2,7 @@ import json
 import os
 import pathlib
 import traceback
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, TypeVar
 
 import cbor2
@@ -193,7 +193,7 @@ class LocalWorld(w.World):
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         event_id = f"evnt_{self.monotonic_ulid(None)}"
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
 
         if data.event_type == "run_created" and not run_id:
             effective_run_id = f"wrun_{self.monotonic_ulid(None)}"

--- a/src/vercel/workflow/worlds/local.py
+++ b/src/vercel/workflow/worlds/local.py
@@ -2,12 +2,13 @@ import json
 import os
 import pathlib
 import traceback
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, TypeVar
 
 import cbor2
 import pydantic
 
+from vercel._internal.polyfills import UTC
 from vercel.workers import client as vqs_client
 
 from .. import world as w
@@ -193,7 +194,7 @@ class LocalWorld(w.World):
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         event_id = f"evnt_{self.monotonic_ulid(None)}"
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         if data.event_type == "run_created" and not run_id:
             effective_run_id = f"wrun_{self.monotonic_ulid(None)}"

--- a/src/vercel/workflow/worlds/vercel.py
+++ b/src/vercel/workflow/worlds/vercel.py
@@ -105,7 +105,7 @@ class VercelWorld(w.World):
         headers["Accept"] = "application/cbor"
         # NOTE: Add a unique header to bypass RSC request memoization.
         # See: https://github.com/vercel/workflow/issues/618
-        headers["X-Request-Time"] = datetime.datetime.now(datetime.UTC).isoformat() + "Z"
+        headers["X-Request-Time"] = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
 
         # Encode body as CBOR if data is provided
         body: bytes | None = None

--- a/src/vercel/workflow/worlds/vercel.py
+++ b/src/vercel/workflow/worlds/vercel.py
@@ -10,6 +10,7 @@ import cbor2
 import httpx
 import pydantic
 
+from vercel._internal.polyfills import UTC
 from vercel.workers import client as vqs_client
 
 from .. import world as w
@@ -105,7 +106,7 @@ class VercelWorld(w.World):
         headers["Accept"] = "application/cbor"
         # NOTE: Add a unique header to bypass RSC request memoization.
         # See: https://github.com/vercel/workflow/issues/618
-        headers["X-Request-Time"] = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
+        headers["X-Request-Time"] = datetime.datetime.now(UTC).isoformat() + "Z"
 
         # Encode body as CBOR if data is provided
         body: bytes | None = None

--- a/tests/integration/test_projects_real_api.py
+++ b/tests/integration/test_projects_real_api.py
@@ -7,6 +7,7 @@ They require VERCEL_TOKEN and VERCEL_TEAM_ID environment variables.
 
 import os
 import time
+from uuid import uuid4
 
 import pytest
 
@@ -29,9 +30,8 @@ class TestProjectsRealAPI:
 
     @pytest.fixture
     def test_project_name(self):
-        """Generate unique test project name."""
-        timestamp = int(time.time())
-        return f"vercel-py-test-{timestamp}"
+        """Generate a collision-resistant test project name."""
+        return f"vercel-py-test-{uuid4().hex}"
 
     def test_get_projects_real_api(self, team_id):
         """Test get_projects with real API and validate actual response structure."""

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -6,7 +6,7 @@ Tests both sync and async variants (Sandbox and AsyncSandbox).
 import json
 import tarfile
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -687,8 +687,8 @@ class TestSandboxList:
 
         project = "sandbox-project"
         limit = 2
-        since = datetime(2024, 1, 15, 9, 0, tzinfo=UTC)
-        until = datetime(2024, 1, 15, 9, 30, tzinfo=UTC)
+        since = datetime(2024, 1, 15, 9, 0, tzinfo=timezone.utc)
+        until = datetime(2024, 1, 15, 9, 30, tzinfo=timezone.utc)
         expected_since = str(int(since.timestamp() * 1000))
         expected_until = str(int(until.timestamp() * 1000))
         next_until = "1705310400000"
@@ -1187,8 +1187,8 @@ class TestSnapshotList:
 
         project = "snapshot-project"
         limit = 2
-        since = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
-        until = datetime(2024, 1, 15, 12, 30, tzinfo=UTC)
+        since = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
+        until = datetime(2024, 1, 15, 12, 30, tzinfo=timezone.utc)
         expected_since = str(int(since.timestamp() * 1000))
         expected_until = str(int(until.timestamp() * 1000))
         next_cursor = 1705320000000
@@ -4113,6 +4113,37 @@ class TestSandboxWaitForStatus:
         sandbox.client.close()
 
     @respx.mock
+    def test_wait_for_status_timeout_formats_string_status(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        """Test timeout formatting preserves raw status strings."""
+        from vercel.sandbox import Sandbox, SandboxStatus
+
+        sandbox_id = "sbx_test123456"
+        pending_response = {**mock_sandbox_get_response, "status": "pending"}
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sandbox": pending_response, "routes": []},
+            )
+        )
+
+        sandbox = Sandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        with pytest.raises(TimeoutError, match="did not reach 'running' status") as exc_info:
+            sandbox.wait_for_status(SandboxStatus.RUNNING, timeout=0.05, poll_interval=0.01)
+
+        assert "'SandboxStatus.RUNNING'" not in str(exc_info.value)
+
+        sandbox.client.close()
+
+    @respx.mock
     def test_wait_for_status_polls(self, mock_env_clear, mock_sandbox_get_response):
         """Test wait_for_status polls until status matches."""
         from vercel.sandbox import Sandbox, SandboxStatus
@@ -4247,6 +4278,38 @@ class TestSandboxWaitForStatus:
         assert sandbox.status is SandboxStatus.PENDING
         await sandbox.wait_for_status(SandboxStatus.RUNNING, poll_interval=0.01)
         assert sandbox.status is SandboxStatus.RUNNING
+
+        await sandbox.client.aclose()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_wait_for_status_async_timeout_formats_string_status(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        """Test async timeout formatting preserves raw status strings."""
+        from vercel.sandbox import AsyncSandbox, SandboxStatus
+
+        sandbox_id = "sbx_test123456"
+        pending_response = {**mock_sandbox_get_response, "status": "pending"}
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sandbox": pending_response, "routes": []},
+            )
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        with pytest.raises(TimeoutError, match="did not reach 'running' status") as exc_info:
+            await sandbox.wait_for_status(SandboxStatus.RUNNING, timeout=0.05, poll_interval=0.01)
+
+        assert "'SandboxStatus.RUNNING'" not in str(exc_info.value)
 
         await sandbox.client.aclose()
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -7,7 +7,6 @@ These tests require real API credentials set via environment variables:
 """
 
 import os
-import time
 import uuid
 from collections.abc import Generator
 from typing import Any
@@ -87,24 +86,20 @@ def blob_token() -> str:
 
 @pytest.fixture
 def unique_test_name() -> str:
-    """Generate a unique test resource name with timestamp.
+    """Generate a collision-resistant test resource name.
 
-    Format: vercel-py-test-{timestamp}-{uuid}
+    Format: vercel-py-test-{uuid}
     """
-    timestamp = int(time.time())
-    unique_id = uuid.uuid4().hex[:8]
-    return f"vercel-py-test-{timestamp}-{unique_id}"
+    return f"vercel-py-test-{uuid.uuid4().hex}"
 
 
 @pytest.fixture
 def unique_blob_path() -> str:
-    """Generate a unique blob path for testing.
+    """Generate a collision-resistant blob path for testing.
 
-    Format: test/{timestamp}-{uuid}/file.txt
+    Format: test/{uuid}/file.txt
     """
-    timestamp = int(time.time())
-    unique_id = uuid.uuid4().hex[:8]
-    return f"test/{timestamp}-{unique_id}/file.txt"
+    return f"test/{uuid.uuid4().hex}/file.txt"
 
 
 class CleanupRegistry:

--- a/tests/test_blob_ops.py
+++ b/tests/test_blob_ops.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,7 +29,7 @@ STORE_ID = "storeid123"
 class TestParseLastModified:
     def test_rfc7231_date(self):
         dt = parse_last_modified("Tue, 15 Nov 1994 08:12:31 GMT")
-        assert dt == datetime(1994, 11, 15, 8, 12, 31, tzinfo=UTC)
+        assert dt == datetime(1994, 11, 15, 8, 12, 31, tzinfo=timezone.utc)
 
     def test_iso8601_date(self):
         dt = parse_last_modified("2024-01-15T10:30:00+00:00")
@@ -40,15 +40,15 @@ class TestParseLastModified:
         assert dt.minute == 30
 
     def test_none_returns_approx_now(self):
-        before = datetime.now(tz=UTC)
+        before = datetime.now(tz=timezone.utc)
         dt = parse_last_modified(None)
-        after = datetime.now(tz=UTC)
+        after = datetime.now(tz=timezone.utc)
         assert before <= dt <= after
 
     def test_invalid_string_returns_approx_now(self):
-        before = datetime.now(tz=UTC)
+        before = datetime.now(tz=timezone.utc)
         dt = parse_last_modified("not-a-date")
-        after = datetime.now(tz=UTC)
+        after = datetime.now(tz=timezone.utc)
         assert before <= dt <= after
 
 

--- a/tests/test_runtime_compatibility.py
+++ b/tests/test_runtime_compatibility.py
@@ -1,5 +1,8 @@
+from datetime import timezone
+
 import vercel.sandbox
 import vercel.workflow
+from vercel._internal.polyfills import UTC, Self, StrEnum
 from vercel.sandbox import SandboxStatus
 
 
@@ -11,3 +14,9 @@ def test_public_modules_import_under_supported_floor() -> None:
 def test_sandbox_status_preserves_string_behavior() -> None:
     assert isinstance(SandboxStatus.RUNNING, str)
     assert str(SandboxStatus.RUNNING) == "running"
+
+
+def test_internal_polyfills_expose_compatibility_surface() -> None:
+    assert Self is not None
+    assert issubclass(StrEnum, str)
+    assert UTC is timezone.utc

--- a/tests/test_runtime_compatibility.py
+++ b/tests/test_runtime_compatibility.py
@@ -1,0 +1,13 @@
+import vercel.sandbox
+import vercel.workflow
+from vercel.sandbox import SandboxStatus
+
+
+def test_public_modules_import_under_supported_floor() -> None:
+    assert vercel.sandbox is not None
+    assert vercel.workflow is not None
+
+
+def test_sandbox_status_preserves_string_behavior() -> None:
+    assert isinstance(SandboxStatus.RUNNING, str)
+    assert str(SandboxStatus.RUNNING) == "running"

--- a/tests/unit/test_blob_client_lifecycle.py
+++ b/tests/unit/test_blob_client_lifecycle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,7 +13,7 @@ from vercel.blob.types import HeadBlobResult, ListBlobResult
 def _head_result() -> HeadBlobResult:
     return HeadBlobResult(
         size=1,
-        uploaded_at=datetime.now(UTC),
+        uploaded_at=datetime.now(timezone.utc),
         pathname="file.txt",
         content_type="text/plain",
         content_disposition="inline",

--- a/tests/unit/test_sandbox_model_network_policy.py
+++ b/tests/unit/test_sandbox_model_network_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from vercel.sandbox import (
     NetworkPolicyCustom,
     NetworkPolicyRule,
@@ -80,8 +82,6 @@ class TestSandboxModelNetworkPolicy:
         assert sandbox.status is SandboxStatus.RUNNING
 
     def test_model_rejects_unknown_status(self) -> None:
-        import pytest
-
         with pytest.raises(ValueError, match="status"):
             SandboxModel.model_validate(
                 {
@@ -105,3 +105,9 @@ class TestSandboxModelNetworkPolicy:
                     "interactivePort": None,
                 }
             )
+
+    def test_sandbox_status_preserves_string_contract(self) -> None:
+        assert SandboxStatus("running") is SandboxStatus.RUNNING
+        assert SandboxStatus.RUNNING == "running"
+        assert isinstance(SandboxStatus.RUNNING, str)
+        assert str(SandboxStatus.RUNNING) == "running"


### PR DESCRIPTION
We recently bumped to 3.11 as our minimum version, but this restores the ability to use 3.10 with some shims until EOL in October.