### PR TITLE
Refactor PTY support around AsyncPTYSession

### DIFF
--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -12,7 +12,6 @@ Prerequisites:
 Usage:
     python examples/13_interactive_shell.py          # Interactive bash shell
     python examples/13_interactive_shell.py --python # Interactive Python REPL
-    python examples/13_interactive_shell.py --test   # Non-interactive CI test
 
 Interactive mode will:
 1. Create a sandbox with interactive support enabled
@@ -22,6 +21,7 @@ Interactive mode will:
 """
 
 import asyncio
+import os
 import sys
 
 from dotenv import load_dotenv
@@ -92,106 +92,22 @@ async def python_repl_example():
         print("Done!")
 
 
-async def test():
-    """Non-interactive test for CI environments.
-
-    This tests the PTY infrastructure without taking over the terminal:
-    1. Creates sandbox with interactive=True
-    2. Verifies interactive port is allocated
-    3. Opens a low-level AsyncPTYSession
-    4. Runs a command through the shared PTY session API
-    5. Verifies output is received
-    """
-
-    print("=" * 60)
-    print("Interactive Shell CI Test (non-interactive)")
-    print("=" * 60)
-    print()
-
-    print("1. Creating sandbox with interactive=True...")
-    sandbox = await AsyncSandbox.create(
-        interactive=True,
-        timeout=120_000,  # 2 minutes
-    )
-
-    try:
-        print(f"   Sandbox ID: {sandbox.sandbox_id}")
-        print(f"   Interactive port: {sandbox.interactive_port}")
-
-        # Verify interactive port
-        assert sandbox.interactive_port is not None, "Interactive port should be set"
-        print("   ✅ Interactive port allocated")
-        print()
-
-        print("2. Opening low-level PTY session...")
-        session = await sandbox.open_pty(
-            ["bash", "-c", "echo 'PTY_TEST_OUTPUT'; sleep 2; echo 'DONE'"],
-        )
-        print(f"   Process ID: {session.process_id}")
-        print(f"   Server process ID: {session.server_process_id}")
-        print("   ✅ PTY session opened")
-        print()
-
-        try:
-            print("3. Sending ready signal and receiving output...")
-            await session.ready()
-            await session.resize(80, 24)
-
-            # Collect output with timeout. asyncio.timeout() is only available in 3.11+.
-            async def collect_output() -> bytes:
-                output = b""
-                async for data in session.iter_output():
-                    output += data
-                    if b"PTY_TEST_OUTPUT" in output:
-                        break
-                return output
-
-            try:
-                output = await asyncio.wait_for(collect_output(), timeout=5)
-            except asyncio.TimeoutError:
-                output = b""
-        finally:
-            await session.close()
-
-        # Verify output
-        output_str = output.decode("utf-8", errors="replace")
-        print(f"   Received {len(output)} bytes")
-
-        if "PTY_TEST_OUTPUT" in output_str:
-            print("   ✅ Expected output received!")
-        else:
-            print("   ⚠️  Output received but test string not found")
-            print(f"   Output preview: {repr(output_str[:200])}")
-
-        print()
-        print("=" * 60)
-        print("✅ All tests passed!")
-        print("=" * 60)
-
-    finally:
-        print()
-        print("Stopping sandbox...")
-        await sandbox.stop()
-        print("Done!")
-
-
 if __name__ == "__main__":
-    import os
-
-    # Auto-detect CI environment (no TTY or CI env var set)
-    is_ci = os.environ.get("CI") == "1" or not sys.stdin.isatty()
+    # This example is intentionally interactive; CI runs should skip it.
+    is_ci = os.environ.get("CI") == "1"
+    has_tty = sys.stdin.isatty() and sys.stdout.isatty()
 
     if len(sys.argv) > 1:
         if sys.argv[1] == "--python":
             asyncio.run(python_repl_example())
-        elif sys.argv[1] == "--test":
-            asyncio.run(test())
         else:
             print(f"Unknown flag: {sys.argv[1]}")
-            print("Usage: python 13_interactive_shell.py [--python|--test]")
+            print("Usage: python 13_interactive_shell.py [--python]")
             sys.exit(1)
-    elif is_ci:
-        # In CI, run non-interactive test automatically
-        asyncio.run(test())
+    elif is_ci or not has_tty:
+        reason = "CI environment detected" if is_ci else "no interactive TTY detected"
+        print(f"Skipping interactive shell example: {reason}.")
+        print("Run this example from a local terminal to exercise AsyncSandbox.shell().")
+        sys.exit(0)
     else:
         asyncio.run(main())

--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -10,8 +10,8 @@ Prerequisites:
 - Or run from a Vercel Function with OIDC credentials
 
 Usage:
-    python examples/13_interactive_shell.py          # Interactive bash shell
-    python examples/13_interactive_shell.py --python # Interactive Python REPL
+    python examples/sandbox_13_interactive_shell.py          # Interactive bash shell
+    python examples/sandbox_13_interactive_shell.py --python # Interactive Python REPL
 
 Interactive mode will:
 1. Create a sandbox with interactive support enabled
@@ -102,7 +102,7 @@ if __name__ == "__main__":
             asyncio.run(python_repl_example())
         else:
             print(f"Unknown flag: {sys.argv[1]}")
-            print("Usage: python 13_interactive_shell.py [--python]")
+            print("Usage: python sandbox_13_interactive_shell.py [--python]")
             sys.exit(1)
     elif is_ci or not has_tty:
         reason = "CI environment detected" if is_ci else "no interactive TTY detected"

--- a/examples/sandbox_13_interactive_shell.py
+++ b/examples/sandbox_13_interactive_shell.py
@@ -98,12 +98,10 @@ async def test():
     This tests the PTY infrastructure without taking over the terminal:
     1. Creates sandbox with interactive=True
     2. Verifies interactive port is allocated
-    3. Sets up sandbox environment (installs PTY server)
-    4. Connects to WebSocket and runs a command
+    3. Opens a low-level AsyncPTYSession
+    4. Runs a command through the shared PTY session API
     5. Verifies output is received
     """
-    from vercel.sandbox.pty.client import PTYClient
-    from vercel.sandbox.pty.shell import setup_sandbox_environment, start_pty_server
 
     print("=" * 60)
     print("Interactive Shell CI Test (non-interactive)")
@@ -125,56 +123,35 @@ async def test():
         print("   ✅ Interactive port allocated")
         print()
 
