### PR TITLE
vercel-queue: Fix auth context in threads and track subscriber group name status

### DIFF
--- a/src/vercel-queue/README.md
+++ b/src/vercel-queue/README.md
@@ -576,17 +576,17 @@ All error types:
 
 ### Identifier Formats
 
-| Identifier     | Input                | Stored queue name                    |
-| -------------- | -------------------- | ------------------------------------ |
-| Topic name     | `[A-Za-z0-9_-]+`     | Same as input                        |
-| Consumer group | Any non-empty string | `sanitize_name(..., fallback=...)`   |
-| Message ID     | Opaque string        | `0-1`, `3-7K9mNpQrS`                 |
-| Receipt handle | Opaque string        | Used for ack and lease calls         |
+| Identifier     | Input                | Stored queue name            |
+| -------------- | -------------------- | ---------------------------- |
+| Topic name     | `[A-Za-z0-9_-]+`     | Same as input                |
+| Consumer group | Any non-empty string | `sanitize_name(...)`         |
+| Message ID     | Opaque string        | `0-1`, `3-7K9mNpQrS`         |
+| Receipt handle | Opaque string        | Used for ack and lease calls |
 
-Use `sanitize_name` to convert arbitrary names to queue-safe names. Plain
-strings are reversibly escaped, including underscores. Use `SanitizedName` only
-when passing a queue-safe name that has already been sanitized and must not be
-escaped again.
+Use `sanitize_name` to convert arbitrary non-empty names to `SanitizedName`
+markers. Plain strings are reversibly escaped, including underscores. Use
+`SanitizedName` only when passing a queue-safe name that has already been
+sanitized and must not be escaped again.
 
 ## Wildcard Topics
 

--- a/src/vercel-queue/examples/binary_buffer/pyproject.toml
+++ b/src/vercel-queue/examples/binary_buffer/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.handle_image:app"

--- a/src/vercel-queue/examples/custom_transport/pyproject.toml
+++ b/src/vercel-queue/examples/custom_transport/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.record_invoice:app"

--- a/src/vercel-queue/examples/large_file_stream/pyproject.toml
+++ b/src/vercel-queue/examples/large_file_stream/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.archive_file:app"

--- a/src/vercel-queue/examples/retry_handling/pyproject.toml
+++ b/src/vercel-queue/examples/retry_handling/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.process_job:app"

--- a/src/vercel-queue/examples/text_stream/pyproject.toml
+++ b/src/vercel-queue/examples/text_stream/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.index_logs:app"

--- a/src/vercel-queue/examples/typed_pydantic/pyproject.toml
+++ b/src/vercel-queue/examples/typed_pydantic/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "elprans/vercel-queues", subdirectory = "src/vercel-queue" }
+vercel-queue = { git = "https://github.com/vercel/vercel-py.git", branch = "main", subdirectory = "src/vercel-queue" }
 
 [tool.vercel]
 entrypoint = "api.handle_order:app"

--- a/src/vercel-queue/pyproject.toml
+++ b/src/vercel-queue/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx[http2]>=0.27.0",
     "python-multipart>=0.0.20",
     "typing_extensions>=4.0.0",
+    "vercel-headers>=0.6.0",
     "vercel-oidc>=0.6.0",
 ]
 
@@ -25,6 +26,7 @@ trio = ["anyio[trio]>=4.0.0"]
 
 [tool.uv.sources]
 vercel-oidc = { workspace = true }
+vercel-headers = { workspace = true }
 
 [tool.hatch.version]
 path = "vercel/queue/version.py"

--- a/src/vercel-queue/tests/unit/helpers.py
+++ b/src/vercel-queue/tests/unit/helpers.py
@@ -19,6 +19,7 @@ from vercel.queue import (
     Message,
     MessageMetadata,
     QueueClient,
+    SanitizedName,
     Topic,
     subscribe,
 )
@@ -281,7 +282,7 @@ def make_metadata(
         delivery_count=1,
         created_at=CREATED_AT_DT,
         topic=topic,
-        consumer_group=consumer_group,
+        consumer_group=SanitizedName(consumer_group),
     )
 
 
@@ -291,6 +292,6 @@ def make_leased_metadata(topic: str, *, message_id: str = "m1") -> MessageMetada
         delivery_count=1,
         created_at=CREATED_AT_DT,
         topic=topic,
-        consumer_group="c",
+        consumer_group=SanitizedName("c"),
         receipt_handle="rh_1",
     )

--- a/src/vercel-queue/tests/unit/test_embedded_server.py
+++ b/src/vercel-queue/tests/unit/test_embedded_server.py
@@ -20,6 +20,7 @@ from vercel.queue import (
     MessageLockedError,
     ProtocolError,
     QueueClient,
+    SanitizedName,
     TextBufferTransport,
     Topic,
 )
@@ -518,7 +519,7 @@ async def test_async_lease_extension_redelivery_and_ack_failures(
         created_at=metadata.created_at,
         expires_at=metadata.expires_at,
         topic=metadata.topic,
-        consumer_group="wrong-test-group",
+        consumer_group=SanitizedName("wrong-test-group"),
         receipt_handle=metadata.receipt_handle,
         content_type=metadata.content_type,
     )

--- a/src/vercel-queue/tests/unit/test_queue_accept_handle.py
+++ b/src/vercel-queue/tests/unit/test_queue_accept_handle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Annotated, Any, cast
 
 import inspect
+import json
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import timedelta
@@ -10,6 +11,7 @@ from datetime import timedelta
 import pytest
 from pydantic import BaseModel
 
