### PR TITLE
workflow: harmonize error handling with JS a bit

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -605,7 +605,7 @@ async def workflow_handler(
                             run_id,
                             w.HookDisposedEvent(correlationId=h.correlation_id),
                         )
-                    except w.EntityConflictError:
+                    except (w.EntityConflictError, w.HookNotFoundError):
                         logger.debug(
                             f"Workflow hook {h.correlation_id!r} has already been disposed"
                         )

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -575,6 +575,12 @@ Event: TypeAlias = Annotated[
 EventAdaptor: pydantic.TypeAdapter[Event] = pydantic.TypeAdapter(Event)
 
 
+# Hook events that require the target hook to still exist: the backend 404s them
+# (and the local world rejects them) once the hook is disposed or never existed,
+# surfacing as HookNotFoundError.
+HOOK_EVENTS_REQUIRING_EXISTENCE = frozenset({"hook_disposed", "hook_received"})
+
+
 class PaginationOptions(BaseModel):
     limit: int | None = pydantic.Field(default=None, exclude_if=lambda e: not e)
     cursor: str | None = pydantic.Field(default=None, exclude_if=lambda e: not e)
@@ -628,8 +634,56 @@ class HTTPError(Exception):
         super().__init__(f"HTTP Error {response.status}")
 
 
+class WorkflowWorldError(Exception):
+    """A non-success response from the workflow backend that isn't mapped to a
+    more specific error. Carries the HTTP status so callers can branch on it
+    (e.g. a 404 on a hook event becomes a HookNotFoundError)."""
+
+    def __init__(
+        self, message: str, *, status: int, code: str | None = None, url: str | None = None
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.url = url
+
+
+class RunExpiredError(WorkflowWorldError):
+    """HTTP 410 — the workflow run has expired and can no longer be advanced."""
+
+
+class ThrottleError(WorkflowWorldError):
+    """HTTP 429 — the backend is throttling requests. ``retry_after`` is the
+    number of seconds to wait before retrying, when the server provides it."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int,
+        code: str | None = None,
+        url: str | None = None,
+        retry_after: int | None = None,
+    ) -> None:
+        super().__init__(message, status=status, code=code, url=url)
+        self.retry_after = retry_after
+
+
 class EntityConflictError(Exception):
     pass
+
+
+class HookNotFoundError(Exception):
+    """Raised when a hook event targets a hook that no longer exists.
+
+    Mirrors the server's HTTP 404 on ``hook_disposed`` / ``hook_received`` for an
+    already-disposed (or never-created) hook. The runtime treats this the same as
+    ``EntityConflictError`` — a benign duplicate to skip.
+    """
+
+    def __init__(self, correlation_id: str) -> None:
+        self.correlation_id = correlation_id
+        super().__init__(f'Hook "{correlation_id}" not found')
 
 
 class TooEarlyError(Exception):

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -674,16 +674,25 @@ class EntityConflictError(Exception):
 
 
 class HookNotFoundError(Exception):
-    """Raised when a hook event targets a hook that no longer exists.
+    """Raised when a hook lookup or hook event targets a hook that does not exist.
 
-    Mirrors the server's HTTP 404 on ``hook_disposed`` / ``hook_received`` for an
-    already-disposed (or never-created) hook. The runtime treats this the same as
-    ``EntityConflictError`` — a benign duplicate to skip.
+    A by-token lookup (``hooks_get_by_token``) that matches no active hook supplies
+    ``token``; the server's HTTP 404 on ``hook_disposed`` / ``hook_received`` for an
+    already-disposed (or never-created) hook supplies ``hook_id``. The runtime
+    treats the event-path case the same as ``EntityConflictError`` — a benign
+    duplicate to skip.
     """
 
-    def __init__(self, correlation_id: str) -> None:
-        self.correlation_id = correlation_id
-        super().__init__(f'Hook "{correlation_id}" not found')
+    def __init__(self, *, token: str | None = None, hook_id: str | None = None) -> None:
+        self.token = token
+        self.hook_id = hook_id
+        if hook_id is not None:
+            message = f'Hook "{hook_id}" not found'
+        elif token is not None:
+            message = f'Hook not found for token "{token}"'
+        else:
+            message = "Hook not found"
+        super().__init__(message)
 
 
 class TooEarlyError(Exception):

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -277,7 +277,7 @@ class LocalWorld(w.World):
                 hook = read_json(hook_path, w.Hook)
                 if hook is not None and hook.token == token:
                     return hook
-        raise w.HookNotFoundError(token)
+        raise w.HookNotFoundError(token=token)
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         # run_created has no existing entity to race on — its create is guarded by
@@ -360,7 +360,7 @@ class LocalWorld(w.World):
             existing_hook = read_json(hook_path, w.Hook)
             if existing_hook is None:
                 # Already disposed (or never created). Mirrors the backend's 404.
-                raise w.HookNotFoundError(data.correlation_id)
+                raise w.HookNotFoundError(hook_id=data.correlation_id)
 
         event = w.EventAdaptor.validate_python(
             data.model_dump()

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -277,7 +277,7 @@ class LocalWorld(w.World):
                 hook = read_json(hook_path, w.Hook)
                 if hook is not None and hook.token == token:
                     return hook
-        raise RuntimeError(f"Hook with token {token!r} not found")
+        raise w.HookNotFoundError(token)
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         # run_created has no existing entity to race on — its create is guarded by

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -355,12 +355,12 @@ class LocalWorld(w.World):
                         f'"{current_run.status}"'
                     )
 
-        hook_events_requiring_existance = ["hook_disposed", "hook_received"]
-        if data.event_type in hook_events_requiring_existance and data.correlation_id:
+        if data.event_type in w.HOOK_EVENTS_REQUIRING_EXISTENCE and data.correlation_id:
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             existing_hook = read_json(hook_path, w.Hook)
             if existing_hook is None:
-                raise RuntimeError(f"Hook {data.correlation_id!r} not found")
+                # Already disposed (or never created). Mirrors the backend's 404.
+                raise w.HookNotFoundError(data.correlation_id)
 
         event = w.EventAdaptor.validate_python(
             data.model_dump()
@@ -654,6 +654,15 @@ class LocalWorld(w.World):
                 raise w.EntityConflictError(f'Wait "{data.correlation_id}" already completed')
 
         elif data.event_type == "hook_disposed":
+            # The existence check above already rejects an already-disposed hook
+            # with HookNotFoundError. This lock guards the narrow cross-process
+            # window where two invocations both still see the hook present: the
+            # loser gets EntityConflictError (swallowed by the runtime) instead
+            # of double-deleting and writing a duplicate hook_disposed event. The
+            # in-process run lock can't serialize separate processes.
+            dispose_lock = self.data_dir / ".locks" / "hooks" / f"{data.correlation_id}.disposed"
+            if not write_exclusive(dispose_lock, ""):
+                raise w.EntityConflictError(f'Hook "{data.correlation_id}" already disposed')
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             existing_hook = read_json(hook_path, w.Hook)
             if existing_hook is not None:

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -354,11 +354,16 @@ class VercelWorld(w.World):
         )
 
     async def hooks_get_by_token(self, token: str) -> w.Hook:
-        return await self._cbor_request(
-            "GET",
-            f"/v2/hooks/by-token?token={token}",
-            schema=w.Hook,
-        )
+        try:
+            return await self._cbor_request(
+                "GET",
+                f"/v2/hooks/by-token?token={token}",
+                schema=w.Hook,
+            )
+        except w.WorkflowWorldError as err:
+            if err.status == 404:
+                raise w.HookNotFoundError(token) from err
+            raise
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         run_id_path = "null" if run_id is None else run_id

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -362,7 +362,7 @@ class VercelWorld(w.World):
             )
         except w.WorkflowWorldError as err:
             if err.status == 404:
-                raise w.HookNotFoundError(token) from err
+                raise w.HookNotFoundError(token=token) from err
             raise
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
@@ -398,7 +398,7 @@ class VercelWorld(w.World):
                 and data.event_type in w.HOOK_EVENTS_REQUIRING_EXISTENCE
                 and correlation_id
             ):