-        print("2. Setting up sandbox environment (installing PTY server)...")
-        await setup_sandbox_environment(sandbox)
-        print("   ✅ PTY server installed")
-        print()
-
-        print("3. Starting PTY server with bash...")
-        # Use bash with a command that outputs, waits, then exits
-        # This gives us time to connect and read output
-        cmd, conn_info = await start_pty_server(
-            sandbox,
+        print("2. Opening low-level PTY session...")
+        session = await sandbox.open_pty(
             ["bash", "-c", "echo 'PTY_TEST_OUTPUT'; sleep 2; echo 'DONE'"],
         )
-        print(f"   Process ID: {conn_info['processId']}")
-        print(f"   Token: {conn_info['token'][:20]}...")
-        print("   ✅ PTY server started")
+        print(f"   Process ID: {session.process_id}")
+        print(f"   Server process ID: {session.server_process_id}")
+        print("   ✅ PTY session opened")
         print()
-
-        print("4. Connecting to WebSocket...")
-        host = sandbox.domain(sandbox.interactive_port)
-        host = host.replace("https://", "").replace("http://", "")
-        ws_url = (
-            f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
-        )
-
-        # Small delay to ensure server is ready
-        await asyncio.sleep(0.5)
-
-        client = await PTYClient.connect(ws_url)
-        print("   ✅ WebSocket connected")
-        print()
-
-        print("5. Sending ready signal and receiving output...")
-        await client.send_ready()
-        await client.send_resize(80, 24)
-
-        # Collect output with timeout. asyncio.timeout() is only available in 3.11+.
-        async def collect_output() -> bytes:
-            output = b""
-            async for data in client.raw_messages():
-                output += data
-                if b"PTY_TEST_OUTPUT" in output:
-                    break
-            return output
 
         try:
-            output = await asyncio.wait_for(collect_output(), timeout=5)
-        except asyncio.TimeoutError:
-            output = b""
+            print("3. Sending ready signal and receiving output...")
+            await session.ready()
+            await session.resize(80, 24)
 
-        await client.close()
+            # Collect output with timeout. asyncio.timeout() is only available in 3.11+.
+            async def collect_output() -> bytes:
+                output = b""
+                async for data in session.iter_output():
+                    output += data
+                    if b"PTY_TEST_OUTPUT" in output:
+                        break
+                return output
+
+            try:
+                output = await asyncio.wait_for(collect_output(), timeout=5)
+            except asyncio.TimeoutError:
+                output = b""
+        finally:
+            await session.close()
 
         # Verify output
         output_str = output.decode("utf-8", errors="replace")

--- a/examples/sandbox_14_pty_test.py
+++ b/examples/sandbox_14_pty_test.py
@@ -1,241 +1,92 @@
 #!/usr/bin/env python3
-"""Example: PTY Infrastructure Test
+"""Example: Low-level async PTY session.
 
-This example tests the PTY infrastructure without taking over the terminal.
-Useful for debugging and verifying the setup works correctly.
+This example exercises ``AsyncSandbox.open_pty()`` and
+``vercel.sandbox.pty.AsyncPTYSession`` directly without taking over the local
+terminal or assembling PTY websocket/bootstrap details manually.
 
 Usage:
-    python examples/15_pty_test.py
+    python examples/sandbox_14_pty_test.py
 """
 
 import asyncio
+from datetime import timedelta
 
 from dotenv import load_dotenv
 
 from vercel.sandbox import AsyncSandbox
-from vercel.sandbox.pty.binary import (
-    BINARY_BASE_URL,
-    CACHE_DIR,
-    DEFAULT_SANDBOX_ARCH,
-    SERVER_BIN_NAME,
-    download_binary_async,
-    get_binary_cache_path,
-)
+from vercel.sandbox.pty import AsyncPTYSession
 
 load_dotenv()
 
+EXPECTED_OUTPUT = "PTY_OK"
 
-async def test_binary_download():
-    """Test downloading the PTY server binary."""
+
+async def collect_output(session: AsyncPTYSession, *, timeout: float = 30.0) -> bytes:
+    """Read PTY output until the expected marker appears."""
+
+    async def _collect() -> bytes:
+        output = b""
+        async for data in session.iter_output():
+            output += data
+            if EXPECTED_OUTPUT.encode() in output:
+                return output
+        return output
+
+    return await asyncio.wait_for(_collect(), timeout=timeout)
+
+
+async def main() -> int:
     print("=" * 60)
-    print("Testing PTY Server Binary Download")
-    print("=" * 60)
-    print()
-
-    print(f"Binary URL: {BINARY_BASE_URL}")
-    print(f"Cache directory: {CACHE_DIR}")
-    print(f"Server binary name: {SERVER_BIN_NAME}")
-    print(f"Default architecture: {DEFAULT_SANDBOX_ARCH}")
-    print()
-
-    cache_path = get_binary_cache_path()
-    print(f"Expected cache path: {cache_path}")
-    print(f"Binary cached: {cache_path.exists()}")
-    print()
-
-    print("Downloading binary (will use cache if available)...")
-    path = await download_binary_async()
-    print(f"Binary path: {path}")
-    print(f"Binary size: {path.stat().st_size:,} bytes")
-    print()
-    print("✅ Binary download test passed!")
-    return True
-
-
-async def test_sandbox_interactive_creation():
-    """Test creating a sandbox with interactive support."""
-    print()
-    print("=" * 60)
-    print("Testing Sandbox Creation with Interactive Support")
+    print("Low-level AsyncPTYSession Example")
     print("=" * 60)
     print()
-
     print("Creating sandbox with interactive=True...")
-    sandbox = await AsyncSandbox.create(
+
+    async with await AsyncSandbox.create(
         interactive=True,
-        timeout=60_000,  # 1 minute
-    )
-
-    print(f"Sandbox ID: {sandbox.sandbox_id}")
-    print(f"Status: {sandbox.status}")
-    print(f"Interactive port: {sandbox.interactive_port}")
-    print()
-
-    if sandbox.interactive_port:
-        print("✅ Interactive port allocated!")
-    else:
-        print("❌ No interactive port - API may not support __interactive flag")
-
-    # Test that the sandbox works
-    print()
-    print("Testing basic command execution...")
-    result = await sandbox.run_command("echo", ["Hello from sandbox!"])
-    output = await result.stdout()
-    print(f"Output: {output.strip()}")
-    print(f"Exit code: {result.exit_code}")
-
-    # Get architecture
-    print()
-    print("Checking sandbox architecture...")
-    result = await sandbox.run_command("uname", ["-m"])
-    arch = (await result.stdout()).strip()
-    print(f"Sandbox architecture: {arch}")
-
-    # Stop sandbox
-    print()
-    print("Stopping sandbox...")
-    await sandbox.stop()
-    print("✅ Sandbox test passed!")
-
-    return sandbox.interactive_port is not None
-
-
-async def test_pty_server_upload():
-    """Test uploading and running the PTY server in a sandbox."""
-    print()
-    print("=" * 60)
-    print("Testing PTY Server Upload and Execution")
-    print("=" * 60)
-    print()
-
-    from vercel.sandbox.pty.binary import get_binary_bytes_async
-    from vercel.sandbox.pty.shell import SERVER_BIN_NAME
-
-    print("Creating sandbox...")
-    sandbox = await AsyncSandbox.create(
-        interactive=True,
-        timeout=120_000,  # 2 minutes
-    )
-
-    try:
+        timeout=timedelta(minutes=5),
+    ) as sandbox:
         print(f"Sandbox ID: {sandbox.sandbox_id}")
+        print(f"Interactive port: {sandbox.interactive_port}")
         print()
+        print("Opening PTY session via AsyncSandbox.open_pty()...")
 
-        # Download binary
-        print("Downloading PTY server binary...")
-        binary = await get_binary_bytes_async()
-        print(f"Binary size: {len(binary):,} bytes")
-
-        # Upload to sandbox
-        print()
-        print("Uploading binary to sandbox...")
-        tmp_path = f"/tmp/{SERVER_BIN_NAME}-test"
-        await sandbox.write_files([{"path": tmp_path, "content": binary}])
-
-        # Make executable and move
-        print("Installing binary...")
-        result = await sandbox.run_command(
-            "bash",
-            [
-                "-c",
-                f'mv "{tmp_path}" /usr/local/bin/{SERVER_BIN_NAME} && '
-                f"chmod +x /usr/local/bin/{SERVER_BIN_NAME}",
-            ],
-            sudo=True,
-        )
-
-        if result.exit_code != 0:
-            print(f"❌ Failed to install binary: {await result.stderr()}")
-            return False
-
-        # Verify installation
-        print()
-        print("Verifying installation...")
-        result = await sandbox.run_command("which", [SERVER_BIN_NAME])
-        if result.exit_code == 0:
-            path = (await result.stdout()).strip()
-            print(f"Binary installed at: {path}")
-        else:
-            print("❌ Binary not found in PATH")
-            return False
-
-        # Check version/help
-        print()
-        print("Checking binary help...")
-        result = await sandbox.run_command(SERVER_BIN_NAME, ["--help"])
-        output = await result.stdout()
-        stderr = await result.stderr()
-
-        # The help might go to stderr
-        help_text = output or stderr
-        if "PTY Tunnel Server" in help_text or "WebSocket" in help_text:
-            print("✅ Binary runs correctly!")
+        async with await sandbox.open_pty(
+            ["/bin/bash"],
+            cols=100,
+            rows=30,
+        ) as session:
+            print(f"PTY process ID: {session.process_id}")
+            print(f"PTY server process ID: {session.server_process_id}")
             print()
-            print("First few lines of help output:")
-            for line in help_text.split("\n")[:5]:
-                print(f"  {line}")
-        else:
-            print("Binary output:")
-            print(help_text[:500])
+            print("Sending ready signal and resize event...")
+            await session.ready()
+            await session.resize(100, 30)
+            print("Writing a simple command through the PTY...")
+            await session.write(f"printf '{EXPECTED_OUTPUT}\\n'; pwd; exit\n")
 
-        print()
-        print("✅ PTY server upload test passed!")
-        return True
+            try:
+                output = await collect_output(session)
+            except asyncio.TimeoutError:
+                print("Timed out waiting for PTY output.")
+                return 1
 
-    finally:
-        print()
-        print("Stopping sandbox...")
-        await sandbox.stop()
+            output_text = output.decode("utf-8", errors="replace")
+            print()
+            print("Received PTY output:")
+            print("-" * 60)
+            print(output_text.rstrip())
+            print("-" * 60)
 
+            if EXPECTED_OUTPUT not in output_text:
+                print("Expected PTY output marker was not observed.")
+                return 1
 
-async def main():
-    """Run all PTY infrastructure tests."""
     print()
-    print("🧪 PTY Infrastructure Test Suite")
-    print()
-
-    results = []
-
-    # Test 1: Binary download
-    try:
-        results.append(("Binary Download", await test_binary_download()))
-    except Exception as e:
-        print(f"❌ Binary download failed: {e}")
-        results.append(("Binary Download", False))
-
-    # Test 2: Sandbox creation with interactive
-    try:
-        results.append(("Sandbox Interactive Creation", await test_sandbox_interactive_creation()))
-    except Exception as e:
-        print(f"❌ Sandbox creation failed: {e}")
-        results.append(("Sandbox Interactive Creation", False))
-
-    # Test 3: PTY server upload
-    try:
-        results.append(("PTY Server Upload", await test_pty_server_upload()))
-    except Exception as e:
-        print(f"❌ PTY server upload failed: {e}")
-        results.append(("PTY Server Upload", False))
-
-    # Summary
-    print()
-    print("=" * 60)
-    print("Test Summary")
-    print("=" * 60)
-    for name, passed in results:
-        status = "✅ PASS" if passed else "❌ FAIL"
-        print(f"  {status}: {name}")
-
-    all_passed = all(passed for _, passed in results)
-    print()
-    if all_passed:
-        print("🎉 All tests passed!")
-    else:
-        print("⚠️  Some tests failed")
-
-    return all_passed
+    print("Low-level PTY session flow completed successfully.")
+    return 0
 
 
 if __name__ == "__main__":
-    success = asyncio.run(main())
-    exit(0 if success else 1)
+    raise SystemExit(asyncio.run(main()))

--- a/examples/sandbox_14_pty_test.py
+++ b/examples/sandbox_14_pty_test.py
@@ -33,7 +33,7 @@ async def collect_output_until(
 
     async def _collect() -> bytes:
         output = b""
-        async for data in session.iter_output():
+        async for data in session.stream:
             output += data
             if marker.encode() in output:
                 return output
@@ -83,8 +83,8 @@ async def main() -> int:
             print(initial_output_text.rstrip())
             print("-" * 60)
 
-            print("Writing a simple command through the PTY...")
-            await session.write(f"printf '{EXPECTED_OUTPUT}\\n'; pwd; exit\n")
+            print("Writing a simple command through the PTY stream...")
+            await session.stream.send(f"printf '{EXPECTED_OUTPUT}\\n'; pwd; exit\n".encode())
 
             try:
                 output = await collect_output_until(session, EXPECTED_OUTPUT)

--- a/examples/sandbox_14_pty_test.py
+++ b/examples/sandbox_14_pty_test.py
@@ -20,16 +20,22 @@ from vercel.sandbox.pty import AsyncPTYSession
 load_dotenv()
 
 EXPECTED_OUTPUT = "PTY_OK"
+PROMPT_MARKER = "$ "
 
 
-async def collect_output(session: AsyncPTYSession, *, timeout: float = 30.0) -> bytes:
+async def collect_output_until(
+    session: AsyncPTYSession,
+    marker: str,
+    *,
+    timeout: float = 30.0,
+) -> bytes:
     """Read PTY output until the expected marker appears."""
 
     async def _collect() -> bytes:
         output = b""
         async for data in session.iter_output():
             output += data
-            if EXPECTED_OUTPUT.encode() in output:
+            if marker.encode() in output:
                 return output
         return output
 
@@ -63,11 +69,25 @@ async def main() -> int:
             print("Sending ready signal and resize event...")
             await session.ready()
             await session.resize(100, 30)
+            print("Waiting for the shell prompt...")
+            try:
+                initial_output = await collect_output_until(session, PROMPT_MARKER)
+            except asyncio.TimeoutError:
+                print("Timed out waiting for the shell prompt.")
+                return 1
+
+            initial_output_text = initial_output.decode("utf-8", errors="replace")
+            print()
+            print("Received initial PTY output:")
+            print("-" * 60)
+            print(initial_output_text.rstrip())
+            print("-" * 60)
+
             print("Writing a simple command through the PTY...")
             await session.write(f"printf '{EXPECTED_OUTPUT}\\n'; pwd; exit\n")
 
             try:
-                output = await collect_output(session)
+                output = await collect_output_until(session, EXPECTED_OUTPUT)
             except asyncio.TimeoutError:
                 print("Timed out waiting for PTY output.")
                 return 1

--- a/src/vercel/_internal/sandbox/constants.py
+++ b/src/vercel/_internal/sandbox/constants.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+# Public sandbox lifecycle default for wait/stop helpers.
+DEFAULT_SANDBOX_WAIT_TIMEOUT = timedelta(seconds=30)
+
+# Public sandbox lifecycle polling cadence for wait/stop helpers.
+DEFAULT_SANDBOX_WAIT_POLL_INTERVAL = timedelta(milliseconds=500)
+
+# Shared PTY bootstrap budget used while waiting for detached server metadata.
+DEFAULT_PTY_CONNECTION_TIMEOUT = timedelta(seconds=30)
+
+# Internal operational budget for downloading the PTY helper binary.
+PTY_BINARY_DOWNLOAD_TIMEOUT = timedelta(seconds=60)
+
+# Public snapshot invariant: non-zero expirations must be at least 24 hours.
+MIN_SNAPSHOT_EXPIRATION = timedelta(hours=24)

--- a/src/vercel/_internal/sandbox/pty_binary.py
+++ b/src/vercel/_internal/sandbox/pty_binary.py
@@ -1,0 +1,72 @@
+"""Internal PTY server binary management helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+BINARY_BASE_URL = "https://pty-tunnel.labs.vercel.dev"
+
+CACHE_DIR = Path.home() / ".cache" / "vercel-sandbox"
+
+SERVER_BIN_NAME = "vc-interactive-server"
+
+# Sandboxes are currently always Linux x86_64
+DEFAULT_SANDBOX_ARCH = "x86_64"
+
+
+def get_binary_cache_path(arch: str | None = None) -> Path:
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+    return CACHE_DIR / f"pty-server-linux-{arch}"
+
+
+def download_binary(arch: str | None = None, *, force: bool = False) -> Path:
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+
+    cache_path = get_binary_cache_path(arch)
+
+    if cache_path.exists() and not force:
+        return cache_path
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    url = f"{BINARY_BASE_URL}/linux-{arch}"
+    with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        cache_path.write_bytes(response.content)
+
+    return cache_path
+
+
+def get_binary_bytes(arch: str | None = None) -> bytes:
+    path = download_binary(arch)
+    return path.read_bytes()
+
+
+async def download_binary_async(arch: str | None = None, *, force: bool = False) -> Path:
+    if arch is None:
+        arch = DEFAULT_SANDBOX_ARCH
+
+    cache_path = get_binary_cache_path(arch)
+
+    if cache_path.exists() and not force:
+        return cache_path
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    url = f"{BINARY_BASE_URL}/linux-{arch}"
+    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        cache_path.write_bytes(response.content)
+
+    return cache_path
+
+
+async def get_binary_bytes_async(arch: str | None = None) -> bytes:
+    path = await download_binary_async(arch)
+    return path.read_bytes()

--- a/src/vercel/_internal/sandbox/pty_binary.py
+++ b/src/vercel/_internal/sandbox/pty_binary.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 import httpx
 
+from .constants import PTY_BINARY_DOWNLOAD_TIMEOUT
+from .time import to_seconds_float
+
 BINARY_BASE_URL = "https://pty-tunnel.labs.vercel.dev"
 
 CACHE_DIR = Path.home() / ".cache" / "vercel-sandbox"
@@ -34,7 +37,10 @@ def download_binary(arch: str | None = None, *, force: bool = False) -> Path:
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
     url = f"{BINARY_BASE_URL}/linux-{arch}"
-    with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=to_seconds_float(PTY_BINARY_DOWNLOAD_TIMEOUT),
+        follow_redirects=True,
+    ) as client:
         response = client.get(url)
         response.raise_for_status()
         cache_path.write_bytes(response.content)
@@ -59,7 +65,10 @@ async def download_binary_async(arch: str | None = None, *, force: bool = False)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
     url = f"{BINARY_BASE_URL}/linux-{arch}"
-    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+    async with httpx.AsyncClient(
+        timeout=to_seconds_float(PTY_BINARY_DOWNLOAD_TIMEOUT),
+        follow_redirects=True,
+    ) as client:
         response = await client.get(url)
         response.raise_for_status()
         cache_path.write_bytes(response.content)

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -5,10 +5,13 @@ import json
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from anyio import ClosedResourceError, EndOfStream
+from anyio.abc import ByteReceiveStream, ByteSendStream
+from anyio.streams.stapled import StapledByteStream
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 
 from .constants import DEFAULT_PTY_CONNECTION_TIMEOUT
@@ -195,14 +198,68 @@ async def _connect_pty_client(url: str) -> PTYClient:
     return await PTYClient.connect(url)
 
 
