### PR TITLE
Refine sandbox duration coercion with typed and boundary helpers

### DIFF
--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -63,7 +63,7 @@ from vercel._internal.sandbox.models import (
     WriteFile,
 )
 from vercel._internal.sandbox.snapshot import SnapshotExpiration
-from vercel._internal.sandbox.time import normalize_duration_ms
+from vercel._internal.sandbox.time import MILLISECOND, coerce_duration
 
 try:
     VERSION = _pkg_version("vercel")
@@ -508,7 +508,7 @@ class BaseSandboxOpsClient:
         data = await self._request_client.request_json(
             "POST",
             f"/v1/sandboxes/{sandbox_id}/extend-timeout",
-            body=JSONBody({"duration": normalize_duration_ms(duration)}),
+            body=JSONBody({"duration": coerce_duration(duration, MILLISECOND) // MILLISECOND}),
         )
         return SandboxResponse.model_validate(data)
 

--- a/src/vercel/_internal/sandbox/core.py
+++ b/src/vercel/_internal/sandbox/core.py
@@ -63,7 +63,7 @@ from vercel._internal.sandbox.models import (
     WriteFile,
 )
 from vercel._internal.sandbox.snapshot import SnapshotExpiration
-from vercel._internal.sandbox.time import MILLISECOND, coerce_duration
+from vercel._internal.sandbox.time import to_ms_int
 
 try:
     VERSION = _pkg_version("vercel")
@@ -502,13 +502,11 @@ class BaseSandboxOpsClient:
             body=JSONBody({"signal": signal}),
         )
 
-    async def extend_timeout(
-        self, *, sandbox_id: str, duration: int | timedelta
-    ) -> SandboxResponse:
+    async def extend_timeout(self, *, sandbox_id: str, duration: timedelta) -> SandboxResponse:
         data = await self._request_client.request_json(
             "POST",
             f"/v1/sandboxes/{sandbox_id}/extend-timeout",
-            body=JSONBody({"duration": coerce_duration(duration, MILLISECOND) // MILLISECOND}),
+            body=JSONBody({"duration": to_ms_int(duration)}),
         )
         return SandboxResponse.model_validate(data)
 

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -21,7 +21,7 @@ from pydantic_core import InitErrorDetails
 
 from vercel._internal.polyfills import StrEnum
 from vercel._internal.sandbox.errors import SandboxError
-from vercel._internal.sandbox.time import normalize_duration_ms
+from vercel._internal.sandbox.time import MILLISECOND, parse_duration
 
 # Source types for Sandbox.create()
 _REDACTED_HEADER_VALUE = "<redacted>"
@@ -480,11 +480,10 @@ class CreateSandboxRequest(_CreateModel):
     @field_validator("timeout", mode="before")
     @classmethod
     def _coerce_timeout(cls, value: object) -> int | None:
-        if value is None:
+        normalized_delta = parse_duration(value, MILLISECOND)
+        if normalized_delta is None:
             return None
-        if isinstance(value, bool) or not isinstance(value, (int, timedelta)):
-            raise TypeError("timeout must be an integer milliseconds value or timedelta")
-        return normalize_duration_ms(value)
+        return normalized_delta // MILLISECOND
 
 
 def parse_source(value: SourceInput | None) -> Source | None:

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -22,7 +22,7 @@ from pydantic_core import InitErrorDetails
 
 from vercel._internal.polyfills import StrEnum
 from vercel._internal.sandbox.errors import SandboxError
-from vercel._internal.sandbox.time import MILLISECOND, parse_duration
+from vercel._internal.sandbox.time import MILLISECOND, parse_duration, to_ms_int
 
 # Source types for Sandbox.create()
 _REDACTED_HEADER_VALUE = "<redacted>"
@@ -487,7 +487,7 @@ class CreateSandboxRequest(_CreateModel):
     def _serialize_timeout(self, value: timedelta | None) -> int | None:
         if value is None:
             return None
-        return value // MILLISECOND
+        return to_ms_int(value)
 
 
 def parse_source(value: SourceInput | None) -> Source | None:

--- a/src/vercel/_internal/sandbox/models.py
+++ b/src/vercel/_internal/sandbox/models.py
@@ -14,6 +14,7 @@ from pydantic import (
     StrictStr,
     TypeAdapter,
     ValidationError,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -479,11 +480,14 @@ class CreateSandboxRequest(_CreateModel):
 
     @field_validator("timeout", mode="before")
     @classmethod
-    def _coerce_timeout(cls, value: object) -> int | None:
-        normalized_delta = parse_duration(value, MILLISECOND)
-        if normalized_delta is None:
+    def _coerce_timeout(cls, value: object) -> timedelta | None:
+        return parse_duration(value, MILLISECOND)
+
+    @field_serializer("timeout")
+    def _serialize_timeout(self, value: timedelta | None) -> int | None:
+        if value is None:
             return None
-        return normalized_delta // MILLISECOND
+        return value // MILLISECOND
 
 
 def parse_source(value: SourceInput | None) -> Source | None:

--- a/src/vercel/_internal/sandbox/snapshot.py
+++ b/src/vercel/_internal/sandbox/snapshot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 
-from vercel._internal.sandbox.time import MILLISECOND, coerce_duration
+from vercel._internal.sandbox.time import MILLISECOND, coerce_duration, to_ms_int
 
 MIN_SNAPSHOT_EXPIRATION = timedelta(milliseconds=86_400_000)
 _ZERO_DELTA = timedelta(seconds=0)
@@ -27,7 +27,7 @@ class SnapshotExpiration:
         self._td = normalized_delta
 
     def __int__(self) -> int:
-        return self._td // MILLISECOND
+        return to_ms_int(self._td)
 
     def __eq__(self, other: object) -> bool:
         match other:

--- a/src/vercel/_internal/sandbox/snapshot.py
+++ b/src/vercel/_internal/sandbox/snapshot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Final
 
-from vercel._internal.sandbox.time import normalize_duration_ms
+from vercel._internal.sandbox.time import MILLISECOND, coerce_duration
 
 MIN_SNAPSHOT_EXPIRATION_MS: Final[int] = 86_400_000
 
@@ -16,9 +16,8 @@ class SnapshotExpiration(int):
     """
 
     def __new__(cls, value: int | timedelta) -> SnapshotExpiration:
-        normalized_value = normalize_duration_ms(value)
-        if normalized_value is None:
-            raise TypeError("Snapshot expiration cannot be None")
+        normalized_delta = coerce_duration(value, MILLISECOND)
+        normalized_value = normalized_delta // MILLISECOND
         if normalized_value != 0 and normalized_value < MIN_SNAPSHOT_EXPIRATION_MS:
             raise ValueError(
                 "Snapshot expiration must be 0 for no expiration or >= 86400000 milliseconds"

--- a/src/vercel/_internal/sandbox/snapshot.py
+++ b/src/vercel/_internal/sandbox/snapshot.py
@@ -1,25 +1,41 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import Final
 
 from vercel._internal.sandbox.time import MILLISECOND, coerce_duration
 
-MIN_SNAPSHOT_EXPIRATION_MS: Final[int] = 86_400_000
+MIN_SNAPSHOT_EXPIRATION = timedelta(milliseconds=86_400_000)
+_ZERO_DELTA = timedelta(seconds=0)
 
 
-class SnapshotExpiration(int):
+@dataclass(eq=False)
+class SnapshotExpiration:
+    _td: timedelta
     """Snapshot expiration in milliseconds.
 
     Valid values are ``0`` for no expiration or any value greater than or equal
     to ``86_400_000`` (24 hours).
     """
 
-    def __new__(cls, value: int | timedelta) -> SnapshotExpiration:
+    def __init__(self, value: int | timedelta):
         normalized_delta = coerce_duration(value, MILLISECOND)
-        normalized_value = normalized_delta // MILLISECOND
-        if normalized_value != 0 and normalized_value < MIN_SNAPSHOT_EXPIRATION_MS:
+        if normalized_delta != _ZERO_DELTA and normalized_delta < MIN_SNAPSHOT_EXPIRATION:
             raise ValueError(
                 "Snapshot expiration must be 0 for no expiration or >= 86400000 milliseconds"
             )
-        return int.__new__(cls, normalized_value)
+        self._td = normalized_delta
+
+    def __int__(self) -> int:
+        return self._td // MILLISECOND
+
+    def __eq__(self, other: object) -> bool:
+        match other:
+            case SnapshotExpiration():
+                return int(self) == int(other)
+            case int() if not isinstance(other, bool):
+                return int(self) == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(int(self))

--- a/src/vercel/_internal/sandbox/time.py
+++ b/src/vercel/_internal/sandbox/time.py
@@ -28,3 +28,11 @@ def parse_duration(value: object, unit: timedelta) -> timedelta | None:
             return coerce_duration(value, unit)
         case _:
             raise TypeError("duration must be an int, float, timedelta, or None")
+
+
+def to_ms_int(td: timedelta) -> int:
+    return td // MILLISECOND
+
+
+def to_seconds_float(td: timedelta) -> float:
+    return td / SECOND

--- a/src/vercel/_internal/sandbox/time.py
+++ b/src/vercel/_internal/sandbox/time.py
@@ -2,14 +2,29 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+MILLISECOND = timedelta(milliseconds=1)
+SECOND = timedelta(seconds=1)
 
-def normalize_duration_ms(value: int | timedelta | None) -> int | None:
+
+def coerce_duration(value: int | float | timedelta, unit: timedelta) -> timedelta:
+    match value:
+        case bool():
+            raise TypeError("duration must be an int, float, or timedelta")
+        case timedelta():
+            return value
+        case int() | float():
+            return value * unit
+        case _:
+            raise TypeError("duration must be an int, float, or timedelta")
+
+
+def parse_duration(value: object, unit: timedelta) -> timedelta | None:
     match value:
         case None:
             return None
-        case int():
-            return value
-        case timedelta():
-            return value // timedelta(milliseconds=1)
+        case bool():
+            raise TypeError("duration must be an int, float, timedelta, or None")
+        case int() | float() | timedelta():
+            return coerce_duration(value, unit)
         case _:
-            raise TypeError("duration must be an int, timedelta, or None")
+            raise TypeError("duration must be an int, float, timedelta, or None")

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -465,7 +465,15 @@ class AsyncSandbox:
 
         Note: this sandbox will be stopped as part of the snapshot creation process.
         """
-        normalized_expiration = None if expiration is None else SnapshotExpiration(expiration)
+        match expiration:
+            case None:
+                normalized_expiration = None
+            case int() | timedelta() if not isinstance(expiration, bool):
+                normalized_expiration = SnapshotExpiration(expiration)
+            case SnapshotExpiration():
+                normalized_expiration = expiration
+            case _:
+                raise TypeError("expiration must be an int, SnapshotExpiration, timedelta, or None")
         response = await self.client.create_snapshot(
             sandbox_id=self.sandbox.id,
             expiration=normalized_expiration,
@@ -910,7 +918,15 @@ class Sandbox:
 
         Note: this sandbox will be stopped as part of the snapshot creation process.
         """
-        normalized_expiration = None if expiration is None else SnapshotExpiration(expiration)
+        match expiration:
+            case None:
+                normalized_expiration = None
+            case int() | timedelta() if not isinstance(expiration, bool):
+                normalized_expiration = SnapshotExpiration(expiration)
+            case SnapshotExpiration():
+                normalized_expiration = expiration
+            case _:
+                raise TypeError("expiration must be an int, SnapshotExpiration, timedelta, or None")
         response = iter_coroutine(
             self.client.create_snapshot(
                 sandbox_id=self.sandbox.id,

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -31,7 +31,7 @@ from vercel._internal.sandbox.models import (
     parse_source,
 )
 from vercel._internal.sandbox.pagination import SandboxListParams
-from vercel._internal.sandbox.time import SECOND, coerce_duration
+from vercel._internal.sandbox.time import MILLISECOND, SECOND, coerce_duration, to_seconds_float
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -299,8 +299,8 @@ class AsyncSandbox:
         import asyncio
 
         target_status = SandboxStatus(status)
-        normalized_timeout = coerce_duration(timeout, SECOND) / SECOND
-        normalized_poll_interval = coerce_duration(poll_interval, SECOND) / SECOND
+        normalized_timeout = to_seconds_float(coerce_duration(timeout, SECOND))
+        normalized_poll_interval = to_seconds_float(coerce_duration(poll_interval, SECOND))
         start = time.monotonic()
         while time.monotonic() - start < normalized_timeout:
             if self.status == target_status:
@@ -453,7 +453,8 @@ class AsyncSandbox:
             duration: The duration in milliseconds or as a ``timedelta`` to
                 extend the timeout by.
         """
-        response = await self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
+        delta = coerce_duration(duration, MILLISECOND)
+        response = await self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=delta)
         self.sandbox = response.sandbox
 
     async def snapshot(
@@ -744,8 +745,8 @@ class Sandbox:
             TimeoutError: If the sandbox does not reach *status* within *timeout*.
         """
         target_status = SandboxStatus(status)
-        normalized_timeout = coerce_duration(timeout, SECOND) / SECOND
-        normalized_poll_interval = coerce_duration(poll_interval, SECOND) / SECOND
+        normalized_timeout = to_seconds_float(coerce_duration(timeout, SECOND))
+        normalized_poll_interval = to_seconds_float(coerce_duration(poll_interval, SECOND))
         start = time.monotonic()
         while time.monotonic() - start < normalized_timeout:
             if self.status == target_status:
@@ -904,8 +905,9 @@ class Sandbox:
             duration: The duration in milliseconds or as a ``timedelta`` to
                 extend the timeout by.
         """
+        delta = coerce_duration(duration, MILLISECOND)
         response = iter_coroutine(
-            self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=duration)
+            self.client.extend_timeout(sandbox_id=self.sandbox.id, duration=delta)
         )
         self.sandbox = response.sandbox
 

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -31,6 +31,7 @@ from vercel._internal.sandbox.models import (
     parse_source,
 )
 from vercel._internal.sandbox.pagination import SandboxListParams
+from vercel._internal.sandbox.time import SECOND, coerce_duration
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -281,15 +282,16 @@ class AsyncSandbox:
         self,
         status: SandboxStatus | str,
         *,
-        timeout: float = 30.0,
-        poll_interval: float = 0.5,
+        timeout: float | timedelta = 30.0,
+        poll_interval: float | timedelta = 0.5,
     ) -> None:
         """Wait for this sandbox to reach the given status.
 
         Args:
             status: The target status to wait for (e.g. ``"running"``).
-            timeout: Maximum time to wait in seconds.
-            poll_interval: Time between status checks in seconds.
+            timeout: Maximum time to wait in seconds or as a ``timedelta``.
+            poll_interval: Time between status checks in seconds or as a
+                ``timedelta``.
 
         Raises:
             TimeoutError: If the sandbox does not reach *status* within *timeout*.
@@ -297,16 +299,19 @@ class AsyncSandbox:
         import asyncio
 
         target_status = SandboxStatus(status)
+        normalized_timeout = coerce_duration(timeout, SECOND) / SECOND
+        normalized_poll_interval = coerce_duration(poll_interval, SECOND) / SECOND
         start = time.monotonic()
-        while time.monotonic() - start < timeout:
+        while time.monotonic() - start < normalized_timeout:
             if self.status == target_status:
                 return
-            await asyncio.sleep(poll_interval)
+            await asyncio.sleep(normalized_poll_interval)
             await self.refresh()
         if self.status == target_status:
             return
         raise TimeoutError(
-            f"Sandbox {self.sandbox_id} did not reach '{target_status}' status within {timeout}s"
+            f"Sandbox {self.sandbox_id} did not reach '{target_status}' status within "
+            f"{normalized_timeout}s"
         )
 
     def domain(self, port: int) -> str:
@@ -414,17 +419,18 @@ class AsyncSandbox:
         self,
         *,
         blocking: bool = False,
-        timeout: float = 30.0,
-        poll_interval: float = 0.5,
+        timeout: float | timedelta = 30.0,
+        poll_interval: float | timedelta = 0.5,
     ) -> None:
         """Stop this sandbox.
 
         Args:
             blocking: When ``True``, wait until the sandbox reaches
                 ``"stopped"`` before returning.
-            timeout: Maximum time to wait in seconds when ``blocking=True``.
-            poll_interval: Time between refreshes in seconds when
+            timeout: Maximum time to wait in seconds or as a ``timedelta`` when
                 ``blocking=True``.
+            poll_interval: Time between refreshes in seconds or as a
+                ``timedelta`` when ``blocking=True``.
 
         Raises:
             TimeoutError: If ``blocking=True`` and the sandbox does not reach
@@ -715,30 +721,34 @@ class Sandbox:
         self,
         status: SandboxStatus | str,
         *,
-        timeout: float = 30.0,
-        poll_interval: float = 0.5,
+        timeout: float | timedelta = 30.0,
+        poll_interval: float | timedelta = 0.5,
     ) -> None:
         """Wait for this sandbox to reach the given status.
 
         Args:
             status: The target status to wait for (e.g. ``"running"``).
-            timeout: Maximum time to wait in seconds.
-            poll_interval: Time between status checks in seconds.
+            timeout: Maximum time to wait in seconds or as a ``timedelta``.
+            poll_interval: Time between status checks in seconds or as a
+                ``timedelta``.
 
         Raises:
             TimeoutError: If the sandbox does not reach *status* within *timeout*.
         """
         target_status = SandboxStatus(status)
+        normalized_timeout = coerce_duration(timeout, SECOND) / SECOND
+        normalized_poll_interval = coerce_duration(poll_interval, SECOND) / SECOND
         start = time.monotonic()
-        while time.monotonic() - start < timeout:
+        while time.monotonic() - start < normalized_timeout:
             if self.status == target_status:
                 return
-            time.sleep(poll_interval)
+            time.sleep(normalized_poll_interval)
             self.refresh()
         if self.status == target_status:
             return
         raise TimeoutError(
-            f"Sandbox {self.sandbox_id} did not reach '{target_status}' status within {timeout}s"
+            f"Sandbox {self.sandbox_id} did not reach '{target_status}' status within "
+            f"{normalized_timeout}s"
         )
 
     def domain(self, port: int) -> str:
@@ -852,17 +862,18 @@ class Sandbox:
         self,
         *,
         blocking: bool = False,
-        timeout: float = 30.0,
-        poll_interval: float = 0.5,
+        timeout: float | timedelta = 30.0,
+        poll_interval: float | timedelta = 0.5,
     ) -> None:
         """Stop this sandbox.
 
         Args:
             blocking: When ``True``, wait until the sandbox reaches
                 ``"stopped"`` before returning.
-            timeout: Maximum time to wait in seconds when ``blocking=True``.
-            poll_interval: Time between refreshes in seconds when
+            timeout: Maximum time to wait in seconds or as a ``timedelta`` when
                 ``blocking=True``.
+            poll_interval: Time between refreshes in seconds or as a
+                ``timedelta`` when ``blocking=True``.
 
         Raises:
             TimeoutError: If ``blocking=True`` and the sandbox does not reach

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -13,11 +13,11 @@ from vercel._internal.sandbox.snapshot import (
     MIN_SNAPSHOT_EXPIRATION,
     SnapshotExpiration as _SnapshotExpiration,
 )
-from vercel._internal.sandbox.time import MILLISECOND
+from vercel._internal.sandbox.time import to_ms_int
 
 from ..oidc import Credentials, get_credentials
 
-MIN_SNAPSHOT_EXPIRATION_MS = MIN_SNAPSHOT_EXPIRATION // MILLISECOND
+MIN_SNAPSHOT_EXPIRATION_MS = to_ms_int(MIN_SNAPSHOT_EXPIRATION)
 SnapshotExpiration = _SnapshotExpiration
 
 

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -10,13 +10,14 @@ from vercel._internal.sandbox import AsyncSandboxOpsClient, SyncSandboxOpsClient
 from vercel._internal.sandbox.models import Snapshot as SnapshotModel
 from vercel._internal.sandbox.pagination import SnapshotListParams
 from vercel._internal.sandbox.snapshot import (
-    MIN_SNAPSHOT_EXPIRATION_MS as _MIN_SNAPSHOT_EXPIRATION_MS,
+    MIN_SNAPSHOT_EXPIRATION,
     SnapshotExpiration as _SnapshotExpiration,
 )
+from vercel._internal.sandbox.time import MILLISECOND
 
 from ..oidc import Credentials, get_credentials
 
-MIN_SNAPSHOT_EXPIRATION_MS = _MIN_SNAPSHOT_EXPIRATION_MS
+MIN_SNAPSHOT_EXPIRATION_MS = MIN_SNAPSHOT_EXPIRATION // MILLISECOND
 SnapshotExpiration = _SnapshotExpiration
 
 

--- a/tests/integration/test_blob_sync_async.py
+++ b/tests/integration/test_blob_sync_async.py
@@ -400,9 +400,7 @@ class TestBlobPut:
 
         import asyncio
 
-        async_result = asyncio.get_event_loop().run_until_complete(
-            put_async("test.txt", b"data", token="test_token")
-        )
+        async_result = asyncio.run(put_async("test.txt", b"data", token="test_token"))
 
         assert sync_result.url == async_result.url
         assert sync_result.pathname == async_result.pathname

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -3209,6 +3209,49 @@ class TestSandboxStop:
         sandbox.client.close()
 
     @respx.mock
+    def test_stop_sync_blocking_accepts_timedelta(self, mock_env_clear, mock_sandbox_get_response):
+        """Test blocking sync stop accepts timedelta inputs."""
+        from vercel.sandbox import Sandbox
+
+        sandbox_id = "sbx_test123456"
+        stopping_response = {**mock_sandbox_get_response, "status": "stopping"}
+        stopped_response = {
+            **mock_sandbox_get_response,
+            "status": "stopped",
+            "stoppedAt": mock_sandbox_get_response["updatedAt"] + 1,
+        }
+
+        get_route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            side_effect=[
+                httpx.Response(200, json={"sandbox": mock_sandbox_get_response, "routes": []}),
+                httpx.Response(200, json={"sandbox": stopping_response, "routes": []}),
+                httpx.Response(200, json={"sandbox": stopped_response, "routes": []}),
+            ]
+        )
+        stop_route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/stop").mock(
+            return_value=httpx.Response(200, json={"sandbox": stopping_response})
+        )
+
+        sandbox = Sandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        sandbox.stop(
+            blocking=True,
+            timeout=timedelta(milliseconds=50),
+            poll_interval=timedelta(milliseconds=10),
+        )
+
+        assert stop_route.called
+        assert sandbox.status == "stopped"
+        assert get_route.call_count == 3
+
+        sandbox.client.close()
+
+    @respx.mock
     @pytest.mark.asyncio
     async def test_stop_async_blocking_polls_until_stopped(
         self, mock_env_clear, mock_sandbox_get_response
@@ -3326,6 +3369,52 @@ class TestSandboxStop:
         assert stop_route.called
         assert sandbox.status == "stopped"
         assert get_route.call_count == 2
+
+        await sandbox.client.aclose()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_stop_async_blocking_accepts_timedelta(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        """Test blocking async stop accepts timedelta inputs."""
+        from vercel.sandbox import AsyncSandbox
+
+        sandbox_id = "sbx_test123456"
+        stopping_response = {**mock_sandbox_get_response, "status": "stopping"}
+        stopped_response = {
+            **mock_sandbox_get_response,
+            "status": "stopped",
+            "stoppedAt": mock_sandbox_get_response["updatedAt"] + 1,
+        }
+
+        get_route = respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            side_effect=[
+                httpx.Response(200, json={"sandbox": mock_sandbox_get_response, "routes": []}),
+                httpx.Response(200, json={"sandbox": stopping_response, "routes": []}),
+                httpx.Response(200, json={"sandbox": stopped_response, "routes": []}),
+            ]
+        )
+        stop_route = respx.post(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}/stop").mock(
+            return_value=httpx.Response(200, json={"sandbox": stopping_response})
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        await sandbox.stop(
+            blocking=True,
+            timeout=timedelta(milliseconds=50),
+            poll_interval=timedelta(milliseconds=10),
+        )
+
+        assert stop_route.called
+        assert sandbox.status == "stopped"
+        assert get_route.call_count == 3
 
         await sandbox.client.aclose()
 
@@ -4185,6 +4274,47 @@ class TestSandboxWaitForStatus:
         sandbox.client.close()
 
     @respx.mock
+    def test_wait_for_status_accepts_timedelta(self, mock_env_clear, mock_sandbox_get_response):
+        """Test wait_for_status accepts timedelta inputs."""
+        from vercel.sandbox import Sandbox, SandboxStatus
+
+        sandbox_id = "sbx_test123456"
+        pending_response = {**mock_sandbox_get_response, "status": "pending"}
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": mock_sandbox_get_response, "routes": []},
+                ),
+            ]
+        )
+
+        sandbox = Sandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        sandbox.wait_for_status(
+            SandboxStatus.RUNNING,
+            timeout=timedelta(milliseconds=50),
+            poll_interval=timedelta(milliseconds=10),
+        )
+        assert sandbox.status is SandboxStatus.RUNNING
+
+        sandbox.client.close()
+
+    @respx.mock
     def test_wait_for_status_timeout(self, mock_env_clear, mock_sandbox_get_response):
         """Test wait_for_status raises TimeoutError."""
         from vercel.sandbox import Sandbox
@@ -4338,6 +4468,50 @@ class TestSandboxWaitForStatus:
 
         with pytest.raises(TimeoutError, match="did not reach 'running' status"):
             await sandbox.wait_for_status("running", timeout=0.05, poll_interval=0.01)
+
+        await sandbox.client.aclose()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_wait_for_status_async_accepts_timedelta(
+        self, mock_env_clear, mock_sandbox_get_response
+    ):
+        """Test async wait_for_status accepts timedelta inputs."""
+        from vercel.sandbox import AsyncSandbox, SandboxStatus
+
+        sandbox_id = "sbx_test123456"
+        pending_response = {**mock_sandbox_get_response, "status": "pending"}
+
+        respx.get(f"{SANDBOX_API_BASE}/v1/sandboxes/{sandbox_id}").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": pending_response, "routes": []},
+                ),
+                httpx.Response(
+                    200,
+                    json={"sandbox": mock_sandbox_get_response, "routes": []},
+                ),
+            ]
+        )
+
+        sandbox = await AsyncSandbox.get(
+            sandbox_id=sandbox_id,
+            token="test_token",
+            team_id="team_test123",
+            project_id="prj_test123",
+        )
+
+        await sandbox.wait_for_status(
+            SandboxStatus.RUNNING,
+            timeout=timedelta(milliseconds=50),
+            poll_interval=timedelta(milliseconds=10),
+        )
+        assert sandbox.status is SandboxStatus.RUNNING
 
         await sandbox.client.aclose()
 

--- a/tests/unit/test_sandbox_time.py
+++ b/tests/unit/test_sandbox_time.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from hypothesis import given, strategies as st
 
+from vercel._internal.sandbox.models import CreateSandboxRequest
 from vercel._internal.sandbox.time import MILLISECOND, SECOND, coerce_duration, parse_duration
 
 MAX_DURATION_MS = timedelta.max // MILLISECOND
@@ -127,3 +128,10 @@ def test_parse_duration_rejects_unsupported_values(value: object) -> None:
 def test_parse_duration_rejects_bool_values(value: bool) -> None:
     with pytest.raises(TypeError, match="duration must be an int, float, timedelta, or None"):
         parse_duration(value, SECOND)
+
+
+def test_create_sandbox_request_preserves_timedelta_until_serialization() -> None:
+    request = CreateSandboxRequest(project_id="prj_test123", timeout=timedelta(minutes=10))
+
+    assert request.timeout == timedelta(minutes=10)
+    assert request.model_dump(by_alias=True, exclude_none=True)["timeout"] == 600_000

--- a/tests/unit/test_sandbox_time.py
+++ b/tests/unit/test_sandbox_time.py
@@ -9,10 +9,16 @@ import pytest
 from hypothesis import given, strategies as st
 
 from vercel._internal.sandbox.models import CreateSandboxRequest
-from vercel._internal.sandbox.time import MILLISECOND, SECOND, coerce_duration, parse_duration
+from vercel._internal.sandbox.time import (
+    MILLISECOND,
+    SECOND,
+    coerce_duration,
+    parse_duration,
+    to_ms_int,
+)
 
-MAX_DURATION_MS = timedelta.max // MILLISECOND
-MIN_DURATION_MS = timedelta.min // MILLISECOND
+MAX_DURATION_MS = to_ms_int(timedelta.max)
+MIN_DURATION_MS = to_ms_int(timedelta.min)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_sandbox_time.py
+++ b/tests/unit/test_sandbox_time.py
@@ -3,29 +3,53 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from hypothesis import given, strategies as st
 
-from vercel._internal.sandbox.time import normalize_duration_ms
+from vercel._internal.sandbox.time import MILLISECOND, SECOND, coerce_duration, parse_duration
 
-MAX_DURATION_MS = timedelta.max // timedelta(milliseconds=1)
-MIN_DURATION_MS = timedelta.min // timedelta(milliseconds=1)
-
-
-@given(st.one_of(st.none(), st.integers()))
-def test_normalize_duration_ms_preserves_none_and_ints(value: int | None) -> None:
-    assert normalize_duration_ms(value) == value
+MAX_DURATION_MS = timedelta.max // MILLISECOND
+MIN_DURATION_MS = timedelta.min // MILLISECOND
 
 
-@given(st.integers(min_value=MIN_DURATION_MS, max_value=MAX_DURATION_MS))
-def test_normalize_duration_ms_matches_equivalent_milliseconds(value: int) -> None:
-    assert normalize_duration_ms(timedelta(milliseconds=value)) == normalize_duration_ms(value)
+@pytest.mark.parametrize(
+    ("unit", "primitive", "equivalent_delta"),
+    [
+        pytest.param(
+            MILLISECOND,
+            st.integers(min_value=MIN_DURATION_MS, max_value=MAX_DURATION_MS),
+            lambda value: timedelta(milliseconds=value),
+            id="milliseconds",
+        ),
+        pytest.param(
+            SECOND,
+            st.floats(
+                min_value=-1_000_000.0,
+                max_value=1_000_000.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            lambda value: timedelta(seconds=value),
+            id="seconds",
+        ),
+    ],
+)
+def test_coerce_duration_matches_equivalent_timedelta(
+    unit: timedelta,
+    primitive: st.SearchStrategy[Any],
+    equivalent_delta: Any,
+) -> None:
+    @given(primitive)
+    def run(value: int | float) -> None:
+        assert coerce_duration(value, unit) == equivalent_delta(value)
+
+    run()
 
 
 @given(
     st.one_of(
-        st.floats(),
         st.text(),
         st.binary(),
         st.lists(st.integers()),
@@ -33,6 +57,73 @@ def test_normalize_duration_ms_matches_equivalent_milliseconds(value: int) -> No
         st.tuples(st.integers(), st.integers()),
     )
 )
-def test_normalize_duration_ms_rejects_unsupported_values(value: object) -> None:
-    with pytest.raises(TypeError, match="duration must be an int, timedelta, or None"):
-        normalize_duration_ms(value)  # type: ignore[arg-type]
+def test_coerce_duration_rejects_unsupported_values(value: object) -> None:
+    with pytest.raises(TypeError, match="duration must be an int, float, or timedelta"):
+        coerce_duration(value, MILLISECOND)  # type: ignore[arg-type]
+
+
+@given(
+    st.booleans(),
+)
+def test_coerce_duration_rejects_bool_values(value: bool) -> None:
+    with pytest.raises(TypeError, match="duration must be an int, float, or timedelta"):
+        coerce_duration(value, SECOND)  # type: ignore[arg-type]
+
+
+@given(st.none())
+def test_parse_duration_preserves_none(value: None) -> None:
+    assert parse_duration(value, MILLISECOND) is None
+
+
+@pytest.mark.parametrize(
+    ("unit", "primitive", "equivalent_delta"),
+    [
+        pytest.param(
+            MILLISECOND,
+            st.integers(min_value=MIN_DURATION_MS, max_value=MAX_DURATION_MS),
+            lambda value: timedelta(milliseconds=value),
+            id="milliseconds",
+        ),
+        pytest.param(
+            SECOND,
+            st.floats(
+                min_value=-1_000_000.0,
+                max_value=1_000_000.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            lambda value: timedelta(seconds=value),
+            id="seconds",
+        ),
+    ],
+)
+def test_parse_duration_matches_equivalent_timedelta(
+    unit: timedelta,
+    primitive: st.SearchStrategy[Any],
+    equivalent_delta: Any,
+) -> None:
+    @given(primitive)
+    def run(value: int | float) -> None:
+        assert parse_duration(value, unit) == equivalent_delta(value)
+
+    run()
+
+
+@given(
+    st.one_of(
+        st.text(),
+        st.binary(),
+        st.lists(st.integers()),
+        st.dictionaries(st.text(), st.integers()),
+        st.tuples(st.integers(), st.integers()),
+    )
+)
+def test_parse_duration_rejects_unsupported_values(value: object) -> None:
+    with pytest.raises(TypeError, match="duration must be an int, float, timedelta, or None"):
+        parse_duration(value, MILLISECOND)
+
+
+@given(st.booleans())
+def test_parse_duration_rejects_bool_values(value: bool) -> None:
+    with pytest.raises(TypeError, match="duration must be an int, float, timedelta, or None"):
+        parse_duration(value, SECOND)


### PR DESCRIPTION
This PR cleans up the internal duration-conversion API used by the sandbox client.

The main outcome is a deliberate split between two helpers in `src/vercel/_internal/sandbox/time.py`:

- `coerce_duration(value, unit)` for typed internal call sites
- `parse_duration(value, unit)` for untyped boundary inputs such as Pydantic field validators

It also exports unit constants:

- `MILLISECOND`
- `SECOND`

This keeps the core conversion logic generic without continuing to grow a family of unit-specific helpers.

## Current API

The current shape is:

```python
delta = coerce_duration(timeout, SECOND)
seconds = delta / SECOND
```

```python
delta = coerce_duration(duration, MILLISECOND)
milliseconds = delta // MILLISECOND
```

For untyped boundary inputs:

```python
normalized_delta = parse_duration(value, MILLISECOND)
if normalized_delta is None:
    return None
return normalized_delta // MILLISECOND
```

This makes two things explicit:

- coercion into a canonical internal representation (`timedelta`)
- projection back into the numeric form the caller actually wants

## Why split `coerce_duration` and `parse_duration`

`coerce_duration()` is intentionally typed:

```python
def coerce_duration(value: int | float | timedelta, unit: timedelta) -> timedelta
```

That makes internal call sites crisp and keeps type checking useful.

`parse_duration()` is intentionally boundary-oriented:

```python
def parse_duration(value: object, unit: timedelta) -> timedelta | None
```

That fits places like Pydantic validators, where the input is genuinely `object` and may be invalid or `None`.

This avoids pushing boundary-validation concerns into the typed helper.

## None handling

We explored letting `coerce_duration()` accept `None`, but it made the ergonomics worse for normal internal call sites:

- it forced optional return types into places that did not need them
- it required extra guards or assertions before applying `/ SECOND` or `// MILLISECOND`

The final decision was:

- `coerce_duration()` does not handle `None`
- `parse_duration()` does handle `None`

That keeps the internal helper simple while still supporting boundary-facing validators cleanly.

## Alternatives considered

### 1. Keep adding more specialized helpers

Example API:

```python
seconds = normalize_duration_seconds(timeout)
milliseconds = normalize_duration_ms(duration)
```

Pros:

- compact call sites
- easy to read in isolation

Cons:

- the helper family keeps growing by unit and output shape
- the real shared abstraction stays hidden
- tests and behavior tend to duplicate across helpers

This is the direction the code was already drifting toward, and this PR intentionally moves away from it.

### 2. Add an `as_type` kwarg to `coerce_duration`

Example API:

```python
seconds = coerce_duration(timeout, SECOND, as_type=float)
milliseconds = coerce_duration(duration, MILLISECOND, as_type=int)
```

Pros:

- one entry point
- hides the projection step

Cons:

- mixes coercion and numeric projection again
- makes the helper responsible for deciding between `/` and `//`
- gets awkward once `timedelta` inputs are involved, because the intended output shape is policy, not something recoverable from the input

This felt more clever than clear.

### 3. Accept a `project` or `transform` lambda

Example API:

```python
seconds = coerce_duration(timeout, SECOND, project=lambda d: d / SECOND)
milliseconds = coerce_duration(duration, MILLISECOND, project=lambda d: d // MILLISECOND)
```

Pros:

- flexible
- can hide optional-style mapping behavior inside the helper

Cons:

- pushes more abstraction into a helper that should stay simple
- makes straightforward unit conversion harder to scan at the call site
- effectively reintroduces “option map” behavior without much Pythonic benefit

We decided this was possible, but not better.

## Why the current shape won

The chosen API keeps the split simple:

- `coerce_duration()` answers “how do I turn a typed duration input into a `timedelta`?”
- `parse_duration()` answers “how do I safely accept an untyped boundary value and maybe get a `timedelta`?”

Then each caller makes its numeric projection explicit:

- `/ SECOND` for fractional seconds
- `// MILLISECOND` for integer milliseconds

That keeps unit semantics visible at the call site and avoids making one helper carry too much policy.

Closes #86
