### PR TITLE
workflows: Fix queue handlers requeueing of failed steps

### DIFF
--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -84,6 +84,7 @@ class HealthCheckPayload(BaseModel):
 
 
 QueuePayload: TypeAlias = WorkflowInvokePayload | StepInvokePayload | HealthCheckPayload
+QueuePayloadAdaptor: pydantic.TypeAdapter[QueuePayload] = pydantic.TypeAdapter(QueuePayload)
 
 
 class StructuredError(BaseModel):

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -149,7 +149,7 @@ class LocalWorld(w.World):
                     # we may get a duplicate invocation but won't lose the scheduled wakeup
                     await self.queue(
                         queue_name,
-                        w.WorkflowInvokePayload.model_validate(payload),
+                        w.QueuePayloadAdaptor.validate_python(payload),
                         deployment_id=body.get("deploymentId"),
                         delay_seconds=delay_seconds,
                     )

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -281,7 +281,7 @@ class VercelWorld(w.World):
                     # we may get a duplicate invocation but won't lose the scheduled wakeup
                     await self.queue(
                         queue_name,
-                        w.WorkflowInvokePayload.model_validate(payload),
+                        w.QueuePayloadAdaptor.validate_python(payload),
                         deployment_id=body.get("deploymentId"),
                         delay_seconds=delay_seconds,
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Shared fixtures for all tests."""
 
+import importlib.util
 import os
 import time
 import uuid
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
@@ -107,3 +109,15 @@ requires_sandbox_credentials = pytest.mark.skipif(
     not has_sandbox_credentials(),
     reason="Requires VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID for sandbox",
 )
+
+
+# Workflow tests import the workflow worlds, which depend on vercel-workers
+# (installed only on Python >= 3.12; see pyproject). Skip collecting them when the
+# package is unavailable, so collection doesn't error on older interpreters.
+_HAS_VERCEL_WORKERS = importlib.util.find_spec("vercel.workers") is not None
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    if not _HAS_VERCEL_WORKERS and collection_path.name.startswith("test_workflow_"):
+        return True
+    return None

--- a/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/tests/unit/test_workflow_step_retry_dispatch.py
@@ -1,0 +1,83 @@
+"""Regression test for step-retry dispatch in the queue-handler wrapper.
+
+When a step fails below ``max_retries``, ``step_handler`` returns a retry timeout
+(``return 1.0``). The wrapper registered by ``World.create_queue_handler``
+(``async_handler``) is responsible for rescheduling the step after that delay.
+
+``async_handler`` must re-enqueue the retry preserving the message's payload type.
+Previously it re-enqueued *every* timeout return as a ``WorkflowInvokePayload``,
+which raised ``ValidationError`` for a ``StepInvokePayload`` → the handler 500'd and
+the step only retried via un-acked redelivery (wrong cadence, no backoff). The fix
+validates against the ``QueuePayload`` union, so a step retry re-enqueues a
+``StepInvokePayload`` on its own queue with the delay.
+
+This drives the real ``async_handler`` closure with a step payload and a handler
+that asks to retry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds.local import LocalWorld
+from vercel.workers._queue.subscribe import subscriptions as _subs_registry
+
+
+class _RecordingWorld(LocalWorld):
+    """LocalWorld whose outbound queue is captured instead of sent over the network."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.queued: list[tuple[str, object, float | None]] = []
+
+    async def queue(self, queue_name: str, message: object, **kwargs: object) -> str:
+        self.queued.append((queue_name, message, kwargs.get("delay_seconds")))  # type: ignore[arg-type]
+        return "msg_test"
+
+
+@pytest.fixture
+def isolated_subscriptions():
+    saved = list(_subs_registry)
+    _subs_registry.clear()
+    try:
+        yield _subs_registry
+    finally:
+        _subs_registry[:] = saved
+
+
+async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> None:
+    world = _RecordingWorld()
+
+    async def handler(payload, *, queue_name, attempt, message_id):
+        # Stand in for step_handler deciding to retry: a non-None timeout return.
+        return 1.0
+
+    # Registers async_handler into the global subscription registry as a side effect.
+    world.create_queue_handler("__wkf_step_", handler)
+    assert len(isolated_subscriptions) == 1
+    async_handler = isolated_subscriptions[0].func
+
+    step_payload = w.StepInvokePayload(
+        workflowName="wf",
+        workflowRunId="wrun_1",
+        workflowStartedAt=0.0,
+        stepId="step_1",
+    ).model_dump()
+    body = {
+        "payload": step_payload,
+        "queueName": "__wkf_step_wf",
+        "deploymentId": "<local>",
+    }
+    meta = {"deliveryCount": 1, "messageId": "m1", "topic": "__wkf_step_wf"}
+
+    await async_handler(body, meta)
+
+    assert world.queued, "step retry was not re-enqueued"
+    qn, msg, delay = world.queued[-1]
+    assert qn == "__wkf_step_wf"
+    step_id = getattr(msg, "step_id", None) or (
+        msg.get("stepId") if isinstance(msg, dict) else None
+    )
+    assert step_id == "step_1"
+    assert delay == 1.0


### PR DESCRIPTION
Currently, the queue handlers, when the underlying handler returns a
retry timeout duration, will try to model_validate it as a
WorkflowInvokePayload, which is incorrect, since it might be a
StepInvokePayload or a HealthCheckPayload.

I think that in practice this probably doesn't mess things up *too*
much other than creating spurious error log traffic, since the queue
message won't have been ACKed and so should still get redelivered.