+class _PTYReceiveStream(ByteReceiveStream):
+    def __init__(self, session: AsyncPTYSession) -> None:
+        self._session = session
+        self._messages: AsyncIterator[bytes] | None = None
+        self._buffer = b""
+        self._closed = False
+
+    async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be at least 1")
+        if self._closed:
+            raise ClosedResourceError
+
+        while not self._buffer:
+            if self._messages is None:
+                self._messages = self._session.client.raw_messages()
+            try:
+                self._buffer = await anext(self._messages)
+            except StopAsyncIteration:
+                raise EndOfStream from None
+
+        data = self._buffer[:max_bytes]
+        self._buffer = self._buffer[max_bytes:]
+        return data
+
+    async def aclose(self) -> None:
+        self._closed = True
+        await self._session.close()
+
+
+class _PTYSendStream(ByteSendStream):
+    def __init__(self, session: AsyncPTYSession) -> None:
+        self._session = session
+        self._closed = False
+
+    async def send(self, item: bytes) -> None:
+        if self._closed:
+            raise ClosedResourceError
+        if not item:
+            return
+        await self._session.client.send_input_bytes(item)
+
+    async def aclose(self) -> None:
+        self._closed = True
+        await self._session.close()
+
+
 @dataclass
 class AsyncPTYSession:
     sandbox: AsyncSandbox
     command: AsyncCommand
     client: PTYClient
     connection_info: ConnectionInfo
+    stream: StapledByteStream = field(init=False)
 
     _closed: bool = False
+
+    def __post_init__(self) -> None:
+        self.stream = StapledByteStream(
+            send_stream=_PTYSendStream(self),
+            receive_stream=_PTYReceiveStream(self),
+        )
 
     @classmethod
     async def open(
@@ -280,16 +337,6 @@ class AsyncPTYSession:
 
     async def resize(self, cols: int, rows: int) -> None:
         await self.client.send_resize(cols, rows)
-
-    async def write(self, text: str) -> None:
-        await self.client.send_input(text)
-
-    async def write_bytes(self, data: bytes) -> None:
-        await self.client.send_input_bytes(data)
-
-    async def iter_output(self) -> AsyncIterator[bytes]:
-        async for data in self.client.raw_messages():
-            yield data
 
     async def close(self) -> None:
         if self._closed:

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -7,7 +7,9 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 
 from .constants import DEFAULT_PTY_CONNECTION_TIMEOUT
 from .pty_binary import SERVER_BIN_NAME, get_binary_bytes_async
@@ -22,6 +24,21 @@ DEFAULT_PTY_COLS = 80
 DEFAULT_PTY_ROWS = 24
 MAX_CONNECTION_INFO_OUTPUT_EXCERPT = 500
 DurationSeconds = int | float | timedelta
+
+
+class ConnectionInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, serialize_by_alias=True)
+
+    port: int
+    token: str
+    process_id: int = Field(
+        validation_alias=AliasChoices("process_id", "processId"),
+        serialization_alias="processId",
+    )
+    server_process_id: int = Field(
+        validation_alias=AliasChoices("server_process_id", "serverProcessId"),
+        serialization_alias="serverProcessId",
+    )
 
 
 def resolve_terminal_size(
@@ -68,7 +85,7 @@ def _append_output_excerpt(excerpt: str, chunk: str) -> str:
     return combined[-MAX_CONNECTION_INFO_OUTPUT_EXCERPT:]
 
 
-def _parse_connection_info_line(line: str) -> dict[str, Any] | None:
+def _parse_connection_info_line(line: str) -> ConnectionInfo | None:
     stripped = line.strip()
     if not (stripped.startswith("{") and stripped.endswith("}")):
         return None
@@ -78,35 +95,21 @@ def _parse_connection_info_line(line: str) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
 
-    if not isinstance(candidate, dict):
+    try:
+        return ConnectionInfo.model_validate(candidate)
+    except ValidationError:
         return None
-
-    port = candidate.get("port")
-    token = candidate.get("token")
-    process_id = candidate.get("processId")
-    server_process_id = candidate.get("serverProcessId")
-
-    if not isinstance(port, int):
-        return None
-    if not isinstance(token, str):
-        return None
-    if not isinstance(process_id, int):
-        return None
-    if not isinstance(server_process_id, int):
-        return None
-
-    return candidate
 
 
 async def read_connection_info(
     cmd: AsyncCommand, timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT
-) -> dict[str, Any]:
+) -> ConnectionInfo:
     """Read connection metadata JSON from the PTY server command output."""
     collected_excerpt = ""
     buffered_stdout = ""
     timeout_seconds = coerce_duration(timeout, SECOND).total_seconds()
 
-    async def read_logs() -> dict[str, Any] | None:
+    async def read_logs() -> ConnectionInfo | None:
         nonlocal buffered_stdout, collected_excerpt
         async for log in cmd.logs():
             if log.stream != "stdout":
@@ -146,7 +149,7 @@ async def start_pty_server(
     cols: int | None = None,
     rows: int | None = None,
     connection_timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT,
-) -> tuple[AsyncCommand, dict[str, Any]]:
+) -> tuple[AsyncCommand, ConnectionInfo]:
     """Start a PTY server command and return its command handle and metadata."""
     terminal_cols, terminal_rows = resolve_terminal_size(cols, rows)
 
