### PR TITLE
Do not run examples on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,5 @@ jobs:
       - name: Run tests, including lint and typecheck
         run: ./scripts/test.sh
 
-      - name: Run example tests
-        run: ./scripts/test-examples.sh
-
       - name: Build package
         run: ./scripts/build.sh


### PR DESCRIPTION
Pending a more thorough way to simulate deployment environments, we are turning these tests off for now. They can still be run locally.