### PR TITLE
workflows: set idempotency_key for workflow reinvocations triggered by waits

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -5,6 +5,7 @@ import functools
 import importlib
 import json
 import logging
+import math
 import random
 import re
 import traceback
@@ -24,6 +25,26 @@ P = ParamSpec("P")
 T = TypeVar("T")
 SUSPENDED_MESSAGE = "<WORKFLOW SUSPENDED>"
 logger = logging.getLogger("vercel.workflow")
+
+# Wait-continuation dispatch — mirrors @workflow/core's wait-continuation.ts.
+# The delayed re-enqueue that wakes a run when a pending wait elapses is keyed on
+# the wait's correlation id, so repeated suspension passes over the same pending
+# wait dedupe to a single timer. Long waits chain in <=23h hops (suffixed with the
+# hop index so the chain advances while same-hop re-observations still dedupe);
+# near-elapsed waits get a per-second bucket so an early delivery can re-enqueue.
+WAIT_CONTINUATION_MAX_DELAY_SECONDS = 82_800
+NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS = 2
+
+
+def _wait_continuation_dispatch(
+    timeout_seconds: int, wait_correlation_id: str, now: datetime
+) -> tuple[float, str]:
+    if timeout_seconds <= NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS:
+        return timeout_seconds, f"{wait_correlation_id}:{int(now.timestamp())}"
+    hop = math.ceil(timeout_seconds / WAIT_CONTINUATION_MAX_DELAY_SECONDS)
+    delay = min(timeout_seconds, WAIT_CONTINUATION_MAX_DELAY_SECONDS)
+    key = wait_correlation_id if hop == 1 else f"{wait_correlation_id}:hop-{hop}"
+    return delay, key
 
 
 class NondeterminismError(Exception):
@@ -387,7 +408,7 @@ async def workflow_handler(
     queue_name: str,
     message_id: str,
     registry: core.Workflows,
-) -> float | None:
+) -> w.QueueContinuation | None:
     world = w.get_world()
     run_id = w.WorkflowInvokePayload.model_validate(message).run_id
     workflow_run = await world.runs_get(run_id)