-                raise w.HookNotFoundError(correlation_id) from err
+                raise w.HookNotFoundError(hook_id=correlation_id) from err
             raise
 
     async def events_list(

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -44,6 +44,11 @@ def _cbor_filter_undefined(value: Mapping[Any, Any], shareable: bool = False) ->
     return {k: None if v is cbor2.undefined else v for k, v in value.items()}
 
 
+# Events whose result the runtime reads back resolved (run/step entity fields);
+# everything else is fetched lazily.
+_EVENTS_NEEDING_RESOLVE = frozenset({"run_created", "run_started", "step_started"})
+
+
 # Lazy wire schema for EventResult — mirrors the JS SDK's EventResultLazyWireSchema.
 # Uses BaseWorkflowRun (no discriminated union) with loose error typing so that
 # unresolved RemoteRefs in error/input/output fields don't cause validation failures.
@@ -175,27 +180,27 @@ class VercelWorld(w.World):
                 result.get("message")
                 or f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}"
             )
+            url = f"{self._base_url}{endpoint}"
+            code = result.get("code")
             if resp.status_code == 409:
                 raise w.EntityConflictError(message)
+            if resp.status_code == 410:
+                raise w.RunExpiredError(message, status=resp.status_code, code=code, url=url)
+            # retryAfter (seconds) is carried in the Retry-After header.
+            retry_after_header = resp.headers.get("retry-after")
+            retry_after: int | None = None
+            if retry_after_header is not None:
+                try:
+                    retry_after = int(retry_after_header)
+                except ValueError:
+                    retry_after = None
             if resp.status_code == 425:
-                # retryAfter (seconds) is carried in the Retry-After header.
-                retry_after_header = resp.headers.get("retry-after")
-                retry_after: int | None = None
-                if retry_after_header is not None:
-                    try:
-                        retry_after = int(retry_after_header)
-                    except ValueError:
-                        retry_after = None
                 raise w.TooEarlyError(message, retry_after=retry_after)
-            raise RuntimeError(
-                message,
-                {
-                    "url": f"{self._base_url}{endpoint}",
-                    "status": resp.status_code,
-                    "code": result.get("code"),
-                    "extras": result,
-                },
-            )
+            if resp.status_code == 429:
+                raise w.ThrottleError(
+                    message, status=resp.status_code, code=code, url=url, retry_after=retry_after
+                )
+            raise w.WorkflowWorldError(message, status=resp.status_code, code=code, url=url)
 
     async def get_deployment_id(self) -> str:
         deployment_id = os.getenv("VERCEL_DEPLOYMENT_ID")
@@ -357,29 +362,39 @@ class VercelWorld(w.World):
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         run_id_path = "null" if run_id is None else run_id
-        remote_ref_behavior = (
-            "resolve"
-            if data.event_type in {"run_created", "run_started", "step_started"}
-            else "lazy"
-        )
-        if remote_ref_behavior == "resolve":
-            return await self._cbor_request(
-                "POST",
-                f"/v3/runs/{run_id_path}/events",
-                data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
-                schema=w.EventResult,
-            )
-        else:
-            # Lazy responses may contain unresolved RemoteRefs that fail
-            # the strict EventResult schema. Use the loose _LazyEventResult
-            # schema that tolerates unresolved refs, matching the JS SDK's
-            # EventResultLazyWireSchema.
-            return await self._cbor_request(
-                "POST",
-                f"/v3/runs/{run_id_path}/events",
-                data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
-                schema=_LazyEventResult,
-            )
+        remote_ref_behavior = "resolve" if data.event_type in _EVENTS_NEEDING_RESOLVE else "lazy"
+        try:
+            if remote_ref_behavior == "resolve":
+                return await self._cbor_request(
+                    "POST",
+                    f"/v3/runs/{run_id_path}/events",
+                    data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
+                    schema=w.EventResult,
+                )
+            else:
+                # Lazy responses may contain unresolved RemoteRefs that fail
+                # the strict EventResult schema. Use the loose _LazyEventResult
+                # schema that tolerates unresolved refs, matching the JS SDK's
+                # EventResultLazyWireSchema.
+                return await self._cbor_request(
+                    "POST",
+                    f"/v3/runs/{run_id_path}/events",
+                    data=data.model_dump() | {"remoteRefBehavior": remote_ref_behavior},
+                    schema=_LazyEventResult,
+                )
+        except w.WorkflowWorldError as err:
+            # The backend 404s hook_disposed / hook_received when the hook is
+            # already disposed or never existed. Translate to a typed
+            # HookNotFoundError so the runtime can treat a duplicate dispose as a
+            # benign skip.
+            correlation_id = getattr(data, "correlation_id", None)
+            if (
+                err.status == 404
+                and data.event_type in w.HOOK_EVENTS_REQUIRING_EXISTENCE
+                and correlation_id
+            ):
+                raise w.HookNotFoundError(correlation_id) from err
+            raise
 
     async def events_list(
         self,

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -1,6 +1,15 @@
 from vercel._internal.workflow.core import BaseHook, HookEvent, Workflows, sleep
 from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
 
+from .errors import (
+    EntityConflictError,
+    HookNotFoundError,
+    RunExpiredError,
+    ThrottleError,
+    TooEarlyError,
+    WorkflowWorldError,
+)
+
 __all__ = [
     "Workflows",
     "sleep",
@@ -10,4 +19,10 @@ __all__ = [
     "HookEvent",
     "get_step_metadata",
     "StepInfo",
+    "EntityConflictError",
+    "HookNotFoundError",
+    "RunExpiredError",
+    "ThrottleError",
+    "TooEarlyError",
+    "WorkflowWorldError",
 ]

--- a/src/vercel/workflow/errors.py
+++ b/src/vercel/workflow/errors.py
@@ -1,0 +1,17 @@
+from vercel._internal.workflow.world import (
+    EntityConflictError,
+    HookNotFoundError,
+    RunExpiredError,
+    ThrottleError,
+    TooEarlyError,
+    WorkflowWorldError,
+)
+
+__all__ = [
+    "EntityConflictError",
+    "HookNotFoundError",
+    "RunExpiredError",
+    "ThrottleError",
+    "TooEarlyError",
+    "WorkflowWorldError",
+]

--- a/tests/unit/test_workflow_hook_disposal.py
+++ b/tests/unit/test_workflow_hook_disposal.py
@@ -1,0 +1,67 @@
+"""LocalWorld hook disposal semantics.
+
+Disposing a hook frees its token and tears down the entity. Re-issuing
+hook_disposed (or delivering a payload) once the hook is gone raises
+HookNotFoundError -- the same typed error the backend's 404 yields, which the
+runtime swallows. A concurrent invocation that loses the dispose-lock race gets
+EntityConflictError instead of double-deleting and writing a duplicate event.
+"""
+
+from __future__ import annotations
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_test"
+TOKEN = "shared-token"
+
+
+def _world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    return local_mod.LocalWorld()
+
+
+async def test_redispose_raises_hook_not_found(tmp_path, monkeypatch) -> None:
+    # Once a hook is disposed (and unlinked), re-disposing it finds no hook and
+    # raises HookNotFoundError -- the same typed error the backend's 404 yields,
+    # which the runtime swallows.
+    world = _world(tmp_path, monkeypatch)
+    await world.events_create(RUN_ID, w.HookCreatedEventData(token=TOKEN).into_event("hook_1"))
+    await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+
+    try:
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+    except w.HookNotFoundError:
+        pass
+    else:
+        raise AssertionError("re-disposing a disposed hook should raise HookNotFoundError")
+
+
+async def test_hook_received_for_missing_hook_raises_hook_not_found(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    data = w.HookReceivedEventData(payload=[b"json{}"])
+
+    try:
+        await world.events_create(RUN_ID, data.into_event("hook_unknown"))
+    except w.HookNotFoundError:
+        pass
+    else:
+        raise AssertionError("hook_received for a missing hook should raise HookNotFoundError")
+
+
+async def test_concurrent_dispose_loser_gets_entity_conflict(tmp_path, monkeypatch) -> None:
+    # Cross-process race: the hook is still present but another process already
+    # claimed the dispose lock. The loser must get EntityConflictError rather
+    # than double-delete and write a duplicate hook_disposed event.
+    world = _world(tmp_path, monkeypatch)
+    await world.events_create(RUN_ID, w.HookCreatedEventData(token=TOKEN).into_event("hook_1"))
+    lock_path = world.data_dir / ".locks" / "hooks" / "hook_1.disposed"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("")
+
+    try:
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+    except w.EntityConflictError:
+        pass
+    else:
+        raise AssertionError("losing the dispose lock should raise EntityConflictError")

--- a/tests/unit/test_workflow_hook_not_found.py
+++ b/tests/unit/test_workflow_hook_not_found.py
@@ -1,0 +1,73 @@
+"""Backend hook-event 404 -> HookNotFoundError mapping (VercelWorld).
+
+The Vercel backend returns 404 on hook_disposed / hook_received when the hook is
+already disposed or never existed. VercelWorld.events_create translates that into
+a typed HookNotFoundError so the runtime can treat a duplicate dispose as a benign
+skip. Other 404s stay a generic WorkflowWorldError carrying the status.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds.vercel import VercelWorld
+
+RUN_ID = "wrun_test"
+
+
+def _world() -> VercelWorld:
+    # Pass a token so events_create doesn't try to fetch an OIDC token.
+    return VercelWorld(token="test-token")
+
+
+@respx.mock
+async def test_hook_disposed_404_maps_to_hook_not_found() -> None:
+    world = _world()
+    respx.post(f"{world._base_url}/v3/runs/{RUN_ID}/events").mock(
+        return_value=httpx.Response(404, json={"message": "hook not found", "code": "not_found"})
+    )
+
+    with pytest.raises(w.HookNotFoundError):
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+
+
+@respx.mock
+async def test_non_hook_404_is_not_translated() -> None:
+    world = _world()
+    respx.post(f"{world._base_url}/v3/runs/{RUN_ID}/events").mock(
+        return_value=httpx.Response(404, json={"message": "run not found"})
+    )
+
+    with pytest.raises(w.WorkflowWorldError) as exc_info:
+        await world.events_create(RUN_ID, w.RunStartedEvent())
+    assert exc_info.value.status == 404
+
+
+@respx.mock
+async def test_410_maps_to_run_expired() -> None:
+    world = _world()
+    respx.post(f"{world._base_url}/v3/runs/{RUN_ID}/events").mock(
+        return_value=httpx.Response(410, json={"message": "run expired"})
+    )
+
+    with pytest.raises(w.RunExpiredError) as exc_info:
+        await world.events_create(RUN_ID, w.RunStartedEvent())
+    assert exc_info.value.status == 410
+
+
+@respx.mock
+async def test_429_maps_to_throttle_with_retry_after() -> None:
+    world = _world()
+    respx.post(f"{world._base_url}/v3/runs/{RUN_ID}/events").mock(
+        return_value=httpx.Response(
+            429, headers={"retry-after": "12"}, json={"message": "slow down"}
+        )
+    )
+
+    with pytest.raises(w.ThrottleError) as exc_info:
+        await world.events_create(RUN_ID, w.RunStartedEvent())
+    assert exc_info.value.status == 429
+    assert exc_info.value.retry_after == 12


### PR DESCRIPTION
Add some error classes that JS didn't have, and catch one of the new ones (HookNotFoundError) when disposing a hook.