### PR TITLE
Get OIDC token from request headers in get_credentials

### DIFF
--- a/src/vercel/oidc/credentials.py
+++ b/src/vercel/oidc/credentials.py
@@ -46,6 +46,7 @@ def get_credentials(
         return Credentials(token=token, project_id=project_id, team_id=team_id)
 
     raise RuntimeError(
-        "Missing credentials. Provide VERCEL_OIDC_TOKEN with VERCEL_PROJECT_ID "
-        "and VERCEL_TEAM_ID, or VERCEL_TOKEN, VERCEL_PROJECT_ID, VERCEL_TEAM_ID."
+        "Missing credentials. "
+        "For local development, run 'vercel link && vercel env pull'. "
+        "Otherwise, set VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID."
     )

--- a/src/vercel/oidc/credentials.py
+++ b/src/vercel/oidc/credentials.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from .token import decode_oidc_payload
+from .token import VercelOidcTokenError, decode_oidc_payload, get_vercel_oidc_token_from_context
 from .types import Credentials
 
 
@@ -15,7 +15,13 @@ def get_credentials(
     if token and project_id and team_id:
         return Credentials(token=token, project_id=project_id, team_id=team_id)
 
-    oidc = os.getenv("VERCEL_OIDC_TOKEN")
+    # Resolve OIDC token from request headers (set by the runtime) or env var.
+    oidc: str | None = None
+    try:
+        oidc = get_vercel_oidc_token_from_context()
+    except VercelOidcTokenError:
+        pass
+
     if oidc:
         project = os.getenv("VERCEL_PROJECT_ID")
         team = os.getenv("VERCEL_TEAM_ID")
@@ -29,7 +35,7 @@ def get_credentials(
         if project and team:
             return Credentials(token=oidc, project_id=project, team_id=team)
         raise RuntimeError(
-            "VERCEL_OIDC_TOKEN present but could not determine VERCEL_PROJECT_ID and VERCEL_TEAM_ID"
+            "OIDC token present but could not determine VERCEL_PROJECT_ID and VERCEL_TEAM_ID"
         )
 
     token = token or os.getenv("VERCEL_TOKEN")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,12 @@ def mock_env_clear(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, Non
     ]
     for var in env_vars_to_clear:
         monkeypatch.delenv(var, raising=False)
+
+    from vercel.cache.context import set_headers
+
+    set_headers(None)
     yield
+    set_headers(None)
 
 
 @pytest.fixture

--- a/tests/integration/test_oidc_sync_async.py
+++ b/tests/integration/test_oidc_sync_async.py
@@ -184,6 +184,28 @@ class TestGetCredentials:
         assert creds.project_id == "prj_oidc_embedded"
         assert creds.team_id == "team_oidc_embedded"
 
+    def test_get_credentials_from_oidc_header_context(self, mock_env_clear):
+        """Test getting credentials from OIDC token in request header context."""
+        from vercel.cache.context import set_headers
+        from vercel.oidc import get_credentials
+
+        payload = {
+            "project_id": "prj_from_header",
+            "owner_id": "team_from_header",
+            "exp": 9999999999,
+        }
+        payload_json = json.dumps(payload)
+        payload_b64 = base64.urlsafe_b64encode(payload_json.encode()).decode().rstrip("=")
+        oidc_token = f"header.{payload_b64}.signature"
+
+        set_headers({"x-vercel-oidc-token": oidc_token})
+
+        creds = get_credentials()
+
+        assert creds.token == oidc_token
+        assert creds.project_id == "prj_from_header"
+        assert creds.team_id == "team_from_header"
+
     def test_get_credentials_oidc_with_env_project_team(self, mock_env_clear, monkeypatch):
         """Test OIDC token with project/team from env vars."""
         from vercel.oidc import get_credentials


### PR DESCRIPTION
Use get_vercel_oidc_token_from_context() instead of reading VERCEL_OIDC_TOKEN env var directly, so the sandbox SDK works in production where the runtime sets the token via the x-vercel-oidc-token request header.