@@ -592,14 +613,20 @@ async def workflow_handler(
 
     now = datetime.now(UTC)
     min_timeout_seconds = -1.0
+    soonest_wait_id: str | None = None
     for sus in context.suspensions.values():
         if isinstance(sus, Wait):
             seconds = (sus.resume_at - now).total_seconds()
-            if min_timeout_seconds < 0:
+            if min_timeout_seconds < 0 or seconds < min_timeout_seconds:
                 min_timeout_seconds = seconds
-            else:
-                min_timeout_seconds = min(min_timeout_seconds, seconds)
-    return None if min_timeout_seconds < 0 else min_timeout_seconds
+                soonest_wait_id = sus.correlation_id
+    if soonest_wait_id is None:
+        return None
+    # Key the delayed wake-up on the soonest pending wait so repeated suspension
+    # passes over it collapse to one timer instead of piling up duplicate wake-ups.
+    timeout_seconds = max(1, math.ceil(min_timeout_seconds))
+    delay, key = _wait_continuation_dispatch(timeout_seconds, soonest_wait_id, now)
+    return w.QueueContinuation(delay_seconds=delay, idempotency_key=key)
 
 
 async def step_handler(
@@ -609,7 +636,7 @@ async def step_handler(
     queue_name: str,
     message_id: str,
     registry: core.Workflows,
-) -> float | None:
+) -> w.QueueContinuation | None:
     world = w.get_world()
     req = w.StepInvokePayload.model_validate(message)
 
@@ -621,7 +648,7 @@ async def step_handler(
     now = datetime.now(UTC)
     if step_run.retry_after and step_run.retry_after > now:
         timeout_seconds = max(1, int((step_run.retry_after - now).total_seconds()))
-        return timeout_seconds
+        return w.QueueContinuation(delay_seconds=timeout_seconds)
 
     # Check max retries FIRST before any state changes
     # step.attempt tracks how many times step_started has been called
@@ -784,7 +811,7 @@ async def step_handler(
             )
 
             # Return timeout to keep message visible for retry
-            return 1.0
+            return w.QueueContinuation(delay_seconds=1.0)
 
     # Re-invoke the workflow to continue execution
     await world.queue(

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -632,10 +632,23 @@ class EntityConflictError(Exception):
     pass
 
 
+@dataclasses.dataclass(frozen=True)
+class QueueContinuation:
+    """A handler's request to re-enqueue its own message after a delay.
+
+    ``idempotency_key`` lets the re-enqueue dedupe — e.g. a wait/sleep
+    continuation keyed on the pending wait so repeated suspension passes over the
+    same wait collapse into one delayed wake-up.
+    """
+
+    delay_seconds: float
+    idempotency_key: str | None = None
+
+
 class QueueHandler(Protocol):
     async def __call__(
         self, message: Any, *, attempt: int, queue_name: str, message_id: str
-    ) -> float | None: ...
+    ) -> QueueContinuation | None: ...
 
 
 class HTTPHandler(Protocol):

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -142,7 +142,7 @@ class LocalWorld(w.World):
                     # Use delaySeconds approach: send new message with delay, then delete current
                     # Clamp to max delay (23h) - for longer sleeps, the workflow will chain
                     # multiple delayed messages until the full sleep duration has elapsed
-                    delay_seconds = min(result, MAX_DELAY_SECONDS)
+                    delay_seconds = min(result.delay_seconds, MAX_DELAY_SECONDS)
 
                     # Send new message with delay BEFORE acknowledging current message
                     # This ensures crash safety: if process dies after send but before ack,
@@ -152,6 +152,7 @@ class LocalWorld(w.World):
                         w.QueuePayloadAdaptor.validate_python(payload),
                         deployment_id=body.get("deploymentId"),
                         delay_seconds=delay_seconds,
+                        idempotency_key=result.idempotency_key,
                     )
             except Exception:
                 traceback.print_exc()
@@ -198,8 +199,8 @@ class LocalWorld(w.World):
 
                 # Handle timeout response
                 timeout_seconds: float | None = None
-                if result:
-                    timeout_seconds = min(result, LOCAL_QUEUE_MAX_VISIBILITY)
+                if result is not None:
+                    timeout_seconds = min(result.delay_seconds, LOCAL_QUEUE_MAX_VISIBILITY)
                 if timeout_seconds:
                     return w.HTTPResponse.json({"timeoutSeconds": timeout_seconds}, status=503)
 

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -274,7 +274,7 @@ class VercelWorld(w.World):
                     # Use delaySeconds approach: send new message with delay, then delete current
                     # Clamp to max delay (23h) - for longer sleeps, the workflow will chain
                     # multiple delayed messages until the full sleep duration has elapsed
-                    delay_seconds = min(result, MAX_DELAY_SECONDS)
+                    delay_seconds = min(result.delay_seconds, MAX_DELAY_SECONDS)
 
                     # Send new message with delay BEFORE acknowledging current message
                     # This ensures crash safety: if process dies after send but before ack,
@@ -284,6 +284,7 @@ class VercelWorld(w.World):
                         w.QueuePayloadAdaptor.validate_python(payload),
                         deployment_id=body.get("deploymentId"),
                         delay_seconds=delay_seconds,
+                        idempotency_key=result.idempotency_key,
                     )
             except Exception:
                 traceback.print_exc()

