### PR TITLE
workflow: configurable sandbox cleanup handlers

### DIFF
--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -151,12 +151,21 @@ class BaseHook:
 
 
 class Workflows:
-    def __init__(self, *, namespace: str | None = None, as_vercel_job: bool = True):
+    def __init__(
+        self,
+        *,
+        as_vercel_job: bool = True,
+        namespace: str | None = None,
+        sandbox_policy: py_sandbox.SandboxPolicy | None = None,
+    ):
         validate_queue_namespace(namespace)
 
         self._namespace = namespace
         self._workflows: dict[str, Workflow] = {}
         self._steps: dict[str, Step] = {}
+        if sandbox_policy is None:
+            sandbox_policy = py_sandbox.SandboxPolicy()
+        self._sandbox_policy = sandbox_policy
         if as_vercel_job and not py_sandbox.in_sandbox():
             from . import runtime
 

--- a/src/vercel/_internal/workflow/py_sandbox.py
+++ b/src/vercel/_internal/workflow/py_sandbox.py
@@ -5,11 +5,13 @@ import contextvars
 import dataclasses
 import datetime as _dt
 import importlib
+import logging
 import os
 import random
 import sys
 import threading
 import types
+import typing
 import weakref
 from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
@@ -17,6 +19,9 @@ from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from importlib.util import spec_from_loader
 from typing import Any, NoReturn
+
+logger = logging.getLogger(__name__)
+
 
 # When True, proxy modules enforce restrictions.  When False (default),
 # attribute access on proxy modules falls through to the real module.
@@ -850,9 +855,80 @@ def _new_sandbox_table() -> dict[str, types.ModuleType]:
     return table
 
 
