### PR TITLE
Rework resume() to better handle workflows with parallel tasks

### DIFF
--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -192,6 +192,7 @@ class WorkflowOrchestratorContext:
             token = self._ctx.set(self)
             try:
                 self._fut = asyncio.ensure_future(obj.func(*args, **kwargs))
+                self.resume_wrapper()  # arm the resume callback
             finally:
                 self._ctx.reset(token)
             return await self._fut
@@ -200,8 +201,6 @@ class WorkflowOrchestratorContext:
         input_data = b"json" + json.dumps((args, kwargs), sort_keys=True).encode()
         sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
-        if self.resume_handle is None and not self._suspended:
-            self.resume_handle = asyncio.get_running_loop().call_soon(self.resume)
         return await sus.future
 
     async def run_wait(self, param: int | float | datetime | str) -> None:
@@ -210,8 +209,6 @@ class WorkflowOrchestratorContext:
             resume_at=(parse_duration_to_date(param)),
         )
         self.suspensions[wait.correlation_id] = wait
-        if self.resume_handle is None and not self._suspended:
-            self.resume_handle = asyncio.get_running_loop().call_soon(self.resume)
         await wait.future
 
     def create_hook(self, token: str | None, hook_cls: type[T]) -> core.HookEvent[T]:
@@ -230,8 +227,6 @@ class WorkflowOrchestratorContext:
         self.suspensions[hook.correlation_id] = hook
         fut = asyncio.Future[T]()
         hook.futures.append(fut)
-        if self.resume_handle is None and not self._suspended:
-            self.resume_handle = asyncio.get_running_loop().call_soon(self.resume)
         return await fut
 
     def dispose_hook(self, *, correlation_id: str) -> None:
@@ -257,12 +252,57 @@ class WorkflowOrchestratorContext:
         elif isinstance(sus, (Suspension, Wait)) and not sus.future.done():
             sus.future.set_exception(exc)
 
+    def resume_wrapper(self) -> None:
+        """Make sure that resume() runs on an empty event loop ready queue."""
+
+        loop = asyncio.get_running_loop()
+        is_ready = bool(loop._ready)  # type: ignore[attr-defined]
+        self.resume_handle = loop.call_soon(self.resume_wrapper)
+        # We only want to resume() when all of the workflow tasks have
+        # suspended, so if anything else is running or ready to run,
+        # we defer. Our resume_handle callback will be at the back of
+        # the _ready queue, so everything else will go first.
+        #
+        # NOTE: Since we check loop._ready, the workflow must be run
+        # in its own dedicated event loop.
+        if is_ready:
+            return
+
+        self.resume()
+
     def resume(self) -> None:
-        self.resume_handle = None
+        """Run over the the event log and try to apply an event.
+
+        The idea is that resume() will be run whenever everything else in the
+        async event loop has paused.
+
+        The core invariant of how resume() interacts with the workflow
+        is that the execution needs to appear identical to the events
+        arriving one at a time (because when they originally arrive
+        they are one at a time, and it needs to be indistinguishable
+        from that.)
+
+        Resolves at most one suspension before breaking.
+
+        If the event log is exhausted, cancel the future and suspend
+        the workflow.
+        """
 
         if self._fut is None:
             return
 
+        # NOTE: resume() does single-step delivery, so we resolve at most
+        # one suspension per invocation of resume().
+        # As an optimization for processing StepCreatedEvent and similar,
+        # we still structure this as a loop, though.
+        # The cases that do *not* invoke a suspension will continue,
+        # and the main bottom of the loop will break.
+        #
+        # This makes sure that resume() gets interleaved directly one
+        # to one with event deliveries, instead of sometimes having
+        # multiple deliveries bunched up before a resume(), which can
+        # lead to mismatches between a recording trace and a replaying
+        # one.
         while (
             self.replay_index < len(self.events) or self.ooo_hook_received_events
         ) and self.suspensions:
