### PR TITLE
[workflows sdk] support namespacing workflows

### DIFF
--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -12,6 +12,7 @@ import pydantic
 from vercel._internal.polyfills import Self
 
 from . import py_sandbox
+from .world import validate_queue_namespace
 
 if TYPE_CHECKING:
     from . import world as w
@@ -24,11 +25,20 @@ DEFAULT_MAX_RETRIES = 3
 
 
 class Workflow(Generic[P, T]):
-    def __init__(self, func: Callable[P, Coroutine[Any, Any, T]]):
+    def __init__(
+        self,
+        func: Callable[P, Coroutine[Any, Any, T]],
+        *,
+        registry: Workflows,
+    ):
         self.func = func
+        self._registry = registry
         self.module = func.__module__
         self.qualname = func.__qualname__
         self.workflow_id = f"workflow//{self.module}.{self.qualname}"
+
+    def _resolve_queue_namespace(self) -> str | None:
+        return self._registry.namespace
 
 
 class Step(Generic[P, T]):
@@ -141,7 +151,10 @@ class BaseHook:
 
 
 class Workflows:
-    def __init__(self, *, as_vercel_job: bool = True):
+    def __init__(self, namespace: str | None = None, *, as_vercel_job: bool = True):
+        validate_queue_namespace(namespace)
+
+        self._namespace = namespace
         self._workflows: dict[str, Workflow] = {}
         self._steps: dict[str, Step] = {}
         if as_vercel_job and not py_sandbox.in_sandbox():
@@ -150,8 +163,13 @@ class Workflows:
             runtime.workflow_entrypoint(self)
             runtime.step_entrypoint(self)
 
+    @property
+    def namespace(self) -> str | None:
+        """The immutable queue namespace for this registry."""
+        return self._namespace
+
     def workflow(self, func: Callable[P, Coroutine[Any, Any, T]]) -> Workflow[P, T]:
-        rv = Workflow(func)
+        rv = Workflow(func, registry=self)
         assert rv.workflow_id not in self._workflows, f"Duplicate workflow ID: {rv.workflow_id}"
         self._workflows[rv.workflow_id] = rv
         return rv

--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -151,7 +151,7 @@ class BaseHook:
 
 
 class Workflows:
-    def __init__(self, namespace: str | None = None, *, as_vercel_job: bool = True):
+    def __init__(self, *, namespace: str | None = None, as_vercel_job: bool = True):
         validate_queue_namespace(namespace)
 
         self._namespace = namespace

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -1122,6 +1122,5 @@ async def resume_hook(token_or_hook: str | w.Hook, payload_json: str) -> w.Hook:
     await world.queue(
         w.get_queue_name("workflow", run.workflow_name, namespace),
         w.WorkflowInvokePayload(runId=hook.run_id),
-        deployment_id=run.deployment_id,
     )
     return hook

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -504,6 +504,7 @@ async def workflow_handler(
     queue_name: str,
     message_id: str,
     registry: core.Workflows,
+    namespace: str | None = None,
 ) -> w.QueueContinuation | None:
     world = w.get_world()
     run_id = w.WorkflowInvokePayload.model_validate(message).run_id
