### PR TITLE
workflow: check whether the replay log actually matches step args

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -80,6 +80,22 @@ class Hook(BaseSuspension, Generic[T]):
             logger.warning("Hook %r resumed but no handler needs it; ignoring: %r", self.token, res)
 
 
+def _correlation_kind(correlation_id: str) -> str:
+    """The kind prefix of a correlation ID (``step`` / ``wait`` / ``hook``)."""
+    return correlation_id.split("_", 1)[0]
+
+
+def _correlation_ulid(correlation_id: str) -> str:
+    """The positional ULID of a correlation ID, stripped of its kind prefix.
+
+    Correlation IDs are ``<kind>_<ulid>`` where the ULID is assigned positionally
+    from a run-seeded monotonic factory. Two calls at the same body position share
+    a ULID regardless of kind, so this is the slot identity used to spot a
+    step/wait/hook swap during replay.
+    """
+    return correlation_id.split("_", 1)[-1]
+
+
 class WorkflowOrchestratorContext:
     _ctx: contextvars.ContextVar[Self] = contextvars.ContextVar("WorkflowContext")
 
@@ -176,6 +192,20 @@ class WorkflowOrchestratorContext:
                 fut.set_exception(StopAsyncIteration)
         self.suspensions.pop(correlation_id, None)
 
+    def _fail_suspension(self, sus: BaseSuspension, exc: Exception) -> None:
+        """Surface ``exc`` on whichever future(s) a suspension is awaiting.
+
+        The error propagates through the body's ``await`` of the step/wait/hook,
+        out of ``run_workflow``, and into the run-failed path.
+        """
+        if isinstance(sus, Hook):
+            while sus.futures:
+                fut = sus.futures.popleft()
+                if not fut.done():
+                    fut.set_exception(exc)
+        elif isinstance(sus, (Suspension, Wait)) and not sus.future.done():
+            sus.future.set_exception(exc)
+
     def resume(self) -> None:
         self.resume_handle = None
 
@@ -202,6 +232,29 @@ class WorkflowOrchestratorContext:
                             # suspension from the task. So we yield here and let the task
                             # suspend and resume again in next iteration.
                             case w.StepCreatedEvent() | w.HookCreatedEvent() | w.WaitCreatedEvent():
+                                # ...unless the body already registered a different-kind
+                                # call at this positional slot (same ULID, different
+                                # prefix). A same-kind match would have hit the dict
+                                # lookup above, so a ULID collision here is a step/wait/
+                                # hook swap -- the body is non-deterministic. Fail loudly
+                                # instead of yielding forever (the matching ID will never
+                                # appear, so plain `return` would deadlock the run).
+                                pos = _correlation_ulid(event.correlation_id)
+                                for sus in self.suspensions.values():
+                                    if _correlation_ulid(sus.correlation_id) == pos:
+                                        self._fail_suspension(
+                                            sus,
+                                            NondeterminismError(
+                                                f"workflow replay diverged at position "
+                                                f"{pos}: recorded a "
+                                                f"{_correlation_kind(event.correlation_id)!r} "
+                                                f"call, but the body now issues a "
+                                                f"{_correlation_kind(sus.correlation_id)!r} "
+                                                "call. The workflow body is "
+                                                "non-deterministic."
+                                            ),
+                                        )
+                                        return
                                 return
                             # HookReceivedEvent is not created from workflows, it may arrive
                             # at any time out of order. At this momemnt we don't need one,
@@ -224,13 +277,14 @@ class WorkflowOrchestratorContext:
                     # the same call the body just issued; a mismatch means the body
                     # is non-deterministic.
                     if sus.step.name != name or [sus.input] != recorded_input:
-                        sus.future.set_exception(
+                        self._fail_suspension(
+                            sus,
                             NondeterminismError(
                                 f"workflow replay diverged at {event.correlation_id}: "
                                 f"recorded step {name!r}, but the body now calls "
                                 f"{sus.step.name!r} with different arguments. The workflow "
                                 "body is non-deterministic."
-                            )
+                            ),
                         )
                         return
                     sus.has_created_event = True

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -26,6 +26,16 @@ SUSPENDED_MESSAGE = "<WORKFLOW SUSPENDED>"
 logger = logging.getLogger(__name__)
 
 
+class NondeterminismError(Exception):
+    """Raised when a workflow's replay diverges from its recorded event log.
+
+    Correlation IDs are assigned positionally (the Nth step/sleep/hook of a body
+    run gets the Nth seeded ID), so if the body issues operations in a different
+    order or with different arguments on replay, recorded results would be
+    matched onto the wrong calls. This is raised instead, failing the run.
+    """
+
+
 @dataclasses.dataclass(kw_only=True)
 class BaseSuspension:
     correlation_id: str
@@ -205,7 +215,27 @@ class WorkflowOrchestratorContext:
                     break
 
             match event:
