### PR TITLE
Bump upstream dependency on `vercel-workers`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "python-dotenv",
     "websockets>=12.0",
     "cbor2>=5.8.0",
-    "vercel-workers>=0.0.12 ; python_version >= '3.12'",
+    "vercel-workers>=0.0.16 ; python_version >= '3.12'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Some versions prior to `0.0.16` included at project script called `test` which would shadow the built-in `test` when running a shell within a venv that includes `vercel` (and it's transient dependency on `vercel-workers`).