### PR TITLE
workflow: fix concurrent sandbox

### DIFF
--- a/src/vercel/workflow/py_sandbox.py
+++ b/src/vercel/workflow/py_sandbox.py
@@ -44,7 +44,7 @@ class _ModulePolicy:
     allowed: frozenset[str] | None = None
     allow_if: Callable[[str], bool] | None = None
 
-    def post_exec(self, *, proxy: _ProxyModule, module: types.ModuleType, random_seed: str) -> None:
+    def post_exec(self, *, proxy: _ProxyModule, module: types.ModuleType) -> None:
         pass
 
     def resolve_attr(self, name: str, real: types.ModuleType) -> Any:
@@ -534,13 +534,11 @@ class _SandboxFinder(MetaPathFinder):
         passthrough: set[str],
         restrictions: dict[str, _ModulePolicy] | None = None,
         blocked: set[str] | None = None,
-        random_seed: str,
     ) -> None:
         self._host = host_modules
         self._passthrough = passthrough
         self._restrictions = restrictions or {}
         self._blocked = blocked or set()
-        self._random_seed = random_seed
 
     def _is_passthrough(self, name: str) -> bool:
         for prefix in self._passthrough:
@@ -571,7 +569,8 @@ class _SandboxFinder(MetaPathFinder):
             if fullname in self._host and self._is_passthrough(fullname):
                 proxy = _ProxyModule(self._host[fullname], policy)
                 policy.post_exec(
-                    proxy=proxy, module=self._host[fullname], random_seed=self._random_seed
+                    proxy=proxy,
+                    module=self._host[fullname],
                 )
                 return spec_from_loader(fullname, _PreloadedLoader(proxy), origin="sandbox")
             real_spec = self._find_real_spec(fullname, path, target)
