### PR TITLE
vercel-headers: Add helpers to run threads/callabacks with header context

### DIFF
--- a/src/vercel-headers/vercel/headers/__init__.py
+++ b/src/vercel-headers/vercel/headers/__init__.py
@@ -1,20 +1,33 @@
 from __future__ import annotations
 
+import sys
+import threading
 import urllib.parse
-from collections.abc import Mapping
-from contextvars import ContextVar
-from typing import Protocol, TypedDict
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import Context, ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from types import MappingProxyType
+from typing import Any, ParamSpec, Protocol, TypedDict, TypeVar
 
 __all__ = [
     "ip_address",
     "geolocation",
     "Geo",
+    "HeadersContext",
     "set_headers",
     "get_headers",
+    "get_headers_context",
+    "context_aware_thread",
+    "headers_from_asgi_scope",
+    "headers_from_wsgi_environ",
 ]
 
 
 _cv_headers: ContextVar[Mapping[str, str] | None] = ContextVar("vercel_headers", default=None)
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # Header constants (same as TS names)
 CITY_HEADER_NAME = "x-vercel-ip-city"
@@ -35,6 +48,89 @@ def set_headers(headers: Mapping[str, str] | None) -> None:
 
 def get_headers() -> Mapping[str, str] | None:
     return _cv_headers.get()
