### PR TITLE
workflow: always import passthrough modules in the host

### DIFF
--- a/src/vercel/_internal/workflow/py_sandbox.py
+++ b/src/vercel/_internal/workflow/py_sandbox.py
@@ -410,6 +410,7 @@ _PASSTHROUGHS: set[str] = {
     "decimal",
     "difflib",
     "dis",
+    "encodings",
     "enum",
     "errno",
     "fractions",
@@ -553,6 +554,21 @@ class _StubModule(types.ModuleType):
         return _restricted(f"{self.__name__}.{name}")
 
 
+def _host_import(fullname: str) -> types.ModuleType:
+    """Import *fullname* into the host module table and return it.
+
+    Temporarily leaves the sandbox context so the import runs with the real
+    ``sys.modules`` and the normal (unrestricted) finders.
+    """
+    table_token = _sandbox_sys_modules.set(None)
+    sandbox_token = _in_sandbox.set(False)
+    try:
+        return importlib.import_module(fullname)
+    finally:
+        _in_sandbox.reset(sandbox_token)
+        _sandbox_sys_modules.reset(table_token)
+
+
 class _SandboxFinder(MetaPathFinder):
     """A MetaPathFinder that controls module loading inside the sandbox.
 
@@ -560,8 +576,8 @@ class _SandboxFinder(MetaPathFinder):
 
     1. If ``X`` **has restrictions** — return a ``_ProxyModule`` that
        intercepts the restricted attributes.
-    2. If ``X`` **is already imported in the host and matches the
-       passthrough set** — return the host module as-is (shared).
+    2. If ``X`` **matches the passthrough set** — return the host module
+       as-is (importing it into the host first if needed).
     3. Otherwise — return ``None`` for a fresh re-import.
     """
 
@@ -627,11 +643,11 @@ class _SandboxFinder(MetaPathFinder):
                 origin=real_spec.origin,
                 is_package=real_spec.submodule_search_locations is not None,
             )
-        if fullname in self._host and self._is_passthrough(fullname):
-            # Unrestricted passthrough — serve from host as-is.
+        if self._is_passthrough(fullname):
+            # Unrestricted passthrough modules: always import from the host
             return spec_from_loader(
                 fullname,
-                _PreloadedLoader(self._host[fullname]),
+                _PreloadedLoader(_host_import(fullname)),
                 origin="sandbox",
             )
         return None

--- a/tests/unit/test_py_sandbox.py
+++ b/tests/unit/test_py_sandbox.py
@@ -894,6 +894,61 @@ class TestPassthroughModules:
         ns = _run_in_sandbox("from collections import Counter; result = dict(Counter('aabbc'))")
         assert ns["result"] == {"a": 2, "b": 2, "c": 1}
 
+    def test_encodings_passthrough_shares_host_codec_modules(self):
+        """Regression: the C codec machinery imports ``encodings.<codec>``
+        on first use of an encoding and pins the module — plus a freshly
+        re-registered ``search_function`` — in interpreter state that can
+        never be cleared.  With ``encodings`` sandboxed, every first-use
+        codec lookup inside a run leaked a private copy of the package
+        (``encodings.aliases`` and the codec module); passthrough reuses
+        the host's modules so nothing new is pinned."""
+        import encodings
+        import importlib
+
+        with workflow_sandbox(random_seed="enc"):
+            # Exercise the C lookup path
+            assert b"\x81".decode("cp1006")
+            mod = sys.modules["encodings.cp1006"]
+            seen = {
+                name: module
+                for name, module in sys.modules.items()
+                if name == "encodings" or name.startswith("encodings.")
+            }
+
+        assert seen["encodings"] is encodings
+        assert seen["encodings.cp1006"] is mod
+        for name, module in seen.items():
+            assert sys.modules[name] is module
+
+    def test_passthrough_submodule_not_loaded_in_host(self, tmp_path):
+        """A submodule of a passthrough package that the host has not
+        imported yet must be imported into the host and shared — a fresh
+        sandbox import would be grafted onto the shared parent package,
+        mutating the host."""
+        import importlib
+
+        from vercel._internal.workflow import py_sandbox
+
+        pkg = tmp_path / "pt_pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "sub.py").write_text("value = 7\n")
+        sys.path.insert(0, str(tmp_path))
+        py_sandbox._PASSTHROUGHS.add("pt_pkg")
+        try:
+            host_pkg = importlib.import_module("pt_pkg")
+            assert "pt_pkg.sub" not in sys.modules
+            with workflow_sandbox(random_seed=SEED):
+                sand_pkg = importlib.import_module("pt_pkg")
+                sub = importlib.import_module("pt_pkg.sub")
+                assert sand_pkg is host_pkg
+            assert sys.modules["pt_pkg.sub"] is sub
+            assert host_pkg.sub is sub
+        finally:
+            py_sandbox._PASSTHROUGHS.discard("pt_pkg")
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("pt_pkg", None)
+            sys.modules.pop("pt_pkg.sub", None)
 
 # ═══════════════════════════════════════════════════════════════
 #  SandboxPolicy.passthrough_modules


### PR DESCRIPTION
Currently we use the host module if it is already imported
and otherwise do a sandbox import. This can lead to importing
a host module repeatedly, which is not what we want.

Also add `encodings` to the passthrough list, because it leaks memory
when reimported (and relies on this fix since the leak is via
submodules).
