### PR TITLE
workflows: add get_step_metadata() that mirrors getStepMetadata() in JS

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -96,6 +96,36 @@ def _correlation_ulid(correlation_id: str) -> str:
     return correlation_id.split("_", 1)[-1]
 
 
+@dataclasses.dataclass(frozen=True)
+class StepInfo:
+    """Metadata about the step currently executing.
+
+    Mirrors the JS SDK's ``getStepMetadata()`` return value. ``step_id`` is stable
+    across retries and unique per logical step call, which makes it a good
+    idempotency key for non-idempotent side effects (payments, emails, queue
+    sends) performed inside a step body.
+    """
+
+    run_id: str
+    step_id: str
+    step_name: str
+    attempt: int
+
+
+_step_ctx: contextvars.ContextVar[StepInfo] = contextvars.ContextVar("WorkflowStepContext")
+
+
+def get_step_metadata() -> StepInfo:
+    """Return metadata for the step currently executing.
+
+    Must be called from within a step body; raises ``RuntimeError`` otherwise.
+    """
+    try:
+        return _step_ctx.get()
+    except LookupError:
+        raise RuntimeError("get_step_metadata() can only be called inside a step") from None
+
+
 class WorkflowOrchestratorContext:
     _ctx: contextvars.ContextVar[Self] = contextvars.ContextVar("WorkflowContext")
 
@@ -669,8 +699,26 @@ async def step_handler(
             raise RuntimeError(f"Unsupported step input encoding for step {req.step_id}")
         args, kwargs = json.loads(step_run.input[0][len(b"json") :].decode())
 
+        logger.debug(
+            "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
+            req.workflow_run_id,
+            step.name,
+            req.step_id,
+            current_attempt,
+        )
+        token = _step_ctx.set(
+            StepInfo(
+                run_id=req.workflow_run_id,
+                step_id=req.step_id,
+                step_name=step.name,
+                attempt=current_attempt,
+            )
+        )
         # Execute the step function
-        result = await step.func(*args, **kwargs)
+        try:
+            result = await step.func(*args, **kwargs)
+        finally:
+            _step_ctx.reset(token)
 
         # Serialize the result
         output = b"json" + json.dumps(result).encode()

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -1,4 +1,13 @@
 from vercel._internal.workflow.core import BaseHook, HookEvent, Workflows, sleep
-from vercel._internal.workflow.runtime import Run, start
+from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
 
-__all__ = ["Workflows", "sleep", "start", "Run", "BaseHook", "HookEvent"]
+__all__ = [
+    "Workflows",
+    "sleep",
+    "start",
+    "Run",
+    "BaseHook",
+    "HookEvent",
+    "get_step_metadata",
+    "StepInfo",
+]

--- a/tests/unit/test_workflow_step_metadata.py
+++ b/tests/unit/test_workflow_step_metadata.py
@@ -1,0 +1,104 @@
+"""Tests for step metadata exposed to step bodies via ``get_step_metadata()``.
+
+Mirrors the JS SDK's ``getStepMetadata()``: a step body can read the stable
+``step_id`` (plus run id, name, attempt) of the step it is executing, e.g. to use
+as an idempotency key for non-idempotent side effects.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vercel._internal.workflow import runtime, world as w
+from vercel._internal.workflow.worlds.local import LocalWorld
+from vercel.workflow import StepInfo, Workflows, get_step_metadata
+
+
+def _encode(args: list, kwargs: dict) -> list[bytes]:
+    return [b"json" + json.dumps([args, kwargs]).encode()]
+
+
+class _RecordingLocalWorld(LocalWorld):
+    """Real LocalWorld for storage; only the outbound (networked) queue is stubbed."""
+
+    def __init__(self, data_dir) -> None:
+        super().__init__()
+        self.data_dir = data_dir
+        self.queued: list[tuple[str, w.QueuePayload]] = []
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_test"
+
+
+def test_get_step_metadata_outside_step_raises() -> None:
+    with pytest.raises(RuntimeError, match="inside a step"):
+        get_step_metadata()
+
+
+async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+
+    registry = Workflows(as_vercel_job=False)
+    captured: list[StepInfo] = []
+
+    @registry.step
+    async def greet(name: str) -> str:
+        captured.append(get_step_metadata())
+        return f"hi {name}"
+
+    # Stand up a running run with a single pending step.
+    run_result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="",
+            workflowName="test-wf",
+            input=_encode(["world"], {}),
+        ).into_event(),
+    )
+    assert run_result.run is not None
+    run_id = run_result.run.run_id
+    await world.events_create(run_id, w.RunStartedEvent())
+
+    step_id = "step_testid"
+    await world.events_create(
+        run_id,
+        w.StepCreatedEventData(stepName=greet.name, input=_encode(["world"], {})).into_event(
+            step_id
+        ),
+    )
+
+    payload = w.StepInvokePayload(
+        workflowName="test-wf",
+        workflowRunId=run_id,
+        workflowStartedAt=0.0,
+        stepId=step_id,
+    )
+    await runtime.step_handler(
+        payload.model_dump(by_alias=True),
+        attempt=1,
+        queue_name=f"__wkf_step_{greet.name}",
+        message_id="msg_1",
+        registry=registry,
+    )
+
+    # The body saw its own metadata.
+    assert len(captured) == 1
+    info = captured[0]
+    assert isinstance(info, StepInfo)
+    assert info.run_id == run_id
+    assert info.step_id == step_id
+    assert info.step_name == greet.name
+    assert info.attempt == 1
+
+    # The step actually ran to completion, and the parent workflow was re-enqueued.
+    step_run = await world.steps_get(run_id, step_id)
+    assert step_run.status == "completed"
+    assert any(qn.startswith("__wkf_workflow_") for qn, _ in world.queued)
+
+    # The context var is cleared once the step body returns.
+    with pytest.raises(RuntimeError, match="inside a step"):
+        get_step_metadata()


### PR DESCRIPTION
The key thing to expose here is the step_id, which can be used as an
idempotency key with external services.