--- a/tests/unit/test_wait_continuation.py
+++ b/tests/unit/test_wait_continuation.py
@@ -1,0 +1,52 @@
+"""Tests for wait-continuation idempotency-key/delay selection.
+
+Mirrors @workflow/core's wait-continuation.ts: the delayed message that wakes a
+run when a pending wait elapses is keyed on the wait's correlation id so repeated
+suspension passes over the same wait collapse to a single timer, with hop/second
+suffixes for the chained-long-wait and near-elapsed cases.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from vercel._internal.polyfills import UTC
+from vercel._internal.workflow.runtime import (
+    NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS,
+    WAIT_CONTINUATION_MAX_DELAY_SECONDS,
+    _wait_continuation_dispatch,
+)
+
+NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+CID = "wait_abc"
+
+
+def test_mid_range_wait_uses_bare_correlation_id() -> None:
+    delay, key = _wait_continuation_dispatch(100, CID, NOW)
+    assert delay == 100
+    assert key == CID
+
+
+def test_repeated_passes_produce_identical_key() -> None:
+    # The whole point: two suspension passes over the same pending wait dedupe.
+    _, k1 = _wait_continuation_dispatch(100, CID, NOW)
+    _, k2 = _wait_continuation_dispatch(100, CID, NOW)
+    assert k1 == k2 == CID
+
+
+def test_long_wait_clamps_delay_and_suffixes_hop() -> None:
+    timeout = WAIT_CONTINUATION_MAX_DELAY_SECONDS * 2 + 5  # spans 3 hops
+    delay, key = _wait_continuation_dispatch(timeout, CID, NOW)
+    assert delay == WAIT_CONTINUATION_MAX_DELAY_SECONDS
+    assert key == f"{CID}:hop-3"
+
+
+def test_single_hop_wait_has_no_suffix() -> None:
+    _, key = _wait_continuation_dispatch(WAIT_CONTINUATION_MAX_DELAY_SECONDS, CID, NOW)
+    assert key == CID
+
+
+def test_near_elapsed_wait_is_second_bucketed() -> None:
+    delay, key = _wait_continuation_dispatch(NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS, CID, NOW)
+    assert delay == NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS
+    assert key == f"{CID}:{int(NOW.timestamp())}"

--- a/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/tests/unit/test_workflow_step_retry_dispatch.py
@@ -29,10 +29,12 @@ class _RecordingWorld(LocalWorld):
 
     def __init__(self) -> None:
         super().__init__()
-        self.queued: list[tuple[str, object, float | None]] = []
+        self.queued: list[tuple[str, object, object, object]] = []
 
     async def queue(self, queue_name: str, message: object, **kwargs: object) -> str:
-        self.queued.append((queue_name, message, kwargs.get("delay_seconds")))  # type: ignore[arg-type]
+        self.queued.append(
+            (queue_name, message, kwargs.get("delay_seconds"), kwargs.get("idempotency_key"))
+        )
         return "msg_test"
 
 
@@ -50,8 +52,8 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> No
     world = _RecordingWorld()
 
     async def handler(payload, *, queue_name, attempt, message_id):
-        # Stand in for step_handler deciding to retry: a non-None timeout return.
-        return 1.0
+        # Stand in for step_handler deciding to retry: a non-None continuation.
+        return w.QueueContinuation(delay_seconds=1.0)
 
     # Registers async_handler into the global subscription registry as a side effect.
     world.create_queue_handler("__wkf_step_", handler)
@@ -74,10 +76,40 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> No
     await async_handler(body, meta)
 
     assert world.queued, "step retry was not re-enqueued"
-    qn, msg, delay = world.queued[-1]
+    qn, msg, delay, _idem = world.queued[-1]
     assert qn == "__wkf_step_wf"
     step_id = getattr(msg, "step_id", None) or (
         msg.get("stepId") if isinstance(msg, dict) else None
     )
     assert step_id == "step_1"
     assert delay == 1.0
+
+
+async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions) -> None:
+    """A QueueContinuation return re-enqueues with its idempotency key, so repeated
+    suspension passes over the same pending wait dedupe to one delayed wake-up."""
+    world = _RecordingWorld()
+
+    async def handler(payload, *, queue_name, attempt, message_id):
+        # Stand in for workflow_handler suspending on a wait.
+        return w.QueueContinuation(delay_seconds=5.0, idempotency_key="wait_xyz")
+
+    world.create_queue_handler("__wkf_workflow_", handler)
+    assert len(isolated_subscriptions) == 1
+    async_handler = isolated_subscriptions[0].func
+
+    wf_payload = w.WorkflowInvokePayload(runId="wrun_1").model_dump()
+    body = {
+        "payload": wf_payload,
+        "queueName": "__wkf_workflow_wf",
+        "deploymentId": "<local>",
+    }
+    meta = {"deliveryCount": 1, "messageId": "m1", "topic": "__wkf_workflow_wf"}
+
+    await async_handler(body, meta)
+
+    assert world.queued, "wait continuation was not re-enqueued"
+    qn, _msg, delay, idem = world.queued[-1]
+    assert qn == "__wkf_workflow_wf"
+    assert delay == 5.0
+    assert idem == "wait_xyz"


### PR DESCRIPTION
This matches the behavior of the JS library.

It requires changing handler from just returning a float to indicate a
re-enqueue to returning a new QueueContinuation that contains a
delay_seconds and an optional idempotency_key.

Another option, if we want to avoid the new type, would be get rid of
this generic re-enqueueing path and have it done explicitly in the
handlers.