@@ -654,7 +655,7 @@ async def workflow_handler(
                     # Instead we use an idempotency_key to pervent
                     # duplicate queueing.
                     await world.queue(
-                        f"__wkf_step_{s.step.name}",
+                        w.get_queue_name("step", s.step.name, namespace),
                         w.StepInvokePayload(
                             workflowName=workflow_run.workflow_name,
                             workflowRunId=run_id,
@@ -718,6 +719,7 @@ async def workflow_handler(
             queue_name=queue_name,
             message_id=message_id,
             registry=registry,
+            namespace=namespace,
         )
 
     now = datetime.now(UTC)
@@ -738,9 +740,12 @@ async def workflow_handler(
     return w.QueueContinuation(delay_seconds=delay, idempotency_key=key)
 
 
-def _step_name_from_queue(queue_name: str) -> str:
+def _step_name_from_queue(queue_name: str, namespace: str | None = None) -> str:
     """The step name encoded in a step queue topic."""
-    return queue_name.removeprefix("__wkf_step_")
+    prefix = w.get_queue_topic_prefix("step", namespace)
+    if not queue_name.startswith(prefix):
+        raise ValueError(f'Invalid step queue name "{queue_name}": expected prefix "{prefix}"')
+    return queue_name.removeprefix(prefix)
 
 
 async def step_handler(
@@ -750,11 +755,12 @@ async def step_handler(
     queue_name: str,
     message_id: str,
     registry: core.Workflows,
+    namespace: str | None = None,
 ) -> w.QueueContinuation | None:
     world = w.get_world()
     req = w.StepInvokePayload.model_validate(message)
 
-    step = registry._get_step(_step_name_from_queue(queue_name))
+    step = registry._get_step(_step_name_from_queue(queue_name, namespace))
 
     # step_started validates state (terminal -> EntityConflictError, retryAfter
     # not reached -> TooEarlyError), increments the attempt, and returns the
@@ -781,7 +787,7 @@ async def step_handler(
         # but whose handler died before re-invoking the workflow.
         logger.debug("Tried starting step %r, but it has already finished", req.step_id)
         await world.queue(
-            f"__wkf_workflow_{req.workflow_name}",
+            w.get_queue_name("workflow", req.workflow_name, namespace),
             w.WorkflowInvokePayload(
                 runId=req.workflow_run_id,
                 requestedAt=datetime.now(UTC),
@@ -815,7 +821,7 @@ async def step_handler(
 
         # Re-invoke the workflow to handle the failed step
         await world.queue(
-            f"__wkf_workflow_{req.workflow_name}",
+            w.get_queue_name("workflow", req.workflow_name, namespace),
             w.WorkflowInvokePayload(
                 runId=req.workflow_run_id,
                 requestedAt=datetime.now(UTC),
@@ -926,7 +932,7 @@ async def step_handler(
 
     # Re-invoke the workflow to continue execution
     await world.queue(
-        f"__wkf_workflow_{req.workflow_name}",
+        w.get_queue_name("workflow", req.workflow_name, namespace),
         w.WorkflowInvokePayload(
             runId=req.workflow_run_id,
             requestedAt=datetime.now(UTC),
@@ -936,16 +942,18 @@ async def step_handler(
 
 
 def workflow_entrypoint(registry: core.Workflows) -> w.HTTPHandler:
+    namespace = registry.namespace
     return w.get_world().create_queue_handler(
-        "__wkf_workflow_",
-        functools.partial(workflow_handler, registry=registry),
+        w.get_queue_topic_prefix("workflow", namespace),
+        functools.partial(workflow_handler, registry=registry, namespace=namespace),
     )
 
 
 def step_entrypoint(registry: core.Workflows) -> w.HTTPHandler:
+    namespace = registry.namespace
     return w.get_world().create_queue_handler(
-        "__wkf_step_",
-        functools.partial(step_handler, registry=registry),
+        w.get_queue_topic_prefix("step", namespace),
+        functools.partial(step_handler, registry=registry, namespace=namespace),
     )
 
 
@@ -1073,9 +1081,13 @@ class Run:
 async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> Run:
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
+    namespace = wf._resolve_queue_namespace()
     input_data = b"json" + json.dumps([args, kwargs], sort_keys=True).encode()
     data = w.RunCreatedEventData(
-        deploymentId=deployment_id, workflowName=wf.workflow_id, input=[input_data]
+        deploymentId=deployment_id,
+        workflowName=wf.workflow_id,
+        input=[input_data],
+        executionContext={"queueNamespace": namespace} if namespace is not None else None,
     )
     result = await world.events_create(None, data.into_event())
 
@@ -1085,7 +1097,7 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
 
     run_id = result.run.run_id
     await world.queue(
-        f"__wkf_workflow_{wf.workflow_id}",
+        w.get_queue_name("workflow", wf.workflow_id, namespace),
         w.WorkflowInvokePayload(runId=run_id),
         deployment_id=deployment_id,
     )
@@ -1103,8 +1115,13 @@ async def resume_hook(token_or_hook: str | w.Hook, payload_json: str) -> w.Hook:
     payload = b"json" + payload_json.encode()
     data = w.HookReceivedEventData(payload=[payload])
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
+    execution_context = run.execution_context or {}
+    namespace = execution_context.get("queueNamespace")
+    if namespace is not None and not isinstance(namespace, str):
+        raise RuntimeError("Workflow run has an invalid queue namespace")
     await world.queue(
-        f"__wkf_workflow_{run.workflow_name}",
+        w.get_queue_name("workflow", run.workflow_name, namespace),
         w.WorkflowInvokePayload(runId=hook.run_id),
+        deployment_id=run.deployment_id,
     )
     return hook

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -2,6 +2,7 @@ import abc
 import dataclasses
 import json
 import os
+import re
 import sys
 from datetime import datetime
 from typing import (
@@ -25,9 +26,40 @@ import pydantic
 from vercel._internal.polyfills import Self
 
 T = TypeVar("T")
-QueuePrefix: TypeAlias = Literal["__wkf_step_", "__wkf_workflow_"]
+QueueKind: TypeAlias = Literal["workflow", "step"]
+QueuePrefix: TypeAlias = str
 # OpenTelemetry trace context for distributed tracing
 TraceCarrier: TypeAlias = dict[str, str]
+
+_QUEUE_NAMESPACE_PATTERN = re.compile(r"^[a-z][a-z0-9]*$")
+
+
+def validate_queue_namespace(namespace: str | None) -> None:
+    """Validate an optional workflow queue namespace."""
+    if namespace is not None and not _QUEUE_NAMESPACE_PATTERN.fullmatch(namespace):
+        raise ValueError(
+            f'Invalid queue namespace "{namespace}": must be lowercase alphanumeric, '
+            "starting with a letter"
+        )
+
+
+def get_queue_topic_prefix(kind: QueueKind, namespace: str | None = None) -> QueuePrefix:
+    """Build the workflow or step queue prefix for an optional namespace."""
+    if kind not in ("workflow", "step"):
+        raise ValueError(f"Invalid queue kind: {kind}")
+    validate_queue_namespace(namespace)
+    if namespace is not None:
+        return f"__{namespace}_wkf_{kind}_"
+    return f"__wkf_{kind}_"
+
+
+def get_queue_name(
+    kind: QueueKind,
+    identifier: str,
+    namespace: str | None = None,
+) -> str:
+    """Build a queue name for an optional namespace."""
+    return f"{get_queue_topic_prefix(kind, namespace)}{identifier}"
 
 
 class BaseModel(pydantic.BaseModel):

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -30,6 +30,18 @@ async def main() -> None:
 steps that can be called only from inside a workflow. `sleep()` creates a
 durable wait in a workflow run.
 
+## Queue namespaces
+
+Pass a namespace to a workflow registry to isolate its workflow and step
+messages on dedicated queue topics:
+
+```python
+workflows = Workflows("billing")
+```
+
+Namespaces must be lowercase alphanumeric and start with a letter. Omit the
+namespace to keep using the default `__wkf_*` topics.
+
 ## Hooks
 
 ```python

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -39,9 +39,6 @@ messages on dedicated queue topics:
 workflows = Workflows("billing")
 ```
 
-Namespaces must be lowercase alphanumeric and start with a letter. Omit the
-namespace to keep using the default `__wkf_*` topics.
-
 ## Hooks
 
 ```python

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -36,7 +36,7 @@ Pass a namespace to a workflow registry to isolate its workflow and step
 messages on dedicated queue topics:
 
 ```python
-workflows = Workflows("billing")
+workflows = Workflows(namespace="billing")
 ```
 
 ## Hooks

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -126,8 +126,10 @@ def test_invalid_queue_namespaces_are_rejected(namespace: str) -> None:
 
 
 def test_workflow_namespace_must_be_keyword_argument() -> None:
+    workflow_factory: Any = Workflows
+
     with pytest.raises(TypeError):
-        Workflows("billing", as_vercel_job=False)  # type: ignore[call-arg]
+        workflow_factory("billing", as_vercel_job=False)
 
 
 def test_workflow_namespace_accepts_keyword_argument() -> None:

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -215,7 +215,7 @@ async def test_multiple_registries_start_on_their_own_topics() -> None:
     ]
 
 
-async def test_resume_hook_uses_stored_namespace_and_original_deployment() -> None:
+async def test_resume_hook_uses_stored_namespace() -> None:
     world = _RecordingWorld(
         run=SimpleNamespace(
             workflow_name="workflow//tests.example",
@@ -229,7 +229,6 @@ async def test_resume_hook_uses_stored_namespace_and_original_deployment() -> No
     await runtime.resume_hook(hook, '{"ok": true}')
 
     assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
-    assert world.queued[0][2]["deployment_id"] == "dpl_original"
 
 
 async def test_resume_legacy_run_uses_default_namespace() -> None:
@@ -246,4 +245,3 @@ async def test_resume_legacy_run_uses_default_namespace() -> None:
     await runtime.resume_hook(hook, '{"ok": true}')
 
     assert world.queued[0][0] == "__wkf_workflow_workflow//tests.example"
-    assert world.queued[0][2]["deployment_id"] == "dpl_legacy"

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -125,8 +125,13 @@ def test_invalid_queue_namespaces_are_rejected(namespace: str) -> None:
         core.Workflows(namespace=namespace, as_vercel_job=False)
 
 
-def test_workflow_namespace_accepts_positional_argument() -> None:
-    wf = Workflows("billing", as_vercel_job=False)
+def test_workflow_namespace_must_be_keyword_argument() -> None:
+    with pytest.raises(TypeError):
+        Workflows("billing", as_vercel_job=False)  # type: ignore[call-arg]
+
+
+def test_workflow_namespace_accepts_keyword_argument() -> None:
+    wf = Workflows(namespace="billing", as_vercel_job=False)
     assert wf.namespace == "billing"
 
 
@@ -134,8 +139,8 @@ def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
     world = FakeWorld()
     w.set_world(world)
 
-    core.Workflows("python1")
-    core.Workflows("python2")
+    core.Workflows(namespace="python1")
+    core.Workflows(namespace="python2")
 
     assert world.prefixes == [
         "__python1_wkf_workflow_",

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from vercel._internal.workflow import core, runtime, world as w
+from vercel.workflow import Workflows
+
+
+class _RecordingWorld:
+    def __init__(
+        self,
+        *,
+        event_error: Exception | None = None,
+        run: Any | None = None,
+    ) -> None:
+        self.prefixes: list[str] = []
+        self.queued: list[tuple[str, w.QueuePayload, dict[str, Any]]] = []
+        self.events: list[w.Event] = []
+        self.event_error = event_error
+        self.run = run or SimpleNamespace(
+            workflow_name="workflow//tests.example",
+            deployment_id="dpl_test",
+            execution_context=None,
+        )
+
+    async def get_deployment_id(self) -> str:
+        return "dpl_test"
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        self.queued.append((queue_name, message, kwargs))
+        return "msg_test"
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        self.prefixes.append(queue_name_prefix)
+
+        async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
+            return w.HTTPResponse(status=200, body=b"", headers={})
+
+        return http_handler
+
+    async def runs_get(self, run_id: str) -> Any:
+        return self.run
+
+    async def steps_get(self, run_id: str, step_id: str) -> Any:
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str) -> Any:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> Any:
+        if self.event_error is not None:
+            raise self.event_error
+        self.events.append(data)
+        if run_id is None:
+            return SimpleNamespace(run=SimpleNamespace(run_id="wrun_test"))
+        return SimpleNamespace()
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+def _set_world(world: _RecordingWorld) -> None:
+    w.set_world(cast(w.World, world))
+
+
+def _run_created_contexts(world: _RecordingWorld) -> list[dict[str, Any] | None]:
+    return [
+        cast(w.RunCreatedEvent, event).event_data.execution_context
+        for event in world.events
+        if event.event_type == "run_created"
+    ]
+
+
+def test_queue_names_default_to_legacy_prefixes() -> None:
+    assert w.get_queue_topic_prefix("workflow") == "__wkf_workflow_"
+    assert w.get_queue_topic_prefix("step") == "__wkf_step_"
+    assert w.get_queue_name("workflow", "example") == "__wkf_workflow_example"
+
+
+def test_queue_names_accept_explicit_namespace() -> None:
+    assert w.get_queue_name("workflow", "example", "python2") == ("__python2_wkf_workflow_example")
+    assert w.get_queue_name("step", "example", "python2") == "__python2_wkf_step_example"
+
+
+@pytest.mark.parametrize("namespace", ["", "123abc", "Custom", "my-framework", "my_namespace"])
+def test_invalid_queue_namespaces_are_rejected(namespace: str) -> None:
+    with pytest.raises(ValueError, match="Invalid queue namespace"):
+        core.Workflows(namespace=namespace, as_vercel_job=False)
+
+
+def test_workflow_namespace_is_positional_and_read_only() -> None:
+    wf = Workflows("billing", as_vercel_job=False)
+    assert wf.namespace == "billing"
+    with pytest.raises(AttributeError):
+        cast(Any, wf).namespace = "email"
+
+
+def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
+    world = _RecordingWorld()
+    _set_world(world)
+
+    core.Workflows("python1")
+    core.Workflows("python2")
+
+    assert world.prefixes == [
+        "__python1_wkf_workflow_",
+        "__python1_wkf_step_",
+        "__python2_wkf_workflow_",
+        "__python2_wkf_step_",
+    ]
+
+
+def test_namespaced_step_queue_is_parsed_with_matching_namespace() -> None:
+    assert (
+        runtime._step_name_from_queue("__python_wkf_step_step//tests.add", "python")
+        == "step//tests.add"
+    )
+
+    with pytest.raises(ValueError, match="expected prefix"):
+        runtime._step_name_from_queue("__wkf_step_step//tests.add", "python")
+
+
+async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
+    world = _RecordingWorld(event_error=w.EntityConflictError("already finished"))
+    _set_world(world)
+    registry = core.Workflows(namespace="python", as_vercel_job=False)
+
+    @registry.step
+    async def add() -> None:
+        pass
+
+    await runtime.step_handler(
+        w.StepInvokePayload(
+            workflowName="workflow//tests.example",
+            workflowRunId="wrun_test",
+            workflowStartedAt=0,
+            stepId="step_test",
+        ).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=f"__python_wkf_step_{add.name}",
+        message_id="msg_test",
+        registry=registry,
+        namespace=registry.namespace,
+    )
+
+    assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
+
+
+async def test_start_uses_registry_namespace_and_persists_it() -> None:
+    world = _RecordingWorld()
+    _set_world(world)
+    registry = core.Workflows(namespace="python", as_vercel_job=False)
+
+    @registry.workflow
+    async def example() -> None:
+        pass
+
+    run = await runtime.start(example)
+
+    assert run.run_id == "wrun_test"
+    assert world.queued[0][0] == f"__python_wkf_workflow_{example.workflow_id}"
+    assert _run_created_contexts(world) == [{"queueNamespace": "python"}]
+
+
+async def test_start_without_namespace_uses_legacy_topic() -> None:
+    world = _RecordingWorld()
+    _set_world(world)
+    registry = core.Workflows(as_vercel_job=False)
+
+    @registry.workflow
+    async def example() -> None:
+        pass
+
+    await runtime.start(example)
+
+    assert world.queued[0][0] == f"__wkf_workflow_{example.workflow_id}"
+    assert _run_created_contexts(world) == [None]
+
+
+async def test_multiple_registries_start_on_their_own_topics() -> None:
+    world = _RecordingWorld()
+    _set_world(world)
+    first_registry = core.Workflows(namespace="first", as_vercel_job=False)
+    second_registry = core.Workflows(namespace="second", as_vercel_job=False)
+
+    @first_registry.workflow
+    async def first_workflow() -> None:
+        pass
+
+    @second_registry.workflow
+    async def second_workflow() -> None:
+        pass
+
+    await runtime.start(first_workflow)
+    await runtime.start(second_workflow)
+
+    assert [queue_name for queue_name, _, _ in world.queued] == [
+        f"__first_wkf_workflow_{first_workflow.workflow_id}",
+        f"__second_wkf_workflow_{second_workflow.workflow_id}",
+    ]
+    assert _run_created_contexts(world) == [
+        {"queueNamespace": "first"},
+        {"queueNamespace": "second"},
+    ]
+
+
+async def test_resume_hook_uses_stored_namespace_and_original_deployment() -> None:
+    world = _RecordingWorld(
+        run=SimpleNamespace(
+            workflow_name="workflow//tests.example",
+            deployment_id="dpl_original",
+            execution_context={"queueNamespace": "python"},
+        )
+    )
+    _set_world(world)
+    hook = cast(w.Hook, SimpleNamespace(run_id="wrun_test", hook_id="hook_test"))
+
+    await runtime.resume_hook(hook, '{"ok": true}')
+
+    assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
+    assert world.queued[0][2]["deployment_id"] == "dpl_original"
+
+
+async def test_resume_legacy_run_uses_default_namespace() -> None:
+    world = _RecordingWorld(
+        run=SimpleNamespace(
+            workflow_name="workflow//tests.example",
+            deployment_id="dpl_legacy",
+            execution_context=None,
+        )
+    )
+    _set_world(world)
+    hook = cast(w.Hook, SimpleNamespace(run_id="wrun_test", hook_id="hook_test"))
+
+    await runtime.resume_hook(hook, '{"ok": true}')
+
+    assert world.queued[0][0] == "__wkf_workflow_workflow//tests.example"
+    assert world.queued[0][2]["deployment_id"] == "dpl_legacy"

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -81,7 +81,7 @@ def _run_created_contexts(world: _RecordingWorld) -> list[dict[str, Any] | None]
     ]
 
 
-def test_queue_names_default_to_legacy_prefixes() -> None:
+def test_queue_names_default_to_unnamespaced_prefixes() -> None:
     assert w.get_queue_topic_prefix("workflow") == "__wkf_workflow_"
     assert w.get_queue_topic_prefix("step") == "__wkf_step_"
     assert w.get_queue_name("workflow", "example") == "__wkf_workflow_example"
@@ -169,7 +169,7 @@ async def test_start_uses_registry_namespace_and_persists_it() -> None:
     assert _run_created_contexts(world) == [{"queueNamespace": "python"}]
 
 
-async def test_start_without_namespace_uses_legacy_topic() -> None:
+async def test_start_without_namespace_uses_unnamespaced_topic() -> None:
     world = _RecordingWorld()
     _set_world(world)
     registry = core.Workflows(as_vercel_job=False)
@@ -226,7 +226,7 @@ async def test_resume_hook_uses_stored_namespace() -> None:
     assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
 
 
-async def test_resume_legacy_run_uses_default_namespace() -> None:
+async def test_resume_run_without_namespace_uses_unnamespaced_topic() -> None:
     world = _RecordingWorld(
         run=SimpleNamespace(
             workflow_name="workflow//tests.example",

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -63,7 +63,7 @@ class FakeWorld(w.World):
     ) -> w.HTTPHandler:
         self.prefixes.append(queue_name_prefix)
 
-        async def http_handler(_request: w.HTTPRequest) -> w.HTTPResponse:
+        async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
             return w.HTTPResponse(status=200, body=b"", headers={})
 
         return http_handler

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -17,12 +17,11 @@ class _RecordingWorld:
         run: Any | None = None,
     ) -> None:
         self.prefixes: list[str] = []
-        self.queued: list[tuple[str, w.QueuePayload, dict[str, Any]]] = []
+        self.queued: list[tuple[str, w.QueuePayload]] = []
         self.events: list[w.Event] = []
         self.event_error = event_error
         self.run = run or SimpleNamespace(
             workflow_name="workflow//tests.example",
-            deployment_id="dpl_test",
             execution_context=None,
         )
 
@@ -30,7 +29,7 @@ class _RecordingWorld:
         return "dpl_test"
 
     async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
-        self.queued.append((queue_name, message, kwargs))
+        self.queued.append((queue_name, message))
         return "msg_test"
 
     def create_queue_handler(
@@ -99,11 +98,9 @@ def test_invalid_queue_namespaces_are_rejected(namespace: str) -> None:
         core.Workflows(namespace=namespace, as_vercel_job=False)
 
 
-def test_workflow_namespace_is_positional_and_read_only() -> None:
+def test_workflow_namespace_accepts_positional_argument() -> None:
     wf = Workflows("billing", as_vercel_job=False)
     assert wf.namespace == "billing"
-    with pytest.raises(AttributeError):
-        cast(Any, wf).namespace = "email"
 
 
 def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
@@ -166,9 +163,8 @@ async def test_start_uses_registry_namespace_and_persists_it() -> None:
     async def example() -> None:
         pass
 
-    run = await runtime.start(example)
+    await runtime.start(example)
 
-    assert run.run_id == "wrun_test"
     assert world.queued[0][0] == f"__python_wkf_workflow_{example.workflow_id}"
     assert _run_created_contexts(world) == [{"queueNamespace": "python"}]
 
@@ -205,7 +201,7 @@ async def test_multiple_registries_start_on_their_own_topics() -> None:
     await runtime.start(first_workflow)
     await runtime.start(second_workflow)
 
-    assert [queue_name for queue_name, _, _ in world.queued] == [
+    assert [queue_name for queue_name, _ in world.queued] == [
         f"__first_wkf_workflow_{first_workflow.workflow_id}",
         f"__second_wkf_workflow_{second_workflow.workflow_id}",
     ]
@@ -219,7 +215,6 @@ async def test_resume_hook_uses_stored_namespace() -> None:
     world = _RecordingWorld(
         run=SimpleNamespace(
             workflow_name="workflow//tests.example",
-            deployment_id="dpl_original",
             execution_context={"queueNamespace": "python"},
         )
     )
@@ -235,7 +230,6 @@ async def test_resume_legacy_run_uses_default_namespace() -> None:
     world = _RecordingWorld(
         run=SimpleNamespace(
             workflow_name="workflow//tests.example",
-            deployment_id="dpl_legacy",
             execution_context=None,
         )
     )

--- a/tests/unit/test_workflow_queue_namespace.py
+++ b/tests/unit/test_workflow_queue_namespace.py
@@ -1,29 +1,55 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any, cast
+from datetime import datetime
+from typing import Any
 
 import pytest
 
+from vercel._internal.polyfills import UTC
 from vercel._internal.workflow import core, runtime, world as w
 from vercel.workflow import Workflows
 
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+RUN_ID = "wrun_test"
+WORKFLOW_NAME = "workflow//tests.example"
 
-class _RecordingWorld:
+
+def _run(execution_context: dict[str, Any] | None = None) -> w.WorkflowRun:
+    return w.NonFinalWorkflowRun(
+        runId=RUN_ID,
+        status="running",
+        deploymentId="dpl_test",
+        workflowName=WORKFLOW_NAME,
+        executionContext=execution_context,
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+
+
+def _hook() -> w.Hook:
+    return w.Hook(
+        runId=RUN_ID,
+        hookId="hook_test",
+        token="hook-token",
+        ownerId="team_test",
+        projectId="prj_test",
+        environment="development",
+        createdAt=NOW,
+    )
+
+
+class FakeWorld(w.World):
     def __init__(
         self,
         *,
-        event_error: Exception | None = None,
-        run: Any | None = None,
+        start_error: Exception | None = None,
+        run: w.WorkflowRun | None = None,
     ) -> None:
         self.prefixes: list[str] = []
         self.queued: list[tuple[str, w.QueuePayload]] = []
         self.events: list[w.Event] = []
-        self.event_error = event_error
-        self.run = run or SimpleNamespace(
-            workflow_name="workflow//tests.example",
-            execution_context=None,
-        )
+        self.start_error = start_error
+        self.run = run or _run()
 
     async def get_deployment_id(self) -> str:
         return "dpl_test"
@@ -37,29 +63,34 @@ class _RecordingWorld:
     ) -> w.HTTPHandler:
         self.prefixes.append(queue_name_prefix)
 
-        async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
+        async def http_handler(_request: w.HTTPRequest) -> w.HTTPResponse:
             return w.HTTPResponse(status=200, body=b"", headers={})
 
         return http_handler
 
-    async def runs_get(self, run_id: str) -> Any:
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
         return self.run
 
-    async def steps_get(self, run_id: str, step_id: str) -> Any:
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
         raise NotImplementedError
 
-    async def hooks_get_by_token(self, token: str) -> Any:
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
         raise NotImplementedError
 
-    async def events_create(self, run_id: str | None, data: w.Event) -> Any:
-        if self.event_error is not None:
-            raise self.event_error
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        if data.event_type == "step_started" and self.start_error is not None:
+            raise self.start_error
         self.events.append(data)
         if run_id is None:
-            return SimpleNamespace(run=SimpleNamespace(run_id="wrun_test"))
-        return SimpleNamespace()
+            return w.EventResult(run=self.run)
+        return w.EventResult()
 
-    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+    async def events_list(
+        self,
+        run_id: str,
+        *,
+        pagination: w.PaginationOptions | None = None,
+    ) -> w.PaginatedResult[w.Event]:
         raise NotImplementedError
 
 
@@ -69,15 +100,11 @@ def _reset_world():
     w.set_world(None)
 
 
-def _set_world(world: _RecordingWorld) -> None:
-    w.set_world(cast(w.World, world))
-
-
-def _run_created_contexts(world: _RecordingWorld) -> list[dict[str, Any] | None]:
+def _run_created_contexts(world: FakeWorld) -> list[dict[str, Any] | None]:
     return [
-        cast(w.RunCreatedEvent, event).event_data.execution_context
+        event.event_data.execution_context
         for event in world.events
-        if event.event_type == "run_created"
+        if isinstance(event, w.RunCreatedEvent)
     ]
 
 
@@ -88,7 +115,7 @@ def test_queue_names_default_to_unnamespaced_prefixes() -> None:
 
 
 def test_queue_names_accept_explicit_namespace() -> None:
-    assert w.get_queue_name("workflow", "example", "python2") == ("__python2_wkf_workflow_example")
+    assert w.get_queue_name("workflow", "example", "python2") == "__python2_wkf_workflow_example"
     assert w.get_queue_name("step", "example", "python2") == "__python2_wkf_step_example"
 
 
@@ -104,8 +131,8 @@ def test_workflow_namespace_accepts_positional_argument() -> None:
 
 
 def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
-    world = _RecordingWorld()
-    _set_world(world)
+    world = FakeWorld()
+    w.set_world(world)
 
     core.Workflows("python1")
     core.Workflows("python2")
@@ -118,19 +145,14 @@ def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
     ]
 
 
-def test_namespaced_step_queue_is_parsed_with_matching_namespace() -> None:
-    assert (
-        runtime._step_name_from_queue("__python_wkf_step_step//tests.add", "python")
-        == "step//tests.add"
-    )
-
+def test_step_queue_rejects_mismatched_namespace() -> None:
     with pytest.raises(ValueError, match="expected prefix"):
         runtime._step_name_from_queue("__wkf_step_step//tests.add", "python")
 
 
 async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
-    world = _RecordingWorld(event_error=w.EntityConflictError("already finished"))
-    _set_world(world)
+    world = FakeWorld(start_error=w.EntityConflictError("already finished"))
+    w.set_world(world)
     registry = core.Workflows(namespace="python", as_vercel_job=False)
 
     @registry.step
@@ -139,8 +161,8 @@ async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
 
     await runtime.step_handler(
         w.StepInvokePayload(
-            workflowName="workflow//tests.example",
-            workflowRunId="wrun_test",
+            workflowName=WORKFLOW_NAME,
+            workflowRunId=RUN_ID,
             workflowStartedAt=0,
             stepId="step_test",
         ).model_dump(by_alias=True),
@@ -151,27 +173,12 @@ async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
         namespace=registry.namespace,
     )
 
-    assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
-
-
-async def test_start_uses_registry_namespace_and_persists_it() -> None:
-    world = _RecordingWorld()
-    _set_world(world)
-    registry = core.Workflows(namespace="python", as_vercel_job=False)
-
-    @registry.workflow
-    async def example() -> None:
-        pass
-
-    await runtime.start(example)
-
-    assert world.queued[0][0] == f"__python_wkf_workflow_{example.workflow_id}"
-    assert _run_created_contexts(world) == [{"queueNamespace": "python"}]
+    assert world.queued[0][0] == f"__python_wkf_workflow_{WORKFLOW_NAME}"
 
 
 async def test_start_without_namespace_uses_unnamespaced_topic() -> None:
-    world = _RecordingWorld()
-    _set_world(world)
+    world = FakeWorld()
+    w.set_world(world)
     registry = core.Workflows(as_vercel_job=False)
 
     @registry.workflow
@@ -184,9 +191,9 @@ async def test_start_without_namespace_uses_unnamespaced_topic() -> None:
     assert _run_created_contexts(world) == [None]
 
 
-async def test_multiple_registries_start_on_their_own_topics() -> None:
-    world = _RecordingWorld()
-    _set_world(world)
+async def test_start_routes_each_registry_to_its_namespace() -> None:
+    world = FakeWorld()
+    w.set_world(world)
     first_registry = core.Workflows(namespace="first", as_vercel_job=False)
     second_registry = core.Workflows(namespace="second", as_vercel_job=False)
 
@@ -212,30 +219,18 @@ async def test_multiple_registries_start_on_their_own_topics() -> None:
 
 
 async def test_resume_hook_uses_stored_namespace() -> None:
-    world = _RecordingWorld(
-        run=SimpleNamespace(
-            workflow_name="workflow//tests.example",
-            execution_context={"queueNamespace": "python"},
-        )
-    )
-    _set_world(world)
-    hook = cast(w.Hook, SimpleNamespace(run_id="wrun_test", hook_id="hook_test"))
+    world = FakeWorld(run=_run({"queueNamespace": "python"}))
+    w.set_world(world)
 
-    await runtime.resume_hook(hook, '{"ok": true}')
+    await runtime.resume_hook(_hook(), '{"ok": true}')
 
-    assert world.queued[0][0] == "__python_wkf_workflow_workflow//tests.example"
+    assert world.queued[0][0] == f"__python_wkf_workflow_{WORKFLOW_NAME}"
 
 
 async def test_resume_run_without_namespace_uses_unnamespaced_topic() -> None:
-    world = _RecordingWorld(
-        run=SimpleNamespace(
-            workflow_name="workflow//tests.example",
-            execution_context=None,
-        )
-    )
-    _set_world(world)
-    hook = cast(w.Hook, SimpleNamespace(run_id="wrun_test", hook_id="hook_test"))
+    world = FakeWorld()
+    w.set_world(world)
 
-    await runtime.resume_hook(hook, '{"ok": true}')
+    await runtime.resume_hook(_hook(), '{"ok": true}')
 
-    assert world.queued[0][0] == "__wkf_workflow_workflow//tests.example"
+    assert world.queued[0][0] == f"__wkf_workflow_{WORKFLOW_NAME}"


### PR DESCRIPTION
Adds support for namespacing workflows into prefixed topics. This is necessary to support multiple workflow entrypoints in a project, e.g. for a Services project with a Django service with workflows + a FastAPI service with workflows

Otherwise, both of these workflow services would race for messages on the same topic and would fail as they have different registries. 

e.g. 

```toml
[[tool.vercel.workflows]]
entrypoint = "flows_a:wf"

[[tool.vercel.workflows]]
entrypoint = "flows_b:wf"
```

Each of these workflows would need to be namespaced:
```python
# flows_a.py
wf = Workflows("a")
# topic prefix = __a_wkf_*

# flows_b.py
wf = Workflows("b")
# topic prefix = __b_wkf_*
```

This will also be necessary to support a project with both JS workflows + Python workflows.

**Note:** While the JS workflows sdk also supports namespacing, they support it via an environment variable. We could possibly consider doing this as well although the in-code definition is helpful in cases where a service can invoke a 2 separate workflows, e.g. FastAPI needs to be able to invoke both Workflow "a" and Workflow "b" and needs to know which topic to enqueue the message to