+@dataclasses.dataclass(frozen=True)
+class SandboxCleanupContext:
+    """Handed to each cleanup handler when a sandbox exits."""
+
+    run_modules: Mapping[str, types.ModuleType]
+    """Snapshot of the run's private module table at exit.
+
+    Values include host-shared (passthrough) modules, not just modules
+    imported freshly for the run.  Lets a handler evict host-cache
+    entries that reference the run's objects instead of clearing a
+    whole cache.
+    """
+
+
+CleanupHandler = Callable[[SandboxCleanupContext], None]
+
+
+def clear_typing_caches(context: SandboxCleanupContext) -> None:
+    """Clear ``typing``'s module-level lru_caches.
+
+    ``typing`` is passthrough, and subscriptions like ``List[X]`` are
+    memoized in its module-level lru_caches.  When workflow code (or
+    pydantic, processing annotations) subscripts a generic with a
+    sandbox-defined class, the cache pins that class — and through its
+    functions' ``__globals__``, the run's entire module graph — until LRU
+    eviction, accumulating up to ~128 dead runs.  ``typing._cleanups``
+    holds the ``cache_clear`` functions for those caches; it is private
+    but long-stable (CPython's own tests rely on it).
+    """
+    for cleanup in getattr(typing, "_cleanups", ()):
+        cleanup()
+
+
+def clear_pydantic_generics_cache(context: SandboxCleanupContext) -> None:
+    """Clear pydantic's generic-parametrization cache.
+
+    The cache is a ``WeakValueDictionary``, but its keys strongly
+    reference the parametrizing classes.  When the parametrized model is
+    reachable from those classes' module globals (the typical case:
+    ``Alias = Gen[Param]``), the key → class → ``__globals__`` → value
+    path keeps the value alive through the cache itself, so entries
+    never self-evict — unbounded growth per run.
+    """
+    generics = _real_sys_modules.get("pydantic._internal._generics")
+    if generics is not None:
+        cache = getattr(generics, "_GENERIC_TYPES_CACHE", None)
+        if cache is not None:
+            cache.clear()
+
+
+ALL_CLEANUPS: tuple[CleanupHandler, ...] = (
+    clear_typing_caches,
+    clear_pydantic_generics_cache,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class SandboxPolicy:
+    """Configuration for the workflow sandbox, passed to ``Workflows``.
+
+    ``cleanups`` are run on the host, in order, after every sandbox
+    teardown; they exist to purge host-shared caches that would
+    otherwise pin the run's module graph (see :data:`ALL_CLEANUPS`).
+    A handler that raises is logged and skipped, and never masks the
+    workflow's own exception.  Handlers must be thread-safe: other runs
+    may be executing concurrently.
+    """
+
+    cleanups: tuple[CleanupHandler, ...] = ()
+
+
 # TODO: we probably want to support some form of sandbox caching
 @contextmanager
-def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
+def workflow_sandbox(*, random_seed: str, policy: SandboxPolicy | None = None) -> Iterator[None]:
     """Activate the workflow sandbox for the current context.
 
     Gives this context its own private ``sys.modules`` table, marks it as
@@ -862,9 +938,12 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
     """
     if not isinstance(random_seed, str):
         raise TypeError("random_seed must be a str")
+    if policy is None:
+        policy = SandboxPolicy()
 
     _ensure_installed()
-    table_token = _sandbox_sys_modules.set(_new_sandbox_table())
+    table = _new_sandbox_table()
+    table_token = _sandbox_sys_modules.set(table)
     sandbox_token = _in_sandbox.set(True)
     random_token = _sandbox_random.set(random.Random(random_seed))
     try:
@@ -873,6 +952,12 @@ def workflow_sandbox(*, random_seed: str) -> Iterator[None]:
         _sandbox_random.reset(random_token)
         _in_sandbox.reset(sandbox_token)
         _sandbox_sys_modules.reset(table_token)
+        context = SandboxCleanupContext(run_modules=dict(table))
+        for handler in policy.cleanups:
+            try:
+                handler(context)
+            except Exception:
+                logger.exception("sandbox cleanup handler %r failed", handler)
 
 
 def in_sandbox() -> bool:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -223,7 +223,9 @@ class WorkflowOrchestratorContext:
             raise RuntimeError(f"Unsupported workflow input encoding for run {workflow_run.run_id}")
         args, kwargs = json.loads(workflow_run.input[0][len(b"json") :].decode())
 
-        with workflow_sandbox(random_seed=workflow_run.run_id):
+        with workflow_sandbox(
+            random_seed=workflow_run.run_id, policy=self.registry._sandbox_policy
+        ):
             mod = importlib.import_module(wf.module)
 
             # Resolve the sandboxed Workflow by qualname from the

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -1,6 +1,7 @@
 from vercel._internal.workflow.core import BaseHook, HookEvent, Workflows, sleep
 from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
 
+from . import sandbox
 from .errors import (
     EntityConflictError,
     HookNotFoundError,
@@ -25,4 +26,5 @@ __all__ = [
     "ThrottleError",
     "TooEarlyError",
     "WorkflowWorldError",
+    "sandbox",
 ]

--- a/src/vercel/workflow/sandbox.py
+++ b/src/vercel/workflow/sandbox.py
@@ -1,0 +1,32 @@
+"""Workflow-sandbox configuration and teardown cleanup handlers.
+
+Cleanup handlers run on the host after every sandbox teardown to purge
+host-shared caches that would otherwise pin the run's module graph.
+None run by default; compose a policy and pass it to ``Workflows``::
+
+    from vercel.workflow import Workflows, sandbox
+
+    workflows = Workflows(
+        sandbox_policy=sandbox.SandboxPolicy(
+            cleanups=(*sandbox.ALL_CLEANUPS, my_cleanup),
+        )
+    )
+"""
+
+from vercel._internal.workflow.py_sandbox import (
+    ALL_CLEANUPS,
+    CleanupHandler,
+    SandboxCleanupContext,
+    SandboxPolicy,
+    clear_pydantic_generics_cache,
+    clear_typing_caches,
+)
+
+__all__ = [
+    "ALL_CLEANUPS",
+    "CleanupHandler",
+    "SandboxPolicy",
+    "SandboxCleanupContext",
+    "clear_pydantic_generics_cache",
+    "clear_typing_caches",
+]

--- a/tests/unit/test_py_sandbox.py
+++ b/tests/unit/test_py_sandbox.py
@@ -16,6 +16,13 @@ import sys
 import pytest
 
 from vercel._internal.workflow.py_sandbox import SandboxRestrictionError, workflow_sandbox
+from vercel.workflow.sandbox import (
+    ALL_CLEANUPS,
+    SandboxCleanupContext,
+    SandboxPolicy,
+)
+
+CLEANUP_ALL = SandboxPolicy(cleanups=ALL_CLEANUPS)
 
 SEED = "test-seed-42"
 
@@ -925,6 +932,68 @@ class TestModuleIsolation:
         # Outside the sandbox the finder returns None, so a normal import works.
         assert importlib.import_module("string") is sys.modules["string"]
 
+    def test_sandbox_classes_not_pinned_by_host_typing_caches(self):
+        """Regression: ``typing`` is passthrough, so subscripting a generic
+        with a sandbox-defined class (``List[C]`` — done implicitly by
+        pydantic when processing annotations) inserts a strong reference to
+        the class into host typing's lru_caches.  That pinned each run's
+        entire module graph until LRU eviction (~128 dead runs).  The
+        ``clear_typing_caches`` handler clears those caches on exit."""
+        import gc
+        import weakref
+
+        def make_ref(seed: str) -> weakref.ref:
+            with workflow_sandbox(random_seed=seed, policy=CLEANUP_ALL):
+                ns: dict = {"__builtins__": sys.modules["builtins"]}
+                exec(  # noqa: S102
+                    "import typing\n"
+                    "import weakref\n"
+                    "class C:\n"
+                    "    pass\n"
+                    "alias = typing.List[C]\n"
+                    "ref = weakref.ref(C)\n",
+                    ns,
+                )
+                return ns["ref"]
+
+        refs = [make_ref(f"seed-{i}") for i in range(3)]
+        gc.collect()
+        assert [r() for r in refs] == [None, None, None]
+
+    def test_sandbox_classes_not_pinned_by_pydantic_generics_cache(self):
+        """Regression: pydantic's ``_GENERIC_TYPES_CACHE`` is a
+        WeakValueDictionary whose keys strongly reference the parametrizing
+        classes.  The module-global binding of the parametrized model closes
+        a strong path from key to value through the cache, so entries never
+        self-evict and every run leaks its classes (and, through their
+        ``__globals__``, its module graph).  The
+        ``clear_pydantic_generics_cache`` handler clears it on exit."""
+        import gc
+        import weakref
+
+        code = (
+            "import typing\n"
+            "import weakref\n"
+            "import pydantic\n"
+            "T = typing.TypeVar('T')\n"
+            "class Param(pydantic.BaseModel):\n"
+            "    pass\n"
+            "class Gen(pydantic.BaseModel, typing.Generic[T]):\n"
+            "    x: typing.Optional[T] = None\n"
+            "alias = Gen[Param]\n"
+            "ref = weakref.ref(Param)\n"
+        )
+
+        def make_ref(seed: str) -> weakref.ref:
+            with workflow_sandbox(random_seed=seed, policy=CLEANUP_ALL):
+                ns: dict = {"__builtins__": sys.modules["builtins"]}
+                exec(code, ns)  # noqa: S102
+                return ns["ref"]
+
+        refs = [make_ref(f"seed-{i}") for i in range(3)]
+        gc.collect()
+        assert [r() for r in refs] == [None, None, None]
+
     @pytest.mark.parametrize("end_barrier", [True, False])
     @pytest.mark.parametrize("start_barrier", [True, False])
     def test_concurrent_thread_sandboxes_have_independent_module_tables(
@@ -991,6 +1060,86 @@ class TestModuleIsolation:
         # each holding exactly the single registration (no duplicate).
         assert results["a"] is not results["b"]
         assert results["a"] == results["b"] == {"step//regpkg.mod.work": 1}
+
+
+# ═══════════════════════════════════════════════════════════════
+#  sandbox policy / teardown cleanups (vercel.workflow.sandbox)
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestSandboxPolicy:
+    def test_cleanup_handler_gets_run_module_snapshot(self):
+        """Handlers run once on teardown and see the run's module table."""
+        calls: list[SandboxCleanupContext] = []
+        policy = SandboxPolicy(cleanups=(calls.append,))
+
+        with workflow_sandbox(random_seed=SEED, policy=policy):
+            import shlex  # noqa: F401
+
+            assert not calls  # not during the run
+        (context,) = calls
+        assert "shlex" in context.run_modules
+
+    def test_cleanup_handlers_run_when_body_raises(self):
+        calls: list[SandboxCleanupContext] = []
+        policy = SandboxPolicy(cleanups=(calls.append,))
+
+        with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+            with workflow_sandbox(random_seed=SEED, policy=policy):
+                raise ValueError("boom")
+        assert len(calls) == 1
+
+    def test_raising_handler_is_isolated(self, caplog):
+        """A failing handler is logged; later handlers still run and the
+        sandbox exits cleanly."""
+
+        def bad(context: SandboxCleanupContext) -> None:
+            raise RuntimeError("handler broke")
+
+        calls: list[SandboxCleanupContext] = []
+        policy = SandboxPolicy(cleanups=(bad, calls.append))
+
+        with caplog.at_level("ERROR"):
+            with workflow_sandbox(random_seed=SEED, policy=policy):
+                pass
+        assert len(calls) == 1
+        assert any("cleanup handler" in r.message for r in caplog.records)
+
+    def test_no_cleanups_by_default(self):
+        """The default policy runs no handlers, so host typing caches pin
+        the run's classes — the pinning ``ALL_CLEANUPS`` opts out of."""
+        import gc
+        import weakref
+
+        from vercel._internal.workflow.py_sandbox import clear_typing_caches
+
+        with workflow_sandbox(random_seed=SEED):
+            ns: dict = {"__builtins__": sys.modules["builtins"]}
+            exec(  # noqa: S102
+                "import typing\nimport weakref\n"
+                "class C:\n    pass\n"
+                "alias = typing.List[C]\n"
+                "ref = weakref.ref(C)\n",
+                ns,
+            )
+            ref: weakref.ref = ns["ref"]
+        del ns
+        gc.collect()
+        try:
+            assert ref() is not None
+        finally:
+            # Don't leave the pinned run behind for other tests.
+            clear_typing_caches(SandboxCleanupContext(run_modules={}))
+        gc.collect()
+        assert ref() is None
+
+    def test_workflows_threads_policy_to_registry(self):
+        from vercel._internal.workflow import core
+
+        policy = SandboxPolicy(cleanups=())
+        registry = core.Workflows(as_vercel_job=False, sandbox_policy=policy)
+        assert registry._sandbox_policy is policy
+        assert core.Workflows(as_vercel_job=False)._sandbox_policy == SandboxPolicy()
 
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Support running user-specified cleanup handlers during sandbox exit
via a `SandboxPolicy` object passed like
Workflows(sandbox_policy=...).  Handlers run on the host after
teardown, in order, each receiving a SandboxCleanupContext with a
snapshot of the run's module table; a raising handler is logged and
skipped so it never masks the workflow's own exception.

There are no default handlers, but we provide opt-in handlers for
clearing `typing` and `pydantic` typing caches. I was reluctant
to do this by default because it's kind of hacky and invasive.

The *point* of all this is because the types in those caches hold
references to their modules globals dict and from there to all the
modules in the sandbox.

Another cleanup handler approach we could try in addition/instead
would be to clear all the module dicts from the sandboxed modules?
I'm nervous that might cause weird explosions though.
