### PR TITLE
workflow: functions for getting current deterministic time

### DIFF
--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -74,6 +74,28 @@ async def sleep(param: int | float | datetime.datetime | str) -> None:
     await ctx.run_wait(param)
 
 
+def now() -> datetime.datetime:
+    from . import runtime
+
+    try:
+        ctx = runtime.WorkflowOrchestratorContext.current()
+    except LookupError:
+        raise RuntimeError("cannot call now() outside workflow") from None
+
+    return ctx.now()
+
+
+def time_ns() -> int:
+    from . import runtime
+
+    try:
+        ctx = runtime.WorkflowOrchestratorContext.current()
+    except LookupError:
+        raise RuntimeError("cannot call time_ns() outside workflow") from None
+
+    return ctx.time_ns()
+
+
 class HookEvent(Generic[T]):
     def __init__(self, *, correlation_id: str, token: str) -> None:
         self._correlation_id = correlation_id

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -27,6 +27,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 SUSPENDED_MESSAGE = "<WORKFLOW SUSPENDED>"
 logger = logging.getLogger("vercel.workflow")
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
 # Wait-continuation dispatch — mirrors @workflow/core's wait-continuation.ts.
 # The delayed re-enqueue that wakes a run when a pending wait elapses is keyed on
@@ -260,6 +261,17 @@ class WorkflowOrchestratorContext:
         )
         self.suspensions[wait.correlation_id] = wait
         await wait.future
+
+    def now(self) -> datetime:
+        if not self.events:
+            raise RuntimeError("now() requires at least one event in the run's event log")
+        event = self.events[max(self.replay_index - 1, 0)]
+        assert event.server_props is not None
+        return event.server_props.created_at
+
+    def time_ns(self) -> int:
+        delta = self.now() - _EPOCH
+        return (delta.days * 86_400 + delta.seconds) * 1_000_000_000 + delta.microseconds * 1_000
 
     def create_hook(self, token: str | None, hook_cls: type[T]) -> core.HookEvent[T]:
         hook = Hook(

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -1,4 +1,4 @@
-from vercel._internal.workflow.core import BaseHook, HookEvent, Workflows, sleep
+from vercel._internal.workflow.core import BaseHook, HookEvent, Workflows, now, sleep, time_ns
 from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
 
 from . import sandbox
@@ -14,8 +14,10 @@ from .sandbox import SandboxPolicy
 
 __all__ = [
     "Workflows",
+    "now",
     "sleep",
     "start",
+    "time_ns",
     "Run",
     "BaseHook",
     "HookEvent",

--- a/tests/unit/test_workflow_determinism.py
+++ b/tests/unit/test_workflow_determinism.py
@@ -10,6 +10,8 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
 from vercel._internal.workflow import core, runtime, world as w
 
 
@@ -212,3 +214,76 @@ async def test_resume_parks_and_cancels_heartbeat_when_nothing_to_deliver() -> N
     assert ctx._suspended
     assert ctx._fut is not None and ctx._fut.cancelled()
     assert ctx.resume_handle.cancelled()  # heartbeat stopped
+
+
+# --- now(): deterministic clock anchored to replay progress, not list tail ------
+
+
+def _stamp(event: w.Event, ts: datetime, *, event_id: str) -> w.Event:
+    return event.model_copy(
+        update={"server_props": w.ServerProps(runId="wrun_test", eventId=event_id, createdAt=ts)}
+    )
+
+
+async def test_now_uses_first_event_before_any_replay() -> None:
+    """Before any suspension has been created/consumed, now() must fall back to
+    the first event in the log, not the last. The log already contains
+    everything from prior invocations, so `events[-1]` would leak a later
+    invocation's timestamp into a call site reached before any of it happened.
+    """
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        _stamp(_created(step, "step_1"), t0, event_id="evt_1"),
+        _stamp(_created(step, "step_2"), t1, event_id="evt_2"),
+    ]
+    ctx = _context(events)
+
+    assert ctx.now() == t0
+
+
+async def test_now_advances_with_replay_index() -> None:
+    """Once resume() has delivered a completion, now() reflects that event's
+    timestamp, not a later, not-yet-consumed event further down the log."""
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    t2 = datetime(2026, 1, 3, tzinfo=timezone.utc)
+    step = core.Step(_greet)
+    events: list[w.Event] = [
+        _stamp(_created(step, "step_1"), t0, event_id="evt_1"),
+        _stamp(_completed("step_1", b'"one"'), t1, event_id="evt_2"),
+        _stamp(_created(step, "step_2"), t2, event_id="evt_3"),
+    ]
+    ctx = _context(events)
+    sus1 = _suspension("step_1", _ARGS)
+    ctx.suspensions["step_1"] = sus1
+
+    ctx.resume()
+
+    assert sus1.future.done() and sus1.future.result() == "one"
+    assert ctx.now() == t1
+
+
+async def test_ctx_now_raises_when_events_empty() -> None:
+    ctx = _context([])
+    with pytest.raises(RuntimeError):
+        ctx.now()
+
+
+async def test_core_now_raises_outside_workflow() -> None:
+    with pytest.raises(RuntimeError):
+        core.now()
+
+
+async def test_time_ns_matches_now_as_nanoseconds() -> None:
+    t0 = datetime(2026, 1, 1, 12, 30, 45, 123456, tzinfo=timezone.utc)
+    events: list[w.Event] = [_stamp(_created(core.Step(_greet), "step_1"), t0, event_id="evt_1")]
+    ctx = _context(events)
+
+    assert ctx.time_ns() == int(t0.timestamp()) * 1_000_000_000 + t0.microsecond * 1_000
+
+
+async def test_core_time_ns_raises_outside_workflow() -> None:
+    with pytest.raises(RuntimeError):
+        core.time_ns()


### PR DESCRIPTION
The time necessarily is an approximation, but we use the timestamp
based on the timestamp of the last event as of where in the trace the
time function is called.

I made this a new function instead of overriding stdlib functions
because I think that approach is more explicit and plays better with
the sandboxing system here, which has passthrough modules.
I'm going to have another PR to make random behave the same way.