@@ -339,9 +379,11 @@ class WorkflowOrchestratorContext:
                         )
                         return
                     sus.has_created_event = True
+                    continue
 
                 case w.HookCreatedEvent() | w.WaitCreatedEvent():
                     self.suspensions[event.correlation_id].has_created_event = True
+                    continue
 
                 case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
                     sus = self.suspensions.pop(event.correlation_id)
@@ -396,9 +438,18 @@ class WorkflowOrchestratorContext:
                     self.hooks[event.correlation_id].has_dispose_event = True
                     self.dispose_hook(correlation_id=event.correlation_id)
 
-        if self.suspensions:
+            # One wake per pass: yield to the body so it drains to its next
+            # suspension before we deliver the next recorded event.
+            break
+
+        # If we did not break out of the loop, that means that the
+        # event log exhausted without doing any work.
+        # Suspend.
+        else:
             self._suspended = True
             self._fut.cancel(SUSPENDED_MESSAGE)
+            if self.resume_handle:
+                self.resume_handle.cancel()
 
 
 async def workflow_handler(

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -8,8 +8,10 @@ import logging
 import math
 import random
 import re
+import sys
 import traceback
 from collections import deque
+from collections.abc import Coroutine
 from datetime import datetime, timedelta
 from typing import Any, Generic, Literal, ParamSpec, TypeVar
 
@@ -147,6 +149,25 @@ def get_step_metadata() -> StepInfo:
         raise RuntimeError("get_step_metadata() can only be called inside a step") from None
 
 
+def _run_in_default_loop(coro: Coroutine[Any, Any, T]) -> T:
+    if sys.version_info >= (3, 11):
+        with asyncio.Runner(loop_factory=asyncio.SelectorEventLoop) as runner:
+            return runner.run(coro)
+    else:
+        # Python 3.10 doesn't support asyncio.Runner or the
+        # loop_factory argument to asyncio.run(). I don't really want
+        # to reimplement run so instead we just warn if the loop
+        # policy is something weird.
+        pol = asyncio.get_event_loop_policy()
+        if not isinstance(pol, asyncio.DefaultEventLoopPolicy):
+            logger.warning(
+                "asyncio event loop policy %r is not the default; workflow "
+                "execution needs the stdlib event loop and may misbehave.",
+                pol,
+            )
+        return asyncio.run(coro)
+
+
 class WorkflowOrchestratorContext:
     _ctx: contextvars.ContextVar[Self] = contextvars.ContextVar("WorkflowContext")
 
@@ -172,7 +193,7 @@ class WorkflowOrchestratorContext:
     def current(cls) -> Self:
         return cls._ctx.get()
 
-    async def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> Any:
+    def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> Any:
         wf = self.registry._get_workflow(workflow_run.workflow_name)
         if not workflow_run.input or not isinstance(workflow_run.input, list):
             raise RuntimeError(f"Invalid workflow input for run {workflow_run.run_id}")
@@ -189,13 +210,31 @@ class WorkflowOrchestratorContext:
             for attr in wf.qualname.split("."):
                 obj = getattr(obj, attr)
 
-            token = self._ctx.set(self)
-            try:
+            async def inner():
                 self._fut = asyncio.ensure_future(obj.func(*args, **kwargs))
                 self.resume_wrapper()  # arm the resume callback
+                await self._fut
+
+            old_loop = asyncio.get_running_loop()
+            token = self._ctx.set(self)
+            try:
+                # The workflow is async, but it is not actually
+                # allowed to perform any IO-full operations, and
+                # resume/resume_wrapper require that it run in an
+                # isolated loop.
+                #
+                # So hide our existing loop and run everything in a
+                # fresh loop. We explicitly specify a factory because
+                # we look at ._ready, which might not exist in uvloop
+                # etc.
+                # TODO: Use a custom loop implementation.
+                asyncio._set_running_loop(None)
+                _run_in_default_loop(inner())
             finally:
+                asyncio._set_running_loop(old_loop)
                 self._ctx.reset(token)
-            return await self._fut
+            assert self._fut
+            return self._fut.result()
 
     async def run_step(self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         input_data = b"json" + json.dumps((args, kwargs), sort_keys=True).encode()
@@ -262,9 +301,6 @@ class WorkflowOrchestratorContext:
         # suspended, so if anything else is running or ready to run,
         # we defer. Our resume_handle callback will be at the back of
         # the _ready queue, so everything else will go first.
-        #
-        # NOTE: Since we check loop._ready, the workflow must be run
-        # in its own dedicated event loop.
         if is_ready:
             return
 
@@ -554,7 +590,7 @@ async def workflow_handler(
         events, seed=run_id, started_at=workflow_started_at, registry=registry
     )
     try:
-        result = await context.run_workflow(workflow_run)
+        result = context.run_workflow(workflow_run)
         output = b"json" + json.dumps(result).encode()
     except BaseException as e:
         if isinstance(e, asyncio.CancelledError) and e.args and e.args[0] == SUSPENDED_MESSAGE:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -168,6 +168,28 @@ def _run_in_default_loop(coro: Coroutine[Any, Any, T]) -> T:
         return asyncio.run(coro)
 
 
+def _run_isolated(coro: Coroutine[Any, Any, T]) -> T:
+    # The workflow is async, but it is not actually allowed to perform
+    # any IO-full operations, and resume/resume_wrapper require that it
+    # run in an isolated loop.
+    #
+    # So hide our existing loop and run everything in a fresh loop. We
+    # explicitly specify a factory because we look at ._ready, which
+    # might not exist in uvloop etc.
+    # TODO: Use a custom loop implementation.
+    old_loop = asyncio.get_running_loop()
+    current_task = asyncio.current_task()
+    if current_task:
+        asyncio._leave_task(old_loop, current_task)
+    asyncio._set_running_loop(None)
+    try:
+        return _run_in_default_loop(coro)
+    finally:
+        asyncio._set_running_loop(old_loop)
+        if current_task:
+            asyncio._enter_task(old_loop, current_task)
+
+
 class WorkflowOrchestratorContext:
     _ctx: contextvars.ContextVar[Self] = contextvars.ContextVar("WorkflowContext")
 
@@ -215,23 +237,10 @@ class WorkflowOrchestratorContext:
                 self.resume_wrapper()  # arm the resume callback
                 await self._fut
 
-            old_loop = asyncio.get_running_loop()
             token = self._ctx.set(self)
             try:
-                # The workflow is async, but it is not actually
-                # allowed to perform any IO-full operations, and
-                # resume/resume_wrapper require that it run in an
-                # isolated loop.
-                #
-                # So hide our existing loop and run everything in a
-                # fresh loop. We explicitly specify a factory because
-                # we look at ._ready, which might not exist in uvloop
-                # etc.
-                # TODO: Use a custom loop implementation.
-                asyncio._set_running_loop(None)
-                _run_in_default_loop(inner())
+                _run_isolated(inner())
             finally:
-                asyncio._set_running_loop(old_loop)
                 self._ctx.reset(token)
             assert self._fut
             return self._fut.result()

--- a/tests/unit/test_workflow_determinism.py
+++ b/tests/unit/test_workflow_determinism.py
@@ -8,6 +8,7 @@ loudly rather than silently returning the wrong value.
 
 import asyncio
 from datetime import datetime, timezone
+from typing import Any
 
 from vercel._internal.workflow import core, runtime, world as w
 
@@ -91,3 +92,123 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
 
     assert wait.future.done()
     assert isinstance(wait.future.exception(), runtime.NondeterminismError)
+
+
+# --- concurrent delivery: the resume_wrapper gate + resume single-step -----------
+#
+# When a body issues several calls from concurrent coroutines, recorded
+# completions must be delivered ONE AT A TIME, each only once the body has fully
+# reacted to the previous one. Otherwise a woken coroutine interleaves with a
+# still-running one and the two issue their next calls in a different order than
+# at record time -> the positional correlation IDs no longer line up ->
+# NondeterminismError. Two pieces cooperate:
+#   * resume_wrapper() is the heartbeat: it re-arms itself every tick and only
+#     runs resume() when the loop's ready queue was otherwise empty (quiescent).
+#   * resume() applies at most one recorded event (single-step), or parks.
+
+_ARGS = b'json[["a"], {}]'
+
+
+def _created(step: "core.Step[Any, Any]", cid: str) -> w.Event:
+    return w.StepCreatedEventData(stepName=step.name, input=[_ARGS]).into_event(cid)
+
+
+def _completed(cid: str, result_json: bytes) -> w.Event:
+    return w.StepCompletedEventData(result=[b"json" + result_json]).into_event(cid)
+
+
+async def test_single_step_delivers_one_completion_per_pass() -> None:
+    """Two concurrently-issued steps both have results in the log, but a single
+    resume() pass resolves only the first; the rest is left for the next pass."""
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        _created(step, "step_1"),
+        _created(step, "step_2"),
+        _completed("step_1", b'"one"'),
+        _completed("step_2", b'"two"'),
+    ]
+    ctx = _context(events)
+    sus1 = _suspension("step_1", _ARGS)
+    sus2 = _suspension("step_2", _ARGS)
+    ctx.suspensions["step_1"] = sus1
+    ctx.suspensions["step_2"] = sus2
+
+    ctx.resume()
+
+    # exactly one completion delivered; its suspension consumed...
+    assert sus1.future.done() and sus1.future.result() == "one"
+    assert "step_1" not in ctx.suspensions
+    # ...the second still pending, and the run not parked (the heartbeat will
+    # deliver it on a later pass).
+    assert not sus2.future.done()
+    assert "step_2" in ctx.suspensions
+    assert not ctx._suspended
+
+
+async def test_resume_wrapper_defers_while_loop_has_pending_work() -> None:
+    """A completion is available, but the loop still has a pending callback (the
+    body mid-reaction). The wrapper must NOT run resume() -- it re-arms and waits
+    for the next tick."""
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        _created(step, "step_1"),
+        _completed("step_1", b'"one"'),
+    ]
+    ctx = _context(events)
+    sus1 = _suspension("step_1", _ARGS)
+    ctx.suspensions["step_1"] = sus1
+
+    loop = asyncio.get_running_loop()
+    pending = loop.call_soon(lambda: None)
+    try:
+        ctx.resume_wrapper()
+
+        assert not sus1.future.done()  # resume() not run -> nothing delivered
+        assert ctx.replay_index == 0  # event log untouched
+        assert ctx.resume_handle is not None  # re-armed for the next tick
+    finally:
+        pending.cancel()
+        if ctx.resume_handle is not None:
+            ctx.resume_handle.cancel()
+
+
+async def test_resume_wrapper_runs_resume_when_quiescent() -> None:
+    """With the ready queue empty, the wrapper runs resume() (delivering one
+    completion) and re-arms itself."""
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        _created(step, "step_1"),
+        _completed("step_1", b'"one"'),
+    ]
+    ctx = _context(events)
+    sus1 = _suspension("step_1", _ARGS)
+    ctx.suspensions["step_1"] = sus1
+
+    ctx.resume_wrapper()
+
+    assert sus1.future.done() and sus1.future.result() == "one"
+    assert ctx.resume_handle is not None  # heartbeat re-armed
+
+    ctx.resume_handle.cancel()
+
+
+async def test_resume_parks_and_cancels_heartbeat_when_nothing_to_deliver() -> None:
+    """Suspension registered and its create replayed, no completion yet -> the
+    run suspends (cancels its future) and stops the heartbeat rather than
+    spinning."""
+    step = core.Step(_greet)
+    events: list[w.Event] = [_created(step, "step_1")]
+    ctx = _context(events)
+    sus1 = _suspension("step_1", _ARGS)
+    ctx.suspensions["step_1"] = sus1
+    # the heartbeat would have armed itself before calling resume().
+    loop = asyncio.get_running_loop()
+    ctx.resume_handle = loop.call_soon(ctx.resume_wrapper)
+
+    ctx.resume()
+
+    assert sus1.has_created_event
+    assert not sus1.future.done()
+    assert ctx._suspended
+    assert ctx._fut is not None and ctx._fut.cancelled()
+    assert ctx.resume_handle.cancelled()  # heartbeat stopped