@@ -580,7 +579,8 @@ class _SandboxFinder(MetaPathFinder):
             return ModuleSpec(
                 fullname,
                 _RestrictedLoader(
-                    real_spec, self._restrictions[fullname], random_seed=self._random_seed
+                    real_spec,
+                    self._restrictions[fullname],
                 ),
                 origin=real_spec.origin,
                 is_package=real_spec.submodule_search_locations is not None,
@@ -610,10 +610,9 @@ class _SandboxFinder(MetaPathFinder):
 
 
 class _RestrictedLoader(Loader):
-    def __init__(self, real_spec: ModuleSpec, policy: _ModulePolicy, *, random_seed: str) -> None:
+    def __init__(self, real_spec: ModuleSpec, policy: _ModulePolicy) -> None:
         self._real_spec = real_spec
         self._policy = policy
-        self._random_seed = random_seed
 
     def create_module(self, spec: ModuleSpec) -> types.ModuleType | None:
         loader = self._real_spec.loader
@@ -626,7 +625,7 @@ class _RestrictedLoader(Loader):
         if loader is not None:
             loader.exec_module(module)
         proxy = sys.modules[module.__name__] = _ProxyModule(module, self._policy)
-        self._policy.post_exec(proxy=proxy, module=module, random_seed=self._random_seed)
+        self._policy.post_exec(proxy=proxy, module=module)
 
 
 class _PreloadedLoader(Loader):
@@ -691,7 +690,7 @@ _sandbox_refcount: int = 0
 
 
 @contextmanager
-def _sandbox_modules(random_seed: str) -> Iterator[None]:
+def _sandbox_modules() -> Iterator[None]:
     """Ref-counted sys.modules patch.
 
     The first caller patches sys.modules with proxy modules and installs
@@ -730,7 +729,6 @@ def _sandbox_modules(random_seed: str) -> Iterator[None]:
         passthrough=_PASSTHROUGHS,
         restrictions=module_restrictions,
         blocked=_BLOCKED,
-        random_seed=random_seed,
     )
 
     with _sandbox_linecache():
@@ -759,7 +757,7 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
     if not isinstance(random_seed, str):
         raise TypeError("random_seed must be a str")
 
-    with _sandbox_modules(random_seed):
+    with _sandbox_modules():
         sandbox_token = _in_sandbox.set(True)
         random_token = _sandbox_random.set(random.Random(random_seed))
         try:
@@ -767,3 +765,7 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
         finally:
             _sandbox_random.reset(random_token)
             _in_sandbox.reset(sandbox_token)
+
+
+def in_sandbox() -> bool:
+    return _in_sandbox.get()

--- a/src/vercel/workflow/py_sandbox.py
+++ b/src/vercel/workflow/py_sandbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import datetime as _dt
 import os
@@ -13,6 +14,12 @@ from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from importlib.util import spec_from_loader
 from typing import Any, NoReturn
+
+# When True, proxy modules enforce restrictions.  When False (default),
+# attribute access on proxy modules falls through to the real module.
+# This allows concurrent coroutines that are NOT running a workflow to
+# use the real module even while the sandbox has replaced sys.modules.
+_in_sandbox: contextvars.ContextVar[bool] = contextvars.ContextVar("_in_sandbox", default=False)
 
 
 class SandboxRestrictionError(RuntimeError):
@@ -39,6 +46,32 @@ class _ModulePolicy:
 
     def post_exec(self, *, proxy: _ProxyModule, module: types.ModuleType, random_seed: str) -> None:
         pass
+
+    def resolve_attr(self, name: str, real: types.ModuleType) -> Any:
+        """Resolve an allowed attribute on the real module.
+
+        Called by ``_ProxyModule.__getattr__`` as the final fallback.
+        Subclasses can override to intercept (e.g. per-context random).
+        """
+        return getattr(real, name)
+
+
+def _context_restricted(name: str, real_fn: Any) -> Callable[..., Any]:
+    """Like ``_restricted`` but falls through to *real_fn* outside sandbox context.
+
+    Used for builtins overrides where CPython's ``LOAD_GLOBAL`` reads
+    ``__dict__`` directly, bypassing ``__getattr__``.
+    """
+
+    def _wrapper(*_args: Any, **_kwargs: Any) -> Any:
+        if _in_sandbox.get(False):
+            raise SandboxRestrictionError(
+                f"Cannot call {name}() inside a workflow. Workflows must be deterministic."
+            )
+        return real_fn(*_args, **_kwargs)
+
+    _wrapper.__qualname__ = f"<context-restricted {name}>"
+    return _wrapper
 
 
 def _blocklist(
@@ -114,12 +147,24 @@ class _RestrictedRandom(random.Random, metaclass=_RestrictedRandomMeta):
         super().seed(a, **kwargs)
 
 
+# Per-sandbox Random instance, so concurrent sandboxes with different
+# seeds don't corrupt each other's random state.
+_sandbox_random: contextvars.ContextVar[random.Random | None] = contextvars.ContextVar(
+    "_sandbox_random", default=None
+)
+
+
 class _RestrictedRandomPolicy(_ModulePolicy):
     def __init__(self) -> None:
         super().__init__("random", overrides={"Random": _RestrictedRandom})
 
-    def post_exec(self, *, proxy: _ProxyModule, module: types.ModuleType, random_seed: str) -> None:
-        module.seed(random_seed)
+    def resolve_attr(self, name: str, real: types.ModuleType) -> Any:
+        inst = _sandbox_random.get(None)
+        if inst is not None:
+            method = getattr(inst, name, None)
+            if method is not None:
+                return method
+        return getattr(real, name)
 
 
 def _wrap_get_loop(real_fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -409,11 +454,26 @@ class _ProxyModule(types.ModuleType):
                 self.__dict__[attr] = val
         if copy_dict:
             self.__dict__.update(real.__dict__)
-        # Overrides go into __dict__ so they are found by direct
-        # dict lookup (important for builtins).
-        self.__dict__.update(policy.overrides)
+            # For dict-based lookups (builtins), overrides must be
+            # context-aware so concurrent coroutines outside the sandbox
+            # can still call the real functions.
+            for key, val in policy.overrides.items():
+                real_fn = real.__dict__.get(key)
+                if real_fn is not None and callable(val):
+                    self.__dict__[key] = _context_restricted(f"{policy.module_name}.{key}", real_fn)
+                else:
+                    self.__dict__[key] = val
+        else:
+            # Overrides go into __dict__ so they are found by direct
+            # dict lookup (important for builtins).
+            self.__dict__.update(policy.overrides)
 
     def __getattr__(self, name: str) -> Any:
+        real = object.__getattribute__(self, "_proxy_real")
+        # Outside a sandbox context, delegate everything to the real module
+        # so concurrent coroutines are not affected by the global proxy.
+        if not _in_sandbox.get(False):
+            return getattr(real, name)
         policy = object.__getattribute__(self, "_proxy_policy")
         if name in policy.drops:
             raise AttributeError(name)
@@ -431,8 +491,7 @@ class _ProxyModule(types.ModuleType):
             # This allows module init code like ``from os import urandom``
             # to succeed — the error fires when the function is *called*.
             return _restricted(f"{policy.module_name}.{name}")
-        real = object.__getattribute__(self, "_proxy_real")
-        return getattr(real, name)
+        return policy.resolve_attr(name, real)
 
     def __repr__(self) -> str:
         real = object.__getattribute__(self, "_proxy_real")
@@ -442,9 +501,17 @@ class _ProxyModule(types.ModuleType):
 class _StubModule(types.ModuleType):
     """A stub module where every attribute access returns a restricted callable."""
 
+    def __init__(self, name: str, real: types.ModuleType | None = None) -> None:
+        super().__init__(name)
+        object.__setattr__(self, "_stub_real", real)
+
     def __getattr__(self, name: str) -> Any:
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
+        if not _in_sandbox.get(False):
+            real = object.__getattribute__(self, "_stub_real")
+            if real is not None:
+                return getattr(real, name)
         return _restricted(f"{self.__name__}.{name}")
 
 
@@ -491,8 +558,9 @@ class _SandboxFinder(MetaPathFinder):
             # Return a stub module instead of raising — other modules may
             # ``import subprocess`` at module level but never call it.
             # Every attribute access on the stub returns a restricted callable.
+            real = self._host.get(fullname)
             return spec_from_loader(
-                fullname, _PreloadedLoader(_StubModule(fullname)), origin="blocked"
+                fullname, _PreloadedLoader(_StubModule(fullname, real)), origin="blocked"
             )
         if fullname in self._restrictions:
             policy = self._restrictions[fullname]
@@ -619,30 +687,33 @@ def _sandbox_linecache() -> Iterator[None]:
         linecache.checkcache = orig_checkcache
 
 
+_sandbox_refcount: int = 0
+
+
 @contextmanager
-def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
-    """Activate the sandbox.
+def _sandbox_modules(random_seed: str) -> Iterator[None]:
+    """Ref-counted sys.modules patch.
 
-    1. Snapshots ``sys.modules`` and replaces its contents in-place
-       (CPython's C-level import uses ``interp->modules`` which is
-       the *same dict object* — replacing ``sys.modules`` with a
-       new dict would not affect ``IMPORT_NAME`` bytecode).
-    2. Installs a ``_SandboxFinder`` at the front of
-       ``sys.meta_path`` — restricted modules are wrapped in
-       ``_ProxyModule`` to block non-deterministic calls;
-       passthrough modules are served from the host as-is.
-    3. Sets fresh workflow/step registries via ContextVar.
-    4. Seeds the global ``random`` module for determinism.
-    5. On exit, restores everything.
+    The first caller patches sys.modules with proxy modules and installs
+    the sandbox finder.  Subsequent concurrent callers are no-ops.
+    The last caller to exit restores everything.
+
+    Thread safety: only called from synchronous code inside async
+    coroutines on the main event loop thread, so no lock is needed.
     """
-    if not isinstance(random_seed, str):
-        raise TypeError("random_seed must be a str")
+    global _sandbox_refcount
 
-    # Snapshot the original contents so we can restore later.
+    _sandbox_refcount += 1
+    if _sandbox_refcount > 1:
+        try:
+            yield
+        finally:
+            _sandbox_refcount -= 1
+        return
+
+    # First sandbox in — snapshot and patch.
     orig_modules = dict(sys.modules)
 
-    # Build a proxy builtins whose __dict__ has the restricted
-    # entries so that CPython's LOAD_GLOBAL sees them.
     builtins_policy = _RESTRICTIONS.get("builtins")
     if builtins_policy is not None:
         proxy_builtins: types.ModuleType = _ProxyModule(
@@ -653,7 +724,6 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
     else:
         proxy_builtins = sys.modules["builtins"]
 
-    # Non-builtins restrictions are handled by the finder.
     module_restrictions = {k: v for k, v in _RESTRICTIONS.items() if k != "builtins"}
     finder = _SandboxFinder(
         host_modules=orig_modules,
@@ -664,7 +734,6 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
     )
 
     with _sandbox_linecache():
-        # Mutate sys.modules IN-PLACE so interp->modules sees the change.
         sys.modules.clear()
         sys.modules["sys"] = sys
         sys.modules["builtins"] = proxy_builtins
@@ -672,8 +741,29 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
         try:
             yield
         finally:
+            _sandbox_refcount -= 1
             if sys.meta_path is not None:
                 sys.meta_path.remove(finder)
-            # Restore original sys.modules contents.
             sys.modules.clear()
             sys.modules.update(orig_modules)
+
+
+@contextmanager
+def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
+    """Activate the workflow sandbox.
+
+    Patches ``sys.modules`` (ref-counted for concurrent sandboxes),
+    sets ``_in_sandbox`` so proxy modules enforce restrictions only in
+    this async context, and provides a per-context seeded ``Random``.
+    """
+    if not isinstance(random_seed, str):
+        raise TypeError("random_seed must be a str")
+
+    with _sandbox_modules(random_seed):
+        sandbox_token = _in_sandbox.set(True)
+        random_token = _sandbox_random.set(random.Random(random_seed))
+        try:
+            yield
+        finally:
+            _sandbox_random.reset(random_token)
+            _in_sandbox.reset(sandbox_token)

--- a/src/vercel/workflow/py_sandbox.py
+++ b/src/vercel/workflow/py_sandbox.py
@@ -750,9 +750,10 @@ def _sandbox_modules() -> Iterator[None]:
 def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
     """Activate the workflow sandbox.
 
-    Patches ``sys.modules`` (ref-counted for concurrent sandboxes),
-    sets ``_in_sandbox`` so proxy modules enforce restrictions only in
-    this async context, and provides a per-context seeded ``Random``.
+    Sets ``_in_sandbox`` so proxy modules are active only in this async
+    context, and provides a per-context seeded ``Random``.  Also
+    ensures ``sys.modules`` is patched to enforce import restrictions
+    before user code runs. See also _sandbox_modules().
     """
     if not isinstance(random_seed, str):
         raise TypeError("random_seed must be a str")

--- a/src/vercel/workflow/py_sandbox.py
+++ b/src/vercel/workflow/py_sandbox.py
@@ -70,7 +70,7 @@ def _context_restricted(name: str, real_fn: Any) -> Callable[..., Any]:
             )
         return real_fn(*_args, **_kwargs)
 
-    _wrapper.__qualname__ = f"<context-restricted {name}>"
+    _wrapper.__qualname__ = f"<workflow-context-restricted {name}>"
     return _wrapper
 
 

--- a/tests/unit/test_py_sandbox.py
+++ b/tests/unit/test_py_sandbox.py
@@ -227,6 +227,143 @@ class TestTimeRestrictions:
     def test_time_constants_allowed(self):
         _run_in_sandbox("import time; _ = time.CLOCK_MONOTONIC")
 
+    @pytest.mark.asyncio
+    async def test_concurrent_coroutine_not_affected_by_sandbox(self):
+        """Regression test: a concurrent coroutine that lazy-imports time
+        while another coroutine has the sandbox active must NOT be
+        restricted — the sandbox context is per-task via ContextVar."""
+        import asyncio
+
+        barrier = asyncio.Event()
+        result = None
+
+        async def sandbox_task():
+            """Activates the sandbox and waits inside it."""
+            with workflow_sandbox(random_seed="test"):
+                barrier.set()
+                await asyncio.sleep(0.05)
+
+        async def victim_task():
+            """Lazy-imports time while sandbox is active, then calls time.time()."""
+            nonlocal result
+            await barrier.wait()
+            import time
+
+            result = time.time()
+
+        await asyncio.gather(sandbox_task(), victim_task())
+        assert isinstance(result, float) and result > 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sandboxes_do_not_corrupt_sys_modules(self):
+        """Two concurrent sandboxes must not corrupt sys.modules.
+
+        The first sandbox to enter patches sys.modules; the second must
+        not snapshot the patched state.  On exit, sys.modules must be
+        fully restored regardless of exit order."""
+        import asyncio
+        import time as real_time
+
+        barrier = asyncio.Barrier(2)
+
+        async def sandbox_a():
+            with workflow_sandbox(random_seed="a"):
+                await barrier.wait()
+                _raises_in_sandbox("import time; time.time()")
+                await asyncio.sleep(0.02)
+
+        async def sandbox_b():
+            with workflow_sandbox(random_seed="b"):
+                await barrier.wait()
+                _raises_in_sandbox("import time; time.time()")
+                await asyncio.sleep(0.01)
+
+        await asyncio.gather(sandbox_a(), sandbox_b())
+        # After both exit, sys.modules must be restored
+        assert sys.modules.get("time") is real_time
+        # Sanity check: no proxy modules leaked
+        assert isinstance(sys.modules["time"].time, type(real_time.time))
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sandboxes_have_independent_random_seeds(self):
+        """Two concurrent sandboxes with different seeds must each see
+        their own deterministic random sequence, not interfere with
+        each other."""
+        import asyncio
+
+        barrier = asyncio.Barrier(2)
+        results: dict[str, list[float]] = {}
+
+        async def run_sandbox(seed: str, res: dict[str, list[float]]):
+            with workflow_sandbox(random_seed=seed):
+                await barrier.wait()
+                ns: dict[str, object] = {}
+                ns["__builtins__"] = sys.modules["builtins"]
+                exec(  # noqa: S102
+                    "import random; result = [random.random() for _ in range(5)]",
+                    ns,
+                )
+                res[seed] = ns["result"]  # type: ignore[assignment]
+
+        await asyncio.gather(run_sandbox("seed-A", results), run_sandbox("seed-B", results))
+        assert "seed-A" in results and "seed-B" in results
+        assert results["seed-A"] != results["seed-B"]
+
+        # Each sequence must be deterministic: run again and compare
+        results2: dict[str, list[float]] = {}
+        barrier = asyncio.Barrier(2)
+
+        await asyncio.gather(run_sandbox("seed-A", results2), run_sandbox("seed-B", results2))
+        assert results["seed-A"] == results2["seed-A"]
+        assert results["seed-B"] == results2["seed-B"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sandboxes_interleaved_random(self):
+        """When two sandboxes interleave their random calls, each must
+        still get its own deterministic sequence."""
+        import asyncio
+
+        step1 = asyncio.Event()
+        step2 = asyncio.Event()
+        results: dict[str, list[float]] = {}
+
+        async def sandbox_a():
+            with workflow_sandbox(random_seed="aaa"):
+                ns = {}
+                ns["__builtins__"] = sys.modules["builtins"]
+                exec("import random; r1 = random.random()", ns)  # noqa: S102
+                step1.set()  # let B run
+                await step2.wait()  # wait for B to call random
+                exec("r2 = random.random()", ns)  # noqa: S102
+                results["a"] = [ns["r1"], ns["r2"]]
+
+        async def sandbox_b():
+            with workflow_sandbox(random_seed="bbb"):
+                await step1.wait()  # wait for A's first call
+                ns = {}
+                ns["__builtins__"] = sys.modules["builtins"]
+                exec("import random; r1 = random.random()", ns)  # noqa: S102
+                step2.set()  # let A continue
+                results["b"] = [ns["r1"]]
+
+        await asyncio.gather(sandbox_a(), sandbox_b())
+
+        # Run A alone to get the expected sequence
+        expected_a: list[float] = []
+        with workflow_sandbox(random_seed="aaa"):
+            ns = {}
+            ns["__builtins__"] = sys.modules["builtins"]
+            exec(  # noqa: S102
+                "import random; result = [random.random(), random.random()]",
+                ns,
+            )
+            expected_a = ns["result"]
+
+        assert results["a"] == expected_a, (
+            f"Sandbox A's random sequence was corrupted by concurrent sandbox B: "
+            f"got {results['a']}, expected {expected_a}"
+        )
+
 
 # ═══════════════════════════════════════════════════════════════
 #  socket restrictions (allowlist)

--- a/tests/unit/test_py_sandbox.py
+++ b/tests/unit/test_py_sandbox.py
@@ -264,17 +264,20 @@ class TestTimeRestrictions:
         import asyncio
         import time as real_time
 
-        barrier = asyncio.Barrier(2)
+        ready_a = asyncio.Event()
+        ready_b = asyncio.Event()
 
         async def sandbox_a():
             with workflow_sandbox(random_seed="a"):
-                await barrier.wait()
+                ready_a.set()
+                await ready_b.wait()
                 _raises_in_sandbox("import time; time.time()")
                 await asyncio.sleep(0.02)
 
         async def sandbox_b():
             with workflow_sandbox(random_seed="b"):
-                await barrier.wait()
+                ready_b.set()
+                await ready_a.wait()
                 _raises_in_sandbox("import time; time.time()")
                 await asyncio.sleep(0.01)
 
@@ -291,12 +294,17 @@ class TestTimeRestrictions:
         each other."""
         import asyncio
 
-        barrier = asyncio.Barrier(2)
         results: dict[str, list[float]] = {}
 
-        async def run_sandbox(seed: str, res: dict[str, list[float]]):
+        async def run_sandbox(
+            seed: str,
+            res: dict[str, list[float]],
+            ready: asyncio.Event,
+            other: asyncio.Event,
+        ):
             with workflow_sandbox(random_seed=seed):
-                await barrier.wait()
+                ready.set()
+                await other.wait()
                 ns: dict[str, object] = {}
                 ns["__builtins__"] = sys.modules["builtins"]
                 exec(  # noqa: S102
@@ -305,15 +313,21 @@ class TestTimeRestrictions:
                 )
                 res[seed] = ns["result"]  # type: ignore[assignment]
 
-        await asyncio.gather(run_sandbox("seed-A", results), run_sandbox("seed-B", results))
+        r1, r2 = asyncio.Event(), asyncio.Event()
+        await asyncio.gather(
+            run_sandbox("seed-A", results, r1, r2),
+            run_sandbox("seed-B", results, r2, r1),
+        )
         assert "seed-A" in results and "seed-B" in results
         assert results["seed-A"] != results["seed-B"]
 
         # Each sequence must be deterministic: run again and compare
         results2: dict[str, list[float]] = {}
-        barrier = asyncio.Barrier(2)
-
-        await asyncio.gather(run_sandbox("seed-A", results2), run_sandbox("seed-B", results2))
+        r1, r2 = asyncio.Event(), asyncio.Event()
+        await asyncio.gather(
+            run_sandbox("seed-A", results2, r1, r2),
+            run_sandbox("seed-B", results2, r2, r1),
+        )
         assert results["seed-A"] == results2["seed-A"]
         assert results["seed-B"] == results2["seed-B"]
 


### PR DESCRIPTION
The same lambda function may host multiple workflow/step handler requests at the same time, we need to be able to switch into/out of sandboxes as concurrent asyncio Tasks switches contexts.