### PR TITLE
Stabilize blob storage example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/examples/blob_storage.py
+++ b/examples/blob_storage.py
@@ -1,10 +1,11 @@
 import asyncio
 import os
+import secrets
 import tempfile
 
 from dotenv import load_dotenv
 
-from vercel.blob import AsyncBlobClient, BlobClient, UploadProgressEvent
+from vercel.blob import AsyncBlobClient, BlobClient, BlobNotFoundError, UploadProgressEvent
 
 load_dotenv()
 
@@ -21,6 +22,19 @@ def on_download_progress(bytes_read: int, total: int | None) -> None:
         print(f"download: {bytes_read} bytes")
 
 
+async def head_with_retry(
+    client: AsyncBlobClient, url_or_path: str, *, attempts: int = 5, delay: float = 0.5
+):
+    for attempt in range(1, attempts + 1):
+        try:
+            return await client.head(url_or_path)
+        except BlobNotFoundError:
+            if attempt == attempts:
+                raise
+            await asyncio.sleep(delay * attempt)
+    raise AssertionError("unreachable")
+
+
 async def main() -> None:
     token = os.getenv("BLOB_READ_WRITE_TOKEN")
     assert token, "Set BLOB_READ_WRITE_TOKEN"
@@ -28,15 +42,16 @@ async def main() -> None:
     # Instantiate clients
     client = AsyncBlobClient(token)
     client_sync = BlobClient(token)
+    folder_prefix = f"examples/assets/{secrets.token_urlsafe(8)}"
 
     # 1) Create a folder entry (async client)
-    folder = await client.create_folder("examples/assets", overwrite=True)
+    folder = await client.create_folder(folder_prefix, overwrite=True)
     print("folder:", folder.pathname)
 
     # 2) Upload a text file via put() (async client)
     data = b"hello from python" * 1024
     uploaded = await client.put(
-        "examples/assets/hello.txt",
+        f"{folder_prefix}/hello.txt",
         data,
         access="public",
         content_type="text/plain",
@@ -46,10 +61,10 @@ async def main() -> None:
     print("uploaded (put):", uploaded.pathname)
 
     # 3) List and head (async client)
-    listing = await client.list_objects(prefix="examples/assets/", limit=5)
+    listing = await client.list_objects(prefix=f"{folder_prefix}/", limit=5)
     print("hasMore:", listing.has_more)
     for b in listing.blobs:
-        meta = await client.head(b.url)
+        meta = await head_with_retry(client, b.url)
         print(" -", b.pathname, b.size, meta.content_type)
 
     # 3b) Get object via get() (async client)
@@ -59,7 +74,7 @@ async def main() -> None:
     # 4) Copy (async client)
     copied = await client.copy(
         uploaded.pathname,
-        "examples/assets/hello-copy.txt",
+        f"{folder_prefix}/hello-copy.txt",
         access="public",
         overwrite=True,
     )
@@ -72,7 +87,7 @@ async def main() -> None:
         tmp_local_path = tmp.name
     uploaded_file = await client.upload_file(
         tmp_local_path,
-        "examples/assets/uploaded-from-file.txt",
+        f"{folder_prefix}/uploaded-from-file.txt",
         access="public",
         content_type="text/plain",
         add_random_suffix=True,
@@ -100,7 +115,8 @@ async def main() -> None:
         pass
 
     # 7) Demonstrate synchronous BlobClient: head + download + cleanup
-    meta_sync = client_sync.head(uploaded.url)
+    uploaded_meta = await head_with_retry(client, uploaded.url)
+    meta_sync = client_sync.head(uploaded_meta.url)
     print("sync head content_type:", meta_sync.content_type)
 
     sync_download_path = os.path.join(tempfile.gettempdir(), "downloaded-hello-sync.txt")
@@ -118,8 +134,8 @@ async def main() -> None:
         pass
 
     # Cleanup using sync client
-    client_sync.delete([uploaded.url, copied.url, uploaded_file.url])
-    print("deleted uploaded, copy, and file-upload objects (sync client)")
+    client_sync.delete([uploaded.url, copied.url, uploaded_file.url, folder.url])
+    print("deleted folder and uploaded objects (sync client)")
 
 
 if __name__ == "__main__":

--- a/examples/blob_storage.py
+++ b/examples/blob_storage.py
@@ -5,7 +5,13 @@ import tempfile
 
 from dotenv import load_dotenv
 
-from vercel.blob import AsyncBlobClient, BlobClient, BlobNotFoundError, UploadProgressEvent
+from vercel.blob import (
+    AsyncBlobClient,
+    BlobClient,
+    BlobNotFoundError,
+    HeadBlobResult,
+    UploadProgressEvent,
+)
 
 load_dotenv()
 
@@ -24,7 +30,7 @@ def on_download_progress(bytes_read: int, total: int | None) -> None:
 
 async def head_with_retry(
     client: AsyncBlobClient, url_or_path: str, *, attempts: int = 5, delay: float = 0.5
-):
+) -> HeadBlobResult:
     for attempt in range(1, attempts + 1):
         try:
             return await client.head(url_or_path)
@@ -73,7 +79,7 @@ async def main() -> None:
 
     # 4) Copy (async client)
     copied = await client.copy(
-        uploaded.pathname,
+        uploaded.url,
         f"{folder_prefix}/hello-copy.txt",
         access="public",
         overwrite=True,

--- a/tests/integration/test_blob_sync_async.py
+++ b/tests/integration/test_blob_sync_async.py
@@ -388,7 +388,8 @@ class TestBlobPut:
         assert request.headers.get("x-cache-control-max-age") == "3600"
 
     @respx.mock
-    def test_put_sync_async_parity(self, mock_env_clear, mock_blob_put_response):
+    @pytest.mark.asyncio
+    async def test_put_sync_async_parity(self, mock_env_clear, mock_blob_put_response):
         """Verify sync and async produce identical results."""
         respx.put(BLOB_API_BASE).mock(return_value=httpx.Response(200, json=mock_blob_put_response))
 
@@ -398,9 +399,7 @@ class TestBlobPut:
         respx.reset()
         respx.put(BLOB_API_BASE).mock(return_value=httpx.Response(200, json=mock_blob_put_response))
 
-        import asyncio
-
-        async_result = asyncio.run(put_async("test.txt", b"data", token="test_token"))
+        async_result = await put_async("test.txt", b"data", token="test_token")
 
         assert sync_result.url == async_result.url
         assert sync_result.pathname == async_result.pathname


### PR DESCRIPTION
Fix intermittent CI failures in examples/blob_storage.py by isolating each run under a unique blob folder prefix and retrying async head() calls briefly after writes. The example was listing objects from a shared prefix and immediately reading metadata, which can race with blob visibility in CI even when the upload has already succeeded.