+from vercel.headers import get_headers, set_headers
 from vercel.queue import (
     ALL_DEPLOYMENTS,
     ByteBufferTransport,
@@ -71,6 +73,12 @@ class _AsyncRequestLike:
         raise AssertionError("get_body should not be called")
 
 
+def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    return [
+        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+    ]
+
+
 def test_accept_message_can_extend_lease(
     eqs: EmbeddedQueueDevServer,
 ) -> None:
@@ -86,7 +94,10 @@ def test_accept_message_can_extend_lease(
 
 def test_sync_message_lifecycle_ack_stops_renewal_without_wait(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
     acknowledged: list[str] = []
 
@@ -103,7 +114,10 @@ def test_sync_message_lifecycle_ack_stops_renewal_without_wait(
             raise AssertionError("ACK must not extend visibility")
 
     monkeypatch.setattr(LeaseRenewal, "stop", stop)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-ack"),
+    )
     lifecycle = _MessageLifecycle(
         message,
         client=cast("SyncQueueClient", Client()),
@@ -113,12 +127,22 @@ def test_sync_message_lifecycle_ack_stops_renewal_without_wait(
     assert lifecycle.__exit__(None, None, None) is None
 
     assert waits == [False]
-    assert acknowledged == ["m1"]
+    assert acknowledged == ["m-ack"]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.ack",
+        "message_id": "m-ack",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+    }
 
 
 def test_sync_message_lifecycle_retry_after_waits_for_renewal_stop(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
     extensions: list[int] = []
 
@@ -136,7 +160,10 @@ def test_sync_message_lifecycle_retry_after_waits_for_renewal_stop(
             extensions.append(duration)
 
     monkeypatch.setattr(LeaseRenewal, "stop", stop)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-retry"),
+    )
     lifecycle = _MessageLifecycle(
         message,
         client=cast("SyncQueueClient", Client()),
@@ -149,11 +176,22 @@ def test_sync_message_lifecycle_retry_after_waits_for_renewal_stop(
 
     assert waits == [True]
     assert extensions == [12]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.retry_after",
+        "message_id": "m-retry",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+        "retry_after_seconds": 12,
+    }
 
 
 def test_sync_message_lifecycle_handoff_waits_for_renewal_stop(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
 
     def stop(self: LeaseRenewal, *, wait: bool = True) -> None:
@@ -170,7 +208,10 @@ def test_sync_message_lifecycle_handoff_waits_for_renewal_stop(
             raise AssertionError("Handoff must not extend visibility")
 
     monkeypatch.setattr(LeaseRenewal, "stop", stop)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-handoff"),
+    )
     lifecycle = _MessageLifecycle(
         message,
         client=cast("SyncQueueClient", Client()),
@@ -181,12 +222,22 @@ def test_sync_message_lifecycle_handoff_waits_for_renewal_stop(
 
     assert lifecycle.__exit__(Handoff, handoff, None) is True
     assert waits == [True]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.handoff",
+        "message_id": "m-handoff",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+    }
 
 
 @pytest.mark.anyio
 async def test_async_message_lifecycle_ack_stops_renewal_without_wait(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
     acknowledged: list[str] = []
 
@@ -203,7 +254,10 @@ async def test_async_message_lifecycle_ack_stops_renewal_without_wait(
             raise AssertionError("ACK must not extend visibility")
 
     monkeypatch.setattr(LeaseRenewal, "stop_async", stop_async)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-async-ack"),
+    )
     lifecycle = _AsyncMessageLifecycle(
         message,
         client=cast("QueueClient", Client()),
@@ -213,13 +267,23 @@ async def test_async_message_lifecycle_ack_stops_renewal_without_wait(
     assert await lifecycle.__aexit__(None, None, None) is None
 
     assert waits == [False]
-    assert acknowledged == ["m1"]
+    assert acknowledged == ["m-async-ack"]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.ack",
+        "message_id": "m-async-ack",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+    }
 
 
 @pytest.mark.anyio
 async def test_async_message_lifecycle_retry_after_waits_for_renewal_stop(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
     extensions: list[int] = []
 
@@ -237,7 +301,10 @@ async def test_async_message_lifecycle_retry_after_waits_for_renewal_stop(
             extensions.append(duration)
 
     monkeypatch.setattr(LeaseRenewal, "stop_async", stop_async)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-async-retry"),
+    )
     lifecycle = _AsyncMessageLifecycle(
         message,
         client=cast("QueueClient", Client()),
@@ -249,12 +316,23 @@ async def test_async_message_lifecycle_retry_after_waits_for_renewal_stop(
 
     assert waits == [True]
     assert extensions == [12]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.retry_after",
+        "message_id": "m-async-retry",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+        "retry_after_seconds": 12,
+    }
 
 
 @pytest.mark.anyio
 async def test_async_message_lifecycle_handoff_waits_for_renewal_stop(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level("INFO", logger="vercel.queue")
     waits: list[bool] = []
 
     async def stop_async(self: LeaseRenewal, *, wait: bool = True) -> None:
@@ -271,7 +349,10 @@ async def test_async_message_lifecycle_handoff_waits_for_renewal_stop(
             raise AssertionError("Handoff must not extend visibility")
 
     monkeypatch.setattr(LeaseRenewal, "stop_async", stop_async)
-    message = Message(payload={"ok": True}, metadata=make_leased_metadata("emails"))
+    message = Message(
+        payload={"ok": True},
+        metadata=make_leased_metadata("emails", message_id="m-async-handoff"),
+    )
     lifecycle = _AsyncMessageLifecycle(
         message,
         client=cast("QueueClient", Client()),
@@ -281,6 +362,13 @@ async def test_async_message_lifecycle_handoff_waits_for_renewal_stop(
 
     assert await lifecycle.__aexit__(Handoff, handoff, None) is True
     assert waits == [True]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.handoff",
+        "message_id": "m-async-handoff",
+        "topic": "emails",
+        "consumer_group": "c",
+        "delivery_count": 1,
+    }
 
 
 def test_accept_message_can_acknowledge(
@@ -1439,6 +1527,57 @@ def test_accept_and_handle_subscriber_exception_leaves_unacked(
     assert not eqs.state.by_id[delivery.message_id].acknowledged
 
 
+def test_sync_accept_and_handle_installs_delivery_headers_context(
+    eqs: EmbeddedQueueDevServer,
+    isolated_subscriptions: None,
+) -> None:
+    seen_headers: list[dict[str, str]] = []
+    set_headers({"x-existing": "outer"})
+    delivery = sync_delivery(eqs, {"ok": True})
+
+    @callback_subscribe(topic="emails")
+    def handle(payload: object) -> None:
+        seen_headers.append(dict(get_headers() or {}))
+
+    assert isinstance(delivery.client, SyncQueueClient)
+    delivery.client.accept_and_handle(
+        delivery.body,
+        {
+            **delivery.headers,
+            "x-vercel-oidc-token": "push-token",
+        },
+    )
+
+    assert seen_headers[0]["x-vercel-oidc-token"] == "push-token"
+    assert get_headers() == {"x-existing": "outer"}
+
+
+@pytest.mark.anyio
+async def test_async_accept_and_handle_installs_delivery_headers_context(
+    eqs: EmbeddedQueueDevServer,
+    isolated_subscriptions: None,
+) -> None:
+    seen_headers: list[dict[str, str]] = []
+    set_headers({"x-existing": "outer"})
+    delivery = await async_delivery(eqs, {"ok": True})
+
+    @callback_subscribe(topic="emails")
+    async def handle(payload: object) -> None:
+        seen_headers.append(dict(get_headers() or {}))
+
+    assert isinstance(delivery.client, QueueClient)
+    await delivery.client.accept_and_handle(
+        delivery.body,
+        {
+            **delivery.headers,
+            "x-vercel-oidc-token": "push-token",
+        },
+    )
+
+    assert seen_headers[0]["x-vercel-oidc-token"] == "push-token"
+    assert get_headers() == {"x-existing": "outer"}
+
+
 def test_accept_and_handle_no_matching_subscriber_raises_clearly(
     eqs: EmbeddedQueueDevServer,
     isolated_subscriptions: None,
@@ -1452,7 +1591,7 @@ def test_accept_and_handle_no_matching_subscriber_raises_clearly(
     assert isinstance(delivery.client, SyncQueueClient)
     with pytest.raises(
         UnhandledMessageError,
-        match="No queue subscribers found for topic 'emails'",
+        match="No queue subscribers found for topic 'emails' and consumer group 'tests'",
     ):
         delivery.client.accept_and_handle(
             delivery.body,

--- a/src/vercel-queue/tests/unit/test_queue_asgi.py
+++ b/src/vercel-queue/tests/unit/test_queue_asgi.py
@@ -12,6 +12,7 @@ import pytest
 
 import vercel.queue._internal.devserver as queue_devserver_internal
 import vercel.queue.devserver as queue_devserver
+from vercel.headers import get_headers, set_headers
 from vercel.queue import ALL_DEPLOYMENTS, QueueClient, QueueClientAsgiApp, asgi_app, subscribe
 from vercel.queue._internal.asgi import AsgiMessage
 from vercel.queue._internal.constants import (
@@ -229,6 +230,38 @@ async def test_asgi_app_passes_request_body_as_async_stream() -> None:
 
     assert sent[0]["status"] == 204
     assert seen_chunks == [b'{"ok"', b": true}"]
+
+
+@pytest.mark.anyio
+async def test_asgi_app_installs_request_headers_for_delivery_context() -> None:
+    seen_headers: list[dict[str, str]] = []
+    set_headers({"x-existing": "outer"})
+
+    class Client(_FakeClient):
+        async def accept_and_handle(
+            self,
+            raw_body: AsyncIterable[bytes],
+            headers: dict[str, str],
+        ) -> None:
+            self.calls.append((raw_body, headers))
+            seen_headers.append(dict(get_headers() or {}))
+            async for _chunk in raw_body:
+                pass
+
+    client = Client()
+    app = QueueClientAsgiApp(cast("QueueClient", client))
+
+    sent = await _call_app(
+        app,
+        headers={
+            **callback_headers(),
+            "x-vercel-oidc-token": "push-token",
+        },
+    )
+
+    assert sent[0]["status"] == 204
+    assert seen_headers[0]["x-vercel-oidc-token"] == "push-token"
+    assert get_headers() == {"x-existing": "outer"}
 
 
 @pytest.mark.anyio

--- a/src/vercel-queue/tests/unit/test_queue_config.py
+++ b/src/vercel-queue/tests/unit/test_queue_config.py
@@ -197,11 +197,12 @@ def test_topic_rejects_invalid_name() -> None:
 def test_name_helpers_are_public() -> None:
     sanitized = queue.SanitizedName("test-group_1")
     assert str(sanitized) == "test-group_1"
-    assert queue.sanitize_name("team/email_high") == "team_Semail__high"
+    result = queue.sanitize_name("team/email_high")
+    assert isinstance(result, queue.SanitizedName)
+    assert result == "team_Semail__high"
+    assert isinstance(queue.sanitize_name("plain-queue_1"), queue.SanitizedName)
     assert queue.sanitize_name("plain-queue_1") == "plain-queue__1"
-    assert queue.sanitize_name(sanitized) == "test-group_1"
-    assert queue.sanitize_name("") == "queue"
-    assert queue.sanitize_name("", fallback="consumer_group") == "consumer_group"
+    assert queue.sanitize_name(sanitized) is sanitized
     assert queue.sanitize_name("emails.DQ") == "emails_DDQ"
     assert "SanitizedName" in queue.__all__
     assert "sanitize_name" in queue.__all__
@@ -214,6 +215,8 @@ def test_name_helpers_are_public() -> None:
     assert not hasattr(queue, "validate_consumer_group_name")
     assert not hasattr(queue, "sanitize_consumer_group_name")
 
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        queue.sanitize_name("")
     with pytest.raises(ValueError, match="name must be a non-empty string"):
         queue.SanitizedName("")
     with pytest.raises(ValueError, match="Invalid queue name"):

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -20,6 +20,7 @@ import pytest
 from anyio import to_thread
 from anyio.lowlevel import current_token
 
+from vercel.headers import get_headers, get_headers_context, set_headers
 from vercel.queue import (
     ALL_DEPLOYMENTS,
     Delivery,
@@ -29,6 +30,7 @@ from vercel.queue import (
     MessageMetadata,
     QueueClient,
     QueueError,
+    SanitizedName,
     ThrottledError,
 )
 from vercel.queue._internal.client import _AsyncMessageLifecycle
@@ -155,6 +157,39 @@ def test_sync_run_lease_renewal_extends_on_enter_and_stops_on_exit(
     assert eqs.state.by_id["msg_1"].lease_deadline_by_consumer["c"] == first_deadline
 
 
+@pytest.mark.anyio
+async def test_lease_extension_runs_with_captured_headers_context() -> None:
+    seen_headers: list[dict[str, str] | None] = []
+    message = Message(
+        payload=None,
+        metadata=replace(
+            make_leased_metadata("emails"),
+            visibility_deadline=datetime.now(timezone.utc) - timedelta(seconds=1),
+        ),
+    )
+    set_headers({"x-vercel-oidc-token": "delivery-token"})
+    headers_context = get_headers_context()
+    set_headers({"x-vercel-oidc-token": "worker-token"})
+
+    def record_extension_headers(_message: Message[Any], _duration: object) -> None:
+        headers = get_headers()
+        seen_headers.append(dict(headers) if headers is not None else None)
+
+    request = _LeaseExtensionRequest(
+        token=_LeaseRenewalToken(object()),
+        message=message,
+        client=_FakeLeaseClient(record_extension_headers),
+        lease_seconds=30,
+        next_extension_at=time.monotonic(),
+        headers_context=headers_context,
+    )
+
+    await _run_lease_extension(request, {request.token: request})
+
+    assert seen_headers == [{"x-vercel-oidc-token": "delivery-token"}]
+    assert get_headers() == {"x-vercel-oidc-token": "worker-token"}
+
+
 def test_lease_debug_logs_worker_start_extension_success_and_stop(
     eqs: EmbeddedQueueDevServer,
     monkeypatch: pytest.MonkeyPatch,
@@ -224,7 +259,7 @@ def test_sync_lease_renewal_noops_without_receipt_handle() -> None:
         delivery_count=1,
         created_at=CREATED_AT_DT,
         topic="emails",
-        consumer_group="c",
+        consumer_group=SanitizedName("c"),
     )
     with _sync_test_client().run_lease_renewal(Message(payload=None, metadata=metadata)):
         time.sleep(0.01)
@@ -370,7 +405,7 @@ async def test_async_lease_renewal_noops_without_receipt_handle() -> None:
         delivery_count=1,
         created_at=CREATED_AT_DT,
         topic="emails",
-        consumer_group="c",
+        consumer_group=SanitizedName("c"),
     )
     renewal = _async_test_client().run_lease_renewal(Message(payload=None, metadata=metadata))
     renewal.start()
@@ -1748,6 +1783,7 @@ def _lease_request(
         client=client,
         lease_seconds=lease_seconds,
         next_extension_at=time.monotonic(),
+        headers_context=get_headers_context(),
     )
 
 

--- a/src/vercel-queue/tests/unit/test_queue_polling.py
+++ b/src/vercel-queue/tests/unit/test_queue_polling.py
@@ -1053,7 +1053,7 @@ def test_acknowledge_normalizes_unexpected_transport_error(
         delivery_count=1,
         created_at=CREATED_AT_DT,
         topic="emails",
-        consumer_group="test-group",
+        consumer_group=SanitizedName("test-group"),
         receipt_handle="rh_1",
     )
 

--- a/src/vercel-queue/tests/unit/test_queue_push.py
+++ b/src/vercel-queue/tests/unit/test_queue_push.py
@@ -425,6 +425,7 @@ async def test_debug_logs_header_only_push_fetch(
 ) -> None:
     monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
     caplog.set_level(logging.INFO, logger="vercel.queue")
+    consumer_group = "api_Scelery__worker_Dpy"
     message_id = await eqs.client.send("emails", {"ok": True})
     assert message_id is not None
 
@@ -433,16 +434,18 @@ async def test_debug_logs_header_only_push_fetch(
         {
             CLOUD_EVENT_HEADER_TYPE: CLOUD_EVENT_TYPE_V2BETA,
             CLOUD_EVENT_HEADER_VQS_TOPIC: "emails",
-            CLOUD_EVENT_HEADER_VQS_CONSUMER_GROUP: "test-group",
+            CLOUD_EVENT_HEADER_VQS_CONSUMER_GROUP: consumer_group,
             CLOUD_EVENT_HEADER_VQS_MESSAGE_ID: message_id,
             CLOUD_EVENT_HEADER_VQS_REGION: "sfo1",
         },
     )
 
+    assert eqs.state.by_id[message_id].lease_deadline_by_consumer[consumer_group] is not None
+
     assert any(
         event["event"] == "push.header_only_fetch"
         and event["topic"] == "emails"
-        and event["consumer_group"] == "test-group"
+        and event["consumer_group"] == consumer_group
         for event in _queue_debug_events(caplog)
     )
 

--- a/src/vercel-queue/tests/unit/test_queue_subscriptions.py
+++ b/src/vercel-queue/tests/unit/test_queue_subscriptions.py
@@ -40,6 +40,7 @@ from vercel.queue import (
 )
 from vercel.queue._internal import subscribers as queue_subscribers
 from vercel.queue._internal.constants import DEFAULT_RETRY_AFTER_SECONDS
+from vercel.queue._internal.names import normalize_name
 from vercel.queue._internal.streams import (
     AsyncStreamPayload,
     SyncStreamPayload,
@@ -49,6 +50,7 @@ from vercel.queue._internal.subscribers import (
     call_subscribers,
     call_subscribers_sync,
     infer_subscriber_transport,
+    poll_targets_for_subscriber,
     register_embedded_dispatcher,
 )
 from vercel.queue.devserver import EmbeddedQueueDevServer
@@ -56,6 +58,7 @@ from vercel.queue.embedded import embedded_queue_service
 from vercel.queue.testing import clear_subscriptions
 
 from .helpers import (
+    CREATED_AT_DT,
     make_metadata,
     wait_until,
 )
@@ -383,6 +386,95 @@ async def test_call_subscribers_invokes_callable_captured_during_matching(
 
     assert calls == [{"ok": True}]
     assert subscriber_ref.calls == 1
+
+
+def test_call_subscribers_sync_debug_logs_handler_start(
+    isolated_subscriptions: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level(logging.INFO, logger="vercel.queue")
+    calls: list[object] = []
+    metadata = MessageMetadata(
+        message_id="msg-debug-sync",
+        delivery_count=3,
+        created_at=CREATED_AT_DT,
+        topic="emails",
+        consumer_group=SanitizedName("test-group"),
+        region="iad1",
+    )
+
+    @subscribe(topic="emails", consumer_group="test-group")
+    def handle(payload: object) -> None:
+        calls.append(payload)
+
+    call_subscribers_sync(Message(payload={"ok": True}, metadata=metadata))
+
+    assert calls == [{"ok": True}]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.handler_start",
+        "message_id": "msg-debug-sync",
+        "topic": "emails",
+        "consumer_group": "test-group",
+        "delivery_count": 3,
+        "region": "iad1",
+        "handler": f"{handle.__module__}.{handle.__qualname__}",
+    }
+
+
+@pytest.mark.anyio
+async def test_call_subscribers_debug_logs_handler_start(
+    isolated_subscriptions: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("VERCEL_QUEUE_DEBUG", "1")
+    caplog.set_level(logging.INFO, logger="vercel.queue")
+    calls: list[object] = []
+    metadata = MessageMetadata(
+        message_id="msg-debug-async",
+        delivery_count=2,
+        created_at=CREATED_AT_DT,
+        topic="emails",
+        consumer_group=SanitizedName("test-group"),
+    )
+
+    @subscribe(topic="emails", consumer_group="test-group")
+    async def handle(payload: object) -> None:
+        calls.append(payload)
+
+    await call_subscribers(Message(payload={"ok": True}, metadata=metadata))
+
+    assert calls == [{"ok": True}]
+    assert _queue_debug_events(caplog)[-1] == {
+        "event": "message.handler_start",
+        "message_id": "msg-debug-async",
+        "topic": "emails",
+        "consumer_group": "test-group",
+        "delivery_count": 2,
+        "handler": f"{handle.__module__}.{handle.__qualname__}",
+    }
+
+
+def test_poll_targets_preserve_sanitized_consumer_group(
+    isolated_subscriptions: None,
+) -> None:
+    @subscribe(topic="emails", consumer_group="team/email_high")
+    def handle(payload: object) -> None:
+        del payload
+
+    ((topic, consumer_group),) = poll_targets_for_subscriber(handle, None)
+    assert topic == "emails"
+    assert isinstance(consumer_group, SanitizedName)
+    assert consumer_group == "team_Semail__high"
+    # Polling feeds targets back through normalize_name; a SanitizedName
+    # must pass through unchanged instead of being escaped a second time.
+    assert normalize_name(consumer_group) is consumer_group
+
+    ((_, explicit_topic_group),) = poll_targets_for_subscriber(handle, ["emails"])
+    assert isinstance(explicit_topic_group, SanitizedName)
+    assert explicit_topic_group == "team_Semail__high"
 
 
 def test_call_subscribers_sync_raises_when_matching_refs_are_dead(

--- a/src/vercel-queue/vercel/queue/_internal/asgi.py
+++ b/src/vercel-queue/vercel/queue/_internal/asgi.py
@@ -5,6 +5,8 @@ from typing import Any, TypeAlias, TypedDict
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 
+from vercel.headers import HeadersContext, headers_from_asgi_scope
+
 from .client import QueueClient
 from .config import CURRENT_DEPLOYMENT, BaseUrl, DeploymentOption
 from .errors import ProtocolError
@@ -58,11 +60,13 @@ class QueueClientAsgiApp:
             await _send_status(send, 405)
             return
 
+        headers = headers_from_asgi_scope(scope)
         try:
-            await self.client.accept_and_handle(
-                _body_chunks(receive),
-                _headers_from_scope(scope),
-            )
+            with HeadersContext(headers).use():
+                await self.client.accept_and_handle(
+                    _body_chunks(receive),
+                    headers,
+                )
         except (ProtocolError, TypeError, ValueError) as exc:
             debug_log("asgi.bad_request", error=repr(exc))
             logger.warning("Vercel Queue push callback rejected: %s", exc)
@@ -123,13 +127,6 @@ async def _body_chunks(receive: AsgiReceive) -> AsyncIterator[bytes]:
             yield body
         if not message.get("more_body", False):
             return
-
-
-def _headers_from_scope(scope: AsgiScope) -> dict[str, str]:
-    headers: dict[str, str] = {}
-    for name, value in scope.get("headers", []):
-        headers[name.decode("latin-1")] = value.decode("latin-1")
-    return headers
 
 
 async def _send_status(send: AsgiSend, status: int) -> None:

--- a/src/vercel-queue/vercel/queue/_internal/client.py
+++ b/src/vercel-queue/vercel/queue/_internal/client.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from types import TracebackType
 from urllib.parse import quote
 
+from vercel.headers import HeadersContext
+
 from .config import (
     CURRENT_DEPLOYMENT,
     BaseUrl,
@@ -62,7 +64,7 @@ from .lease import (
     retry_sync_follow_up,
     visibility_timeout_seconds,
 )
-from .log import debug_log
+from .log import debug_log, debug_log_for_msg
 from .messages import (
     message_from_part_async,
     message_with_region,
@@ -288,19 +290,18 @@ class BaseQueueClient:
         resolved_topic = validate_topic_name(topic)
         consumer = normalize_name(
             consumer_group,
-            fallback="consumer_group",
             field="consumer_group",
         )
         transport = transport or cast("Transport[T]", receive_transport_for_topic(topic))
         async with self._runtime.stream_post(
-            self._url(resolved_topic, "consumer", consumer),
+            self._url(resolved_topic, "consumer", str(consumer)),
             headers=headers,
         ) as response:
             if response.status_code == 204:
                 debug_log(
                     "receive.empty",
                     topic=resolved_topic,
-                    consumer_group=consumer,
+                    consumer_group=str(consumer),
                     status_code=204,
                 )
                 return
@@ -310,7 +311,7 @@ class BaseQueueClient:
             async for part_headers, body in parse_multipart_messages(response):
                 message = await message_from_part_async(
                     resolved_topic,
-                    consumer,
+                    str(consumer),
                     transport,
                     part_headers,
                     body,
@@ -339,7 +340,6 @@ class BaseQueueClient:
         topic = validate_topic_name(topic)
         consumer = normalize_name(
             consumer_group,
-            fallback="consumer_group",
             field="consumer_group",
         )
         transport = transport or cast("Transport[T]", receive_transport_for_topic(topic))
@@ -357,7 +357,7 @@ class BaseQueueClient:
             try:
                 message = await self._poll_by_id_once(
                     topic,
-                    consumer,
+                    str(consumer),
                     current_message_id,
                     lease_duration=lease_duration,
                     transport=transport,
@@ -443,7 +443,7 @@ class BaseQueueClient:
         debug_log(
             "push.header_only_fetch",
             topic=metadata.topic,
-            consumer_group=metadata.consumer_group,
+            consumer_group=str(metadata.consumer_group),
         )
         message = await self._poll_by_id(
             Topic[T](metadata.topic),
@@ -497,7 +497,7 @@ class BaseQueueClient:
                 metadata,
                 metadata.topic,
                 "consumer",
-                metadata.consumer_group,
+                str(metadata.consumer_group),
                 "lease",
                 metadata.receipt_handle,
             ),
@@ -512,12 +512,14 @@ class BaseQueueClient:
         self,
         message: Message[Any],
         lease_duration: Duration | None = None,
+        headers_context: HeadersContext | None = None,
     ) -> LeaseRenewal:
         """Create a context manager that keeps a message lease alive."""
         return LeaseRenewal(
             message,
             client=self,
             lease_duration=lease_duration,
+            headers_context=headers_context,
         )
 
 
@@ -592,15 +594,22 @@ class Delivery(Generic[T]):
             finalize_payload_sync(self._message.payload)
 
         if isinstance(exc, Handoff):
+            debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
             self._renewal.extend(exc.timeout_seconds, self._client.extend_lease)
+            debug_log_for_msg(
+                "message.retry_after",
+                self._message,
+                retry_after_seconds=exc.timeout_seconds,
+            )
             return True
         if exc is None:
             retry_sync_follow_up(
                 lambda: self._client.acknowledge(self._message),
                 event_prefix="acknowledge",
             )
+            debug_log_for_msg("message.ack", self._message)
         return None
 
     async def __aenter__(self) -> Message[T]:
@@ -774,19 +783,22 @@ class QueueClient(BaseQueueClient):
         if transport is None:
             metadata = parse_push_delivery_metadata(headers)
             transport = infer_subscriber_transport(metadata)
-        message = await self._accept(
-            raw_body,
-            headers,
-            transport=transport,
-            lease_duration=processing_lease_duration,
-        )
-        lifecycle = _AsyncMessageLifecycle(
-            message,
-            client=self,
-            lease_duration=processing_lease_duration,
-        )
-        async with lifecycle:
-            await call_subscribers(message)
+        # Delivery headers carry the auth context for follow-up queue calls,
+        # including lease renewals running outside this call stack.
+        with HeadersContext(headers).use():
+            message = await self._accept(
+                raw_body,
+                headers,
+                transport=transport,
+                lease_duration=processing_lease_duration,
+            )
+            lifecycle = _AsyncMessageLifecycle(
+                message,
+                client=self,
+                lease_duration=processing_lease_duration,
+            )
+            async with lifecycle:
+                await call_subscribers(message)
 
     @overload
     def poll(
@@ -1002,11 +1014,17 @@ class _AsyncMessageLifecycle:
             await finalize_payload_async(self._message.payload)
 
         if isinstance(exc, Handoff):
+            debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
             await self._renewal.extend_async(
                 exc.timeout_seconds,
                 self._client.extend_lease,
+            )
+            debug_log_for_msg(
+                "message.retry_after",
+                self._message,
+                retry_after_seconds=exc.timeout_seconds,
             )
             return True
         if exc is None:
@@ -1014,6 +1032,7 @@ class _AsyncMessageLifecycle:
                 lambda: self._client.acknowledge(self._message),
                 event_prefix="acknowledge",
             )
+            debug_log_for_msg("message.ack", self._message)
         return None
 
 

--- a/src/vercel-queue/vercel/queue/_internal/client_sync.py
+++ b/src/vercel-queue/vercel/queue/_internal/client_sync.py
@@ -6,6 +6,8 @@ import concurrent.futures
 from collections.abc import Iterator, Mapping
 from types import TracebackType
 
+from vercel.headers import HeadersContext
+
 from .asynctools import iter_async_iterator, iter_coroutine
 from .client import BaseQueueClient, Delivery
 from .config import CURRENT_DEPLOYMENT, BaseUrl, DeploymentOption
@@ -22,6 +24,7 @@ from .lease import (
     processing_lease_seconds,
     retry_sync_follow_up,
 )
+from .log import debug_log_for_msg
 from .messages import sync_message_payload
 from .names import SanitizedName
 from .polling import run_poll_and_handle_sync, start_sync_polling_thread
@@ -176,23 +179,26 @@ class QueueClient(BaseQueueClient):
         if transport is None:
             metadata = parse_push_delivery_metadata(headers)
             transport = infer_subscriber_transport(metadata)
-        message = sync_message_payload(
-            iter_coroutine(
-                self._accept(
-                    raw_body,
-                    headers,
-                    transport=transport,
-                    lease_duration=processing_lease_duration,
+        # Delivery headers carry the auth context for follow-up queue calls,
+        # including lease renewals running outside this call stack.
+        with HeadersContext(headers).use():
+            message = sync_message_payload(
+                iter_coroutine(
+                    self._accept(
+                        raw_body,
+                        headers,
+                        transport=transport,
+                        lease_duration=processing_lease_duration,
+                    )
                 )
             )
-        )
-        lifecycle = _MessageLifecycle(
-            message,
-            client=self,
-            lease_duration=processing_lease_duration,
-        )
-        with lifecycle:
-            call_subscribers_sync(message)
+            lifecycle = _MessageLifecycle(
+                message,
+                client=self,
+                lease_duration=processing_lease_duration,
+            )
+            with lifecycle:
+                call_subscribers_sync(message)
 
     @overload
     def poll(
@@ -361,15 +367,22 @@ class _MessageLifecycle:
             finalize_payload_sync(self._message.payload)
 
         if isinstance(exc, Handoff):
+            debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
             self._renewal.extend(exc.timeout_seconds, self._client.extend_lease)
+            debug_log_for_msg(
+                "message.retry_after",
+                self._message,
+                retry_after_seconds=exc.timeout_seconds,
+            )
             return True
         if exc is None:
             retry_sync_follow_up(
                 lambda: self._client.acknowledge(self._message),
                 event_prefix="acknowledge",
             )
+            debug_log_for_msg("message.ack", self._message)
         return None
 
 

--- a/src/vercel-queue/vercel/queue/_internal/errors.py
+++ b/src/vercel-queue/vercel/queue/_internal/errors.py
@@ -190,9 +190,11 @@ class ReceiptHandleMismatchError(MessageLockedError):
 class UnhandledMessageError(QueueError, RuntimeError):
     status_code = 500
 
-    def __init__(self, topic: str | None) -> None:
+    def __init__(self, topic: str | None, consumer_group: str | None = None) -> None:
         self.topic = topic
-        super().__init__(f"No queue subscribers found for topic {topic!r}.")
+        self.consumer_group = consumer_group
+        suffix = f" and consumer group {consumer_group!r}" if consumer_group is not None else ""
+        super().__init__(f"No queue subscribers found for topic {topic!r}{suffix}.")
 
 
 class ThrottledError(QueueError, RuntimeError):

--- a/src/vercel-queue/vercel/queue/_internal/lease.py
+++ b/src/vercel-queue/vercel/queue/_internal/lease.py
@@ -47,6 +47,8 @@ from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskGroup
 from anyio.lowlevel import EventLoopToken, current_token
 from anyio.streams.memory import MemoryObjectSendStream
 
+from vercel.headers import HeadersContext, get_headers_context
+
 from .errors import QueueError, ThrottledError
 from .log import debug_log
 from .streams import (
@@ -111,6 +113,7 @@ class _LeaseExtensionRequest:
     client: LeaseAsyncClient
     lease_seconds: int
     next_extension_at: float
+    headers_context: HeadersContext
 
 
 @dataclass(kw_only=True)
@@ -217,10 +220,12 @@ class LeaseRenewal:
         message: Message[Any],
         client: LeaseAsyncClient,
         lease_duration: Duration | None = None,
+        headers_context: HeadersContext | None = None,
     ) -> None:
         self._message = message
         self._client = client
         self._lease_seconds = processing_lease_seconds(lease_duration)
+        self._headers_context = headers_context or get_headers_context()
         self._token: _LeaseRenewalToken | None = None
         self._entered = False
         self._closed = False
@@ -277,6 +282,7 @@ class LeaseRenewal:
             client=self._client,
             lease_seconds=self._lease_seconds,
             next_extension_at=_next_extension_at(self._message.metadata, self._lease_seconds),
+            headers_context=self._headers_context,
         )
 
     def _reset_start_after_failure(self) -> None:
@@ -846,7 +852,11 @@ async def _run_lease_extension(
         lease_seconds=request.lease_seconds,
     )
     try:
-        await request.client._renew_lease(request.message, request.lease_seconds)  # noqa: SLF001
+        with request.headers_context.use():
+            await request.client._renew_lease(  # noqa: SLF001
+                request.message,
+                request.lease_seconds,
+            )
     except QueueError as exc:
         if _is_client_error(exc):
             active.pop(request.token, None)

--- a/src/vercel-queue/vercel/queue/_internal/log.py
+++ b/src/vercel-queue/vercel/queue/_internal/log.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import json
 import logging
@@ -8,6 +8,9 @@ import os
 import re
 from collections.abc import Mapping
 from urllib.parse import unquote, urlsplit, urlunsplit
+
+if TYPE_CHECKING:
+    from .types import Message, MessageMetadata
 
 _LOGGER_NAME = "vercel.queue"
 _REDACTED = "<redacted>"
@@ -48,6 +51,33 @@ def debug_log(event: str, **fields: Any) -> None:
     logging.getLogger(_LOGGER_NAME).info(
         json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     )
+
+
+def _message_metadata(message: Message[Any] | MessageMetadata) -> MessageMetadata:
+    return cast("MessageMetadata", getattr(message, "metadata", message))
+
+
+def message_debug_fields(message: Message[Any] | MessageMetadata) -> dict[str, object]:
+    metadata = _message_metadata(message)
+    fields: dict[str, object] = {
+        "message_id": metadata.message_id,
+        "topic": metadata.topic,
+        "consumer_group": str(metadata.consumer_group),
+        "delivery_count": metadata.delivery_count,
+    }
+    if metadata.region is not None:
+        fields["region"] = metadata.region
+    return fields
+
+
+def debug_log_for_msg(
+    event: str,
+    message: Message[Any] | MessageMetadata,
+    **fields: Any,
+) -> None:
+    if not debug_enabled():
+        return
+    debug_log(event, **message_debug_fields(message), **fields)
 
 
 def safe_header_names(headers: Mapping[Any, object]) -> list[str]:

--- a/src/vercel-queue/vercel/queue/_internal/messages.py
+++ b/src/vercel-queue/vercel/queue/_internal/messages.py
@@ -16,6 +16,7 @@ from .constants import (
 )
 from .errors import MessageCorruptedError
 from .http import headers_from_raw
+from .names import SanitizedName
 from .streams import AsyncStreamPayload, AsyncTextStreamPayload
 from .types import (
     Message,
@@ -28,9 +29,15 @@ from .types import (
 T = TypeVar("T")
 
 
+def _ensure_sanitized_name(value: str | SanitizedName) -> SanitizedName:
+    if isinstance(value, SanitizedName):
+        return value
+    return SanitizedName(value)
+
+
 async def message_from_part_async(
     topic: str,
-    consumer_group: str,
+    consumer_group: str | SanitizedName,
     transport: Transport[T],
     headers: RawHeaders,
     payload: AsyncIterator[bytes],
@@ -48,7 +55,7 @@ async def message_from_part_async(
 
 def _message_metadata_from_part(
     topic: str,
-    consumer_group: str,
+    consumer_group: str | SanitizedName,
     headers: RawHeaders,
 ) -> MessageMetadata:
     headers = headers_from_raw(headers)
@@ -75,7 +82,7 @@ def _message_metadata_from_part(
             VQS_HEADER_EXPIRES_AT,
         ),
         topic=topic,
-        consumer_group=consumer_group,
+        consumer_group=_ensure_sanitized_name(consumer_group),
         receipt_handle=ReceiptHandle(receipt_handle),
         content_type=headers.get(HEADER_CONTENT_TYPE, ""),
     )

--- a/src/vercel-queue/vercel/queue/_internal/names.py
+++ b/src/vercel-queue/vercel/queue/_internal/names.py
@@ -25,7 +25,7 @@ def _is_valid_vqs_name(name: str) -> bool:
 
 # Keep this in sync with @vercel/build-utils:lambda.ts/sanitizeConsumerName
 # https://raw.githubusercontent.com/vercel/vercel/refs/heads/main/packages/build-utils/src/lambda.ts
-def _sanitize_name(name: str, *, fallback: str) -> str:
+def _sanitize_name(name: str) -> str:
     result = ""
     for char in name:
         if char == "_":
@@ -38,19 +38,21 @@ def _sanitize_name(name: str, *, fallback: str) -> str:
             result += char
         else:
             result += f"_{ord(char):02X}"
-    return result or fallback
+    if not result:
+        raise ValueError("name must be a non-empty string")
+    return result
 
 
-def sanitize_name(name: str | SanitizedName, *, fallback: str = "queue") -> str:
-    """Return a valid VQS queue name for arbitrary input.
+def sanitize_name(name: str | SanitizedName) -> SanitizedName:
+    """Return a VQS-safe name marker for arbitrary input.
 
     Plain strings are reversibly encoded, including underscores. Use
     ``SanitizedName`` for values that are already VQS-safe and must not be
     encoded again.
     """
     if isinstance(name, SanitizedName):
-        return str(name)
-    return _sanitize_name(name, fallback=fallback)
+        return name
+    return SanitizedName(_sanitize_name(name))
 
 
 def validate_name(name: object, *, field: str = "name") -> str:
@@ -80,14 +82,13 @@ def validate_subscription_pattern(topic: str) -> str:
 def normalize_name(
     name: str | SanitizedName,
     *,
-    fallback: str = "queue",
     field: str = "name",
-) -> str:
+) -> SanitizedName:
     if isinstance(name, SanitizedName):
-        return str(name)
+        return name
     if not name:
         raise ValueError(f"{field} must be a non-empty string")
-    return sanitize_name(name, fallback=fallback)
+    return sanitize_name(name)
 
 
 # Only add public symbols to __all__; internal helpers must stay unexported.

--- a/src/vercel-queue/vercel/queue/_internal/polling.py
+++ b/src/vercel-queue/vercel/queue/_internal/polling.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Iterator
 import anyio
 
 from .errors import InvalidLimitError
+from .names import SanitizedName
 from .subscribers import call_subscriber, call_subscriber_sync, poll_targets_for_subscriber
 from .types import Duration, StrContainer, duration_to_float_seconds
 
@@ -35,7 +36,7 @@ async def _poll_topic_batch_async(
     poll: Callable[..., Any],
     subscriber: Callable[..., Any],
     topic: str,
-    consumer_group: str,
+    consumer_group: SanitizedName,
     request_limit: int,
     lease_duration: Duration | None,
 ) -> int:
@@ -57,7 +58,7 @@ def _poll_topic_batch_sync(
     poll: Callable[..., Iterator[Any]],
     subscriber: Callable[..., Any],
     topic: str,
-    consumer_group: str,
+    consumer_group: SanitizedName,
     request_limit: int,
     lease_duration: Duration | None,
     stop: threading.Event,

--- a/src/vercel-queue/vercel/queue/_internal/push.py
+++ b/src/vercel-queue/vercel/queue/_internal/push.py
@@ -38,6 +38,7 @@ from .http import (
 )
 from .log import debug_log
 from .messages import parse_optional_datetime, parse_required_datetime
+from .names import SanitizedName
 from .types import (
     Headers,
     Message,
@@ -132,7 +133,7 @@ def _parse_push_delivery_metadata(headers: Headers) -> MessageMetadata:
             delivery_count=1,
             created_at=datetime.now(timezone.utc),
             topic=topic,
-            consumer_group=consumer_group,
+            consumer_group=SanitizedName(consumer_group),
             receipt_handle=None,
             content_type=headers.get(HEADER_CONTENT_TYPE),
             region=region,
@@ -157,7 +158,7 @@ def _parse_push_delivery_metadata(headers: Headers) -> MessageMetadata:
             CLOUD_EVENT_HEADER_VQS_EXPIRES_AT,
         ),
         topic=topic,
-        consumer_group=consumer_group,
+        consumer_group=SanitizedName(consumer_group),
         receipt_handle=ReceiptHandle(receipt_handle),
         content_type=content_type,
         region=region,
@@ -175,7 +176,7 @@ def _debug_metadata(metadata: MessageMetadata) -> dict[str, object]:
         "created_at": metadata.created_at,
         "expires_at": metadata.expires_at,
         "topic": metadata.topic,
-        "consumer_group": metadata.consumer_group,
+        "consumer_group": str(metadata.consumer_group),
         "receipt_handle": metadata.receipt_handle,
         "content_type": metadata.content_type,
         "region": metadata.region,

--- a/src/vercel-queue/vercel/queue/_internal/subscribers.py
+++ b/src/vercel-queue/vercel/queue/_internal/subscribers.py
@@ -18,6 +18,7 @@ from .errors import (
     SubscriptionError,
     UnhandledMessageError,
 )
+from .log import debug_enabled, debug_log_for_msg
 from .names import (
     SanitizedName,
     normalize_name,
@@ -122,7 +123,7 @@ class InvocationPlan:
 class _Subscription:
     func_ref: _SubscriberRef
     order: int
-    consumer_group: str
+    consumer_group: SanitizedName
     invocation: InvocationPlan
     topic: str
     retry_after_seconds: int | None = None
@@ -174,12 +175,13 @@ def _build_registry_snapshot(
     exact: dict[tuple[str, str], list[_Subscription]] = {}
     prefix: dict[str, list[_Subscription]] = {}
     for sub in live_subscriptions:
+        consumer_group = str(sub.consumer_group)
         if sub.topic == "*":
-            wildcard.setdefault(sub.consumer_group, []).append(sub)
+            wildcard.setdefault(consumer_group, []).append(sub)
         elif sub.topic.endswith("*"):
-            prefix.setdefault(sub.consumer_group, []).append(sub)
+            prefix.setdefault(consumer_group, []).append(sub)
         else:
-            exact.setdefault((sub.consumer_group, sub.topic), []).append(sub)
+            exact.setdefault((consumer_group, sub.topic), []).append(sub)
 
     return _RegistrySnapshot(
         subscriptions=live_subscriptions,
@@ -222,7 +224,7 @@ def register_embedded_dispatcher(dispatcher: EmbeddedDispatcher) -> None:
     for subscription in subscriptions:
         dispatcher.register_subscription(
             topic=subscription.topic,
-            consumer_group=subscription.consumer_group,
+            consumer_group=str(subscription.consumer_group),
             retry_after_seconds=subscription.retry_after_seconds,
             initial_delay_seconds=subscription.initial_delay_seconds,
             max_concurrency=subscription.max_concurrency,
@@ -268,7 +270,7 @@ def _notify_embedded_dispatchers(subscription: _Subscription) -> None:
     for dispatcher in dispatchers:
         dispatcher.register_subscription(
             topic=subscription.topic,
-            consumer_group=subscription.consumer_group,
+            consumer_group=str(subscription.consumer_group),
             retry_after_seconds=subscription.retry_after_seconds,
             initial_delay_seconds=subscription.initial_delay_seconds,
             max_concurrency=subscription.max_concurrency,
@@ -457,9 +459,21 @@ def _call_subscription(
     invocation = matched.subscription.invocation
 
     payload = invocation.prepare_payload(message)
+    if debug_enabled():
+        debug_log_for_msg(
+            "message.handler_start",
+            metadata,
+            handler=_handler_name(matched.func),
+        )
     if invocation.mode == "message":
         return matched.func(Message(payload=payload, metadata=metadata))
     return matched.func(payload)
+
+
+def _handler_name(func: _Subscriber) -> str:
+    module = getattr(func, "__module__", type(func).__module__)
+    qualname = getattr(func, "__qualname__", type(func).__qualname__)
+    return f"{module}.{qualname}"
 
 
 def _log_handler_exception(exc: BaseException, metadata: MessageMetadata) -> None:
@@ -536,7 +550,7 @@ def reject_async_subscriber_for_sync(subscriber: _Subscriber) -> None:
 def poll_targets_for_subscriber(
     subscriber: _Subscriber,
     topics: StrContainer | None,
-) -> tuple[tuple[str, str], ...]:
+) -> tuple[tuple[str, SanitizedName], ...]:
     matched = _subscription_for_func(subscriber)
     subscription = matched.subscription
     if topics is None:
@@ -549,7 +563,7 @@ def poll_targets_for_subscriber(
     if isinstance(topics, str):
         raise TypeError("topics must be an iterable of topic strings, not a string")
 
-    targets: list[tuple[str, str]] = []
+    targets: list[tuple[str, SanitizedName]] = []
     seen: set[str] = set()
     for topic in topics:
         if not isinstance(topic, str):
@@ -593,12 +607,12 @@ async def _maybe_await_result(result: Any) -> Any:
     return result
 
 
-def _default_consumer_group(func: _Subscriber) -> str:
+def _default_consumer_group(func: _Subscriber) -> SanitizedName:
     module = getattr(func, "__module__", None)
     qualname = getattr(func, "__qualname__", getattr(func, "__name__", "subscriber"))
     if module:
-        return sanitize_name(f"{module}.{qualname}", fallback="consumer_group")
-    return sanitize_name(str(qualname), fallback="consumer_group")
+        return sanitize_name(f"{module}.{qualname}")
+    return sanitize_name(str(qualname))
 
 
 def _fully_qualified_handler_name(func: _Subscriber) -> str:
@@ -701,7 +715,6 @@ def _register_subscription(
         if consumer_group is None
         else normalize_name(
             consumer_group,
-            fallback="consumer_group",
             field="consumer_group",
         )
     )
@@ -909,7 +922,7 @@ def get_subscriptions() -> tuple[Subscription, ...]:
                 Subscription(
                     func=func,
                     topic=sub.topic,
-                    consumer_group=sub.consumer_group,
+                    consumer_group=str(sub.consumer_group),
                     retry_after_seconds=sub.retry_after_seconds,
                     initial_delay_seconds=sub.initial_delay_seconds,
                     max_concurrency=sub.max_concurrency,
@@ -919,8 +932,11 @@ def get_subscriptions() -> tuple[Subscription, ...]:
     return tuple(subscriptions)
 
 
-def _no_matching_subscriptions_error(topic: str | None) -> UnhandledMessageError:
-    return UnhandledMessageError(topic)
+def _no_matching_subscriptions_error(
+    topic: str | None,
+    consumer_group: str | None = None,
+) -> UnhandledMessageError:
+    return UnhandledMessageError(topic, consumer_group)
 
 
 def _matching_prefix_subscriptions(
@@ -963,7 +979,7 @@ def _matching_subscriptions(
     metadata: MessageMetadata,
 ) -> tuple[_MatchedSubscription, ...]:
     snapshot = _registry_snapshot
-    consumer_group = metadata.consumer_group
+    consumer_group = str(metadata.consumer_group)
     topic = metadata.topic
     matching = _live_candidates(
         _merge_candidates_in_order(
@@ -977,7 +993,7 @@ def _matching_subscriptions(
         )
     )
     if not matching:
-        raise _no_matching_subscriptions_error(metadata.topic)
+        raise _no_matching_subscriptions_error(metadata.topic, str(metadata.consumer_group))
     return matching
 
 

--- a/src/vercel-queue/vercel/queue/_internal/types.py
+++ b/src/vercel-queue/vercel/queue/_internal/types.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from .constants import DEFAULT_RETRY_AFTER_SECONDS
-from .names import SanitizedName, validate_topic_name
+from .names import SanitizedName, validate_name, validate_topic_name
 
 T = TypeVar("T")
 _TYPE_VAR_TYPE = type(T)
@@ -155,7 +155,7 @@ class MessageMetadata:
     topic: str
     """Topic name the message belongs to."""
 
-    consumer_group: str
+    consumer_group: SanitizedName
     """Consumer group that owns this delivery."""
 
     receipt_handle: ReceiptHandle | None = None
@@ -172,6 +172,13 @@ class MessageMetadata:
 
     visibility_deadline: datetime | None = None
     """Current processing deadline, when supplied by the service."""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "consumer_group",
+            SanitizedName(validate_name(self.consumer_group, field="consumer_group")),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1908,6 +1908,7 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "python-multipart" },
     { name = "typing-extensions" },
+    { name = "vercel-headers" },
     { name = "vercel-oidc" },
 ]
 
@@ -1931,6 +1932,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", marker = "extra == 'devserver'" },
+    { name = "vercel-headers", editable = "src/vercel-headers" },
     { name = "vercel-oidc", editable = "src/vercel-oidc" },
 ]
 provides-extras = ["devserver", "trio", "typed"]


### PR DESCRIPTION
Use `vercel.headers` helpers to keep track of current request context
so that the background lease extension thread has access to the correct
OIDC token.

Make `sanitize_name` return `SanitizedName` and not `str`, this way we
keep a type-level guardrail against accidentally double-encoding
consumer group names.

Add more logging around message lifecycle.