--- a/tests/unit/test_workflow_run_isolated.py
+++ b/tests/unit/test_workflow_run_isolated.py
@@ -1,0 +1,56 @@
+"""Isolated-loop execution for workflow bodies.
+
+``run_workflow`` runs the (async but IO-free) workflow body in a fresh event
+loop so it can inspect the loop's ``_ready`` queue. ``_run_isolated`` hides the
+caller's running loop *and* its current task before doing so, then restores both
+afterward -- restoring the current task is what makes this work on Python 3.14,
+which errors if a new loop is entered while the outer task is still current.
+"""
+
+import asyncio
+
+import pytest
+
+from vercel._internal.workflow import runtime
+
+
+async def test_run_isolated_returns_result() -> None:
+    async def body() -> int:
+        return 41 + 1
+
+    assert runtime._run_isolated(body()) == 42
+
+
+async def test_run_isolated_runs_in_fresh_loop_and_restores_caller() -> None:
+    outer_loop = asyncio.get_running_loop()
+    outer_task = asyncio.current_task()
+    inner_loop: dict[str, asyncio.AbstractEventLoop] = {}
+
+    async def body() -> None:
+        inner_loop["loop"] = asyncio.get_running_loop()
+
+    runtime._run_isolated(body())
+
+    assert inner_loop["loop"] is not outer_loop
+    assert asyncio.get_running_loop() is outer_loop
+    assert asyncio.current_task() is outer_task
+    # The caller's loop is still usable after the isolated run.
+    await asyncio.sleep(0)
+
+
+async def test_run_isolated_propagates_exceptions_and_restores_caller() -> None:
+    outer_loop = asyncio.get_running_loop()
+    outer_task = asyncio.current_task()
+
+    class Boom(Exception):
+        pass
+
+    async def body() -> None:
+        raise Boom
+
+    with pytest.raises(Boom):
+        runtime._run_isolated(body())
+
+    assert asyncio.get_running_loop() is outer_loop
+    assert asyncio.current_task() is outer_task
+    await asyncio.sleep(0)


### PR DESCRIPTION
Having concurrent tasks in workflows is subtle, but its workable
because async concurrency is not real concurrency and is in principle
at least possible to make deterministic.

The core problem I was running into was resume() deciding to suspend
because there was a suspension pending, even though it had woken up
some other task that had productive work to do.
(The particular disasterous case that prompted all this was something
along the lines of one task waiting on a hook while another task
needed to run a step to publish the label of the hook. If that step
didn't trigger, deadlock.)

In order to fix that problem, we need to only suspend if no
suspensions were activated by resume() and when there are no ready
tasks in the event loop (since those might launch more steps, etc).
Doing this while preserving the same ordering of task executions
on all replays is a little subtle. The key idea is that it needs
to behave as if the events in the log were applied one at a time.
(Since they may have come in originally one at a time!)

So what we do is:
 * Arrange for resume() to always and only be called when the
   event loop ready queue is empty
 * Only activate one suspension per execution, so that it can
   resolve without interference.
 * Only cancel when the event log is exhausted and we did no work

--

Since we inspect `_ready`, this requires that we do this in an
isolated event loop. That's already the case for our vercel queue
based environments, but to avoid relying on this I make the workflows
run in its own isolated loop directly.

Eventually we'll probably want to have our own custom event loop I
think.
