### PR TITLE
vercel-cache: Add strict mode

### DIFF
--- a/src/vercel-cache/tests/integration/test_cache_sync_async.py
+++ b/src/vercel-cache/tests/integration/test_cache_sync_async.py
@@ -4,7 +4,81 @@ Tests RuntimeCache and AsyncRuntimeCache using the in-memory fallback
 when cache environment variables are not set.
 """
 
+import httpx
 import pytest
+from respx import MockRouter
+
+
+class TestBuildCacheStrictErrors:
+    def test_strict_set_raises_for_non_200(self, respx_mock: MockRouter) -> None:
+        from vercel.cache.cache_build import BuildCache, RuntimeCacheError
+
+        route = respx_mock.route(method="POST", url="https://cache.test/key").mock(
+            return_value=httpx.Response(500)
+        )
+        cache = BuildCache(endpoint="https://cache.test", headers={}, strict=True)
+
+        with pytest.raises(RuntimeCacheError, match="Failed to set cache: 500"):
+            cache.set("key", {"value": "payload"})
+        assert route.called
+
+    def test_strict_delete_raises_for_non_200(self, respx_mock: MockRouter) -> None:
+        from vercel.cache.cache_build import BuildCache, RuntimeCacheError
+
+        route = respx_mock.route(method="DELETE", url="https://cache.test/key").mock(
+            return_value=httpx.Response(500)
+        )
+        cache = BuildCache(endpoint="https://cache.test", headers={}, strict=True)
+
+        with pytest.raises(RuntimeCacheError, match="Failed to delete cache: 500"):
+            cache.delete("key")
+        assert route.called
+
+    def test_strict_get_404_returns_miss(self, respx_mock: MockRouter) -> None:
+        from vercel.cache.cache_build import BuildCache
+
+        route = respx_mock.route(method="GET", url="https://cache.test/key").mock(
+            return_value=httpx.Response(404)
+        )
+        cache = BuildCache(endpoint="https://cache.test", headers={}, strict=True)
+
+        assert cache.get("key") is None
+        assert route.called
+
+    def test_strict_get_raises_for_5xx(self, respx_mock: MockRouter) -> None:
+        from vercel.cache.cache_build import BuildCache, RuntimeCacheError
+
+        route = respx_mock.route(method="GET", url="https://cache.test/key").mock(
+            return_value=httpx.Response(503)
+        )
+        cache = BuildCache(endpoint="https://cache.test", headers={}, strict=True)
+
+        with pytest.raises(RuntimeCacheError, match="Failed to get cache: 503"):
+            cache.get("key")
+        assert route.called
+
+
+class TestRuntimeCacheStrictErrors:
+    def test_strict_runtime_cache_set_raises_for_non_200(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: MockRouter,
+    ) -> None:
+        import vercel.cache.runtime_cache as runtime_cache
+        from vercel.cache import RuntimeCache, RuntimeCacheError
+
+        monkeypatch.setenv("RUNTIME_CACHE_ENDPOINT", "https://cache.test")
+        monkeypatch.setenv("RUNTIME_CACHE_HEADERS", "{}")
+        monkeypatch.setattr(runtime_cache, "_build_cache_instance", None)
+
+        route = respx_mock.route(method="POST", url="https://cache.test/key").mock(
+            return_value=httpx.Response(500)
+        )
+        cache = RuntimeCache(key_hash_function=lambda key: key, strict=True)
+
+        with pytest.raises(RuntimeCacheError, match="Failed to set cache: 500"):
+            cache.set("key", {"value": "payload"})
+        assert route.called
 
 
 class TestRuntimeCacheInMemory:

--- a/src/vercel-cache/vercel/cache/__init__.py
+++ b/src/vercel-cache/vercel/cache/__init__.py
@@ -1,8 +1,10 @@
+from .cache_build import RuntimeCacheError
 from .purge import dangerously_delete_by_tag, invalidate_by_tag
 from .runtime_cache import AsyncRuntimeCache, RuntimeCache, get_cache
 
 __all__ = [
     "RuntimeCache",
+    "RuntimeCacheError",
     "AsyncRuntimeCache",
     "get_cache",
     "invalidate_by_tag",

--- a/src/vercel-cache/vercel/cache/cache_build.py
+++ b/src/vercel-cache/vercel/cache/cache_build.py
@@ -19,6 +19,10 @@ ASYNC_CLIENT_LIMITS = httpx.Limits(max_keepalive_connections=0)
 DEFAULT_TIMEOUT = 30.0
 
 
+class RuntimeCacheError(RuntimeError):
+    """Raised when strict Runtime Cache operations fail."""
+
+
 class BuildCache(Cache):
     def __init__(
         self,
@@ -26,10 +30,12 @@ class BuildCache(Cache):
         endpoint: str,
         headers: Mapping[str, str],
         on_error: Callable[[Exception], None] | None = None,
+        strict: bool = False,
     ) -> None:
         self._endpoint = endpoint.rstrip("/") + "/"
         self._headers = dict(headers)
         self._on_error = on_error
+        self._strict = strict
         self._client = httpx.Client(timeout=httpx.Timeout(30.0))
 
     def get(self, key: str):
@@ -49,10 +55,12 @@ class BuildCache(Cache):
                 # Track cache hit
                 track("cache_get", hit=True)
                 return r.json()
-            raise RuntimeError(f"Failed to get cache: {r.status_code} {r.reason_phrase}")
+            raise RuntimeCacheError(f"Failed to get cache: {r.status_code} {r.reason_phrase}")
         except Exception as e:
             if self._on_error:
                 self._on_error(e)
+            if self._strict:
+                raise
             return None
 
     def set(
@@ -77,7 +85,7 @@ class BuildCache(Cache):
                 content=json.dumps(value),
             )
             if r.status_code != 200:
-                raise RuntimeError(f"Failed to set cache: {r.status_code} {r.reason_phrase}")
+                raise RuntimeCacheError(f"Failed to set cache: {r.status_code} {r.reason_phrase}")
             # Track telemetry
             track(
                 "cache_set",
@@ -87,15 +95,21 @@ class BuildCache(Cache):
         except Exception as e:
             if self._on_error:
                 self._on_error(e)
+            if self._strict:
+                raise
 
     def delete(self, key: str) -> None:
         try:
             r = self._client.delete(self._endpoint + key, headers=self._headers)
             if r.status_code != 200:
-                raise RuntimeError(f"Failed to delete cache: {r.status_code} {r.reason_phrase}")
+                raise RuntimeCacheError(
+                    f"Failed to delete cache: {r.status_code} {r.reason_phrase}"
+                )
         except Exception as e:
             if self._on_error:
                 self._on_error(e)
+            if self._strict:
+                raise
 
     def expire_tag(self, tag: str | Sequence[str]) -> None:
         try:
@@ -106,10 +120,14 @@ class BuildCache(Cache):
                 headers=self._headers,
             )
             if r.status_code != 200:
-                raise RuntimeError(f"Failed to revalidate tag: {r.status_code} {r.reason_phrase}")
+                raise RuntimeCacheError(
+                    f"Failed to revalidate tag: {r.status_code} {r.reason_phrase}"
+                )
         except Exception as e:
             if self._on_error:
                 self._on_error(e)
+            if self._strict:
+                raise
 
     def __contains__(self, key: str) -> bool:
         try:

--- a/src/vercel-cache/vercel/cache/runtime_cache.py
+++ b/src/vercel-cache/vercel/cache/runtime_cache.py
@@ -23,26 +23,29 @@ class RuntimeCache(Cache):
         key_hash_function: Callable[[str], str] | None = None,
         namespace: str | None = None,
         namespace_separator: str | None = None,
+        strict: bool = False,
     ) -> None:
         # Transform keys to match get_cache behavior
         self._make_key = create_key_transformer(key_hash_function, namespace, namespace_separator)
+        self._strict = strict
 
     def get(self, key: str):
-        return resolve_cache(sync=True).get(self._make_key(key))
+        return resolve_cache(sync=True, strict=self._strict).get(self._make_key(key))
 
     def set(self, key: str, value: object, options: dict | None = None):
-        return resolve_cache(sync=True).set(self._make_key(key), value, options)
+        cache = resolve_cache(sync=True, strict=self._strict)
+        return cache.set(self._make_key(key), value, options)
 
     def delete(self, key: str):
-        return resolve_cache(sync=True).delete(self._make_key(key))
+        return resolve_cache(sync=True, strict=self._strict).delete(self._make_key(key))
 
     def expire_tag(self, tag: str | Sequence[str]):
         # Tag invalidation is not namespaced/hashed by design
-        return resolve_cache(sync=True).expire_tag(tag)
+        return resolve_cache(sync=True, strict=self._strict).expire_tag(tag)
 
     def __contains__(self, key: str) -> bool:
         # Delegate membership to the underlying cache implementation with transformed key
-        return self._make_key(key) in resolve_cache(sync=True)
+        return self._make_key(key) in resolve_cache(sync=True, strict=self._strict)
 
     def __getitem__(self, key: str):
         if key in self:
@@ -116,7 +119,11 @@ def get_cache(
     )
 
 
-def _get_cache_implementation(debug: bool = False, sync: bool = True) -> Cache | AsyncCache:
+def _get_cache_implementation(
+    debug: bool = False,
+    sync: bool = True,
+    strict: bool = False,
+) -> Cache | AsyncCache:
     global _in_memory_cache_instance, _async_in_memory_cache_instance
     global _build_cache_instance, _async_build_cache_instance, _warned_cache_unavailable
 
@@ -163,7 +170,9 @@ def _get_cache_implementation(debug: bool = False, sync: bool = True) -> Cache |
                 headers=parsed_headers,
                 on_error=lambda e: print(e),
             )
-        return _build_cache_instance
+        if not strict:
+            return _build_cache_instance
+        return BuildCache(endpoint=endpoint, headers=parsed_headers, strict=True)
     else:
         if _async_build_cache_instance is None:
             _async_build_cache_instance = AsyncBuildCache(
@@ -175,14 +184,14 @@ def _get_cache_implementation(debug: bool = False, sync: bool = True) -> Cache |
 
 
 @overload
-def resolve_cache(sync: Literal[True] = ...) -> Cache: ...
+def resolve_cache(sync: Literal[True] = ..., strict: bool = ...) -> Cache: ...
 
 
 @overload
-def resolve_cache(sync: Literal[False]) -> AsyncCache: ...
+def resolve_cache(sync: Literal[False], strict: bool = ...) -> AsyncCache: ...
 
 
-def resolve_cache(sync: bool = True) -> Cache | AsyncCache:
+def resolve_cache(sync: bool = True, strict: bool = False) -> Cache | AsyncCache:
     ctx = get_context()
     if sync:
         cache = getattr(ctx, "cache", None)
@@ -192,4 +201,4 @@ def resolve_cache(sync: bool = True) -> Cache | AsyncCache:
         cache = getattr(ctx, "async_cache", None)
         if cache is not None:
             return cast(AsyncCache, cache)
-    return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", sync)
+    return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", sync, strict)


### PR DESCRIPTION
Normally, HTTP errors on cache operations do not propagate, which is
fine for optional cache, but not if the cache is intended to be used as
an ephemeral data backend like Redis.  Introduce strict mode (via
`strict=True` on clients) that raises errors instead of swallowing them.
