### PR TITLE
Export sandbox helper types

### DIFF
--- a/src/vercel/sandbox/__init__.py
+++ b/src/vercel/sandbox/__init__.py
@@ -11,6 +11,7 @@ from vercel._internal.sandbox import (
 from .command import AsyncCommand, AsyncCommandFinished, Command, CommandFinished
 from .models import (
     GitSource,
+    LogLine,
     NetworkPolicy,
     NetworkPolicyCustom,
     NetworkPolicyRule,
@@ -23,6 +24,7 @@ from .models import (
     SnapshotSource,
     Source,
     TarballSource,
+    WriteFile,
 )
 from .sandbox import AsyncSandbox, Sandbox
 from .snapshot import (
@@ -50,11 +52,13 @@ __all__ = [
     "AsyncCommandFinished",
     "Command",
     "CommandFinished",
+    "LogLine",
     # Source types
     "Source",
     "GitSource",
     "TarballSource",
     "SnapshotSource",
+    "WriteFile",
     "Resources",
     "SandboxValidationError",
     "SandboxValidationIssue",

--- a/tests/live/test_sandbox_live.py
+++ b/tests/live/test_sandbox_live.py
@@ -81,8 +81,7 @@ class TestSandboxLive:
 
     def test_file_operations(self, vercel_token, vercel_team_id, cleanup_registry, tmp_path):
         """Test sandbox file write and read operations."""
-        from vercel.sandbox import Sandbox
-        from vercel.sandbox.models import WriteFile
+        from vercel.sandbox import Sandbox, WriteFile
 
         sandbox = Sandbox.create(
             token=vercel_token,


### PR DESCRIPTION
Re-export WriteFile and LogLine from vercel.sandbox so callers can import those helper types from the public package surface, and update the live sandbox file operations test to use the supported top-level WriteFile import path. Closes #87