### PR TITLE
allow to set async cache into context

### DIFF
--- a/src/vercel/cache/context.py
+++ b/src/vercel/cache/context.py
@@ -10,6 +10,7 @@ _cv_wait_until: ContextVar[Callable[[Awaitable[object]], None] | None] = Context
     "vercel_wait_until", default=None
 )
 _cv_cache: ContextVar[object | None] = ContextVar("vercel_cache", default=None)
+_cv_async_cache: ContextVar[object | None] = ContextVar("vercel_async_cache", default=None)
 _cv_purge: ContextVar[PurgeAPI | None] = ContextVar("vercel_purge", default=None)
 _cv_headers: ContextVar[Mapping[str, str] | None] = ContextVar("vercel_headers", default=None)
 
@@ -18,6 +19,7 @@ _cv_headers: ContextVar[Mapping[str, str] | None] = ContextVar("vercel_headers",
 class _ContextSnapshot:
     wait_until: Callable[[Awaitable[object]], None] | None
     cache: object | None
+    async_cache: object | None
     purge: PurgeAPI | None
     headers: Mapping[str, str] | None
 
@@ -26,6 +28,7 @@ def get_context() -> _ContextSnapshot:
     return _ContextSnapshot(
         wait_until=_cv_wait_until.get(),
         cache=_cv_cache.get(),
+        async_cache=_cv_async_cache.get(),
         purge=_cv_purge.get(),
         headers=_cv_headers.get(),
     )
@@ -35,6 +38,7 @@ def set_context(
     *,
     wait_until: Callable[[Awaitable[object]], None] | None = None,
     cache: object | None = None,
+    async_cache: object | None = None,
     purge: PurgeAPI | None = None,
     headers: Mapping[str, str] | None = None,
 ) -> None:
@@ -42,6 +46,8 @@ def set_context(
         _cv_wait_until.set(wait_until)
     if cache is not None:
         _cv_cache.set(cache)
+    if async_cache is not None:
+        _cv_async_cache.set(async_cache)
     if purge is not None:
         _cv_purge.set(purge)
     if headers is not None:

--- a/src/vercel/cache/runtime_cache.py
+++ b/src/vercel/cache/runtime_cache.py
@@ -76,13 +76,40 @@ class AsyncRuntimeCache(AsyncCache):
         return await resolve_cache(sync=False).contains(self._make_key(key))
 
 
+@overload
+def get_cache(
+    *,
+    key_hash_function: Callable[[str], str] | None = ...,
+    namespace: str | None = ...,
+    namespace_separator: str | None = ...,
+    sync: Literal[True] = ...,
+) -> RuntimeCache: ...
+
+
+@overload
+def get_cache(
+    *,
+    key_hash_function: Callable[[str], str] | None = ...,
+    namespace: str | None = ...,
+    namespace_separator: str | None = ...,
+    sync: Literal[False],
+) -> AsyncRuntimeCache: ...
+
+
 def get_cache(
     *,
     key_hash_function: Callable[[str], str] | None = None,
     namespace: str | None = None,
     namespace_separator: str | None = None,
-) -> RuntimeCache:
-    return RuntimeCache(
+    sync: bool = True,
+) -> RuntimeCache | AsyncRuntimeCache:
+    if sync:
+        return RuntimeCache(
+            key_hash_function=key_hash_function,
+            namespace=namespace,
+            namespace_separator=namespace_separator,
+        )
+    return AsyncRuntimeCache(
         key_hash_function=key_hash_function,
         namespace=namespace,
         namespace_separator=namespace_separator,
@@ -157,7 +184,12 @@ def resolve_cache(sync: Literal[False]) -> AsyncCache: ...
 
 def resolve_cache(sync: bool = True) -> Cache | AsyncCache:
     ctx = get_context()
-    cache = getattr(ctx, "cache", None)
-    if cache is not None:
-        return cast(Cache, cache) if sync else cast(AsyncCache, cache)
+    if sync:
+        cache = getattr(ctx, "cache", None)
+        if cache is not None:
+            return cast(Cache, cache)
+    else:
+        cache = getattr(ctx, "async_cache", None)
+        if cache is not None:
+            return cast(AsyncCache, cache)
     return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", sync)


### PR DESCRIPTION
Split the `cache` key in the context object into `cache` and `async_cache` to allow both of them to be configured in the `set_context` and to retrieve the required cache instance in the `get_cache` method