### PR TITLE
fix(workflow): align VercelWorld endpoints with JS SDK upstream

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -299,7 +299,9 @@ async def workflow_handler(
         return None
 
     # Load all events into memory before running
-    events = await get_all_workflow_run_events(run_id)
+    loaded = await get_all_workflow_run_events(run_id)
+    events = loaded.events
+    events_cursor = loaded.cursor
 
     # Check for any elapsed waits and create wait_completed events
     now = datetime.now(UTC)
@@ -320,16 +322,47 @@ async def workflow_handler(
     # Create all wait_completed events
     for wait_event in waits_to_complete:
         try:
-            result = await world.events_create(
+            await world.events_create(
                 run_id, w.WaitCompletedEvent(correlationId=wait_event.correlation_id)
             )
         except w.EntityConflictError:
             # Another concurrent invocation already completed this wait
             logger.debug(f"Wait {wait_event.correlation_id!r} is already completed")
             continue
-        # Add the event to the events array so the workflow can see it
-        assert result.event is not None
-        events.append(result.event)
+
+    if waits_to_complete:
+        # Reload events after wait completions. Try incremental load first
+        # (using cursor), fall back to full reload if the incremental result
+        # doesn't contain all the wait_completed events we just created.
+        if events_cursor:
+            delta = await get_all_workflow_run_events(run_id, after_cursor=events_cursor)
+            delta_completed_ids = {
+                e.correlation_id for e in delta.events if e.event_type == "wait_completed"
+            }
+            saw_all = all(w_.correlation_id in delta_completed_ids for w_ in waits_to_complete)
+            if saw_all:
+                # Merge delta into existing events, deduplicating by eventId
+                existing_ids = {e.server_props.event_id for e in events if e.server_props}
+                for event in delta.events:
+                    eid = event.server_props.event_id if event.server_props else None
+                    if eid not in existing_ids:
+                        if eid:
+                            existing_ids.add(eid)
+                        events.append(event)
+                events_cursor = delta.cursor or events_cursor
+            else:
+                loaded = await get_all_workflow_run_events(run_id)
+                events = loaded.events
+                events_cursor = loaded.cursor
+        else:
+            loaded = await get_all_workflow_run_events(run_id)
+            events = loaded.events
+            events_cursor = loaded.cursor
+
+        # A concurrent handler may have written a terminal run event after
+        # the initial snapshot. If so, this delivery is done.
+        if _has_terminal_run_event(events, run_id):
+            return None
 
     context = WorkflowOrchestratorContext(
         events, seed=run_id, started_at=workflow_started_at, registry=registry
@@ -635,9 +668,19 @@ def step_entrypoint(registry: core.Workflows) -> w.HTTPHandler:
     )
 
 
-async def get_all_workflow_run_events(run_id: str) -> list[w.Event]:
-    all_events = []
-    cursor: str | None = None
+class _LoadedEvents:
+    __slots__ = ("events", "cursor")
+
+    def __init__(self, events: list[w.Event], cursor: str | None) -> None:
+        self.events = events
+        self.cursor = cursor
+
+
+async def get_all_workflow_run_events(
+    run_id: str, *, after_cursor: str | None = None
+) -> _LoadedEvents:
+    all_events: list[w.Event] = []
+    cursor: str | None = after_cursor
     has_more = True
 
     world = w.get_world()
@@ -652,7 +695,17 @@ async def get_all_workflow_run_events(run_id: str) -> list[w.Event]:
         all_events.extend(response.data)
         has_more = response.has_more
         cursor = response.cursor
-    return all_events
+    return _LoadedEvents(all_events, cursor)
+
+
+def _has_terminal_run_event(events: list[w.Event], run_id: str) -> bool:
+    """Check if the event log contains a terminal run event (completed/failed/cancelled)."""
+    return any(
+        e.server_props is not None
+        and e.server_props.run_id == run_id
+        and e.event_type in ("run_completed", "run_failed", "run_cancelled")
+        for e in events
+    )
 
 
 duration_re = re.compile(

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -595,6 +595,8 @@ class EventResult(BaseModel):
     step: WorkflowStep | None = None
     hook: Any | None = None
     wait: Any | None = None
+    cursor: str | None = None
+    has_more: bool | None = pydantic.Field(default=None, alias="hasMore")
 
 
 class HTTPRequest(metaclass=abc.ABCMeta):

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -44,6 +44,28 @@ def _cbor_filter_undefined(value: Mapping[Any, Any], shareable: bool = False) ->
     return {k: None if v is cbor2.undefined else v for k, v in value.items()}
 
 
+# Lazy wire schema for EventResult — mirrors the JS SDK's EventResultLazyWireSchema.
+# Uses BaseWorkflowRun (no discriminated union) with loose error typing so that
+# unresolved RemoteRefs in error/input/output fields don't cause validation failures.
+class _LazyWorkflowRun(w.BaseWorkflowRun):
+    """Loose run schema that accepts any error shape (may be a RemoteRef)."""
+
+    error: Any = None
+    input: Any = None
+    output: Any = None
+
+
+class _LazyEventResult(w.EventResult):
+    """Loose EventResult that tolerates unresolved RemoteRefs in nested objects.
+    Event data fields (e.g. payload, input, output) may contain RemoteRef dicts
+    instead of their expected types, so we accept Any for event and run."""
+
+    event: Any = None  # type: ignore[assignment]
+    events: Any = None  # type: ignore[assignment]
+    run: _LazyWorkflowRun | None = None  # type: ignore[assignment]
+    step: Any = None  # type: ignore[assignment]
+
+
 class VercelWorld(w.World):
     def __init__(
         self,
@@ -62,7 +84,7 @@ class VercelWorld(w.World):
         # header if override is set)
         # When not using proxy, use the default workflow-server URL (with /api path appended)
         if self._using_proxy:
-            self._base_url = "https://api.vercel.com/v2/workflow"
+            self._base_url = "https://api.vercel.com/v1/workflow"
         else:
             default_host = WORKFLOW_SERVER_URL_OVERRIDE or "https://vercel-workflow.com"
             self._base_url = f"{default_host}/api"
@@ -126,12 +148,20 @@ class VercelWorld(w.World):
             )
 
         # utils.ts, parseResponseBody
-        if "application/cbor" in resp.headers.get("Content-Type", ""):
+        content_type = resp.headers.get("Content-Type", "")
+        if "application/cbor" in content_type:
             result = cbor2.loads(
                 resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
             )
         else:
-            result = resp.json()
+            try:
+                result = resp.json()
+            except Exception:
+                # Server may return CBOR without the correct Content-Type header
+                # (e.g. through a proxy). Try CBOR decoding as fallback.
+                result = cbor2.loads(
+                    resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
+                )
 
         if resp.is_success:
             if isinstance(schema, pydantic.TypeAdapter):
@@ -139,6 +169,8 @@ class VercelWorld(w.World):
             else:
                 return schema.model_validate(result)
         else:
+            if not isinstance(result, dict):
+                result = {}
             message = (
                 result.get("message")
                 or f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}"
@@ -198,10 +230,9 @@ class VercelWorld(w.World):
                 deployment_id=deployment_id,
                 token=self._token if self._using_proxy else None,
                 base_url=self._base_url if self._using_proxy else None,
-                # The proxy will strip `/queues` from the path, and add `/api` in front,
-                # so this ends up being `/api/v2/messages` when arriving at the queue server,
-                # which is the same as the default basePath in VQS client.
-                base_path="/queues/v2/messages" if self._using_proxy else None,
+                # The proxy will strip the `/queues-proxy` prefix before forwarding to VQS,
+                # so `/queues-proxy/api/v3/topic` arrives as `/api/v3/topic` at the queue server.
+                base_path="/queues-proxy/api/v3/topic" if self._using_proxy else None,
                 headers=self._headers | headers,
             )
             return response["messageId"]
@@ -320,12 +351,24 @@ class VercelWorld(w.World):
             if data.event_type in {"run_created", "run_started", "step_started"}
             else "lazy"
         )
-        return await self._cbor_request(
-            "POST",
-            f"/v2/runs/{run_id_path}/events",
-            data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
-            schema=w.EventResult,
-        )
+        if remote_ref_behavior == "resolve":
+            return await self._cbor_request(
+                "POST",
+                f"/v3/runs/{run_id_path}/events",
+                data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
+                schema=w.EventResult,
+            )
+        else:
+            # Lazy responses may contain unresolved RemoteRefs that fail
+            # the strict EventResult schema. Use the loose _LazyEventResult
+            # schema that tolerates unresolved refs, matching the JS SDK's
+            # EventResultLazyWireSchema.
+            return await self._cbor_request(
+                "POST",
+                f"/v3/runs/{run_id_path}/events",
+                data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
+                schema=_LazyEventResult,
+            )
 
     async def events_list(
         self,
@@ -341,6 +384,6 @@ class VercelWorld(w.World):
         query = f"?{query_string}" if query_string else ""
         return await self._cbor_request(
             "GET",
-            f"/v2/runs/{run_id}/events{query}",
+            f"/v3/runs/{run_id}/events{query}",
             schema=w.PaginatedResult[w.Event],
         )


### PR DESCRIPTION
## Summary

Align the Python SDK's VercelWorld with the JS SDK (`@workflow/world-vercel`) upstream changes.

### Endpoint fixes
- Fix proxy base URL: `/v2/workflow` → `/v1/workflow` (was never v2 in JS SDK)
- Upgrade event endpoints from `/v2` to `/v3` (runs/steps/hooks stay on `/v2`)
- Fix queue proxy path: `/queues/v2/messages` → `/queues-proxy/api/v3/topic`

### Protocol fixes
- Add CBOR fallback when response Content-Type header doesn't match body encoding
- Add `cursor` and `hasMore` fields to `EventResult` for v3 compatibility

### Lazy remoteRefBehavior (perf optimization)
- Use `lazy` remoteRefBehavior for non-critical events (`run_created`, `run_started`, `step_started` use `resolve`; all others use `lazy`) to skip S3 ref resolution (~200-460ms per event)
- Add `_LazyWorkflowRun` / `_LazyEventResult` loose schemas mirroring the JS SDK's `EventResultLazyWireSchema`

### Runtime alignment
- Reload events after `wait_completed` using cursor-based incremental fetch with fallback to full reload, matching the JS SDK pattern
- Add terminal run event check after reloading to exit early if a concurrent handler already completed/failed/cancelled the run