@@ -168,7 +171,7 @@ async def start_pty_server(
     return cmd, connection_info
 
 
-def build_ws_url(sandbox: AsyncSandbox, connection_info: dict[str, Any]) -> str:
+def build_ws_url(sandbox: AsyncSandbox, connection_info: ConnectionInfo) -> str:
     interactive_port = sandbox.interactive_port
     if interactive_port is None:
         raise RuntimeError(
@@ -179,7 +182,7 @@ def build_ws_url(sandbox: AsyncSandbox, connection_info: dict[str, Any]) -> str:
     host = host.replace("https://", "").replace("http://", "")
     return (
         f"wss://{host}/ws/client"
-        f"?token={connection_info['token']}&processId={connection_info['processId']}"
+        f"?token={connection_info.token}&processId={connection_info.process_id}"
     )
 
 
@@ -197,7 +200,7 @@ class AsyncPTYSession:
     sandbox: AsyncSandbox
     command: AsyncCommand
     client: PTYClient
-    connection_info: dict[str, Any]
+    connection_info: ConnectionInfo
 
     _closed: bool = False
 
@@ -258,15 +261,15 @@ class AsyncPTYSession:
 
     @property
     def process_id(self) -> int | None:
-        return self.connection_info.get("processId")
+        return self.connection_info.process_id
 
     @property
     def server_process_id(self) -> int | None:
-        return self.connection_info.get("serverProcessId")
+        return self.connection_info.server_process_id
 
     @property
     def port(self) -> int | None:
-        return self.connection_info.get("port")
+        return self.connection_info.port
 
     @property
     def is_open(self) -> bool:

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 DEFAULT_PTY_COLS = 80
 DEFAULT_PTY_ROWS = 24
+MAX_CONNECTION_INFO_OUTPUT_EXCERPT = 500
 DurationSeconds = int | float | timedelta
 
 
@@ -60,27 +61,66 @@ async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
     )
 
 
+def _append_output_excerpt(excerpt: str, chunk: str) -> str:
+    combined = excerpt + chunk
+    if len(combined) <= MAX_CONNECTION_INFO_OUTPUT_EXCERPT:
+        return combined
+    return combined[-MAX_CONNECTION_INFO_OUTPUT_EXCERPT:]
+
+
+def _parse_connection_info_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not (stripped.startswith("{") and stripped.endswith("}")):
+        return None
+
+    try:
+        candidate = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(candidate, dict):
+        return None
+
+    port = candidate.get("port")
+    token = candidate.get("token")
+    process_id = candidate.get("processId")
+    server_process_id = candidate.get("serverProcessId")
+
+    if not isinstance(port, int):
+        return None
+    if not isinstance(token, str):
+        return None
+    if not isinstance(process_id, int):
+        return None
+    if not isinstance(server_process_id, int):
+        return None
+
+    return candidate
+
+
 async def read_connection_info(
     cmd: AsyncCommand, timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT
 ) -> dict[str, Any]:
     """Read connection metadata JSON from the PTY server command output."""
-    collected = ""
+    collected_excerpt = ""
+    buffered_stdout = ""
     timeout_seconds = coerce_duration(timeout, SECOND).total_seconds()
 
     async def read_logs() -> dict[str, Any] | None:
-        nonlocal collected
+        nonlocal buffered_stdout, collected_excerpt
         async for log in cmd.logs():
             if log.stream != "stdout":
                 continue
-            collected += log.data
-            for line in collected.split("\n"):
-                line = line.strip()
-                if not (line.startswith("{") and line.endswith("}")):
-                    continue
-                try:
-                    return json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+
+            chunk = log.data
+            collected_excerpt = _append_output_excerpt(collected_excerpt, chunk)
+            buffered_stdout += chunk
+
+            while "\n" in buffered_stdout:
+                line, buffered_stdout = buffered_stdout.split("\n", 1)
+                connection_info = _parse_connection_info_line(line)
+                if connection_info is not None:
+                    return connection_info
         return None
 
     try:
@@ -92,7 +132,7 @@ async def read_connection_info(
 
     raise RuntimeError(
         f"Failed to get connection info from PTY server within {timeout_seconds}s. "
-        f"Collected output: {collected[:500]}"
+        f"Collected output: {collected_excerpt}"
     )
 
 

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -174,7 +174,7 @@ class AsyncPTYSession:
         _client_factory: PTYClientFactory | None = None,
         _connection_timeout: DurationSeconds = 30.0,
     ) -> AsyncPTYSession:
-        if not sandbox.interactive_port:
+        if sandbox.interactive_port is None:
             raise RuntimeError(
                 "Sandbox was not created with interactive=True. "
                 "Create with: await AsyncSandbox.create(interactive=True)"
@@ -226,6 +226,10 @@ class AsyncPTYSession:
     @property
     def port(self) -> int | None:
         return self.connection_info.get("port")
+
+    @property
+    def is_open(self) -> bool:
+        return not self._closed and self.client.is_open
 
     async def ready(self) -> None:
         await self.client.send_ready()

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from .pty_binary import SERVER_BIN_NAME, get_binary_bytes_async
+
+if TYPE_CHECKING:
+    from vercel.sandbox.command import AsyncCommand
+    from vercel.sandbox.pty.client import PTYClient
+    from vercel.sandbox.sandbox import AsyncSandbox
+
+DEFAULT_PTY_COLS = 80
+DEFAULT_PTY_ROWS = 24
+
+
+def resolve_terminal_size(
+    cols: int | None = None,
+    rows: int | None = None,
+) -> tuple[int, int]:
+    if cols is not None and rows is not None:
+        return cols, rows
+
+    try:
+        detected_cols, detected_rows = os.get_terminal_size()
+    except OSError:
+        detected_cols, detected_rows = DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS
+
+    return cols or detected_cols, rows or detected_rows
+
+
+async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
+    """Install the PTY server binary in the sandbox if not present."""
+    result = await sandbox.run_command("command", ["-v", SERVER_BIN_NAME])
+    if result.exit_code == 0:
+        return
+
+    binary = await get_binary_bytes_async()
+
+    tmp_path = f"/tmp/{SERVER_BIN_NAME}-install"
+    await sandbox.write_files([{"path": tmp_path, "content": binary}])
+
+    await sandbox.run_command(
+        "bash",
+        [
+            "-c",
+            f'mv "{tmp_path}" /usr/local/bin/{SERVER_BIN_NAME} && '
+            f"chmod +x /usr/local/bin/{SERVER_BIN_NAME}",
+        ],
+        sudo=True,
+    )
+
+
+async def read_connection_info(cmd: AsyncCommand, timeout: float = 30.0) -> dict[str, Any]:
+    """Read connection metadata JSON from the PTY server command output."""
+    collected = ""
+
+    async def read_logs() -> dict[str, Any] | None:
+        nonlocal collected
+        async for log in cmd.logs():
+            if log.stream != "stdout":
+                continue
+            collected += log.data
+            for line in collected.split("\n"):
+                line = line.strip()
+                if not (line.startswith("{") and line.endswith("}")):
+                    continue
+                try:
+                    return json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+        return None
+
+    try:
+        result = await asyncio.wait_for(read_logs(), timeout=timeout)
+        if result is not None:
+            return result
+    except TimeoutError:
+        pass
+
+    raise RuntimeError(
+        f"Failed to get connection info from PTY server within {timeout}s. "
+        f"Collected output: {collected[:500]}"
+    )
+
+
+async def start_pty_server(
+    sandbox: AsyncSandbox,
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    sudo: bool = False,
+    cols: int | None = None,
+    rows: int | None = None,
+    connection_timeout: float = 30.0,
+) -> tuple[AsyncCommand, dict[str, Any]]:
+    """Start a PTY server command and return its command handle and metadata."""
+    terminal_cols, terminal_rows = resolve_terminal_size(cols, rows)
+
+    cmd = await sandbox.run_command_detached(
+        SERVER_BIN_NAME,
+        [
+            f"--port={sandbox.interactive_port}",
+            "--mode=client",
+            f"--cols={terminal_cols}",
+            f"--rows={terminal_rows}",
+            *command,
+        ],
+        env={"TERM": "xterm-256color", **(env or {})},
+        cwd=cwd,
+        sudo=sudo,
+    )
+
+    connection_info = await read_connection_info(cmd, timeout=connection_timeout)
+    return cmd, connection_info
+
+
+def build_ws_url(sandbox: AsyncSandbox, connection_info: dict[str, Any]) -> str:
+    interactive_port = sandbox.interactive_port
+    if interactive_port is None:
+        raise RuntimeError(
+            "Sandbox was not created with interactive=True. "
+            "Create with: await AsyncSandbox.create(interactive=True)"
+        )
+    host = sandbox.domain(interactive_port)
+    host = host.replace("https://", "").replace("http://", "")
+    return (
+        f"wss://{host}/ws/client"
+        f"?token={connection_info['token']}&processId={connection_info['processId']}"
+    )
+
+
+PTYClientFactory = Callable[[str], Awaitable["PTYClient"]]
+
+
+async def _connect_pty_client(url: str) -> PTYClient:
+    from vercel.sandbox.pty.client import PTYClient
+
+    return await PTYClient.connect(url)
+
+
+@dataclass
+class AsyncPTYSession:
+    sandbox: AsyncSandbox
+    command: AsyncCommand
+    client: PTYClient
+    connection_info: dict[str, Any]
+
+    _closed: bool = False
+
+    @classmethod
+    async def open(
+        cls,
+        sandbox: AsyncSandbox,
+        command: list[str] | None = None,
+        *,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        sudo: bool = False,
+        cols: int | None = None,
+        rows: int | None = None,
+        _client_factory: PTYClientFactory | None = None,
+        _connection_timeout: float = 30.0,
+    ) -> AsyncPTYSession:
+        if not sandbox.interactive_port:
+            raise RuntimeError(
+                "Sandbox was not created with interactive=True. "
+                "Create with: await AsyncSandbox.create(interactive=True)"
+            )
+
+        session_command = command or ["/bin/bash"]
+        client_factory = _client_factory or _connect_pty_client
+
+        await setup_sandbox_environment(sandbox)
+
+        detached_command: AsyncCommand | None = None
+        client: PTYClient | None = None
+
+        try:
+            detached_command, connection_info = await start_pty_server(
+                sandbox,
+                session_command,
+                env=env,
+                cwd=cwd,
+                sudo=sudo,
+                cols=cols,
+                rows=rows,
+                connection_timeout=_connection_timeout,
+            )
+            client = await client_factory(build_ws_url(sandbox, connection_info))
+            return cls(
+                sandbox=sandbox,
+                command=detached_command,
+                client=client,
+                connection_info=connection_info,
+            )
+        except Exception:
+            if client is not None:
+                with suppress(Exception):
+                    await client.close()
+            if detached_command is not None:
+                with suppress(Exception):
+                    await detached_command.kill()
+            raise
+
+    @property
+    def process_id(self) -> int | None:
+        return self.connection_info.get("processId")
+
+    @property
+    def server_process_id(self) -> int | None:
+        return self.connection_info.get("serverProcessId")
+
+    @property
+    def port(self) -> int | None:
+        return self.connection_info.get("port")
+
+    async def ready(self) -> None:
+        await self.client.send_ready()
+
+    async def resize(self, cols: int, rows: int) -> None:
+        await self.client.send_resize(cols, rows)
+
+    async def write(self, text: str) -> None:
+        await self.client.send_input(text)
+
+    async def write_bytes(self, data: bytes) -> None:
+        await self.client.send_input_bytes(data)
+
+    async def iter_output(self) -> AsyncIterator[bytes]:
+        async for data in self.client.raw_messages():
+            yield data
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        close_error: Exception | None = None
+
+        try:
+            await self.client.close()
+        except Exception as exc:  # pragma: no cover - defensive best-effort cleanup
+            close_error = exc
+
+        try:
+            await self.command.kill()
+        except Exception as exc:  # pragma: no cover - defensive best-effort cleanup
+            if close_error is None:
+                close_error = exc
+
+        if close_error is not None:
+            raise close_error
+
+    async def __aenter__(self) -> AsyncPTYSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -6,9 +6,11 @@ import os
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from .pty_binary import SERVER_BIN_NAME, get_binary_bytes_async
+from .time import SECOND, coerce_duration
 
 if TYPE_CHECKING:
     from vercel.sandbox.command import AsyncCommand
@@ -17,6 +19,7 @@ if TYPE_CHECKING:
 
 DEFAULT_PTY_COLS = 80
 DEFAULT_PTY_ROWS = 24
+DurationSeconds = int | float | timedelta
 
 
 def resolve_terminal_size(
@@ -56,9 +59,12 @@ async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
     )
 
 
-async def read_connection_info(cmd: AsyncCommand, timeout: float = 30.0) -> dict[str, Any]:
+async def read_connection_info(
+    cmd: AsyncCommand, timeout: DurationSeconds = 30.0
+) -> dict[str, Any]:
     """Read connection metadata JSON from the PTY server command output."""
     collected = ""
+    timeout_seconds = coerce_duration(timeout, SECOND).total_seconds()
 
     async def read_logs() -> dict[str, Any] | None:
         nonlocal collected
@@ -77,14 +83,14 @@ async def read_connection_info(cmd: AsyncCommand, timeout: float = 30.0) -> dict
         return None
 
     try:
-        result = await asyncio.wait_for(read_logs(), timeout=timeout)
+        result = await asyncio.wait_for(read_logs(), timeout=timeout_seconds)
         if result is not None:
             return result
     except TimeoutError:
         pass
 
     raise RuntimeError(
-        f"Failed to get connection info from PTY server within {timeout}s. "
+        f"Failed to get connection info from PTY server within {timeout_seconds}s. "
         f"Collected output: {collected[:500]}"
     )
 
@@ -98,7 +104,7 @@ async def start_pty_server(
     sudo: bool = False,
     cols: int | None = None,
     rows: int | None = None,
-    connection_timeout: float = 30.0,
+    connection_timeout: DurationSeconds = 30.0,
 ) -> tuple[AsyncCommand, dict[str, Any]]:
     """Start a PTY server command and return its command handle and metadata."""
     terminal_cols, terminal_rows = resolve_terminal_size(cols, rows)
@@ -166,7 +172,7 @@ class AsyncPTYSession:
         cols: int | None = None,
         rows: int | None = None,
         _client_factory: PTYClientFactory | None = None,
-        _connection_timeout: float = 30.0,
+        _connection_timeout: DurationSeconds = 30.0,
     ) -> AsyncPTYSession:
         if not sandbox.interactive_port:
             raise RuntimeError(

--- a/src/vercel/_internal/sandbox/pty_session.py
+++ b/src/vercel/_internal/sandbox/pty_session.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
+from .constants import DEFAULT_PTY_CONNECTION_TIMEOUT
 from .pty_binary import SERVER_BIN_NAME, get_binary_bytes_async
 from .time import SECOND, coerce_duration
 
@@ -60,7 +61,7 @@ async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
 
 
 async def read_connection_info(
-    cmd: AsyncCommand, timeout: DurationSeconds = 30.0
+    cmd: AsyncCommand, timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT
 ) -> dict[str, Any]:
     """Read connection metadata JSON from the PTY server command output."""
     collected = ""
@@ -104,7 +105,7 @@ async def start_pty_server(
     sudo: bool = False,
     cols: int | None = None,
     rows: int | None = None,
-    connection_timeout: DurationSeconds = 30.0,
+    connection_timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT,
 ) -> tuple[AsyncCommand, dict[str, Any]]:
     """Start a PTY server command and return its command handle and metadata."""
     terminal_cols, terminal_rows = resolve_terminal_size(cols, rows)
@@ -172,7 +173,7 @@ class AsyncPTYSession:
         cols: int | None = None,
         rows: int | None = None,
         _client_factory: PTYClientFactory | None = None,
-        _connection_timeout: DurationSeconds = 30.0,
+        _connection_timeout: DurationSeconds = DEFAULT_PTY_CONNECTION_TIMEOUT,
     ) -> AsyncPTYSession:
         if sandbox.interactive_port is None:
             raise RuntimeError(

--- a/src/vercel/_internal/sandbox/snapshot.py
+++ b/src/vercel/_internal/sandbox/snapshot.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 
-from vercel._internal.sandbox.time import MILLISECOND, coerce_duration, to_ms_int
+from vercel._internal.sandbox.constants import MIN_SNAPSHOT_EXPIRATION
+from vercel._internal.sandbox.time import (
+    MILLISECOND,
+    coerce_duration,
+    to_ms_int,
+)
 
-MIN_SNAPSHOT_EXPIRATION = timedelta(milliseconds=86_400_000)
 _ZERO_DELTA = timedelta(seconds=0)
 
 

--- a/src/vercel/sandbox/pty/__init__.py
+++ b/src/vercel/sandbox/pty/__init__.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from .client import PTYClient
 from .protocol import Message, MessageType, message, message_bytes, parse, ready, resize
+from .session import AsyncPTYSession
 
 __all__ = [
+    "AsyncPTYSession",
     # Client
     "PTYClient",
     # Protocol

--- a/src/vercel/sandbox/pty/binary.py
+++ b/src/vercel/sandbox/pty/binary.py
@@ -1,135 +1,27 @@
-"""PTY server binary management - download and cache from Vercel CDN.
-
-The PTY server is a Go binary that runs inside the sandbox to manage
-pseudo-terminal sessions. This module handles downloading and caching
-the binary from Vercel's CDN.
-"""
+"""Public PTY server binary helpers."""
 
 from __future__ import annotations
 
-from pathlib import Path
+from vercel._internal.sandbox.pty_binary import (
+    BINARY_BASE_URL,
+    CACHE_DIR,
+    DEFAULT_SANDBOX_ARCH,
+    SERVER_BIN_NAME,
+    download_binary,
+    download_binary_async,
+    get_binary_bytes,
+    get_binary_bytes_async,
+    get_binary_cache_path,
+)
 
-import httpx
-
-BINARY_BASE_URL = "https://pty-tunnel.labs.vercel.dev"
-
-CACHE_DIR = Path.home() / ".cache" / "vercel-sandbox"
-
-SERVER_BIN_NAME = "vc-interactive-server"
-
-# Sandboxes are currently always Linux x86_64
-DEFAULT_SANDBOX_ARCH = "x86_64"
-
-
-def get_binary_cache_path(arch: str | None = None) -> Path:
-    """Get the cache path for the PTY server binary.
-
-    Args:
-        arch: Target sandbox architecture (x86_64 or aarch64).
-            Defaults to x86_64 (current sandbox architecture).
-
-    Returns:
-        Path to the cached binary file.
-    """
-    if arch is None:
-        arch = DEFAULT_SANDBOX_ARCH
-    return CACHE_DIR / f"pty-server-linux-{arch}"
-
-
-def download_binary(arch: str | None = None, *, force: bool = False) -> Path:
-    """Download the PTY server binary if not already cached.
-
-    Args:
-        arch: Target sandbox architecture (x86_64 or aarch64).
-            Defaults to x86_64 (current sandbox architecture).
-        force: Force re-download even if cached.
-
-    Returns:
-        Path to the cached binary.
-
-    Raises:
-        httpx.HTTPError: If the download fails.
-    """
-    if arch is None:
-        arch = DEFAULT_SANDBOX_ARCH
-
-    cache_path = get_binary_cache_path(arch)
-
-    if cache_path.exists() and not force:
-        return cache_path
-
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
-
-    # Download from Vercel CDN
-    url = f"{BINARY_BASE_URL}/linux-{arch}"
-    with httpx.Client(timeout=60.0, follow_redirects=True) as client:
-        response = client.get(url)
-        response.raise_for_status()
-        cache_path.write_bytes(response.content)
-
-    return cache_path
-
-
-def get_binary_bytes(arch: str | None = None) -> bytes:
-    """Get the PTY server binary bytes, downloading if necessary.
-
-    This is the main entry point for getting the binary content to upload
-    to a sandbox.
-
-    Args:
-        arch: Target sandbox architecture (x86_64 or aarch64).
-            Defaults to x86_64 (current sandbox architecture).
-
-    Returns:
-        Binary content as bytes.
-    """
-    path = download_binary(arch)
-    return path.read_bytes()
-
-
-async def download_binary_async(arch: str | None = None, *, force: bool = False) -> Path:
-    """Download the PTY server binary asynchronously.
-
-    Args:
-        arch: Target sandbox architecture (x86_64 or aarch64).
-            Defaults to x86_64 (current sandbox architecture).
-        force: Force re-download even if cached.
-
-    Returns:
-        Path to the cached binary.
-
-    Raises:
-        httpx.HTTPError: If the download fails.
-    """
-    if arch is None:
-        arch = DEFAULT_SANDBOX_ARCH
-
-    cache_path = get_binary_cache_path(arch)
-
-    if cache_path.exists() and not force:
-        return cache_path
-
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
-
-    # Download from Vercel CDN
-    url = f"{BINARY_BASE_URL}/linux-{arch}"
-    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
-        response = await client.get(url)
-        response.raise_for_status()
-        cache_path.write_bytes(response.content)
-
-    return cache_path
-
-
-async def get_binary_bytes_async(arch: str | None = None) -> bytes:
-    """Get the PTY server binary bytes asynchronously.
-
-    Args:
-        arch: Target sandbox architecture (x86_64 or aarch64).
-            Defaults to x86_64 (current sandbox architecture).
-
-    Returns:
-        Binary content as bytes.
-    """
-    path = await download_binary_async(arch)
-    return path.read_bytes()
+__all__ = [
+    "BINARY_BASE_URL",
+    "CACHE_DIR",
+    "DEFAULT_SANDBOX_ARCH",
+    "SERVER_BIN_NAME",
+    "download_binary",
+    "download_binary_async",
+    "get_binary_bytes",
+    "get_binary_bytes_async",
+    "get_binary_cache_path",
+]

--- a/src/vercel/sandbox/pty/session.py
+++ b/src/vercel/sandbox/pty/session.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from vercel._internal.sandbox.pty_session import AsyncPTYSession
+
+__all__ = ["AsyncPTYSession"]

--- a/src/vercel/sandbox/pty/shell.py
+++ b/src/vercel/sandbox/pty/shell.py
@@ -144,7 +144,7 @@ async def _forward_stdin(
 
     loop.add_reader(stdin_fd, on_stdin_ready)
     try:
-        while not stop_event.is_set() and session.client.is_open:
+        while not stop_event.is_set() and session.is_open:
             # Wait for stdin data or stop signal
             wait_task = asyncio.create_task(data_ready.wait())
             stop_task = asyncio.create_task(stop_event.wait())

--- a/src/vercel/sandbox/pty/shell.py
+++ b/src/vercel/sandbox/pty/shell.py
@@ -12,16 +12,9 @@ from typing import TYPE_CHECKING
 
 import websockets
 
-from vercel._internal.sandbox.pty_session import (
-    build_ws_url,
-    setup_sandbox_environment,
-    start_pty_server,
-)
-
-from .client import PTYClient
+from .session import AsyncPTYSession
 
 if TYPE_CHECKING:
-    from ..command import AsyncCommand
     from ..sandbox import AsyncSandbox
 
 
@@ -56,27 +49,16 @@ async def start_interactive_shell(
 
     command = command or ["/bin/bash"]
 
-    # Setup sandbox environment (install PTY server if needed)
     print("Setting up interactive session...", file=sys.stderr)
-    await setup_sandbox_environment(sandbox)
-
-    # Start PTY server
-    print("Starting PTY server...", file=sys.stderr)
-    cmd, conn_info = await start_pty_server(sandbox, command, env=env, cwd=cwd, sudo=sudo)
-
-    client = await PTYClient.connect(build_ws_url(sandbox, conn_info))
-    try:
-        await _run_interactive_loop(client, cmd)
-    finally:
-        await client.close()
+    async with await sandbox.open_pty(command, env=env, cwd=cwd, sudo=sudo) as session:
+        await _run_interactive_loop(session)
 
 
-async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
+async def _run_interactive_loop(session: AsyncPTYSession) -> None:
     """Main interactive loop - forward stdin/stdout between terminal and sandbox.
 
     Args:
-        client: Connected PTY client.
-        cmd: The PTY server command handle.
+        session: Connected PTY session.
     """
     # Get initial terminal size
     try:
@@ -85,8 +67,8 @@ async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
         cols, rows = 80, 24
 
     # Send ready and initial resize
-    await client.send_ready()
-    await client.send_resize(cols, rows)
+    await session.ready()
+    await session.resize(cols, rows)
 
     # Save terminal settings
     stdin_fd = sys.stdin.fileno()
@@ -107,7 +89,7 @@ async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
             try:
                 new_cols, new_rows = os.get_terminal_size()
                 loop.call_soon_threadsafe(
-                    lambda: asyncio.create_task(client.send_resize(new_cols, new_rows))
+                    lambda: asyncio.create_task(session.resize(new_cols, new_rows))
                 )
             except OSError:
                 pass
@@ -115,8 +97,8 @@ async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
         signal.signal(signal.SIGWINCH, on_resize)
 
         # Create tasks for stdin and stdout forwarding
-        stdin_task = asyncio.create_task(_forward_stdin(client, stop_event, loop))
-        stdout_task = asyncio.create_task(_forward_stdout(client))
+        stdin_task = asyncio.create_task(_forward_stdin(session, stop_event, loop))
+        stdout_task = asyncio.create_task(_forward_stdout(session))
 
         # Wait for either to complete (connection closed or error)
         done, pending = await asyncio.wait(
@@ -141,14 +123,16 @@ async def _run_interactive_loop(client: PTYClient, cmd: AsyncCommand) -> None:
 
 
 async def _forward_stdin(
-    client: PTYClient, stop_event: asyncio.Event, loop: asyncio.AbstractEventLoop
+    session: AsyncPTYSession,
+    stop_event: asyncio.Event,
+    loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Forward local stdin to the PTY client.
 
     Uses asyncio's add_reader for efficient non-blocking I/O instead of polling.
 
     Args:
-        client: Connected PTY client.
+        session: Connected PTY session.
         stop_event: Event that signals when to stop.
         loop: The event loop for registering the reader.
     """
@@ -160,7 +144,7 @@ async def _forward_stdin(
 
     loop.add_reader(stdin_fd, on_stdin_ready)
     try:
-        while not stop_event.is_set() and client.is_open:
+        while not stop_event.is_set() and session.client.is_open:
             # Wait for stdin data or stop signal
             wait_task = asyncio.create_task(data_ready.wait())
             stop_task = asyncio.create_task(stop_event.wait())
@@ -185,7 +169,7 @@ async def _forward_stdin(
             try:
                 data = os.read(stdin_fd, 4096)
                 if data:
-                    await client.send_input_bytes(data)
+                    await session.write_bytes(data)
                 else:
                     # EOF on stdin
                     break
@@ -195,14 +179,14 @@ async def _forward_stdin(
         loop.remove_reader(stdin_fd)
 
 
-async def _forward_stdout(client: PTYClient) -> None:
+async def _forward_stdout(session: AsyncPTYSession) -> None:
     """Forward PTY output to local stdout.
 
     Args:
-        client: Connected PTY client.
+        session: Connected PTY session.
     """
     try:
-        async for data in client.raw_messages():
+        async for data in session.iter_output():
             sys.stdout.buffer.write(data)
             sys.stdout.buffer.flush()
     except websockets.ConnectionClosed:

--- a/src/vercel/sandbox/pty/shell.py
+++ b/src/vercel/sandbox/pty/shell.py
@@ -10,8 +10,6 @@ import termios
 import tty
 from typing import TYPE_CHECKING
 
-import websockets
-
 from .session import AsyncPTYSession
 
 if TYPE_CHECKING:
@@ -169,7 +167,7 @@ async def _forward_stdin(
             try:
                 data = os.read(stdin_fd, 4096)
                 if data:
-                    await session.write_bytes(data)
+                    await session.stream.send(data)
                 else:
                     # EOF on stdin
                     break
@@ -185,10 +183,6 @@ async def _forward_stdout(session: AsyncPTYSession) -> None:
     Args:
         session: Connected PTY session.
     """
-    try:
-        async for data in session.iter_output():
-            sys.stdout.buffer.write(data)
-            sys.stdout.buffer.flush()
-    except websockets.ConnectionClosed:
-        # Connection closing is expected when session ends
-        pass
+    async for data in session.stream:
+        sys.stdout.buffer.write(data)
+        sys.stdout.buffer.flush()

--- a/src/vercel/sandbox/pty/shell.py
+++ b/src/vercel/sandbox/pty/shell.py
@@ -1,18 +1,8 @@
-"""Interactive shell session management.
-
-This module provides the high-level orchestration for interactive shell
-sessions with Vercel Sandboxes. It handles:
-
-1. Setting up the sandbox environment (installing PTY server binary)
-2. Starting the PTY server in client mode
-3. Connecting via WebSocket
-4. Forwarding stdin/stdout between local terminal and remote sandbox
-"""
+"""Interactive shell session management."""
 
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import signal
 import sys
@@ -22,143 +12,17 @@ from typing import TYPE_CHECKING
 
 import websockets
 
-from .binary import SERVER_BIN_NAME, get_binary_bytes_async
+from vercel._internal.sandbox.pty_session import (
+    build_ws_url,
+    setup_sandbox_environment,
+    start_pty_server,
+)
+
 from .client import PTYClient
 
 if TYPE_CHECKING:
     from ..command import AsyncCommand
     from ..sandbox import AsyncSandbox
-
-
-async def setup_sandbox_environment(sandbox: AsyncSandbox) -> None:
-    """Install the PTY server binary in the sandbox if not present.
-
-    This downloads the Go PTY server binary and uploads it to the sandbox,
-    making it available for interactive shell sessions.
-
-    Args:
-        sandbox: The sandbox to set up.
-    """
-    # Check if already installed
-    result = await sandbox.run_command("command", ["-v", SERVER_BIN_NAME])
-    if result.exit_code == 0:
-        return
-
-    # Download binary for sandbox architecture (defaults to x86_64)
-    binary = await get_binary_bytes_async()
-
-    # Upload to sandbox
-    tmp_path = f"/tmp/{SERVER_BIN_NAME}-install"
-    await sandbox.write_files([{"path": tmp_path, "content": binary}])
-
-    # Move to /usr/local/bin and make executable
-    await sandbox.run_command(
-        "bash",
-        [
-            "-c",
-            f'mv "{tmp_path}" /usr/local/bin/{SERVER_BIN_NAME} && '
-            f"chmod +x /usr/local/bin/{SERVER_BIN_NAME}",
-        ],
-        sudo=True,
-    )
-
-
-async def start_pty_server(
-    sandbox: AsyncSandbox,
-    command: list[str],
-    *,
-    env: dict[str, str] | None = None,
-    cwd: str | None = None,
-    sudo: bool = False,
-) -> tuple[AsyncCommand, dict]:
-    """Start the PTY server in the sandbox and return connection info.
-
-    Args:
-        sandbox: The sandbox to run in.
-        command: Command to execute (e.g., ["python3"] or ["/bin/bash"]).
-        env: Additional environment variables.
-        cwd: Working directory.
-        sudo: Run with elevated privileges.
-
-    Returns:
-        Tuple of (command handle, connection info dict).
-        Connection info contains: port, token, processId, serverProcessId
-
-    Raises:
-        RuntimeError: If connection info cannot be parsed.
-    """
-    # Get terminal size
-    try:
-        cols, rows = os.get_terminal_size()
-    except OSError:
-        # Default size if not a terminal
-        cols, rows = 80, 24
-
-    # Start PTY server in client mode
-    cmd = await sandbox.run_command_detached(
-        SERVER_BIN_NAME,
-        [
-            f"--port={sandbox.interactive_port}",
-            "--mode=client",
-            f"--cols={cols}",
-            f"--rows={rows}",
-            *command,
-        ],
-        env={"TERM": "xterm-256color", **(env or {})},
-        cwd=cwd,
-        sudo=sudo,
-    )
-
-    # Read connection info from command stdout
-    connection_info = await _read_connection_info(cmd)
-
-    return cmd, connection_info
-
-
-async def _read_connection_info(cmd: AsyncCommand, timeout: float = 30.0) -> dict:
-    """Read connection info JSON from command stdout.
-
-    The PTY server outputs a JSON line with connection details:
-    {"port": N, "token": "...", "processId": N, "serverProcessId": N}
-
-    Args:
-        cmd: The command handle to read from.
-        timeout: Maximum time to wait for connection info.
-
-    Returns:
-        Parsed connection info dictionary.
-
-    Raises:
-        RuntimeError: If connection info is not received within timeout.
-    """
-    collected = ""
-
-    async def read_logs():
-        nonlocal collected
-        async for log in cmd.logs():
-            if log.stream == "stdout":
-                collected += log.data
-                # Try to parse as JSON
-                for line in collected.split("\n"):
-                    line = line.strip()
-                    if line.startswith("{") and line.endswith("}"):
-                        try:
-                            return json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-        return None
-
-    try:
-        result = await asyncio.wait_for(read_logs(), timeout=timeout)
-        if result:
-            return result
-    except TimeoutError:
-        pass
-
-    raise RuntimeError(
-        f"Failed to get connection info from PTY server within {timeout}s. "
-        f"Collected output: {collected[:500]}"
-    )
 
 
 async def start_interactive_shell(
@@ -200,14 +64,7 @@ async def start_interactive_shell(
     print("Starting PTY server...", file=sys.stderr)
     cmd, conn_info = await start_pty_server(sandbox, command, env=env, cwd=cwd, sudo=sudo)
 
-    # Build WebSocket URL
-    host = sandbox.domain(sandbox.interactive_port)
-    # Remove protocol prefix for WebSocket URL
-    host = host.replace("https://", "").replace("http://", "")
-    ws_url = f"wss://{host}/ws/client?token={conn_info['token']}&processId={conn_info['processId']}"
-
-    # Connect and run interactive loop
-    client = await PTYClient.connect(ws_url)
+    client = await PTYClient.connect(build_ws_url(sandbox, conn_info))
     try:
         await _run_interactive_loop(client, cmd)
     finally:

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -550,6 +550,7 @@ class AsyncSandbox:
         Returns:
             An ``AsyncPTYSession`` that owns the remote PTY process and
             websocket tunnel lifecycle without taking over local terminal I/O.
+            Read and write PTY bytes through ``session.stream``.
         """
         return await AsyncPTYSession.open(
             self,

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -494,9 +494,12 @@ class AsyncSandbox:
         """Start an interactive shell session.
 
         This takes over the terminal and provides a full interactive experience,
-        forwarding stdin/stdout between the local terminal and the remote sandbox.
+        forwarding stdin/stdout between the local terminal and a remote
+        ``AsyncPTYSession`` managed by this sandbox.
 
-        Requires the sandbox to be created with interactive=True.
+        Requires the sandbox to be created with ``interactive=True``. For
+        low-level PTY lifecycle control without terminal takeover, use
+        ``open_pty()`` instead.
 
         Args:
             command: Command to execute (default: ["/bin/bash"]).
@@ -537,7 +540,7 @@ class AsyncSandbox:
 
         Returns:
             An ``AsyncPTYSession`` that owns the remote PTY process and
-            websocket tunnel lifecycle.
+            websocket tunnel lifecycle without taking over local terminal I/O.
         """
         return await AsyncPTYSession.open(
             self,

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -40,6 +40,7 @@ from .command import (
     Command,
     CommandFinished,
 )
+from .pty.session import AsyncPTYSession
 from .pty.shell import start_interactive_shell
 from .snapshot import (
     AsyncSnapshot,
@@ -511,6 +512,42 @@ class AsyncSandbox:
                 await sandbox.shell(["python3"])
         """
         await start_interactive_shell(self, command, env=env, cwd=cwd, sudo=sudo)
+
+    async def open_pty(
+        self,
+        command: builtins.list[str] | None = None,
+        *,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        sudo: bool = False,
+        cols: int | None = None,
+        rows: int | None = None,
+    ) -> AsyncPTYSession:
+        """Open a low-level async PTY session without taking over the terminal.
+
+        Requires the sandbox to be created with ``interactive=True``.
+
+        Args:
+            command: Command to execute inside the PTY (default: ``["/bin/bash"]``).
+            env: Additional environment variables.
+            cwd: Working directory.
+            sudo: Run with elevated privileges.
+            cols: Initial PTY width in columns.
+            rows: Initial PTY height in rows.
+
+        Returns:
+            An ``AsyncPTYSession`` that owns the remote PTY process and
+            websocket tunnel lifecycle.
+        """
+        return await AsyncPTYSession.open(
+            self,
+            command,
+            env=env,
+            cwd=cwd,
+            sudo=sudo,
+            cols=cols,
+            rows=rows,
+        )
 
     # Async context manager to ensure cleanup
     async def __aenter__(self) -> AsyncSandbox:

--- a/src/vercel/sandbox/sandbox.py
+++ b/src/vercel/sandbox/sandbox.py
@@ -10,6 +10,10 @@ from os import PathLike
 from typing import Any
 
 from vercel._internal.iter_coroutine import iter_coroutine
+from vercel._internal.sandbox.constants import (
+    DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT,
+)
 from vercel._internal.sandbox.core import AsyncSandboxOpsClient, SyncSandboxOpsClient
 from vercel._internal.sandbox.errors import SandboxNotFoundError
 from vercel._internal.sandbox.models import (
@@ -31,7 +35,12 @@ from vercel._internal.sandbox.models import (
     parse_source,
 )
 from vercel._internal.sandbox.pagination import SandboxListParams
-from vercel._internal.sandbox.time import MILLISECOND, SECOND, coerce_duration, to_seconds_float
+from vercel._internal.sandbox.time import (
+    MILLISECOND,
+    SECOND,
+    coerce_duration,
+    to_seconds_float,
+)
 
 from ..oidc import Credentials, get_credentials
 from .command import (
@@ -283,8 +292,8 @@ class AsyncSandbox:
         self,
         status: SandboxStatus | str,
         *,
-        timeout: float | timedelta = 30.0,
-        poll_interval: float | timedelta = 0.5,
+        timeout: float | timedelta = DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        poll_interval: float | timedelta = DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
     ) -> None:
         """Wait for this sandbox to reach the given status.
 
@@ -420,8 +429,8 @@ class AsyncSandbox:
         self,
         *,
         blocking: bool = False,
-        timeout: float | timedelta = 30.0,
-        poll_interval: float | timedelta = 0.5,
+        timeout: float | timedelta = DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        poll_interval: float | timedelta = DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
     ) -> None:
         """Stop this sandbox.
 
@@ -770,8 +779,8 @@ class Sandbox:
         self,
         status: SandboxStatus | str,
         *,
-        timeout: float | timedelta = 30.0,
-        poll_interval: float | timedelta = 0.5,
+        timeout: float | timedelta = DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        poll_interval: float | timedelta = DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
     ) -> None:
         """Wait for this sandbox to reach the given status.
 
@@ -911,8 +920,8 @@ class Sandbox:
         self,
         *,
         blocking: bool = False,
-        timeout: float | timedelta = 30.0,
-        poll_interval: float | timedelta = 0.5,
+        timeout: float | timedelta = DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        poll_interval: float | timedelta = DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
     ) -> None:
         """Stop this sandbox.
 

--- a/src/vercel/sandbox/snapshot.py
+++ b/src/vercel/sandbox/snapshot.py
@@ -7,12 +7,10 @@ from typing import Literal
 
 from vercel._internal.iter_coroutine import iter_coroutine
 from vercel._internal.sandbox import AsyncSandboxOpsClient, SyncSandboxOpsClient
+from vercel._internal.sandbox.constants import MIN_SNAPSHOT_EXPIRATION
 from vercel._internal.sandbox.models import Snapshot as SnapshotModel
 from vercel._internal.sandbox.pagination import SnapshotListParams
-from vercel._internal.sandbox.snapshot import (
-    MIN_SNAPSHOT_EXPIRATION,
-    SnapshotExpiration as _SnapshotExpiration,
-)
+from vercel._internal.sandbox.snapshot import SnapshotExpiration as _SnapshotExpiration
 from vercel._internal.sandbox.time import to_ms_int
 
 from ..oidc import Credentials, get_credentials

--- a/tests/integration/test_sandbox_sync_async.py
+++ b/tests/integration/test_sandbox_sync_async.py
@@ -4171,6 +4171,29 @@ class TestSandboxRefresh:
 class TestSandboxWaitForStatus:
     """Test sandbox wait_for_status operations."""
 
+    def test_wait_and_stop_share_named_public_duration_defaults(self):
+        from inspect import signature
+
+        from vercel._internal.sandbox.constants import (
+            DEFAULT_SANDBOX_WAIT_POLL_INTERVAL,
+            DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        )
+        from vercel.sandbox import AsyncSandbox, Sandbox
+
+        async_wait = signature(AsyncSandbox.wait_for_status)
+        async_stop = signature(AsyncSandbox.stop)
+        sync_wait = signature(Sandbox.wait_for_status)
+        sync_stop = signature(Sandbox.stop)
+
+        assert async_wait.parameters["timeout"].default == DEFAULT_SANDBOX_WAIT_TIMEOUT
+        assert async_wait.parameters["poll_interval"].default == DEFAULT_SANDBOX_WAIT_POLL_INTERVAL
+        assert async_stop.parameters["timeout"].default == DEFAULT_SANDBOX_WAIT_TIMEOUT
+        assert async_stop.parameters["poll_interval"].default == DEFAULT_SANDBOX_WAIT_POLL_INTERVAL
+        assert sync_wait.parameters["timeout"].default == DEFAULT_SANDBOX_WAIT_TIMEOUT
+        assert sync_wait.parameters["poll_interval"].default == DEFAULT_SANDBOX_WAIT_POLL_INTERVAL
+        assert sync_stop.parameters["timeout"].default == DEFAULT_SANDBOX_WAIT_TIMEOUT
+        assert sync_stop.parameters["poll_interval"].default == DEFAULT_SANDBOX_WAIT_POLL_INTERVAL
+
     @respx.mock
     def test_wait_for_status_already_matched(self, mock_env_clear, mock_sandbox_get_response):
         """Test wait_for_status returns immediately if already at target status."""

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -70,7 +70,7 @@ class FakePTYClient:
 
 class FakeShellSession:
     def __init__(self, *, output: list[bytes] | None = None, is_open: bool = True) -> None:
-        self.client = SimpleNamespace(is_open=is_open)
+        self.is_open = is_open
         self.output = output or []
         self.calls: list[tuple] = []
         self.closed = False
@@ -220,6 +220,7 @@ async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> 
     assert session.process_id == 101
     assert session.server_process_id == 202
     assert session.port == 9999
+    assert session.is_open is True
 
     await session.ready()
     await session.resize(100, 50)
@@ -238,6 +239,7 @@ async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> 
     await session.close()
 
     assert client.closed is True
+    assert session.is_open is False
     assert sandbox._detached_command.kill_calls == [15]
 
 

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -12,6 +12,7 @@ import pytest
 from vercel._internal.sandbox.constants import DEFAULT_PTY_CONNECTION_TIMEOUT
 from vercel._internal.sandbox.pty_session import (
     AsyncPTYSession,
+    ConnectionInfo,
     PTYClientFactory,
     read_connection_info,
 )
@@ -267,7 +268,7 @@ async def test_read_connection_info_accepts_timedelta_timeout(monkeypatch) -> No
         cast(AsyncCommand, cmd), timeout=timedelta(milliseconds=250)
     )
 
-    assert connection_info["processId"] == 101
+    assert connection_info.process_id == 101
     assert recorded == [0.25]
 
 
@@ -315,12 +316,12 @@ async def test_read_connection_info_ignores_stdout_noise_before_metadata() -> No
 
     connection_info = await read_connection_info(cast(AsyncCommand, cmd))
 
-    assert connection_info == {
-        "port": 9999,
-        "token": "test-token",
-        "processId": 101,
-        "serverProcessId": 202,
-    }
+    assert connection_info == ConnectionInfo(
+        port=9999,
+        token="test-token",
+        process_id=101,
+        server_process_id=202,
+    )
 
 
 @pytest.mark.asyncio
@@ -337,7 +338,7 @@ async def test_read_connection_info_accepts_partial_json_across_stdout_chunks() 
 
     connection_info = await read_connection_info(cast(AsyncCommand, cmd))
 
-    assert connection_info["token"] == "test-token"
+    assert connection_info.token == "test-token"
 
 
 @pytest.mark.asyncio
@@ -357,7 +358,7 @@ async def test_read_connection_info_ignores_malformed_and_wrong_shape_json() -> 
 
     connection_info = await read_connection_info(cast(AsyncCommand, cmd))
 
-    assert connection_info["serverProcessId"] == 202
+    assert connection_info.server_process_id == 202
 
 
 @pytest.mark.asyncio
@@ -379,6 +380,24 @@ async def test_read_connection_info_times_out_with_bounded_output_excerpt() -> N
     assert "wrong-shape" not in message
     assert repeated[-100:] in message
     assert len(message.split("Collected output: ", 1)[1]) <= 500
+
+
+@pytest.mark.asyncio
+async def test_read_connection_info_returns_connection_info_model() -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog(
+                "stdout",
+                '{"port": 9999, "token": "test-token", "processId": 101, "serverProcessId": 202}\n',
+            )
+        ]
+    )
+
+    connection_info = await read_connection_info(cast(AsyncCommand, cmd))
+
+    assert isinstance(connection_info, ConnectionInfo)
+    assert connection_info.process_id == 101
+    assert connection_info.server_process_id == 202
 
 
 @pytest.mark.asyncio
@@ -448,12 +467,12 @@ async def test_async_pty_session_open_passes_timedelta_connection_timeout(monkey
         assert bound_sandbox is sandbox
         assert command == ["/bin/bash"]
         recorded.append(kwargs["connection_timeout"])
-        return sandbox._detached_command, {
-            "port": 9999,
-            "token": "test-token",
-            "processId": 101,
-            "serverProcessId": 202,
-        }
+        return sandbox._detached_command, ConnectionInfo(
+            port=9999,
+            token="test-token",
+            process_id=101,
+            server_process_id=202,
+        )
 
     async def fake_connect(url: str) -> FakePTYClient:
         assert url == "wss://pty.example.test/ws/client?token=test-token&processId=101"
@@ -486,12 +505,12 @@ async def test_async_pty_session_open_uses_shared_default_connection_timeout(
         assert bound_sandbox is sandbox
         assert command == ["/bin/bash"]
         recorded.append(kwargs["connection_timeout"])
-        return sandbox._detached_command, {
-            "port": 9999,
-            "token": "test-token",
-            "processId": 101,
-            "serverProcessId": 202,
-        }
+        return sandbox._detached_command, ConnectionInfo(
+            port=9999,
+            token="test-token",
+            process_id=101,
+            server_process_id=202,
+        )
 
     async def fake_connect(url: str) -> FakePTYClient:
         assert url == "wss://pty.example.test/ws/client?token=test-token&processId=101"

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from vercel._internal.sandbox.pty_session import AsyncPTYSession, PTYClientFactory
+from vercel.sandbox import AsyncSandbox
+from vercel.sandbox.pty import AsyncPTYSession as PublicAsyncPTYSession
+
+
+@dataclass
+class FakeLog:
+    stream: str
+    data: str
+
+
+class FakeDetachedCommand:
+    def __init__(self, logs: list[FakeLog]) -> None:
+        self._logs = logs
+        self.kill_calls: list[int] = []
+
+    async def logs(self):
+        for log in self._logs:
+            yield log
+
+    async def kill(self, signal: int = 15) -> None:
+        self.kill_calls.append(signal)
+
+
+class FakePTYClient:
+    def __init__(self, *, output: list[bytes] | None = None) -> None:
+        self.output = output or []
+        self.calls: list[tuple] = []
+        self.closed = False
+
+    async def send_ready(self) -> None:
+        self.calls.append(("ready",))
+
+    async def send_resize(self, cols: int, rows: int) -> None:
+        self.calls.append(("resize", cols, rows))
+
+    async def send_input(self, text: str) -> None:
+        self.calls.append(("write", text))
+
+    async def send_input_bytes(self, data: bytes) -> None:
+        self.calls.append(("write_bytes", data))
+
+    async def raw_messages(self):
+        for chunk in self.output:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeSandbox:
+    def __init__(
+        self,
+        *,
+        interactive_port: int | None = 1337,
+        install_present: bool = True,
+        detached_command: FakeDetachedCommand | None = None,
+    ) -> None:
+        self.interactive_port = interactive_port
+        self._install_present = install_present
+        self._detached_command = detached_command or FakeDetachedCommand(
+            [
+                FakeLog(
+                    "stdout",
+                    '{"port": 9999, "token": "test-token", "processId": 101, '
+                    '"serverProcessId": 202}\n',
+                )
+            ]
+        )
+        self.run_command_calls: list[tuple] = []
+        self.write_files_calls: list[list[dict]] = []
+        self.detached_calls: list[tuple] = []
+
+    async def run_command(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ):
+        self.run_command_calls.append((cmd, args or [], cwd, env or {}, sudo))
+        if cmd == "command" and args == ["-v", "vc-interactive-server"]:
+            exit_code = 0 if self._install_present else 1
+            return SimpleNamespace(exit_code=exit_code)
+        return SimpleNamespace(exit_code=0)
+
+    async def write_files(self, files: list[dict]) -> None:
+        self.write_files_calls.append(files)
+
+    async def run_command_detached(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> FakeDetachedCommand:
+        self.detached_calls.append((cmd, args or [], cwd, env or {}, sudo))
+        return self._detached_command
+
+    def domain(self, port: int | None) -> str:
+        assert port == self.interactive_port
+        return "https://pty.example.test"
+
+
+@pytest.mark.asyncio
+async def test_public_pty_session_export_is_supported_surface() -> None:
+    assert PublicAsyncPTYSession is AsyncPTYSession
+
+
+@pytest.mark.asyncio
+async def test_open_requires_interactive_sandbox() -> None:
+    sandbox = FakeSandbox(interactive_port=None)
+
+    with pytest.raises(RuntimeError, match="interactive=True"):
+        await AsyncPTYSession.open(cast(AsyncSandbox, sandbox))
+
+
+@pytest.mark.asyncio
+async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> None:
+    sandbox = FakeSandbox(install_present=False)
+    client = FakePTYClient(output=[b"hello ", b"world"])
+
+    async def fake_binary_bytes() -> bytes:
+        return b"pty-binary"
+
+    async def fake_connect(url: str) -> FakePTYClient:
+        assert url == "wss://pty.example.test/ws/client?token=test-token&processId=101"
+        return client
+
+    monkeypatch.setattr(
+        "vercel._internal.sandbox.pty_session.get_binary_bytes_async",
+        fake_binary_bytes,
+    )
+
+    session = await AsyncPTYSession.open(
+        cast(AsyncSandbox, sandbox),
+        ["/bin/bash"],
+        cols=120,
+        rows=40,
+        _client_factory=cast(PTYClientFactory, fake_connect),
+    )
+
+    assert sandbox.write_files_calls == [
+        [{"path": "/tmp/vc-interactive-server-install", "content": b"pty-binary"}]
+    ]
+    assert sandbox.run_command_calls[1] == (
+        "bash",
+        [
+            "-c",
+            'mv "/tmp/vc-interactive-server-install" /usr/local/bin/vc-interactive-server && '
+            "chmod +x /usr/local/bin/vc-interactive-server",
+        ],
+        None,
+        {},
+        True,
+    )
+    assert sandbox.detached_calls == [
+        (
+            "vc-interactive-server",
+            ["--port=1337", "--mode=client", "--cols=120", "--rows=40", "/bin/bash"],
+            None,
+            {"TERM": "xterm-256color"},
+            False,
+        )
+    ]
+    assert session.process_id == 101
+    assert session.server_process_id == 202
+    assert session.port == 9999
+
+    await session.ready()
+    await session.resize(100, 50)
+    await session.write("pwd\n")
+    await session.write_bytes(b"exit\n")
+    output = [chunk async for chunk in session.iter_output()]
+
+    assert output == [b"hello ", b"world"]
+    assert client.calls == [
+        ("ready",),
+        ("resize", 100, 50),
+        ("write", "pwd\n"),
+        ("write_bytes", b"exit\n"),
+    ]
+
+    await session.close()
+
+    assert client.closed is True
+    assert sandbox._detached_command.kill_calls == [15]
+
+
+@pytest.mark.asyncio
+async def test_open_cleans_up_detached_command_when_client_connection_fails(
+    monkeypatch,
+) -> None:
+    sandbox = FakeSandbox()
+
+    async def fake_connect(url: str) -> FakePTYClient:
+        raise RuntimeError(f"boom: {url}")
+
+    with pytest.raises(RuntimeError, match="boom: wss://pty.example.test"):
+        await AsyncPTYSession.open(
+            cast(AsyncSandbox, sandbox),
+            _client_factory=cast(PTYClientFactory, fake_connect),
+        )
+
+    assert sandbox._detached_command.kill_calls == [15]
+
+
+@pytest.mark.asyncio
+async def test_async_sandbox_open_pty_delegates_to_session(monkeypatch) -> None:
+    sandbox = FakeSandbox()
+    expected = object()
+    recorded: list[tuple] = []
+
+    async def fake_open(cls, bound_sandbox, command, **kwargs):
+        recorded.append((cls, bound_sandbox, command, kwargs))
+        return expected
+
+    monkeypatch.setattr(AsyncPTYSession, "open", classmethod(fake_open))
+
+    result = await AsyncSandbox.open_pty(
+        cast(AsyncSandbox, sandbox),
+        ["/bin/sh"],
+        env={"FOO": "bar"},
+        cwd="/workspace",
+        sudo=True,
+        cols=90,
+        rows=30,
+    )
+
+    assert result is expected
+    assert recorded == [
+        (
+            AsyncPTYSession,
+            sandbox,
+            ["/bin/sh"],
+            {
+                "env": {"FOO": "bar"},
+                "cwd": "/workspace",
+                "sudo": True,
+                "cols": 90,
+                "rows": 30,
+            },
+        )
+    ]

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import Mock
 
 import pytest
+from anyio import EndOfStream
 
 from vercel._internal.sandbox.constants import DEFAULT_PTY_CONNECTION_TIMEOUT
 from vercel._internal.sandbox.pty_session import (
@@ -73,22 +74,15 @@ class FakePTYClient:
 class FakeShellSession:
     def __init__(self, *, output: list[bytes] | None = None, is_open: bool = True) -> None:
         self.is_open = is_open
-        self.output = output or []
         self.calls: list[tuple] = []
         self.closed = False
+        self.stream = FakeShellStream(self, output=output or [])
 
     async def ready(self) -> None:
         self.calls.append(("ready",))
 
     async def resize(self, cols: int, rows: int) -> None:
         self.calls.append(("resize", cols, rows))
-
-    async def write_bytes(self, data: bytes) -> None:
-        self.calls.append(("write_bytes", data))
-
-    async def iter_output(self):
-        for chunk in self.output:
-            yield chunk
 
     async def close(self) -> None:
         self.closed = True
@@ -98,6 +92,36 @@ class FakeShellSession:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.close()
+
+
+class FakeShellStream:
+    def __init__(self, session: FakeShellSession, *, output: list[bytes]) -> None:
+        self._session = session
+        self._output = output
+        self._index = 0
+
+    def __aiter__(self) -> FakeShellStream:
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return await self.receive()
+        except EndOfStream:
+            raise StopAsyncIteration from None
+
+    async def send(self, data: bytes) -> None:
+        self._session.calls.append(("stream_send", data))
+
+    async def receive(self, max_bytes: int = 65536) -> bytes:
+        if self._index >= len(self._output):
+            raise EndOfStream
+
+        chunk = self._output[self._index]
+        self._index += 1
+        return chunk[:max_bytes]
+
+    async def aclose(self) -> None:
+        await self._session.close()
 
 
 class FakeSandbox:
@@ -174,7 +198,7 @@ async def test_open_requires_interactive_sandbox() -> None:
 @pytest.mark.asyncio
 async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> None:
     sandbox = FakeSandbox(install_present=False)
-    client = FakePTYClient(output=[b"hello ", b"world"])
+    client = FakePTYClient(output=[b"hello world"])
 
     async def fake_binary_bytes() -> bytes:
         return b"pty-binary"
@@ -226,19 +250,21 @@ async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> 
 
     await session.ready()
     await session.resize(100, 50)
-    await session.write("pwd\n")
-    await session.write_bytes(b"exit\n")
-    output = [chunk async for chunk in session.iter_output()]
+    await session.stream.send(b"pwd\n")
+    assert await session.stream.receive(5) == b"hello"
+    assert await session.stream.receive() == b" world"
+    with pytest.raises(EndOfStream):
+        await session.stream.receive()
+    await session.stream.send(b"exit\n")
 
-    assert output == [b"hello ", b"world"]
     assert client.calls == [
         ("ready",),
         ("resize", 100, 50),
-        ("write", "pwd\n"),
+        ("write_bytes", b"pwd\n"),
         ("write_bytes", b"exit\n"),
     ]
 
-    await session.close()
+    await session.stream.aclose()
 
     assert client.closed is True
     assert session.is_open is False

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import timedelta
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import cast
@@ -7,7 +9,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from vercel._internal.sandbox.pty_session import AsyncPTYSession, PTYClientFactory
+from vercel._internal.sandbox.pty_session import (
+    AsyncPTYSession,
+    PTYClientFactory,
+    read_connection_info,
+)
 from vercel.sandbox import AsyncSandbox
 from vercel.sandbox.pty import AsyncPTYSession as PublicAsyncPTYSession
 from vercel.sandbox.pty.shell import _run_interactive_loop, start_interactive_shell
@@ -236,6 +242,32 @@ async def test_open_installs_server_when_missing_and_streams_io(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_read_connection_info_accepts_timedelta_timeout(monkeypatch) -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog(
+                "stdout",
+                '{"port": 9999, "token": "test-token", "processId": 101, '
+                '"serverProcessId": 202}\n',
+            )
+        ]
+    )
+    recorded: list[float | None] = []
+    original_wait_for = asyncio.wait_for
+
+    async def fake_wait_for(awaitable, timeout=None):
+        recorded.append(timeout)
+        return await original_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr("vercel._internal.sandbox.pty_session.asyncio.wait_for", fake_wait_for)
+
+    connection_info = await read_connection_info(cmd, timeout=timedelta(milliseconds=250))
+
+    assert connection_info["processId"] == 101
+    assert recorded == [0.25]
+
+
+@pytest.mark.asyncio
 async def test_open_cleans_up_detached_command_when_client_connection_fails(
     monkeypatch,
 ) -> None:
@@ -290,6 +322,42 @@ async def test_async_sandbox_open_pty_delegates_to_session(monkeypatch) -> None:
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_pty_session_open_passes_timedelta_connection_timeout(monkeypatch) -> None:
+    sandbox = FakeSandbox()
+    client = FakePTYClient()
+    recorded: list[timedelta] = []
+
+    async def fake_start_pty_server(bound_sandbox, command, **kwargs):
+        assert bound_sandbox is sandbox
+        assert command == ["/bin/bash"]
+        recorded.append(kwargs["connection_timeout"])
+        return sandbox._detached_command, {
+            "port": 9999,
+            "token": "test-token",
+            "processId": 101,
+            "serverProcessId": 202,
+        }
+
+    async def fake_connect(url: str) -> FakePTYClient:
+        assert url == "wss://pty.example.test/ws/client?token=test-token&processId=101"
+        return client
+
+    monkeypatch.setattr(
+        "vercel._internal.sandbox.pty_session.start_pty_server",
+        fake_start_pty_server,
+    )
+
+    session = await AsyncPTYSession.open(
+        cast(AsyncSandbox, sandbox),
+        _client_factory=cast(PTYClientFactory, fake_connect),
+        _connection_timeout=timedelta(seconds=5),
+    )
+
+    assert recorded == [timedelta(seconds=5)]
+    await session.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -296,6 +296,92 @@ async def test_read_connection_info_uses_shared_default_timeout(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_read_connection_info_ignores_stdout_noise_before_metadata() -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog("stdout", "booting pty server\n"),
+            FakeLog(
+                "stderr",
+                '{"port": 1, "token": "wrong", "processId": 2, "serverProcessId": 3}\n',
+            ),
+            FakeLog("stdout", "still starting\n"),
+            FakeLog(
+                "stdout",
+                '{"port": 9999, "token": "test-token", "processId": 101, "serverProcessId": 202}\n',
+            ),
+            FakeLog("stdout", "trailing log\n"),
+        ]
+    )
+
+    connection_info = await read_connection_info(cast(AsyncCommand, cmd))
+
+    assert connection_info == {
+        "port": 9999,
+        "token": "test-token",
+        "processId": 101,
+        "serverProcessId": 202,
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_connection_info_accepts_partial_json_across_stdout_chunks() -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog("stdout", '{"port": 9999, "token": "test-'),
+            FakeLog(
+                "stdout",
+                'token", "processId": 101, "serverProcessId": 202}\n',
+            ),
+        ]
+    )
+
+    connection_info = await read_connection_info(cast(AsyncCommand, cmd))
+
+    assert connection_info["token"] == "test-token"
+
+
+@pytest.mark.asyncio
+async def test_read_connection_info_ignores_malformed_and_wrong_shape_json() -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog("stdout", '{"port": 9999, "token": }\n'),
+            FakeLog("stdout", '{"port": 9999, "token": "missing newline"'),
+            FakeLog("stdout", "}\n"),
+            FakeLog("stdout", '{"token": "missing-fields"}\n'),
+            FakeLog(
+                "stdout",
+                '{"port": 9999, "token": "test-token", "processId": 101, "serverProcessId": 202}\n',
+            ),
+        ]
+    )
+
+    connection_info = await read_connection_info(cast(AsyncCommand, cmd))
+
+    assert connection_info["serverProcessId"] == 202
+
+
+@pytest.mark.asyncio
+async def test_read_connection_info_times_out_with_bounded_output_excerpt() -> None:
+    repeated = "x" * 600
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog("stdout", "starting\n"),
+            FakeLog("stdout", '{"token": "wrong-shape"}\n'),
+            FakeLog("stdout", repeated),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match=r"within 0\.01s") as exc_info:
+        await read_connection_info(cast(AsyncCommand, cmd), timeout=timedelta(milliseconds=10))
+
+    message = str(exc_info.value)
+    assert "starting" not in message
+    assert "wrong-shape" not in message
+    assert repeated[-100:] in message
+    assert len(message.split("Collected output: ", 1)[1]) <= 500
+
+
+@pytest.mark.asyncio
 async def test_open_cleans_up_detached_command_when_client_connection_fails(
     monkeypatch,
 ) -> None:

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
 from vercel._internal.sandbox.pty_session import AsyncPTYSession, PTYClientFactory
 from vercel.sandbox import AsyncSandbox
 from vercel.sandbox.pty import AsyncPTYSession as PublicAsyncPTYSession
+from vercel.sandbox.pty.shell import _run_interactive_loop, start_interactive_shell
 
 
 @dataclass
@@ -54,6 +56,40 @@ class FakePTYClient:
 
     async def close(self) -> None:
         self.closed = True
+
+    @property
+    def is_open(self) -> bool:
+        return not self.closed
+
+
+class FakeShellSession:
+    def __init__(self, *, output: list[bytes] | None = None, is_open: bool = True) -> None:
+        self.client = SimpleNamespace(is_open=is_open)
+        self.output = output or []
+        self.calls: list[tuple] = []
+        self.closed = False
+
+    async def ready(self) -> None:
+        self.calls.append(("ready",))
+
+    async def resize(self, cols: int, rows: int) -> None:
+        self.calls.append(("resize", cols, rows))
+
+    async def write_bytes(self, data: bytes) -> None:
+        self.calls.append(("write_bytes", data))
+
+    async def iter_output(self):
+        for chunk in self.output:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def __aenter__(self) -> FakeShellSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
 
 
 class FakeSandbox:
@@ -254,3 +290,65 @@ async def test_async_sandbox_open_pty_delegates_to_session(monkeypatch) -> None:
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_start_interactive_shell_delegates_via_open_pty(monkeypatch) -> None:
+    sandbox = FakeSandbox()
+    session = FakeShellSession()
+    recorded: list[tuple] = []
+
+    async def fake_open_pty(command, **kwargs):
+        recorded.append((command, kwargs))
+        return session
+
+    async def fake_loop(bound_session):
+        assert bound_session is session
+
+    monkeypatch.setattr(sandbox, "open_pty", fake_open_pty, raising=False)
+    monkeypatch.setattr("vercel.sandbox.pty.shell._run_interactive_loop", fake_loop)
+
+    await start_interactive_shell(
+        cast(AsyncSandbox, sandbox),
+        ["/bin/sh"],
+        env={"FOO": "bar"},
+        cwd="/workspace",
+        sudo=True,
+    )
+
+    assert recorded == [(["/bin/sh"], {"env": {"FOO": "bar"}, "cwd": "/workspace", "sudo": True})]
+    assert session.closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_interactive_loop_uses_session_surface(monkeypatch) -> None:
+    session = FakeShellSession(output=[b"hello from pty"], is_open=False)
+    stdin = SimpleNamespace(fileno=lambda: 0)
+    stdout_buffer = SimpleNamespace(write=Mock(), flush=Mock())
+    stdout = SimpleNamespace(buffer=stdout_buffer)
+    signal_calls: list[tuple] = []
+
+    monkeypatch.setattr("vercel.sandbox.pty.shell.sys.stdin", stdin)
+    monkeypatch.setattr("vercel.sandbox.pty.shell.sys.stdout", stdout)
+    monkeypatch.setattr("vercel.sandbox.pty.shell.os.get_terminal_size", lambda: (120, 40))
+    monkeypatch.setattr("vercel.sandbox.pty.shell.termios.tcgetattr", lambda fd: "saved-settings")
+    monkeypatch.setattr("vercel.sandbox.pty.shell.termios.tcsetattr", Mock())
+    monkeypatch.setattr("vercel.sandbox.pty.shell.tty.setraw", Mock())
+    monkeypatch.setattr("vercel.sandbox.pty.shell.os.read", lambda fd, size: b"")
+
+    def fake_signal(sig, handler):
+        signal_calls.append((sig, handler))
+        return None
+
+    monkeypatch.setattr("vercel.sandbox.pty.shell.signal.signal", fake_signal)
+
+    await _run_interactive_loop(cast(AsyncPTYSession, session))
+
+    assert session.calls[:2] == [("ready",), ("resize", 120, 40)]
+    assert stdout_buffer.write.call_args_list == [((b"hello from pty",),)]
+    assert stdout_buffer.flush.call_count == 1
+    assert signal_calls[0][1] is not None
+    assert signal_calls[-1] == (
+        signal_calls[0][0],
+        start_interactive_shell.__globals__["signal"].SIG_DFL,
+    )

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from vercel._internal.sandbox.constants import DEFAULT_PTY_CONNECTION_TIMEOUT
 from vercel._internal.sandbox.pty_session import (
     AsyncPTYSession,
     PTYClientFactory,
@@ -271,6 +272,30 @@ async def test_read_connection_info_accepts_timedelta_timeout(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_read_connection_info_uses_shared_default_timeout(monkeypatch) -> None:
+    cmd = FakeDetachedCommand(
+        [
+            FakeLog(
+                "stdout",
+                '{"port": 9999, "token": "test-token", "processId": 101, "serverProcessId": 202}\n',
+            )
+        ]
+    )
+    recorded: list[float | None] = []
+    original_wait_for = asyncio.wait_for
+
+    async def fake_wait_for(awaitable, timeout=None):
+        recorded.append(timeout)
+        return await original_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr("vercel._internal.sandbox.pty_session.asyncio.wait_for", fake_wait_for)
+
+    await read_connection_info(cast(AsyncCommand, cmd))
+
+    assert recorded == [DEFAULT_PTY_CONNECTION_TIMEOUT.total_seconds()]
+
+
+@pytest.mark.asyncio
 async def test_open_cleans_up_detached_command_when_client_connection_fails(
     monkeypatch,
 ) -> None:
@@ -360,6 +385,43 @@ async def test_async_pty_session_open_passes_timedelta_connection_timeout(monkey
     )
 
     assert recorded == [timedelta(seconds=5)]
+    await session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_pty_session_open_uses_shared_default_connection_timeout(
+    monkeypatch,
+) -> None:
+    sandbox = FakeSandbox()
+    client = FakePTYClient()
+    recorded: list[timedelta] = []
+
+    async def fake_start_pty_server(bound_sandbox, command, **kwargs):
+        assert bound_sandbox is sandbox
+        assert command == ["/bin/bash"]
+        recorded.append(kwargs["connection_timeout"])
+        return sandbox._detached_command, {
+            "port": 9999,
+            "token": "test-token",
+            "processId": 101,
+            "serverProcessId": 202,
+        }
+
+    async def fake_connect(url: str) -> FakePTYClient:
+        assert url == "wss://pty.example.test/ws/client?token=test-token&processId=101"
+        return client
+
+    monkeypatch.setattr(
+        "vercel._internal.sandbox.pty_session.start_pty_server",
+        fake_start_pty_server,
+    )
+
+    session = await AsyncPTYSession.open(
+        cast(AsyncSandbox, sandbox),
+        _client_factory=cast(PTYClientFactory, fake_connect),
+    )
+
+    assert recorded == [DEFAULT_PTY_CONNECTION_TIMEOUT]
     await session.close()
 
 

--- a/tests/unit/test_pty_session.py
+++ b/tests/unit/test_pty_session.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 from dataclasses import dataclass
+from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import Mock
@@ -14,7 +14,7 @@ from vercel._internal.sandbox.pty_session import (
     PTYClientFactory,
     read_connection_info,
 )
-from vercel.sandbox import AsyncSandbox
+from vercel.sandbox import AsyncCommand, AsyncSandbox
 from vercel.sandbox.pty import AsyncPTYSession as PublicAsyncPTYSession
 from vercel.sandbox.pty.shell import _run_interactive_loop, start_interactive_shell
 
@@ -247,8 +247,7 @@ async def test_read_connection_info_accepts_timedelta_timeout(monkeypatch) -> No
         [
             FakeLog(
                 "stdout",
-                '{"port": 9999, "token": "test-token", "processId": 101, '
-                '"serverProcessId": 202}\n',
+                '{"port": 9999, "token": "test-token", "processId": 101, "serverProcessId": 202}\n',
             )
         ]
     )
@@ -261,7 +260,9 @@ async def test_read_connection_info_accepts_timedelta_timeout(monkeypatch) -> No
 
     monkeypatch.setattr("vercel._internal.sandbox.pty_session.asyncio.wait_for", fake_wait_for)
 
-    connection_info = await read_connection_info(cmd, timeout=timedelta(milliseconds=250))
+    connection_info = await read_connection_info(
+        cast(AsyncCommand, cmd), timeout=timedelta(milliseconds=250)
+    )
 
     assert connection_info["processId"] == 101
     assert recorded == [0.25]


### PR DESCRIPTION
This PR refactors PTY support around a reusable low-level `AsyncPTYSession` so PTY access in `vercel-py` is no longer effectively tied to the terminal-taking `AsyncSandbox.shell()` workflow.

The current shape is:

- `AsyncSandbox.shell()` remains the high-level helper for interactive local terminal takeover
- `AsyncSandbox.open_pty()` is the low-level acquisition path for callers that want PTY access without depending on `sys.stdin` / `sys.stdout`
- `AsyncPTYSession` owns the remote PTY lifecycle end-to-end: PTY helper installation, detached PTY server startup, websocket connection, readiness, resize, metadata, and teardown

This keeps the shell UX intact while giving downstream PTY consumers a first-class session abstraction instead of requiring manual bootstrap work.

The result is a clearer separation between terminal UX and PTY session management, plus a lower-level API that is easier to compose in provider-style integrations.

## API Shape

The low-level PTY contract is now centered on `AsyncPTYSession` plus a stream-shaped I/O surface:

```python
async with await sandbox.open_pty(
    ["/bin/bash"],
    cols=100,
    rows=30,
) as session:
    await session.ready()
    await session.resize(100, 30)

    await session.stream.send(b"printf 'PTY_OK\\n'; pwd; exit\\n")

    output = b""
    async for chunk in session.stream:
        output += chunk
        if b"PTY_OK" in output:
            break
```

That is the intended usage now: lifecycle methods like `ready()` and `resize()` stay on the session, while PTY bytes flow through `session.stream`.

A slightly more direct receive loop looks like this:

```python
await session.stream.send(b"echo hello\\n")

buffer = b""
while True:
    chunk = await session.stream.receive()
    buffer += chunk
    if b"hello" in buffer:
        break
```

Closing the stream closes the session, since there is no separate meaningful I/O path once the websocket-backed PTY stream is gone.
