### PR TITLE
workflow: multiple fixes

### DIFF
--- a/src/vercel/_internal/workflow/py_sandbox.py
+++ b/src/vercel/_internal/workflow/py_sandbox.py
@@ -323,6 +323,7 @@ _RESTRICTIONS: dict[str, _ModulePolicy] = {
         # all-caps constants (AF_*, SOCK_*, SOL_*, SO_*, IPPROTO_*, etc.)
         allow_if=str.isupper,
     ),
+    "asyncio": _RestrictedAsyncioPolicy("asyncio"),
     "_asyncio": _RestrictedAsyncioPolicy("asyncio.events"),
     "threading": _blocklist(
         "threading",
@@ -360,6 +361,7 @@ _PASSTHROUGHS: set[str] = {
     "abc",
     "array",
     "ast",
+    "asyncio",
     "base64",
     "binascii",
     "bisect",
@@ -734,6 +736,9 @@ def _sandbox_modules() -> Iterator[None]:
     with _sandbox_linecache():
         sys.modules.clear()
         sys.modules["sys"] = sys
+        for key in orig_modules:
+            if key == "importlib" or key.startswith("importlib."):
+                sys.modules[key] = orig_modules[key]
         sys.modules["builtins"] = proxy_builtins
         sys.meta_path.insert(0, finder)
         try:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -4,6 +4,7 @@ import dataclasses
 import functools
 import importlib
 import json
+import logging
 import random
 import re
 import traceback
@@ -22,6 +23,7 @@ from .py_sandbox import workflow_sandbox
 P = ParamSpec("P")
 T = TypeVar("T")
 SUSPENDED_MESSAGE = "<WORKFLOW SUSPENDED>"
+logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -47,6 +49,7 @@ class Wait(BaseSuspension):
 class Hook(BaseSuspension, Generic[T]):
     token: str
     disposed: bool = False
+    has_dispose_event: bool = False
     futures: deque[asyncio.Future[T]] = dataclasses.field(default_factory=deque)
     hook_cls: type[T]
 
@@ -67,6 +70,9 @@ class WorkflowOrchestratorContext:
         self, events: list[w.Event], *, seed: str, started_at: int, registry: core.Workflows
     ):
         self.events = events
+        # List of Out-of-order HookReceivedEvent: such events may arrive at any time unexpectedly,
+        # so we stash them separately for delayed consumption
+        self.ooo_hook_received_events: deque[w.HookReceivedEvent] = deque()
         self.replay_index = 0
         prng = random.Random(seed)
         self.generate_ulid = functools.partial(ulid.monotonic_factory(prng.random), started_at)
@@ -147,7 +153,10 @@ class WorkflowOrchestratorContext:
         hook = self.hooks[correlation_id]
         hook.disposed = True
         while hook.futures:
-            hook.futures.popleft().set_exception(StopAsyncIteration)
+            fut = hook.futures.popleft()
+            if not fut.done():
+                fut.set_exception(StopAsyncIteration)
+        self.suspensions.pop(correlation_id, None)
 
     def resume(self) -> None:
         self.resume_handle = None
@@ -155,9 +164,37 @@ class WorkflowOrchestratorContext:
         if self._fut is None:
             return
 
-        while self.replay_index < len(self.events) and self.suspensions:
-            event = self.events[self.replay_index]
-            self.replay_index += 1
+        while (
+            self.replay_index < len(self.events) or self.ooo_hook_received_events
+        ) and self.suspensions:
+            event: w.Event | None = None
+            if self.ooo_hook_received_events:
+                event = self.ooo_hook_received_events[0]
+                if event.correlation_id in self.suspensions:
+                    self.ooo_hook_received_events.popleft()
+                else:
+                    event = None
+            if event is None:
+                if self.replay_index < len(self.events):
+                    event = self.events[self.replay_index]
+                    if event.correlation_id not in self.suspensions:
+                        match event:
+                            # In case of multitasking, one task may progress twice in a row,
+                            # when we see the replayed event before actually having the
+                            # suspension from the task. So we yield here and let the task
+                            # suspend and resume again in next iteration.
+                            case w.StepCreatedEvent() | w.HookCreatedEvent() | w.WaitCreatedEvent():
+                                return
+                            # HookReceivedEvent is not created from workflows, it may arrive
+                            # at any time out of order. At this momemnt we don't need one,
+                            # so we just stash it and continue with the event log.
+                            case w.HookReceivedEvent():
+                                self.ooo_hook_received_events.append(event)
+                                self.replay_index += 1
+                                continue
+                    self.replay_index += 1
+                else:
+                    break
 
             match event:
                 case w.StepCreatedEvent() | w.HookCreatedEvent() | w.WaitCreatedEvent():
@@ -213,8 +250,8 @@ class WorkflowOrchestratorContext:
                         self.suspensions.pop(event.correlation_id)
 
                 case w.HookDisposedEvent():
-                    self.suspensions.pop(event.correlation_id, None)
-                    self.hooks.pop(event.correlation_id)
+                    self.hooks[event.correlation_id].has_dispose_event = True
+                    self.dispose_hook(correlation_id=event.correlation_id)
 
         if self.suspensions:
             self._fut.cancel(SUSPENDED_MESSAGE)
@@ -232,7 +269,11 @@ async def workflow_handler(
     run_id = w.WorkflowInvokePayload.model_validate(message).run_id
     workflow_run = await world.runs_get(run_id)
     if workflow_run.status == "pending":
-        result = await world.events_create(run_id, w.RunStartedEvent())
+        try:
+            result = await world.events_create(run_id, w.RunStartedEvent())
+        except w.EntityConflictError:
+            logger.debug(f"Workflow run {run_id} has already been started")
+            return None
         assert result.run is not None
         workflow_run = result.run
     elif workflow_run.status == "cancelled":
@@ -269,9 +310,14 @@ async def workflow_handler(
 
     # Create all wait_completed events
     for wait_event in waits_to_complete:
-        result = await world.events_create(
-            run_id, w.WaitCompletedEvent(correlationId=wait_event.correlation_id)
-        )
+        try:
+            result = await world.events_create(
+                run_id, w.WaitCompletedEvent(correlationId=wait_event.correlation_id)
+            )
+        except w.EntityConflictError:
+            # Another concurrent invocation already completed this wait
+            logger.debug(f"Wait {wait_event.correlation_id!r} is already completed")
+            continue
         # Add the event to the events array so the workflow can see it
         assert result.event is not None
         events.append(result.event)
@@ -287,52 +333,106 @@ async def workflow_handler(
             # Workflow suspended, continue outside the try..except block
             pass
         elif isinstance(e, Exception):
-            await world.events_create(
-                run_id,
-                w.RunFailedEventData(error=str(e)).into_event(),
-            )
+            try:
+                await world.events_create(
+                    run_id,
+                    w.RunFailedEventData(error=str(e)).into_event(),
+                )
+            except w.EntityConflictError:
+                logger.warning(f"Workflow run {run_id} was already completed")
             return None
         else:
             raise
     else:
-        await world.events_create(
-            run_id,
-            w.RunCompletedEventData(output=[output]).into_event(),
-        )
+        try:
+            await world.events_create(
+                run_id,
+                w.RunCompletedEventData(output=[output]).into_event(),
+            )
+        except w.EntityConflictError:
+            logger.warning(f"Workflow run {run_id} was already completed")
         return None
 
+    # Now that the workflow is fully suspended, we can create all pending events in parallel
+    events_created = False
     async with anyio.create_task_group() as tg:
         for sus in context.suspensions.values():
             if sus.has_created_event:
                 pass
+
             elif isinstance(sus, Suspension):
-                step_data = w.StepCreatedEventData(stepName=sus.step.name, input=[sus.input])
-                tg.start_soon(world.events_create, run_id, step_data.into_event(sus.correlation_id))
-                tg.start_soon(
-                    world.queue,
-                    f"__wkf_step_{sus.step.name}",
-                    w.StepInvokePayload(
-                        workflowName=workflow_run.workflow_name,
-                        workflowRunId=run_id,
-                        workflowStartedAt=workflow_started_at,
-                        stepId=sus.correlation_id,
-                        requestedAt=datetime.now(UTC),
-                    ),
-                )
+
+                async def create_step(s=sus):
+                    step_data = w.StepCreatedEventData(stepName=s.step.name, input=[s.input])
+                    try:
+                        await world.events_create(run_id, step_data.into_event(s.correlation_id))
+                    except w.EntityConflictError:
+                        logger.debug(f"Workflow step {s.correlation_id!r} has already been created")
+                    await world.queue(
+                        f"__wkf_step_{s.step.name}",
+                        w.StepInvokePayload(
+                            workflowName=workflow_run.workflow_name,
+                            workflowRunId=run_id,
+                            workflowStartedAt=workflow_started_at,
+                            stepId=s.correlation_id,
+                            requestedAt=datetime.now(UTC),
+                        ),
+                    )
+
+                tg.start_soon(create_step)
+                events_created = True
+
             elif isinstance(sus, Wait):
-                wait_data = w.WaitCreatedEventData(resumeAt=sus.resume_at)
-                tg.start_soon(world.events_create, run_id, wait_data.into_event(sus.correlation_id))
+
+                async def create_wait(s=sus):
+                    wait_data = w.WaitCreatedEventData(resumeAt=s.resume_at)
+                    try:
+                        await world.events_create(run_id, wait_data.into_event(s.correlation_id))
+                    except w.EntityConflictError:
+                        logger.debug(f"Workflow wait {s.correlation_id!r} has already been created")
+
+                tg.start_soon(create_wait)
+                events_created = True
+
             elif isinstance(sus, Hook):
-                hook_data = w.HookCreatedEventData(token=sus.token)
-                tg.start_soon(world.events_create, run_id, hook_data.into_event(sus.correlation_id))
+
+                async def create_hook(s=sus):
+                    hook_data = w.HookCreatedEventData(token=s.token)
+                    try:
+                        await world.events_create(run_id, hook_data.into_event(s.correlation_id))
+                    except w.EntityConflictError:
+                        logger.debug(f"Workflow hook {s.correlation_id!r} has already been created")
+
+                tg.start_soon(create_hook)
+                events_created = True
 
         for hook in context.hooks.values():
-            if hook.disposed:
-                tg.start_soon(
-                    world.events_create,
-                    run_id,
-                    w.HookDisposedEvent(correlationId=hook.correlation_id),
-                )
+            if hook.disposed and not hook.has_dispose_event:
+
+                async def dispose_hook(h=hook):
+                    try:
+                        await world.events_create(
+                            run_id,
+                            w.HookDisposedEvent(correlationId=h.correlation_id),
+                        )
+                    except w.EntityConflictError:
+                        logger.debug(
+                            f"Workflow hook {h.correlation_id!r} has already been disposed"
+                        )
+
+                tg.start_soon(dispose_hook)
+                events_created = True
+
+    if not context.suspensions and events_created:
+        # We captured a SUSPENDED_MESSAGE but there is no suspension - this is likely caused
+        # by a disposed hook that cleared its suspensions. Just retry if event log changed.
+        return await workflow_handler(
+            message,
+            attempt=attempt,
+            queue_name=queue_name,
+            message_id=message_id,
+            registry=registry,
+        )
 
     now = datetime.now(UTC)
     min_timeout_seconds = -1.0
@@ -415,10 +515,14 @@ async def step_handler(
             return None
 
         # Start the step via event (increments attempt counter)
-        start_result = await world.events_create(
-            req.workflow_run_id,
-            w.StepStartedEvent(correlationId=req.step_id),
-        )
+        try:
+            start_result = await world.events_create(
+                req.workflow_run_id,
+                w.StepStartedEvent(correlationId=req.step_id),
+            )
+        except w.EntityConflictError:
+            logger.debug(f"Workflow step {req.step_id!r} was already started")
+            return None
 
         # Use the step entity from the event response
         if not start_result.step:

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -624,6 +624,10 @@ class HTTPError(Exception):
         super().__init__(f"HTTP Error {response.status}")
 
 
+class EntityConflictError(Exception):
+    pass
+
+
 class QueueHandler(Protocol):
     async def __call__(
         self, message: Any, *, attempt: int, queue_name: str, message_id: str

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import os
 import pathlib
 import traceback
@@ -48,7 +49,7 @@ def read_json(path: pathlib.Path, schema: type[T] | pydantic.TypeAdapter[T]) -> 
 def write_json(path: pathlib.Path, data: w.BaseModel | dict, *, overwrite: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists() and not overwrite:
-        raise FileExistsError()
+        raise w.EntityConflictError(f"File already exists: {path}")
     if isinstance(data, w.BaseModel):
         data = data.model_dump()
     with path.open("wb") as f:
@@ -73,13 +74,15 @@ class LocalWorld(w.World):
 
     def delete_all_hooks_for_run(self, run_id: str) -> None:
         hooks_dir = self.data_dir / "hooks"
+        if not hooks_dir.exists():
+            return
         for hook_path in hooks_dir.iterdir():
             if hook_path.suffix != ".json":
                 continue
             hook = read_json(hook_path, w.Hook)
             if hook is not None and hook.run_id == run_id:
                 hashed_token = hashlib.sha256(hook.token.encode()).hexdigest()
-                constraint_path = hooks_dir / "tokens" / f"${hashed_token}.json"
+                constraint_path = hooks_dir / "tokens" / f"{hashed_token}.json"
                 constraint_path.unlink(missing_ok=True)
                 hook_path.unlink(missing_ok=True)
 
@@ -93,6 +96,7 @@ class LocalWorld(w.World):
         *,
         deployment_id: str | None = None,
         idempotency_key: str | None = None,
+        delay_seconds: float | None = None,
         **kwargs,
     ) -> str:
         payload = {
@@ -100,11 +104,15 @@ class LocalWorld(w.World):
             "queueName": queue_name,
             "deploymentId": "<local>",
         }
+        vqs_delay: int | None = None
+        if delay_seconds is not None:
+            vqs_delay = max(1, math.ceil(delay_seconds))
         response = await vqs_client.send_async(
             "".join(char if char.isalnum() or char in "-_" else "-" for char in queue_name),
             payload,
             idempotency_key=idempotency_key,
             deployment_id="<local>",
+            delay_seconds=vqs_delay,
         )
         return response["messageId"]
 
@@ -569,6 +577,16 @@ class LocalWorld(w.World):
             )
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             write_json(hook_path, hook)
+
+        elif data.event_type == "wait_completed" and data.correlation_id:
+            wait_lock = (
+                self.data_dir
+                / ".locks"
+                / "waits"
+                / f"{effective_run_id}-{data.correlation_id}.completed"
+            )
+            if not write_exclusive(wait_lock, ""):
+                raise w.EntityConflictError(f'Wait "{data.correlation_id}" already completed')
 
         elif data.event_type == "hook_disposed":
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -135,9 +135,14 @@ class VercelWorld(w.World):
             else:
                 return schema.model_validate(result)
         else:
-            raise RuntimeError(
+            message = (
                 result.get("message")
-                or f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}",
+                or f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}"
+            )
+            if resp.status_code == 409:
+                raise w.EntityConflictError(message)
+            raise RuntimeError(
+                message,
                 {
                     "url": f"{self._base_url}{endpoint}",
                     "status": resp.status_code,

--- a/tests/unit/test_py_sandbox.py
+++ b/tests/unit/test_py_sandbox.py
@@ -603,6 +603,41 @@ class TestAsyncioRestrictions:
 
             assert sorted(results) == [1, 2]
 
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="TaskGroup requires Python 3.11+")
+    async def test_taskgroup_cancels_siblings_on_error(self):
+        """TaskGroup must correctly cancel siblings when one task fails.
+
+        Regression: when asyncio was a plain passthrough (no restriction
+        proxy), CancelledError inside the sandbox was a different class
+        than the one used by the C _asyncio extension, so TaskGroup's
+        _on_task_done failed with:
+            AttributeError: 'NoneType' object has no attribute 'append'
+        """
+        with workflow_sandbox(random_seed=SEED):
+            import asyncio
+
+            cancelled = asyncio.Event()
+
+            async def failing():
+                raise ValueError("boom")
+
+            async def slow():
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
+            with pytest.raises(ExceptionGroup) as exc_info:  # noqa: F821
+                async with asyncio.TaskGroup() as tg:
+                    tg.create_task(slow())
+                    tg.create_task(failing())
+
+            assert len(exc_info.value.exceptions) == 1
+            assert isinstance(exc_info.value.exceptions[0], ValueError)
+            assert cancelled.is_set()
+
 
 # ═══════════════════════════════════════════════════════════════
 #  asyncio loop proxy with uvloop


### PR DESCRIPTION
* Added EntityConflictError to quietly retry
* Fixed local world bug in clearing hooks
* Fixed `workflow.sleep()` in local world
* Emulate EntityConflictError in local world with locks
* Sandbox: pass through importlib and basic asyncio to fix bugs:
  * Some third parties depend on importlib global state
  * CancelledError must not be recreated for TaskGroup to work
* Fixed out-of-order hook events
* Fixed hook disposal
* Fixed a bug in resume() when extra loop iteration is needed