-                case w.StepCreatedEvent() | w.HookCreatedEvent() | w.WaitCreatedEvent():
+                case w.StepCreatedEvent(
+                    event_data=w.StepCreatedEventData(step_name=name, input=recorded_input)
+                ):
+                    sus = self.suspensions[event.correlation_id]
+                    assert isinstance(sus, Suspension)
+                    # The recorded step at this (positional) correlation ID must be
+                    # the same call the body just issued; a mismatch means the body
+                    # is non-deterministic.
+                    if sus.step.name != name or [sus.input] != recorded_input:
+                        sus.future.set_exception(
+                            NondeterminismError(
+                                f"workflow replay diverged at {event.correlation_id}: "
+                                f"recorded step {name!r}, but the body now calls "
+                                f"{sus.step.name!r} with different arguments. The workflow "
+                                "body is non-deterministic."
+                            )
+                        )
+                        return
+                    sus.has_created_event = True
+
+                case w.HookCreatedEvent() | w.WaitCreatedEvent():
                     self.suspensions[event.correlation_id].has_created_event = True
 
                 case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):

--- a/tests/unit/test_workflow_determinism.py
+++ b/tests/unit/test_workflow_determinism.py
@@ -7,6 +7,7 @@ loudly rather than silently returning the wrong value.
 """
 
 import asyncio
+from datetime import datetime, timezone
 
 from vercel._internal.workflow import core, runtime, world as w
 
@@ -66,3 +67,27 @@ async def test_matching_step_does_not_raise() -> None:
 
     assert not sus.future.done()
     assert sus.has_created_event
+
+
+async def test_wait_step_swap_raises_nondeterminism() -> None:
+    """Recorded a step at this positional slot, but the body now issues a wait
+    with the same positional ULID -> NondeterminismError (not a silent stall).
+
+    The kind prefixes differ, so the recorded ``step_1`` never matches the
+    body's ``wait_1`` by full correlation ID; the positional ULID does, which is
+    how the swap is caught.
+    """
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event("step_1")
+    ]
+    ctx = _context(events)
+    wait = runtime.Wait(
+        correlation_id="wait_1", resume_at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    ctx.suspensions["wait_1"] = wait
+
+    ctx.resume()
+
+    assert wait.future.done()
+    assert isinstance(wait.future.exception(), runtime.NondeterminismError)

--- a/tests/unit/test_workflow_determinism.py
+++ b/tests/unit/test_workflow_determinism.py
@@ -1,0 +1,68 @@
+"""Replay determinism detection.
+
+Correlation IDs are assigned positionally, so a body that issues steps in a
+different order or with different arguments on replay would have recorded
+results matched onto the wrong calls. ``resume()`` must detect this and fail
+loudly rather than silently returning the wrong value.
+"""
+
+import asyncio
+
+from vercel._internal.workflow import core, runtime, world as w
+
+
+async def _greet(name: str) -> str:
+    return name
+
+
+def _context(events: list[w.Event]) -> runtime.WorkflowOrchestratorContext:
+    ctx = runtime.WorkflowOrchestratorContext(
+        events,
+        seed="wrun_test",
+        started_at=0,
+        registry=core.Workflows(as_vercel_job=False),
+    )
+    # resume() short-circuits unless a workflow future is in flight.
+    ctx._fut = asyncio.get_event_loop().create_future()
+    return ctx
+
+
+def _suspension(correlation_id: str, args_json: bytes) -> runtime.Suspension:
+    return runtime.Suspension(
+        correlation_id=correlation_id, step=core.Step(_greet), input=args_json
+    )
+
+
+async def test_reordered_step_args_raise_nondeterminism() -> None:
+    """Recorded step input "a" but the body now calls the same step with "b"
+    on replay -> NondeterminismError."""
+    step = core.Step(_greet)
+    cid = "step_1"
+    events: list[w.Event] = [
+        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event(cid)
+    ]
+    ctx = _context(events)
+    sus = _suspension(cid, b'json[["b"], {}]')
+    ctx.suspensions[cid] = sus
+
+    ctx.resume()
+
+    assert sus.future.done()
+    assert isinstance(sus.future.exception(), runtime.NondeterminismError)
+
+
+async def test_matching_step_does_not_raise() -> None:
+    """Same step + same input -> no error, suspension is marked replayed."""
+    step = core.Step(_greet)
+    cid = "step_1"
+    events: list[w.Event] = [
+        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event(cid)
+    ]
+    ctx = _context(events)
+    sus = _suspension(cid, b'json[["a"], {}]')
+    ctx.suspensions[cid] = sus
+
+    ctx.resume()
+
+    assert not sus.future.done()
+    assert sus.has_created_event


### PR DESCRIPTION
Add a check in resume() that when creating a step, the arguments match
with what is in the log, and raise a NondeterminismError then.

Even with the sandbox, there are ways to get nondeterminism. The
biggest one is set iteration, which remains a big footgun.

Also check for when there is a type mismatch for a given position.

I'm not totally sure if we actually want to do this, though? In
particular, was it deliberate that we weren't?