+
+
+@dataclass(frozen=True)
+class HeadersContext:
+    """Immutable snapshot of the current Vercel request headers."""
+
+    headers: Mapping[str, str] | None
+
+    @contextmanager
+    def use(self) -> Iterator[None]:
+        token = _cv_headers.set(self.headers)
+        try:
+            yield
+        finally:
+            _cv_headers.reset(token)
+
+    def run(self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+        with self.use():
+            return func(*args, **kwargs)
+
+
+def get_headers_context() -> HeadersContext:
+    headers = _cv_headers.get()
+    if headers is None:
+        return HeadersContext(None)
+    return HeadersContext(MappingProxyType(dict(headers)))
+
+
+if sys.version_info >= (3, 14):
+
+    def context_aware_thread(
+        group: None = None,
+        target: Callable[..., object] | None = None,
+        name: str | None = None,
+        args: Iterable[Any] = (),
+        kwargs: Mapping[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+        context: Context | None = None,
+    ) -> threading.Thread:
+        headers_context = get_headers_context()
+        if target is not None:
+            target = _wrap_thread_target(headers_context, target)
+        return threading.Thread(
+            group=group,
+            target=target,
+            name=name,
+            args=tuple(args),
+            kwargs=None if kwargs is None else dict(kwargs),
+            daemon=daemon,
+            context=context,
+        )
+
+else:
+
+    def context_aware_thread(
+        group: None = None,
+        target: Callable[..., object] | None = None,
+        name: str | None = None,
+        args: Iterable[Any] = (),
+        kwargs: Mapping[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+    ) -> threading.Thread:
+        headers_context = get_headers_context()
+        if target is not None:
+            target = _wrap_thread_target(headers_context, target)
+        return threading.Thread(
+            group=group,
+            target=target,
+            name=name,
+            args=tuple(args),
+            kwargs=None if kwargs is None else dict(kwargs),
+            daemon=daemon,
+        )
+
+
+def _wrap_thread_target(context: HeadersContext, target: Callable[P, R]) -> Callable[P, R]:
+    @wraps(target)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        return context.run(target, *args, **kwargs)
+
+    return wrapped
 
 
 class _HeadersLike(Protocol):
@@ -69,6 +165,28 @@ def _get_flag(country_code: str | None) -> str | None:
     if not country_code or len(country_code) != 2 or not country_code.isalpha():
         return None
     return "".join(chr(EMOJI_FLAG_UNICODE_STARTING_POSITION + ord(c)) for c in country_code.upper())
+
+
+def headers_from_asgi_scope(scope: Mapping[str, Any]) -> dict[str, str]:
+    """Return request headers decoded from an ASGI scope."""
+    return {
+        name.decode("latin-1"): value.decode("latin-1") for name, value in scope.get("headers", [])
+    }
+
+
+def headers_from_wsgi_environ(environ: Mapping[str, Any]) -> dict[str, str]:
+    """Return request headers decoded from a WSGI environ mapping."""
+    headers: dict[str, str] = {}
+    if "CONTENT_TYPE" in environ:
+        headers["Content-Type"] = str(environ["CONTENT_TYPE"])
+    if "CONTENT_LENGTH" in environ:
+        headers["Content-Length"] = str(environ["CONTENT_LENGTH"])
+    for name, value in environ.items():
+        if not name.startswith("HTTP_"):
+            continue
+        header_name = name[5:].replace("_", "-").title()
+        headers[header_name] = str(value)
+    return headers
 
 
 def ip_address(input: _RequestLike | _HeadersLike) -> str | None:

--- a/tests/unit/test_headers_context.py
+++ b/tests/unit/test_headers_context.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+
+import pytest
+
+from vercel.headers import (
+    HeadersContext,
+    context_aware_thread,
+    get_headers,
+    get_headers_context,
+    headers_from_asgi_scope,
+    headers_from_wsgi_environ,
+    set_headers,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_headers_context() -> Generator[None, None, None]:
+    set_headers(None)
+    try:
+        yield
+    finally:
+        set_headers(None)
+
+
+def test_headers_context_run_installs_and_restores_headers() -> None:
+    set_headers({"x-current": "outer"})
+    context = get_headers_context()
+    set_headers({"x-current": "inner"})
+
+    def read_headers() -> Mapping[str, str] | None:
+        return get_headers()
+
+    assert context.run(read_headers) == {"x-current": "outer"}
+    assert get_headers() == {"x-current": "inner"}
+
+
+def test_headers_context_use_installs_and_restores_headers() -> None:
+    set_headers({"x-current": "outer"})
+    context = get_headers_context()
+    set_headers({"x-current": "inner"})
+
+    with context.use():
+        assert get_headers() == {"x-current": "outer"}
+
+    assert get_headers() == {"x-current": "inner"}
+
+
+def test_headers_context_use_accepts_explicit_headers() -> None:
+    set_headers({"x-current": "outer"})
+
+    with HeadersContext({"x-current": "explicit"}).use():
+        assert get_headers() == {"x-current": "explicit"}
+
+    assert get_headers() == {"x-current": "outer"}
+
+
+def test_headers_context_restores_after_exception() -> None:
+    set_headers({"x-current": "outer"})
+    context = get_headers_context()
+    set_headers({"x-current": "inner"})
+
+    def fail() -> None:
+        assert get_headers() == {"x-current": "outer"}
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        context.run(fail)
+
+    assert get_headers() == {"x-current": "inner"}
+
+
+def test_headers_context_use_restores_after_exception() -> None:
+    set_headers({"x-current": "outer"})
+    context = get_headers_context()
+    set_headers({"x-current": "inner"})
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with context.use():
+            assert get_headers() == {"x-current": "outer"}
+            raise RuntimeError("boom")
+
+    assert get_headers() == {"x-current": "inner"}
+
+
+def test_headers_context_is_snapshot_isolated() -> None:
+    headers = {"x-current": "initial"}
+    set_headers(headers)
+    context = get_headers_context()
+
+    headers["x-current"] = "mutated"
+    set_headers({"x-current": "latest"})
+
+    assert context.run(get_headers) == {"x-current": "initial"}
+    with pytest.raises(TypeError):
+        context.headers["x-current"] = "changed"  # type: ignore[index]
+
+
+def test_context_aware_thread_runs_with_creation_headers() -> None:
+    seen: list[Mapping[str, str] | None] = []
+    set_headers({"x-current": "thread"})
+    thread = context_aware_thread(target=lambda: seen.append(get_headers()))
+    set_headers({"x-current": "main"})
+
+    thread.start()
+    thread.join(timeout=5)
+
+    assert seen == [{"x-current": "thread"}]
+    assert get_headers() == {"x-current": "main"}
+
+
+def test_headers_from_asgi_scope_decodes_latin1_headers() -> None:
+    scope = {
+        "headers": [
+            (b"x-test", b"ok"),
+            (b"x-city", "S\xe3o Paulo".encode("latin-1")),
+        ]
+    }
+
+    assert headers_from_asgi_scope(scope) == {
+        "x-test": "ok",
+        "x-city": "S\xe3o Paulo",
+    }
+
+
+def test_headers_from_asgi_scope_uses_last_duplicate_header() -> None:
+    assert headers_from_asgi_scope({"headers": [(b"x-test", b"first"), (b"x-test", b"last")]}) == {
+        "x-test": "last"
+    }
+
+
+def test_headers_from_wsgi_environ_extracts_http_headers() -> None:
+    assert headers_from_wsgi_environ(
+        {
+            "CONTENT_TYPE": "application/json",
+            "CONTENT_LENGTH": "12",
+            "HTTP_X_VERCEL_OIDC_TOKEN": "token",
+            "HTTP_CE_VQSMESSAGEID": "msg_1",
+            "REQUEST_METHOD": "POST",
+        }
+    ) == {
+        "Content-Type": "application/json",
+        "Content-Length": "12",
+        "X-Vercel-Oidc-Token": "token",
+        "Ce-Vqsmessageid": "msg_1",
+    }
+
+
+def test_headers_from_wsgi_environ_stringifies_values() -> None:
+    assert headers_from_wsgi_environ({"HTTP_X_COUNT": 3}) == {"X-Count": "3"}


### PR DESCRIPTION
Headers are stored in a ContextVar and so are not available to threads
that did not call set_headers explicitly.  Make it easier to spawn
threads with header context properly inherited (use
`context_aware_thread` instead of `threading.Thread`), as well as run
a code block with a header context snapshot:

    headerctx = get_headers_context()

    ...

    with headerctx.use():
        ...

or

    headerctx.run(cb)

Also, add helpers to extract headers from ASGI scopes or WSGI environs.
