### PR TITLE
feat: add vercel.cron module

### DIFF
--- a/src/vercel/cron/__init__.py
+++ b/src/vercel/cron/__init__.py
@@ -1,0 +1,7 @@
+from .crontab import CronSchedule, CronTab, CronTabError
+
+__all__ = [
+    "CronSchedule",
+    "CronTab",
+    "CronTabError",
+]

--- a/src/vercel/cron/crontab.py
+++ b/src/vercel/cron/crontab.py
@@ -101,7 +101,7 @@ class CronTab:
 
         return decorator
 
-    def __call__(self) -> list[tuple[str, str]]:
+    def get_crons(self) -> list[tuple[str, str]]:
         result = []
         for fn, sched in self._jobs:
             _resolve(fn)

--- a/src/vercel/cron/crontab.py
+++ b/src/vercel/cron/crontab.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+_Field = int | str
+
+
+class CronTabError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class CronSchedule:
+    minute: _Field = "*"
+    hour: _Field = "*"
+    day: _Field = "*"
+    month: _Field = "*"
+    day_of_week: _Field = "*"
+
+    @classmethod
+    def from_str(cls, s: str) -> CronSchedule:
+        parts = s.split()
+        if len(parts) != 5:
+            raise CronTabError(f"Expected 5 cron fields, got {len(parts)}: {s!r}")
+        return cls(*parts)
+
+    def __str__(self) -> str:
+        return f"{self.minute} {self.hour} {self.day} {self.month} {self.day_of_week}"
+
+
+def _resolve(fn: Callable[..., Any]) -> None:
+    module_name = fn.__module__
+    name = fn.__name__
+    qualname = fn.__qualname__
+
+    if qualname != name:
+        raise CronTabError(
+            f"Cannot register {qualname!r}: only module-level functions are supported"
+        )
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        raise CronTabError(
+            f"Cannot register {name!r}: module {module_name!r} not found in sys.modules"
+        )
+
+    obj = getattr(module, name, None)
+    if obj is not fn:
+        raise CronTabError(f"Cannot register {name!r}: could not resolve {module_name}:{name}")
+
+
+class CronTab:
+    def __init__(self) -> None:
+        self._jobs: list[tuple[Callable[..., Any], CronSchedule]] = []
+
+    @overload
+    def register(self, schedule: str | CronSchedule, /) -> Callable[[_F], _F]: ...
+
+    @overload
+    def register(
+        self,
+        *,
+        minute: _Field = "*",
+        hour: _Field = "*",
+        day: _Field = "*",
+        month: _Field = "*",
+        day_of_week: _Field = "*",
+    ) -> Callable[[_F], _F]: ...
+
+    def register(
+        self,
+        schedule: str | CronSchedule | None = None,
+        *,
+        minute: _Field = "*",
+        hour: _Field = "*",
+        day: _Field = "*",
+        month: _Field = "*",
+        day_of_week: _Field = "*",
+    ) -> Callable[[_F], _F]:
+        if schedule is not None:
+            if isinstance(schedule, str):
+                sched = CronSchedule.from_str(schedule)
+            else:
+                sched = schedule
+        else:
+            sched = CronSchedule(
+                minute=minute,
+                hour=hour,
+                day=day,
+                month=month,
+                day_of_week=day_of_week,
+            )
+
+        def decorator(fn: _F) -> _F:
+            self._jobs.append((fn, sched))
+            return fn
+
+        return decorator
+
+    def __call__(self) -> list[tuple[str, str]]:
+        result = []
+        for fn, sched in self._jobs:
+            _resolve(fn)
+            module = fn.__module__
+            name = fn.__name__
+            result.append((f"{module}:{name}", str(sched)))
+        return result

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,0 +1,203 @@
+"""Tests for vercel.cron."""
+
+import pytest
+
+from vercel.cron import CronSchedule, CronTab, CronTabError
+
+# --- Module-level functions for registration tests ---
+
+_ct_string = CronTab()
+_ct_string2 = CronTab()
+_ct_sched = CronTab()
+_ct_sched_default = CronTab()
+_ct_kwarg1 = CronTab()
+_ct_kwarg2 = CronTab()
+_ct_kwarg_defaults = CronTab()
+_ct_preserves = CronTab()
+_ct_preserves_name = CronTab()
+_ct_call = CronTab()
+
+
+@_ct_string.register("* * * * 5")
+def _job_string():
+    pass
+
+
+@_ct_string2.register("*/15 0 1,15 * 1-5")
+def _job_string2():
+    pass
+
+
+_sched_obj = CronSchedule(minute="0", hour="6")
+
+
+@_ct_sched.register(_sched_obj)
+def _job_sched():
+    pass
+
+
+@_ct_sched_default.register(CronSchedule())
+def _job_sched_default():
+    pass
+
+
+@_ct_kwarg1.register(hour=0)
+def _job_kwarg1():
+    pass
+
+
+@_ct_kwarg2.register(minute="*/15", day_of_week=5)
+def _job_kwarg2():
+    pass
+
+
+@_ct_kwarg_defaults.register()
+def _job_kwarg_defaults():
+    pass
+
+
+@_ct_preserves.register("0 0 * * *")
+def _job_preserves():
+    return 42
+
+
+@_ct_preserves_name.register(hour=0)
+def _job_preserves_name():
+    pass
+
+
+@_ct_call.register("0 0 * * *")
+def _job_daily():
+    pass
+
+
+@_ct_call.register(minute="*/15")
+def _job_frequent():
+    pass
+
+
+@_ct_call.register(CronSchedule(hour=6, day_of_week=1))
+def _job_weekly():
+    pass
+
+
+# --- Tests ---
+
+
+class TestCronSchedule:
+    def test_defaults(self):
+        s = CronSchedule()
+        assert str(s) == "* * * * *"
+
+    def test_all_fields(self):
+        s = CronSchedule(minute="0", hour="6", day="1", month="1", day_of_week="0")
+        assert str(s) == "0 6 1 1 0"
+
+    def test_int_fields(self):
+        s = CronSchedule(minute=30, hour=6)
+        assert str(s) == "30 6 * * *"
+
+    def test_mixed_fields(self):
+        s = CronSchedule(minute="*/15", hour=0)
+        assert str(s) == "*/15 0 * * *"
+
+    def test_frozen(self):
+        s = CronSchedule()
+        with pytest.raises(AttributeError):
+            s.minute = "0"  # type: ignore[misc]
+
+    def test_equality(self):
+        a = CronSchedule(hour="6")
+        b = CronSchedule(hour="6")
+        assert a == b
+
+    def test_inequality(self):
+        a = CronSchedule(hour="6")
+        b = CronSchedule(hour="7")
+        assert a != b
+
+
+class TestCronTabRegisterString:
+    def test_basic(self):
+        assert len(_ct_string._jobs) == 1
+        assert str(_ct_string._jobs[0][1]) == "* * * * 5"
+
+    def test_complex_expression(self):
+        assert str(_ct_string2._jobs[0][1]) == "*/15 0 1,15 * 1-5"
+
+    def test_invalid_field_count(self):
+        ct = CronTab()
+        with pytest.raises(CronTabError, match="Expected 5 cron fields, got 3"):
+            ct.register("* * *")
+
+
+class TestCronTabRegisterSchedule:
+    def test_basic(self):
+        assert _ct_sched._jobs[0][1] is _sched_obj
+
+    def test_default_schedule(self):
+        assert str(_ct_sched_default._jobs[0][1]) == "* * * * *"
+
+
+class TestCronTabRegisterKwargs:
+    def test_single_kwarg(self):
+        assert str(_ct_kwarg1._jobs[0][1]) == "* 0 * * *"
+
+    def test_multiple_kwargs(self):
+        assert str(_ct_kwarg2._jobs[0][1]) == "*/15 * * * 5"
+
+    def test_no_args_all_defaults(self):
+        assert str(_ct_kwarg_defaults._jobs[0][1]) == "* * * * *"
+
+
+class TestCronTabRegisterPreservesFunction:
+    def test_returns_original_function(self):
+        assert _job_preserves() == 42
+
+    def test_preserves_name(self):
+        assert _job_preserves_name.__name__ == "_job_preserves_name"
+
+
+class TestCronTabRejectsUnresolvable:
+    def test_rejects_local_function(self):
+        ct = CronTab()
+
+        @ct.register("0 0 * * *")
+        def local_job():
+            pass
+
+        with pytest.raises(CronTabError, match="only module-level functions"):
+            ct()
+
+    def test_rejects_lambda(self):
+        ct = CronTab()
+        ct.register("0 0 * * *")(lambda: None)
+        with pytest.raises(CronTabError, match="only module-level functions"):
+            ct()
+
+    def test_rejects_method(self):
+        ct = CronTab()
+
+        class Jobs:
+            @ct.register("0 0 * * *")
+            def my_job(self):
+                pass
+
+        with pytest.raises(CronTabError, match="only module-level functions"):
+            ct()
+
+
+class TestCronTabCall:
+    def test_empty(self):
+        ct = CronTab()
+        assert ct() == []
+
+    def test_entries(self):
+        result = _ct_call()
+        module = __name__
+        assert result == [
+            (f"{module}:_job_daily", "0 0 * * *"),
+            (f"{module}:_job_frequent", "*/15 * * * *"),
+            (f"{module}:_job_weekly", "* 6 * * 1"),
+        ]
+

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -167,13 +167,13 @@ class TestCronTabRejectsUnresolvable:
             pass
 
         with pytest.raises(CronTabError, match="only module-level functions"):
