### PR TITLE
feat: support an @cron decorator that makes a function a dynamic cron entrypoint

### DIFF
--- a/src/vercel/cron/__init__.py
+++ b/src/vercel/cron/__init__.py
@@ -1,7 +1,8 @@
-from .crontab import CronSchedule, CronTab, CronTabError
+from .crontab import CronSchedule, CronTab, CronTabError, cron
 
 __all__ = [
     "CronSchedule",
     "CronTab",
     "CronTabError",
+    "cron",
 ]

--- a/src/vercel/cron/crontab.py
+++ b/src/vercel/cron/crontab.py
@@ -53,6 +53,14 @@ def _resolve(fn: Callable[..., Any]) -> None:
         raise CronTabError(f"Cannot register {name!r}: could not resolve {module_name}:{name}")
 
 
+def _make_schedule(schedule: str | CronSchedule | None, **kwargs: _Field) -> CronSchedule:
+    if schedule is not None:
+        if isinstance(schedule, str):
+            return CronSchedule.from_str(schedule)
+        return schedule
+    return CronSchedule(**kwargs)
+
+
 class CronTab:
     def __init__(self) -> None:
         self._jobs: list[tuple[Callable[..., Any], CronSchedule]] = []
@@ -72,28 +80,9 @@ class CronTab:
     ) -> Callable[[_F], _F]: ...
 
     def register(
-        self,
-        schedule: str | CronSchedule | None = None,
-        *,
-        minute: _Field = "*",
-        hour: _Field = "*",
-        day: _Field = "*",
-        month: _Field = "*",
-        day_of_week: _Field = "*",
+        self, schedule: str | CronSchedule | None = None, **kwargs: _Field
     ) -> Callable[[_F], _F]:
-        if schedule is not None:
-            if isinstance(schedule, str):
-                sched = CronSchedule.from_str(schedule)
-            else:
-                sched = schedule
-        else:
-            sched = CronSchedule(
-                minute=minute,
-                hour=hour,
-                day=day,
-                month=month,
-                day_of_week=day_of_week,
-            )
+        sched = _make_schedule(schedule, **kwargs)
 
         def decorator(fn: _F) -> _F:
             self._jobs.append((fn, sched))
@@ -109,3 +98,32 @@ class CronTab:
             name = fn.__name__
             result.append((f"{module}:{name}", str(sched)))
         return result
+
+
+@overload
+def cron(schedule: str | CronSchedule, /) -> Callable[[_F], _F]: ...
+
+
+@overload
+def cron(
+    *,
+    minute: _Field = "*",
+    hour: _Field = "*",
+    day: _Field = "*",
+    month: _Field = "*",
+    day_of_week: _Field = "*",
+) -> Callable[[_F], _F]: ...
+
+
+def cron(schedule: str | CronSchedule | None = None, **kwargs: _Field) -> Callable[[_F], _F]:
+    sched = _make_schedule(schedule, **kwargs)
+
+    def decorator(fn: _F) -> _F:
+        def get_crons() -> list[tuple[str, str]]:
+            _resolve(fn)
+            return [(f"{fn.__module__}:{fn.__name__}", str(sched))]
+
+        fn.get_crons = get_crons  # type: ignore[attr-defined]
+        return fn
+
+    return decorator

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from vercel.cron import CronSchedule, CronTab, CronTabError
+from vercel.cron import CronSchedule, CronTab, CronTabError, cron
 
 # --- Module-level functions for registration tests ---
 
@@ -78,6 +78,21 @@ def _job_frequent():
 
 @_ct_call.register(CronSchedule(hour=6, day_of_week=1))
 def _job_weekly():
+    pass
+
+
+@cron("0 0 * * *")
+def _cron_string():
+    return "hello"
+
+
+@cron(hour=6)
+def _cron_kwargs():
+    pass
+
+
+@cron(CronSchedule(minute="*/5"))
+def _cron_schedule():
     pass
 
 
@@ -200,3 +215,31 @@ class TestCronTabCall:
             (f"{module}:_job_frequent", "*/15 * * * *"),
             (f"{module}:_job_weekly", "* 6 * * 1"),
         ]
+
+
+class TestCronDecorator:
+    def test_callable(self):
+        assert _cron_string() == "hello"
+
+    def test_preserves_name(self):
+        assert _cron_string.__name__ == "_cron_string"
+
+    def test_get_crons_string(self):
+        module = __name__
+        assert _cron_string.get_crons() == [(f"{module}:_cron_string", "0 0 * * *")]
+
+    def test_get_crons_kwargs(self):
+        module = __name__
+        assert _cron_kwargs.get_crons() == [(f"{module}:_cron_kwargs", "* 6 * * *")]
+
+    def test_get_crons_schedule(self):
+        module = __name__
+        assert _cron_schedule.get_crons() == [(f"{module}:_cron_schedule", "*/5 * * * *")]
+
+    def test_rejects_local_function(self):
+        @cron("0 0 * * *")
+        def local_job():
+            pass
+
+        with pytest.raises(CronTabError, match="only module-level functions"):
+            local_job.get_crons()


### PR DESCRIPTION
Allow annotating a single function with `@cron(...)` and letting that
provide the schedule to vercel.
