### PR TITLE
workflow: fix racy recreation of hook

### DIFF
--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -596,7 +596,10 @@ class LocalWorld(w.World):
             )
             if not token_claimed:
                 existing_claim = json.loads(constraint_path.read_text())
-                if existing_claim["hookId"] == data.correlation_id:
+                if (
+                    existing_claim["runId"] == effective_run_id
+                    and existing_claim["hookId"] == data.correlation_id
+                ):
                     # Same hook re-claiming its own token (replay re-issue or
                     # crash recovery). Idempotent, not a cross-workflow conflict.
                     raise w.EntityConflictError(

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -595,6 +595,13 @@ class LocalWorld(w.World):
                 ),
             )
             if not token_claimed:
+                existing_claim = json.loads(constraint_path.read_text())
+                if existing_claim["hookId"] == data.correlation_id:
+                    # Same hook re-claiming its own token (replay re-issue or
+                    # crash recovery). Idempotent, not a cross-workflow conflict.
+                    raise w.EntityConflictError(
+                        f'Hook "{data.correlation_id}" has already been created'
+                    )
                 conflict_event = w.HookConflictEvent(
                     correlationId=data.correlation_id,
                     eventData=w.HookConflictEventData(token=hook_data.token),

--- a/tests/unit/test_workflow_hook_conflict.py
+++ b/tests/unit/test_workflow_hook_conflict.py
@@ -1,0 +1,52 @@
+"""LocalWorld hook-token conflict semantics.
+
+A hook's token is claimed exclusively the first time its ``hook_created`` event
+is issued. A second issue can mean two different things, and the world must tell
+them apart:
+
+- the *same* hook (same correlation id) re-claiming its token -- a replay
+  re-issue or an overlapping/retried invocation of the same run. This is
+  idempotent, so the world raises ``EntityConflictError`` (which the runtime
+  swallows), mirroring the backend's hookId-keyed idempotency.
+- a *different* hook claiming a token already in use -- a genuine cross-workflow
+  conflict, surfaced as a ``HookConflictEvent``.
+"""
+
+from __future__ import annotations
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_test"
+TOKEN = "shared-token"
+
+
+def _world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    return local_mod.LocalWorld()
+
+
+async def test_same_hook_reclaim_raises_entity_conflict(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    event = w.HookCreatedEventData(token=TOKEN).into_event("hook_1")
+
+    await world.events_create(RUN_ID, event)
+
+    try:
+        await world.events_create(RUN_ID, event)
+    except w.EntityConflictError:
+        pass
+    else:
+        raise AssertionError("re-claiming the same hook's token should raise EntityConflictError")
+
+
+async def test_different_hook_same_token_conflicts(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+
+    await world.events_create(RUN_ID, w.HookCreatedEventData(token=TOKEN).into_event("hook_1"))
+    result = await world.events_create(
+        RUN_ID, w.HookCreatedEventData(token=TOKEN).into_event("hook_2")
+    )
+
+    assert isinstance(result.event, w.HookConflictEvent)
+    assert result.event.event_data.token == TOKEN


### PR DESCRIPTION
We need to support two simultaneous invocations of a workflow both
creating a hook concurrently.

When trying to create a hook from a token, if it has already been
claimed, check whether hookId matches. If it does, it's the same hook,
not just one with a conflicting token, so raise EntityConflictError
instead of marking it as a hook conflict.