-            ct()
+            ct.get_crons()
 
     def test_rejects_lambda(self):
         ct = CronTab()
         ct.register("0 0 * * *")(lambda: None)
         with pytest.raises(CronTabError, match="only module-level functions"):
-            ct()
+            ct.get_crons()
 
     def test_rejects_method(self):
         ct = CronTab()
@@ -184,20 +184,19 @@ class TestCronTabRejectsUnresolvable:
                 pass
 
         with pytest.raises(CronTabError, match="only module-level functions"):
-            ct()
+            ct.get_crons()
 
 
 class TestCronTabCall:
     def test_empty(self):
         ct = CronTab()
-        assert ct() == []
+        assert ct.get_crons() == []
 
     def test_entries(self):
-        result = _ct_call()
+        result = _ct_call.get_crons()
         module = __name__
         assert result == [
             (f"{module}:_job_daily", "0 0 * * *"),
             (f"{module}:_job_frequent", "*/15 * * * *"),
             (f"{module}:_job_weekly", "* 6 * * 1"),
         ]
-


### PR DESCRIPTION
CronTab provides a decorator-based registry for cron jobs.
CronSchedule is a frozen dataclass for the five cron fields.
Calling a CronTab returns (module:name, schedule) pairs,
validated to ensure only module-level functions are registered.

This will allow it to be consumed by
https://github.com/vercel/vercel/pull/15930
