### PR TITLE
workflow: fix some races in step_handler

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -641,6 +641,11 @@ async def workflow_handler(
     return w.QueueContinuation(delay_seconds=delay, idempotency_key=key)
 
 
+def _step_name_from_queue(queue_name: str) -> str:
+    """The step name encoded in a step queue topic."""
+    return queue_name.removeprefix("__wkf_step_")
+
+
 async def step_handler(
     message: Any,
     *,
@@ -652,19 +657,49 @@ async def step_handler(
     world = w.get_world()
     req = w.StepInvokePayload.model_validate(message)
 
-    # Get the step entity
-    step_run = await world.steps_get(req.workflow_run_id, req.step_id)
-    step = registry._get_step(step_run.step_name)
+    step = registry._get_step(_step_name_from_queue(queue_name))
 
-    # Check if retry_after timestamp hasn't been reached yet
-    now = datetime.now(UTC)
-    if step_run.retry_after and step_run.retry_after > now:
-        timeout_seconds = max(1, int((step_run.retry_after - now).total_seconds()))
+    # step_started validates state (terminal -> EntityConflictError, retryAfter
+    # not reached -> TooEarlyError), increments the attempt, and returns the
+    # updated step entity, so no step pre-read is needed.
+    try:
+        start_result = await world.events_create(
+            req.workflow_run_id,
+            w.StepStartedEvent(correlationId=req.step_id),
+        )
+    except w.TooEarlyError as e:
+        # retryAfter not reached yet — keep the message visible and retry later.
+        timeout_seconds = max(1, e.retry_after or 1)
+        logger.debug(
+            "[Workflows] '%s' - step '%s' retryAfter not reached, deferring %ds",
+            req.workflow_run_id,
+            step.name,
+            timeout_seconds,
+        )
         return w.QueueContinuation(delay_seconds=timeout_seconds)
+    except w.EntityConflictError:
+        # Step already in a terminal state — a duplicate delivery, or a concurrent
+        # worker finished it. Re-enqueue the workflow so it observes the outcome,
+        # then ack. This is also the crash-recovery path for a step that finished
+        # but whose handler died before re-invoking the workflow.
+        logger.debug(f"Tried starting step {req.step_id!r}, but it has already finished")
+        await world.queue(
+            f"__wkf_workflow_{req.workflow_name}",
+            w.WorkflowInvokePayload(
+                runId=req.workflow_run_id,
+                requestedAt=datetime.now(UTC),
+            ),
+        )
+        return None
 
-    # Check max retries FIRST before any state changes
-    # step.attempt tracks how many times step_started has been called
-    # Use > here (not >=) because this guards against re-invocation AFTER all attempts are used
+    # Use the step entity from the event response
+    if not start_result.step:
+        raise RuntimeError(f"step_started event for '{req.step_id}' did not return step entity")
+    step_run = start_result.step
+    current_attempt = step_run.attempt
+
+    # Check max retries AFTER step_started (the attempt was just incremented).
+    # Use > here (not >=) because this guards re-invocation AFTER all attempts are used.
     if step_run.attempt > step.max_retries + 1:
         retry_count = step_run.attempt - 1
         error_message = (
@@ -692,42 +727,6 @@ async def step_handler(
         return None
 
     try:
-        # Check step status
-        if step_run.status not in ["pending", "running"]:
-            logger.warning(
-                "[Workflows] '%s' - Step invoked erroneously, "
-                "expected status 'pending' or 'running', got '%s' instead, "
-                "skipping execution",
-                req.workflow_run_id,
-                step_run.status,
-            )
-
-            # Re-enqueue workflow if step is in terminal state
-            is_terminal_step = step_run.status in ["completed", "failed", "cancelled"]
-            if is_terminal_step:
-                await world.queue(
-                    f"__wkf_workflow_{req.workflow_name}",
-                    w.WorkflowInvokePayload(runId=req.workflow_run_id),
-                )
-            return None
-
-        # Start the step via event (increments attempt counter)
-        try:
-            start_result = await world.events_create(
-                req.workflow_run_id,
-                w.StepStartedEvent(correlationId=req.step_id),
-            )
-        except w.EntityConflictError:
-            logger.debug(f"Workflow step {req.step_id!r} was already started")
-            return None
-
-        # Use the step entity from the event response
-        if not start_result.step:
-            raise RuntimeError(f"step_started event for '{req.step_id}' did not return step entity")
-        step_run = start_result.step
-
-        current_attempt = step_run.attempt
-
         if not step_run.started_at:
             raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
 

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -682,7 +682,7 @@ async def step_handler(
         # worker finished it. Re-enqueue the workflow so it observes the outcome,
         # then ack. This is also the crash-recovery path for a step that finished
         # but whose handler died before re-invoking the workflow.
-        logger.debug(f"Tried starting step {req.step_id!r}, but it has already finished")
+        logger.debug(f"Tried starting step %r, but it has already finished", req.step_id)
         await world.queue(
             f"__wkf_workflow_{req.workflow_name}",
             w.WorkflowInvokePayload(

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -682,7 +682,7 @@ async def step_handler(
         # worker finished it. Re-enqueue the workflow so it observes the outcome,
         # then ack. This is also the crash-recovery path for a step that finished
         # but whose handler died before re-invoking the workflow.
-        logger.debug(f"Tried starting step %r, but it has already finished", req.step_id)
+        logger.debug("Tried starting step %r, but it has already finished", req.step_id)
         await world.queue(
             f"__wkf_workflow_{req.workflow_name}",
             w.WorkflowInvokePayload(

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -632,6 +632,19 @@ class EntityConflictError(Exception):
     pass
 
 
+class TooEarlyError(Exception):
+    """Raised when a step is started before its ``retryAfter`` timestamp.
+
+    Mirrors the server's HTTP 425 response. ``retry_after`` is the number of
+    seconds remaining before the step may be started, used to size the
+    re-delivery delay.
+    """
+
+    def __init__(self, message: str, retry_after: int | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 @dataclasses.dataclass(frozen=True)
 class QueueContinuation:
     """A handler's request to re-enqueue its own message after a delay.

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -510,9 +510,10 @@ class LocalWorld(w.World):
         elif data.event_type == "step_started":
             if validated_step:
                 if validated_step.retry_after and validated_step.retry_after > now:
-                    raise RuntimeError(
+                    raise w.TooEarlyError(
                         f'Cannot start step "{data.correlation_id}": '
-                        f"retryAfter timestamp has not been reached yet"
+                        f"retryAfter timestamp has not been reached yet",
+                        retry_after=math.ceil((validated_step.retry_after - now).total_seconds()),
                     )
 
                 step_composite_key = f"{effective_run_id}-{data.correlation_id}"

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -177,6 +177,16 @@ class VercelWorld(w.World):
             )
             if resp.status_code == 409:
                 raise w.EntityConflictError(message)
+            if resp.status_code == 425:
+                # retryAfter (seconds) is carried in the Retry-After header.
+                retry_after_header = resp.headers.get("retry-after")
+                retry_after: int | None = None
+                if retry_after_header is not None:
+                    try:
+                        retry_after = int(retry_after_header)
+                    except ValueError:
+                        retry_after = None
+                raise w.TooEarlyError(message, retry_after=retry_after)
             raise RuntimeError(
                 message,
                 {

--- a/tests/unit/test_workflow_step_handler.py
+++ b/tests/unit/test_workflow_step_handler.py
@@ -1,0 +1,291 @@
+"""Tests for step_handler's start-first control flow and the too-early/terminal paths.
+
+step_handler mirrors the upstream JS step-handler: it issues ``step_started``
+first and lets the world surface state as typed errors — ``TooEarlyError``
+(retryAfter not reached, HTTP 425) and ``EntityConflictError`` (terminal step,
+HTTP 409) — instead of pre-reading the step. A too-early step defers via a queue
+timeout; a terminal step re-enqueues the parent workflow and acks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from vercel._internal.polyfills import UTC
+from vercel._internal.workflow import core, runtime, world as w
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+RUN_ID = "wrun_test"
+STEP_ID = "step_test"
+WORKFLOW_NAME = "workflow//tests.wf"
+
+
+def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
+    return w.NonFinalWorkflowStep(
+        runId=RUN_ID,
+        stepId=STEP_ID,
+        stepName=step_name,
+        status="running",
+        attempt=attempt,
+        createdAt=NOW,
+        updatedAt=NOW,
+        startedAt=NOW,
+        input=[b"json[[], {}]"],
+    )
+
+
+class FakeWorld(w.World):
+    """In-memory world driving step_handler.
+
+    ``step`` is the persisted step ``steps_get`` returns (the pre-read snapshot).
+    ``step_started`` then raises ``start_error`` if set — modelling the step's
+    state changing between the read and the write — otherwise returns
+    ``started_step``.
+    """
+
+    def __init__(
+        self,
+        *,
+        step: w.WorkflowStep | None = None,
+        started_step: w.WorkflowStep | None = None,
+        start_error: Exception | None = None,
+    ) -> None:
+        self.step = step
+        self.started_step = started_step
+        self.start_error = start_error
+        self.queued: list[tuple[str, Any]] = []
+        self.events: list[Any] = []
+
+    async def get_deployment_id(self) -> str:
+        return ""
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_fake"
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
+        assert self.step is not None, "test did not set a persisted step"
+        return self.step
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        raise NotImplementedError
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        if data.event_type == "step_started":
+            if self.start_error is not None:
+                raise self.start_error
+            return w.EventResult(step=self.started_step)
+        self.events.append(data)
+        return w.EventResult()
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+@pytest.fixture
+def registry() -> core.Workflows:
+    return core.Workflows(as_vercel_job=False)
+
+
+async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
+    payload = w.StepInvokePayload(
+        workflowName=WORKFLOW_NAME,
+        workflowRunId=RUN_ID,
+        workflowStartedAt=0.0,
+        stepId=STEP_ID,
+    )
+    return await runtime.step_handler(
+        payload.model_dump(by_alias=True),
+        attempt=1,
+        queue_name=f"__wkf_step_{step_name}",
+        message_id="msg_1",
+        registry=registry,
+    )
+
+
+def _event_types(fake: FakeWorld) -> list[str]:
+    return [e.event_type for e in fake.events]
+
+
+def _workflow_enqueues(fake: FakeWorld) -> list[tuple[str, Any]]:
+    return [q for q in fake.queued if q[0] == f"__wkf_workflow_{WORKFLOW_NAME}"]
+
+
+async def test_too_early_defers_without_running(registry: core.Workflows) -> None:
+    """A step_started TooEarlyError (retryAfter not reached) defers via a queue
+    timeout sized to retry_after, and the body never runs."""
+    ran = False
+
+    @registry.step
+    async def my_step() -> str:
+        nonlocal ran
+        ran = True
+        return "ok"
+
+    fake = FakeWorld(start_error=w.TooEarlyError("too early", retry_after=42))
+    w.set_world(fake)
+
+    result = await _invoke(registry, my_step.name)
+
+    assert result == w.QueueContinuation(delay_seconds=42)
+    assert ran is False
+    assert fake.events == []
+    assert fake.queued == []
+
+
+async def test_too_early_without_retry_after_defaults_to_one(registry: core.Workflows) -> None:
+    @registry.step
+    async def my_step() -> str:
+        return "ok"
+
+    fake = FakeWorld(start_error=w.TooEarlyError("too early"))
+    w.set_world(fake)
+
+    result = await _invoke(registry, my_step.name)
+
+    assert result == w.QueueContinuation(delay_seconds=1)
+
+
+async def test_step_started_conflict_reenqueues_workflow_and_acks(registry: core.Workflows) -> None:
+    """Read-then-write race: steps_get sees the step running, but a concurrent worker
+    drives it to a terminal state before this delivery's step_started lands, so
+    step_started conflicts. The handler must re-enqueue the parent workflow and ack.
+
+    The old handler returned here without re-enqueueing, relying on the concurrent
+    worker to do it — but that worker can crash after writing the terminal event and
+    before re-enqueueing, hanging the run. Re-enqueueing from the conflict path makes
+    this delivery a reliable backstop.
+    """
+    ran = False
+
+    @registry.step
+    async def my_step() -> str:
+        nonlocal ran
+        ran = True
+        return "ok"
+
+    # steps_get returns a running step; step_started then conflicts because the step
+    # reached a terminal state between the read and the write.
+    fake = FakeWorld(
+        step=_running_step(my_step.name, attempt=1),
+        start_error=w.EntityConflictError('Cannot modify step in terminal state "completed"'),
+    )
+    w.set_world(fake)
+
+    result = await _invoke(registry, my_step.name)
+
+    assert result is None
+    assert ran is False
+    assert fake.events == []
+    enqueues = _workflow_enqueues(fake)
+    assert len(enqueues) == 1
+    assert enqueues[0][1].run_id == RUN_ID
+
+
+async def test_max_retries_checked_after_start(registry: core.Workflows) -> None:
+    """The max-retries guard runs on the attempt returned by step_started. A
+    step whose incremented attempt exceeds max_retries + 1 is failed and the
+    workflow re-enqueued — the body never runs."""
+    ran = False
+
+    @registry.step
+    async def my_step() -> str:
+        nonlocal ran
+        ran = True
+        return "ok"
+
+    my_step.max_retries = 0
+    # step_started returns attempt=2 > max_retries(0) + 1
+    fake = FakeWorld(started_step=_running_step(my_step.name, attempt=2))
+    w.set_world(fake)
+
+    result = await _invoke(registry, my_step.name)
+
+    assert result is None
+    assert ran is False
+    assert _event_types(fake) == ["step_failed"]
+    assert len(_workflow_enqueues(fake)) == 1
+
+
+async def test_happy_path_completes_and_reenqueues(registry: core.Workflows) -> None:
+    @registry.step
+    async def my_step() -> str:
+        return "ok"
+
+    fake = FakeWorld(started_step=_running_step(my_step.name, attempt=1))
+    w.set_world(fake)
+
+    result = await _invoke(registry, my_step.name)
+
+    assert result is None
+    assert _event_types(fake) == ["step_completed"]
+    assert len(_workflow_enqueues(fake)) == 1
+
+
+async def test_local_world_step_started_too_early_raises(tmp_path, monkeypatch) -> None:
+    """LocalWorld surfaces a future retryAfter as TooEarlyError (the 425 analog),
+    carrying the seconds remaining — not a bare RuntimeError — so the handler's
+    `except TooEarlyError` defers locally the same way it does against prod."""
+    from vercel._internal.workflow.worlds import local as local_mod
+
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = local_mod.LocalWorld()
+
+    future = datetime.now(UTC) + timedelta(seconds=30)
+    step = w.NonFinalWorkflowStep(
+        runId=RUN_ID,
+        stepId=STEP_ID,
+        stepName="step//tests.my_step",
+        status="pending",
+        attempt=0,
+        createdAt=NOW,
+        updatedAt=NOW,
+        retryAfter=future,
+        input=[b"json[[], {}]"],
+    )
+    local_mod.write_json(world.data_dir / "steps" / f"{RUN_ID}-{STEP_ID}.json", step.model_dump())
+
+    with pytest.raises(w.TooEarlyError) as ei:
+        await world.events_create(RUN_ID, w.StepStartedEvent(correlationId=STEP_ID))
+
+    assert ei.value.retry_after is not None
+    assert 1 <= ei.value.retry_after <= 30
+
+
+async def test_vercel_world_maps_425_to_too_early() -> None:
+    """VercelWorld maps an HTTP 425 to TooEarlyError, reading the seconds from
+    the Retry-After header (exercising the shared response mapping)."""
+    from vercel._internal.workflow.worlds import vercel as vercel_mod
+
+    world = vercel_mod.VercelWorld(token="tok")
+
+    with respx.mock:
+        respx.route(method="POST").mock(
+            return_value=httpx.Response(
+                425, headers={"Retry-After": "17"}, json={"message": "too early"}
+            )
+        )
+        with pytest.raises(w.TooEarlyError) as ei:
+            await world._cbor_request("POST", "/test", schema=w.EventResult, data={"x": 1})
+
+    assert ei.value.retry_after == 17
+    assert "too early" in str(ei.value)


### PR DESCRIPTION
Currently we look up the step, do a check for exceeding max_retries
and for if the step is already in a terminal state, and if it is we
queue it up again and return None.

*Then* we try creating step. There are two issues here, one small and
one worse, that can happen if the step gets invoked twice
concurrently.

1. A check-then-use race with the attempt count can lead to exceeding
   max attempts.
2. If one step completes and then crashes without queueing, and then
   the other will fail to create the event and currently returns that
   all is well, so the requeue never happens.

Rework all this to not actually get the step_run and instead drive
everything off the result of events_create.

Also replace the runtime-side retry_after handling with processing
world-side reports of the errors.

I think this clearly worth fixing but it is also all pretty
low-probability, I realize now. I think that for two steps to be
running concurrently, one of them needs to fail to extend its lease
for quite a long time while still running and to still be in the very
early stages of processing the message.
