### PR TITLE
workflow: improvements to `@wf.step` decorator

### DIFF
--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import functools
 import json
 from collections.abc import AsyncIterator, Callable, Coroutine, Generator
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, overload
@@ -37,7 +38,7 @@ class Step(Generic[P, T]):
         self.func = func
         self.name = f"step//{func.__module__}.{func.__qualname__}"
         self.max_retries = max_retries
-        self.__wrapped__ = func
+        functools.update_wrapper(self, func)
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         from . import runtime

--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import json
 from collections.abc import AsyncIterator, Callable, Coroutine, Generator
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, overload
 
 import pydantic
 
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 T = TypeVar("T")
 
+DEFAULT_MAX_RETRIES = 3
+
 
 class Workflow(Generic[P, T]):
     def __init__(self, func: Callable[P, Coroutine[Any, Any, T]]):
@@ -29,11 +31,13 @@ class Workflow(Generic[P, T]):
 
 
 class Step(Generic[P, T]):
-    max_retries: int = 3
-
-    def __init__(self, func: Callable[P, Coroutine[Any, Any, T]]):
+    def __init__(
+        self, func: Callable[P, Coroutine[Any, Any, T]], *, max_retries: int = DEFAULT_MAX_RETRIES
+    ):
         self.func = func
         self.name = f"step//{func.__module__}.{func.__qualname__}"
+        self.max_retries = max_retries
+        self.__wrapped__ = func
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         from . import runtime
@@ -154,11 +158,29 @@ class Workflows:
     def _get_workflow(self, workflow_id: str) -> Workflow[Any, Any]:
         return self._workflows[workflow_id]
 
-    def step(self, func: Callable[P, Coroutine[Any, Any, T]]) -> Step[P, T]:
-        rv = Step(func)
-        assert rv.name not in self._steps, f"Duplicate step name: {rv.name}"
-        self._steps[rv.name] = rv
-        return rv
+    @overload
+    def step(self, func: Callable[P, Coroutine[Any, Any, T]]) -> Step[P, T]: ...
+
+    @overload
+    def step(
+        self, *, max_retries: int = ...
+    ) -> Callable[[Callable[P, Coroutine[Any, Any, T]]], Step[P, T]]: ...
+
+    def step(
+        self,
+        func: Callable[P, Coroutine[Any, Any, T]] | None = None,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> Step[P, T] | Callable[[Callable[P, Coroutine[Any, Any, T]]], Step[P, T]]:
+        def register(f: Callable[P, Coroutine[Any, Any, T]]) -> Step[P, T]:
+            rv = Step(f, max_retries=max_retries)
+            assert rv.name not in self._steps, f"Duplicate step name: {rv.name}"
+            self._steps[rv.name] = rv
+            return rv
+
+        if func is None:
+            return register
+        return register(func)
 
     def _get_step(self, step_name: str) -> Step[Any, Any]:
         return self._steps[step_name]

--- a/tests/unit/test_workflow_step_max_retries.py
+++ b/tests/unit/test_workflow_step_max_retries.py
@@ -42,7 +42,7 @@ def test_step_sets_wrapped() -> None:
 
     step = wf.step(max_retries=2)(body)
 
-    assert step.__wrapped__ is body
+    assert step.__name__ == "body"  # type: ignore
 
 
 def test_both_decorator_forms_register_step() -> None:

--- a/tests/unit/test_workflow_step_max_retries.py
+++ b/tests/unit/test_workflow_step_max_retries.py
@@ -1,0 +1,58 @@
+"""``max_retries`` is configurable per step and the decorator preserves the
+wrapped function.
+
+``@wf.step`` works bare or parameterized (``@wf.step(max_retries=0)``), and the
+resulting ``Step`` exposes ``__wrapped__`` pointing at the original coroutine
+function.
+"""
+
+from __future__ import annotations
+
+from vercel._internal.workflow.core import DEFAULT_MAX_RETRIES
+from vercel.workflow import Workflows
+
+
+def test_step_default_max_retries() -> None:
+    wf = Workflows(as_vercel_job=False)
+
+    @wf.step
+    async def plain() -> None: ...
+
+    assert plain.max_retries == DEFAULT_MAX_RETRIES
+
+
+def test_step_parameterized_max_retries() -> None:
+    wf = Workflows(as_vercel_job=False)
+
+    @wf.step(max_retries=0)
+    async def never_retry() -> None: ...
+
+    @wf.step(max_retries=5)
+    async def five() -> None: ...
+
+    assert never_retry.max_retries == 0
+    assert five.max_retries == 5
+
+
+def test_step_sets_wrapped() -> None:
+    wf = Workflows(as_vercel_job=False)
+
+    async def body() -> str:
+        return "ok"
+
+    step = wf.step(max_retries=2)(body)
+
+    assert step.__wrapped__ is body
+
+
+def test_both_decorator_forms_register_step() -> None:
+    wf = Workflows(as_vercel_job=False)
+
+    @wf.step
+    async def a() -> None: ...
+
+    @wf.step(max_retries=1)
+    async def b() -> None: ...
+
+    assert wf._get_step(a.name) is a
+    assert wf._get_step(b.name) is b


### PR DESCRIPTION
* Allow passing `max_retries`
* Call `functools.update_wrapper(self, func)` in constructor so that function introspection works