### PR TITLE
Fix background-thread queue auth and error recovery

### DIFF
--- a/integrations/vercel-celery/tests/unit/test_celery_broker.py
+++ b/integrations/vercel-celery/tests/unit/test_celery_broker.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 import sys
+import threading
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -27,13 +28,16 @@ import vercel.integrations.celery as public_vqs_celery
 import vercel.integrations.celery._broker as vqs_celery
 from vercel.headers import get_headers, set_headers
 from vercel.queue import (
+    CommunicationError as QueueCommunicationError,
     Duration,
     Handoff,
     Message,
     MessageMetadata,
     RetryAfter,
     SanitizedName,
+    TokenResolutionError,
     Topic,
+    UnauthorizedError,
 )
 from vercel.queue._internal import subscribers as queue_subscribers
 
@@ -125,9 +129,11 @@ class FakeSyncQueueClient:
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
         self.sent: list[dict[str, Any]] = []
+        self.send_headers: list[dict[str, str] | None] = []
         self.message_batches: list[list[FakeMessage]] = []
         self.acknowledged: list[MessageMetadata] = []
         self.ack_headers: list[dict[str, str] | None] = []
+        self.poll_headers: list[dict[str, str] | None] = []
         self.visibility_changes: list[tuple[MessageMetadata, Duration]] = []
         self.visibility_headers: list[dict[str, str] | None] = []
         self.lease_renewals: list[FakeLeaseRenewal] = []
@@ -138,6 +144,8 @@ class FakeSyncQueueClient:
         FakeSyncQueueClient.instances.append(self)
 
     def send(self, topic: str, payload: dict[str, Any], **kwargs: Any) -> None:
+        headers = get_headers()
+        self.send_headers.append(dict(headers) if headers is not None else None)
         self.sent.append({"topic": topic, "payload": payload, "kwargs": kwargs})
 
     def poll(
@@ -146,6 +154,8 @@ class FakeSyncQueueClient:
         consumer_group: str,
         **kwargs: Any,
     ) -> Iterator[FakeDelivery]:
+        headers = get_headers()
+        self.poll_headers.append(dict(headers) if headers is not None else None)
         batch = self.message_batches.pop(0) if self.message_batches else []
         self.last_topic = topic
         self.last_consumer_group = consumer_group
@@ -172,13 +182,18 @@ class FakeSyncQueueClient:
         self.visibility_headers.append(dict(headers) if headers is not None else None)
         self.visibility_changes.append((metadata, duration))
 
+    def retry_after(
+        self,
+        message: Message[dict[str, Any]] | MessageMetadata,
+        delay: Duration,
+    ) -> None:
+        self.extend_lease(message, delay)
+
     def run_lease_renewal(
         self,
         message: Message[dict[str, Any]],
         lease_duration: Duration | None = None,
-        headers_context: Any | None = None,
     ) -> FakeLeaseRenewal:
-        del headers_context
         renewal = FakeLeaseRenewal(message=message, lease_duration=lease_duration)
         self.lease_renewals.append(renewal)
         return renewal
@@ -257,6 +272,7 @@ def clean_celery_integration_state() -> Iterator[None]:
         vqs_celery._push_channels.clear()
         vqs_celery._finalize_hook_state.installed = False
         vqs_celery._finalize_hook_state.register_queues = False
+        set_headers(None)
 
 
 @pytest.fixture(autouse=True)
@@ -311,7 +327,6 @@ def track(channel: vqs_celery._BaseChannel, tag: str, queued_message: FakeMessag
         message=queued_message,
         lease_renewal=renewal,
         queue_client=channel._queue_client,
-        headers_context=vqs_celery.get_headers_context(),
     )
 
 
@@ -1064,6 +1079,48 @@ def test_start_embedded_worker_uses_solo_worker_options(
     assert embedded.thread.daemon is True
 
 
+def test_start_embedded_worker_thread_does_not_inherit_header_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_headers: list[dict[str, str] | None] = []
+    worker_started = threading.Event()
+
+    class FakeWorkController:
+        consumer = object()
+
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            headers = get_headers()
+            seen_headers.append(dict(headers) if headers is not None else None)
+            worker_started.set()
+
+    app = CeleryApp("worker-context")
+    monkeypatch.setattr(app, "WorkController", FakeWorkController)
+    monkeypatch.setattr(vqs_celery, "_wait_for_embedded_worker_channel", lambda worker: None)
+
+    set_headers({"x-vercel-oidc-token": "boot"})
+    try:
+        _REAL_START_EMBEDDED_WORKER(app)
+    finally:
+        set_headers(None)
+
+    assert worker_started.wait(5)
+    assert seen_headers == [None]
+
+
+def test_transports_treat_auth_and_network_errors_as_recoverable() -> None:
+    for transport in (
+        public_vqs_celery.VercelQueueTransport,
+        public_vqs_celery.VercelQueuePollTransport,
+        public_vqs_celery.VercelQueuePushTransport,
+    ):
+        assert TokenResolutionError in transport.connection_errors
+        assert UnauthorizedError in transport.connection_errors
+        assert QueueCommunicationError in transport.connection_errors
+
+
 def test_embedded_worker_ready_requires_channel_for_same_app() -> None:
     @dataclass
     class FakeWorker:
@@ -1485,8 +1542,8 @@ def test_registered_callback_delivers_to_active_push_channel() -> None:
     assert renewal.entered == 1
 
 
-def test_push_delivery_follow_ups_use_delivery_header_contexts() -> None:
-    app = CeleryApp("callback-context")
+def test_push_delivery_follow_ups_do_not_replay_delivery_headers() -> None:
+    app = CeleryApp("callback-no-context-replay")
     configure_push_broker(app)
     app.conf.task_queues = (Queue("emails"),)
     channel = make_push_channel(requeue_delay_seconds=7)
@@ -1509,10 +1566,83 @@ def test_push_delivery_follow_ups_use_delivery_header_contexts() -> None:
     channel.basic_reject(second_tag, requeue=True)
 
     fake_client = cast("FakeSyncQueueClient", channel._queue_client)
-    assert fake_client.ack_headers == [{"x-vercel-oidc-token": "token-1"}]
-    assert fake_client.visibility_headers == [{"x-vercel-oidc-token": "token-2"}]
+    assert fake_client.ack_headers == [{"x-vercel-oidc-token": "current"}]
+    assert fake_client.visibility_headers == [{"x-vercel-oidc-token": "current"}]
     assert get_headers() == {"x-vercel-oidc-token": "current"}
     assert len(FakeSyncQueueClient.instances) == 1
+
+
+def deliver_push_message(headers: dict[str, str]) -> None:
+    set_headers(headers)
+    try:
+        with pytest.raises(Handoff):
+            registered_callback()(FakeMessage(message(), topic="emails"))
+    finally:
+        set_headers(None)
+
+
+def test_publish_without_request_context_does_not_install_delivery_headers() -> None:
+    app = CeleryApp("no-context-fallback-put")
+    configure_push_broker(app)
+    app.conf.task_queues = (Queue("emails"),)
+    channel = make_push_channel()
+    received: list[Any] = []
+    channel.basic_consume("emails", no_ack=False, callback=received.append, consumer_tag="ctag")
+    vqs_celery.register_celery_app_queues(app)
+
+    deliver_push_message({"x-vercel-oidc-token": "token-1"})
+    channel._put("emails", message())
+
+    deliver_push_message({"x-vercel-oidc-token": "token-2"})
+    channel._put("emails", message())
+
+    fake_client = cast("FakeSyncQueueClient", channel._queue_client)
+    assert fake_client.send_headers == [None, None]
+
+
+def test_publish_preserves_ambient_request_context() -> None:
+    app = CeleryApp("context-ambient")
+    configure_push_broker(app)
+    app.conf.task_queues = (Queue("emails"),)
+    channel = make_push_channel()
+    received: list[Any] = []
+    channel.basic_consume("emails", no_ack=False, callback=received.append, consumer_tag="ctag")
+    vqs_celery.register_celery_app_queues(app)
+
+    deliver_push_message({"x-vercel-oidc-token": "stale"})
+    set_headers({"x-vercel-oidc-token": "current"})
+    try:
+        channel._put("emails", message())
+    finally:
+        set_headers(None)
+
+    fake_client = cast("FakeSyncQueueClient", channel._queue_client)
+    assert fake_client.send_headers == [{"x-vercel-oidc-token": "current"}]
+
+
+def test_poll_without_request_context_does_not_install_delivery_headers() -> None:
+    app = CeleryApp("no-context-fallback-poll")
+    configure_push_broker(app)
+    app.conf.task_queues = (Queue("emails"),)
+    push_channel = make_push_channel()
+    received: list[Any] = []
+    push_channel.basic_consume(
+        "emails",
+        no_ack=False,
+        callback=received.append,
+        consumer_tag="ctag",
+    )
+    vqs_celery.register_celery_app_queues(app)
+    deliver_push_message({"x-vercel-oidc-token": "token-1"})
+
+    channel = make_poll_channel()
+    fake_client = cast("FakeSyncQueueClient", channel._queue_client)
+    fake_client.message_batches.append([FakeMessage(message())])
+    payload = channel._get("emails")
+    channel.basic_ack(payload["properties"]["delivery_tag"])
+
+    assert fake_client.poll_headers == [None]
+    assert fake_client.ack_headers == [None]
 
 
 def test_registered_callback_matches_push_channel_consumer_group() -> None:

--- a/integrations/vercel-celery/vercel/integrations/celery/__init__.py
+++ b/integrations/vercel-celery/vercel/integrations/celery/__init__.py
@@ -4,6 +4,7 @@ from kombu.transport import TRANSPORT_ALIASES, virtual
 
 from celery.app import backends as celery_backends
 from celery.app.defaults import DEFAULTS as CELERY_DEFAULTS
+from vercel.queue import CommunicationError, TokenResolutionError, UnauthorizedError
 
 from ._broker import (
     AutoChannel,
@@ -20,6 +21,21 @@ from ._result_backend import DEFAULT_RESULT_BACKEND_ALIAS, VercelRuntimeCacheBac
 from .version import __version__
 
 _DEFAULT_CONNECTION_PARAMS = {"hostname": None, "port": None}
+# Token resolution depends on request-scoped OIDC context that may be
+# momentarily unavailable on Celery-owned threads (and refreshes with the next
+# push delivery). A cached token can also expire between local resolution and the
+# remote request, producing UnauthorizedError once before the next resolution
+# evicts it. CommunicationError is ordinary network trouble. Treat all three as
+# recoverable connection failures so the Celery consumer restarts instead of
+# shutting the worker down permanently. Kombu's own connection_errors use
+# amqp.exceptions.ConnectionError, not the builtin, so CommunicationError must be
+# listed explicitly.
+_CONNECTION_ERRORS = (
+    *virtual.Transport.connection_errors,
+    TokenResolutionError,
+    UnauthorizedError,
+    CommunicationError,
+)
 
 
 class VercelQueueTransport(virtual.Transport):
@@ -33,6 +49,7 @@ class VercelQueueTransport(virtual.Transport):
     driver_type = "vercel"
     driver_name = "Vercel Queue Service"
     default_connection_params = _DEFAULT_CONNECTION_PARAMS
+    connection_errors = _CONNECTION_ERRORS
 
 
 class VercelQueuePollTransport(virtual.Transport):
@@ -46,6 +63,7 @@ class VercelQueuePollTransport(virtual.Transport):
     driver_type = "vercel"
     driver_name = "Vercel Queue Service (poll)"
     default_connection_params = _DEFAULT_CONNECTION_PARAMS
+    connection_errors = _CONNECTION_ERRORS
 
 
 class VercelQueuePushTransport(virtual.Transport):
@@ -59,6 +77,7 @@ class VercelQueuePushTransport(virtual.Transport):
     driver_type = "vercel"
     driver_name = "Vercel Queue Service (push)"
     default_connection_params = _DEFAULT_CONNECTION_PARAMS
+    connection_errors = _CONNECTION_ERRORS
 
 
 def install_vercel_celery_integration(

--- a/integrations/vercel-celery/vercel/integrations/celery/_broker.py
+++ b/integrations/vercel-celery/vercel/integrations/celery/_broker.py
@@ -22,7 +22,6 @@ from kombu.utils import json as kombu_json
 import vercel.queue as vqs
 import vercel.queue.sync as vqs_sync
 from celery import Celery, _state as celery_state
-from vercel.headers import HeadersContext, get_headers_context
 
 from .version import __version__
 
@@ -142,7 +141,6 @@ class _TrackedDelivery:
     message: vqs.Message[dict[str, Any]]
     lease_renewal: vqs.LeaseRenewal
     queue_client: vqs_sync.QueueClient
-    headers_context: HeadersContext
 
 
 def is_vercel_runtime() -> bool:
@@ -250,14 +248,10 @@ class _BaseChannel(virtual.Channel):
             if requeue:
                 tracked_message = self._stop_tracking_delivery(delivery_tag)
                 if tracked_message is not None:
-                    message.headers_context.run(
-                        message.queue_client.extend_lease,
-                        tracked_message,
-                        self.requeue_delay_seconds,
-                    )
+                    message.queue_client.retry_after(tracked_message, self.requeue_delay_seconds)
             else:
                 try:
-                    message.headers_context.run(message.queue_client.acknowledge, message.message)
+                    message.queue_client.acknowledge(message.message)
                 finally:
                     self._stop_tracking_delivery(delivery_tag)
         if message is not None and self._qos is not None:
@@ -324,11 +318,7 @@ class _BaseChannel(virtual.Channel):
         tracked_message = self._stop_tracking_delivery(delivery_tag)
         if tracked_message is None:
             return
-        tracked.headers_context.run(
-            tracked.queue_client.extend_lease,
-            tracked_message,
-            self.requeue_delay_seconds,
-        )
+        tracked.queue_client.retry_after(tracked_message, self.requeue_delay_seconds)
 
     def _restore(self, message: Any) -> None:
         return None
@@ -344,10 +334,8 @@ class _BaseChannel(virtual.Channel):
         message: vqs.Message[dict[str, Any]],
         *,
         queue_client: vqs_sync.QueueClient | None = None,
-        headers_context: HeadersContext | None = None,
     ) -> dict[str, Any]:
         queue_client = queue_client or self._queue_client
-        headers_context = headers_context or get_headers_context()
         payload = dict(message.payload)
         properties = payload.get("properties")
         properties = {} if not isinstance(properties, dict) else dict(properties)
@@ -365,14 +353,12 @@ class _BaseChannel(virtual.Channel):
         lease_renewal = queue_client.run_lease_renewal(
             tracked_message,
             lease_duration=self.lease_duration,
-            headers_context=headers_context,
         )
         lease_renewal.__enter__()
         self._messages_by_tag[delivery_tag] = _TrackedDelivery(
             message=tracked_message,
             lease_renewal=lease_renewal,
             queue_client=queue_client,
-            headers_context=headers_context,
         )
         return payload
 
@@ -388,7 +374,7 @@ class _BaseChannel(virtual.Channel):
         if tracked is None:
             return
         try:
-            tracked.headers_context.run(tracked.queue_client.acknowledge, tracked.message)
+            tracked.queue_client.acknowledge(tracked.message)
         finally:
             self._stop_tracking_delivery(delivery_tag)
 
@@ -402,11 +388,7 @@ class _BaseChannel(virtual.Channel):
             if tracked_message is None:
                 continue
             try:
-                tracked.headers_context.run(
-                    tracked.queue_client.extend_lease,
-                    tracked_message,
-                    0,
-                )
+                tracked.queue_client.retry_after(tracked_message, 0)
             except Exception as exc:  # noqa: BLE001
                 debug_log(
                     "celery.delivery_release_failed",
@@ -477,7 +459,7 @@ class _BaseChannel(virtual.Channel):
         for delivery in deliveries:
             message = delivery.accept()
             try:
-                self._queue_client.extend_lease(message, self.requeue_delay_seconds)
+                self._queue_client.retry_after(message, self.requeue_delay_seconds)
             except Exception as exc:  # noqa: BLE001
                 debug_log(
                     "celery.poll_batch_release_failed",
@@ -527,8 +509,7 @@ class _BaseChannel(virtual.Channel):
                 raise vqs.RetryAfter(self.push_retry_delay_seconds)
 
             message = vqs.Message(payload=payload, metadata=metadata)
-            headers_context = get_headers_context()
-            payload = self._track_message(message, headers_context=headers_context)
+            payload = self._track_message(message)
             try:
                 # _deliver enters Kombu's normal consumer path. That path is now
                 # responsible for basic_ack/basic_reject, which in turn ACKs or
@@ -546,11 +527,7 @@ class _BaseChannel(virtual.Channel):
                     if self._qos is not None:
                         super().basic_reject(delivery_tag, requeue=False)
                 if tracked_message is not None:
-                    headers_context.run(
-                        self._queue_client.extend_lease,
-                        tracked_message,
-                        self.push_retry_delay_seconds,
-                    )
+                    self._queue_client.retry_after(tracked_message, self.push_retry_delay_seconds)
                 debug_log(
                     "celery.push_handoff_failed",
                     queue=queue,

--- a/src/vercel-headers/vercel/headers/__init__.py
+++ b/src/vercel-headers/vercel/headers/__init__.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import sys
-import threading
 import urllib.parse
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
-from contextvars import Context, ContextVar
+from contextvars import ContextVar
 from dataclasses import dataclass
-from functools import wraps
-from types import MappingProxyType
 from typing import Any, ParamSpec, Protocol, TypedDict, TypeVar
 
 __all__ = [
@@ -18,8 +14,6 @@ __all__ = [
     "HeadersContext",
     "set_headers",
     "get_headers",
-    "get_headers_context",
-    "context_aware_thread",
     "headers_from_asgi_scope",
     "headers_from_wsgi_environ",
 ]
@@ -67,70 +61,6 @@ class HeadersContext:
     def run(self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         with self.use():
             return func(*args, **kwargs)
-
-
-def get_headers_context() -> HeadersContext:
-    headers = _cv_headers.get()
-    if headers is None:
-        return HeadersContext(None)
-    return HeadersContext(MappingProxyType(dict(headers)))
-
-
-if sys.version_info >= (3, 14):
-
-    def context_aware_thread(
-        group: None = None,
-        target: Callable[..., object] | None = None,
-        name: str | None = None,
-        args: Iterable[Any] = (),
-        kwargs: Mapping[str, Any] | None = None,
-        *,
-        daemon: bool | None = None,
-        context: Context | None = None,
-    ) -> threading.Thread:
-        headers_context = get_headers_context()
-        if target is not None:
-            target = _wrap_thread_target(headers_context, target)
-        return threading.Thread(
-            group=group,
-            target=target,
-            name=name,
-            args=tuple(args),
-            kwargs=None if kwargs is None else dict(kwargs),
-            daemon=daemon,
-            context=context,
-        )
-
-else:
-
-    def context_aware_thread(
-        group: None = None,
-        target: Callable[..., object] | None = None,
-        name: str | None = None,
-        args: Iterable[Any] = (),
-        kwargs: Mapping[str, Any] | None = None,
-        *,
-        daemon: bool | None = None,
-    ) -> threading.Thread:
-        headers_context = get_headers_context()
-        if target is not None:
-            target = _wrap_thread_target(headers_context, target)
-        return threading.Thread(
-            group=group,
-            target=target,
-            name=name,
-            args=tuple(args),
-            kwargs=None if kwargs is None else dict(kwargs),
-            daemon=daemon,
-        )
-
-
-def _wrap_thread_target(context: HeadersContext, target: Callable[P, R]) -> Callable[P, R]:
-    @wraps(target)
-    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
-        return context.run(target, *args, **kwargs)
-
-    return wrapped
 
 
 class _HeadersLike(Protocol):

--- a/src/vercel-oidc/vercel/oidc/token.py
+++ b/src/vercel-oidc/vercel/oidc/token.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 from collections.abc import Mapping
+from typing import Any
 
 import httpx
 
@@ -18,6 +21,9 @@ from .utils import (
 )
 
 BASE_URL = "https://api.vercel.com/v1"
+_cached_oidc_token_lock = threading.Lock()
+_cached_oidc_token: str | None = None
+_cached_oidc_payload: dict[str, Any] | None = None
 
 
 class VercelOidcTokenError(Exception):
@@ -31,26 +37,15 @@ class VercelOidcTokenError(Exception):
 def get_vercel_oidc_token_from_context() -> str:
     # Prefer request header registered in the OIDC context,
     # fall back to environment variable like the TypeScript SDK.
-    headers = get_headers()
-    if headers:
-        # Normalize headers to lowercase keys
-        lower_headers: dict[str, str] = {}
-        if isinstance(headers, Mapping):
-            for k, v in headers.items():
-                lower_headers[str(k).lower()] = v
-        elif isinstance(headers, (list, tuple)):
-            for item in headers:
-                if isinstance(item, (list, tuple)) and len(item) == 2:
-                    k, v = item
-                    lower_headers[str(k).lower()] = v
-        elif hasattr(headers, "keys") and hasattr(headers, "__getitem__"):
-            for k in headers.keys():
-                v = headers[k]
-                lower_headers[str(k).lower()] = v
-
-        token_from_header = lower_headers.get("x-vercel-oidc-token")
-        if token_from_header:
-            return token_from_header
+    token_from_header = _token_from_headers(get_headers())
+    if token_from_header:
+        token = _select_header_or_cached_token(token_from_header)
+        if token is not None:
+            return token
+    else:
+        token_from_cache = _get_cached_unexpired_token()
+        if token_from_cache is not None:
+            return token_from_cache
 
     token_from_env = os.getenv("VERCEL_OIDC_TOKEN")
     if not token_from_env:
@@ -59,6 +54,86 @@ def get_vercel_oidc_token_from_context() -> str:
             "Do you have the OIDC option enabled in the Vercel project settings?"
         )
     return token_from_env
+
+
+def _token_from_headers(headers: object) -> str | None:
+    if not headers:
+        return None
+    lower_headers: dict[str, str] = {}
+    if isinstance(headers, Mapping):
+        for k, v in headers.items():
+            lower_headers[str(k).lower()] = v
+    elif isinstance(headers, (list, tuple)):
+        for item in headers:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                k, v = item
+                lower_headers[str(k).lower()] = v
+    elif hasattr(headers, "keys") and hasattr(headers, "__getitem__"):
+        for k in headers.keys():
+            v = headers[k]
+            lower_headers[str(k).lower()] = v
+    return lower_headers.get("x-vercel-oidc-token")
+
+
+def _select_header_or_cached_token(token: str) -> str | None:
+    try:
+        payload = get_token_payload(token)
+    except Exception:
+        return token
+    if _is_past_expiration(payload):
+        return _get_cached_unexpired_token()
+
+    with _cached_oidc_token_lock:
+        global _cached_oidc_payload, _cached_oidc_token
+        if _cached_oidc_token is None or _cached_oidc_payload is None:
+            _cached_oidc_token = token
+            _cached_oidc_payload = payload
+            return token
+        if _is_past_expiration(_cached_oidc_payload):
+            _cached_oidc_token = token
+            _cached_oidc_payload = payload
+            return token
+        if _expires_after(payload, _cached_oidc_payload):
+            _cached_oidc_token = token
+            _cached_oidc_payload = payload
+            return token
+        return _cached_oidc_token
+
+
+def _get_cached_unexpired_token() -> str | None:
+    with _cached_oidc_token_lock:
+        global _cached_oidc_payload, _cached_oidc_token
+        if _cached_oidc_token is None or _cached_oidc_payload is None:
+            return None
+        if _is_past_expiration(_cached_oidc_payload):
+            _cached_oidc_token = None
+            _cached_oidc_payload = None
+            return None
+        return _cached_oidc_token
+
+
+def _is_past_expiration(payload: dict[str, Any]) -> bool:
+    exp = payload.get("exp")
+    if not isinstance(exp, (int, float)):
+        return True
+    return exp <= time.time()
+
+
+def _expires_after(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    left_exp = left.get("exp")
+    right_exp = right.get("exp")
+    if not isinstance(left_exp, (int, float)):
+        return False
+    if not isinstance(right_exp, (int, float)):
+        return True
+    return left_exp > right_exp
+
+
+def _clear_cached_oidc_token() -> None:
+    with _cached_oidc_token_lock:
+        global _cached_oidc_payload, _cached_oidc_token
+        _cached_oidc_token = None
+        _cached_oidc_payload = None
 
 
 # for TS parity

--- a/src/vercel-queue/tests/unit/conftest.py
+++ b/src/vercel-queue/tests/unit/conftest.py
@@ -4,6 +4,8 @@ from collections.abc import Iterator
 
 import pytest
 
+from vercel.headers import set_headers
+from vercel.oidc.token import _clear_cached_oidc_token
 from vercel.queue._internal.http import reset_http_client_pools_for_tests
 from vercel.queue._internal.lease import reset_lease_renewal_worker_for_tests
 from vercel.queue.devserver import EmbeddedQueueDevServer
@@ -41,12 +43,17 @@ def reset_default_queue_clients() -> Iterator[None]:
     reset_lease_renewal_worker_for_tests()
     reset_http_client_pools_for_tests()
     reset_queue_clients()
+    set_headers(None)
+    _clear_cached_oidc_token()
 
-    yield
-
-    reset_lease_renewal_worker_for_tests()
-    reset_http_client_pools_for_tests()
-    reset_queue_clients()
+    try:
+        yield
+    finally:
+        reset_lease_renewal_worker_for_tests()
+        reset_http_client_pools_for_tests()
+        reset_queue_clients()
+        set_headers(None)
+        _clear_cached_oidc_token()
 
 
 @pytest.fixture

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -20,7 +20,9 @@ import pytest
 from anyio import to_thread
 from anyio.lowlevel import current_token
 
-from vercel.headers import get_headers, get_headers_context, set_headers
+from vercel.headers import get_headers, set_headers
+from vercel.oidc import get_vercel_oidc_token_sync
+from vercel.oidc.token import _clear_cached_oidc_token
 from vercel.queue import (
     ALL_DEPLOYMENTS,
     CommunicationError,
@@ -158,7 +160,7 @@ def test_sync_run_lease_renewal_extends_on_enter_and_stops_on_exit(
 
 
 @pytest.mark.anyio
-async def test_lease_extension_runs_with_captured_headers_context() -> None:
+async def test_lease_extension_does_not_install_captured_headers_context() -> None:
     seen_headers: list[dict[str, str] | None] = []
     message = Message(
         payload=None,
@@ -168,7 +170,6 @@ async def test_lease_extension_runs_with_captured_headers_context() -> None:
         ),
     )
     set_headers({"x-vercel-oidc-token": "delivery-token"})
-    headers_context = get_headers_context()
     set_headers({"x-vercel-oidc-token": "worker-token"})
 
     def record_extension_headers(_message: Message[Any], _duration: object) -> None:
@@ -181,13 +182,35 @@ async def test_lease_extension_runs_with_captured_headers_context() -> None:
         client=_FakeLeaseClient(record_extension_headers),
         lease_seconds=30,
         next_extension_at=time.monotonic(),
-        headers_context=headers_context,
     )
 
     await _run_lease_extension(request, {request.token: request})
 
-    assert seen_headers == [{"x-vercel-oidc-token": "delivery-token"}]
+    assert seen_headers == [{"x-vercel-oidc-token": "worker-token"}]
     assert get_headers() == {"x-vercel-oidc-token": "worker-token"}
+
+
+def test_lease_start_primes_oidc_cache_from_ambient_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+    message = Message(payload=None, metadata=make_leased_metadata("emails"))
+    renewal = _sync_test_client().run_lease_renewal(message, lease_duration=30)
+
+    monkeypatch.setattr(
+        "vercel.queue._internal.lease._ensure_lease_renewal_thread",
+        lambda: None,
+    )
+    monkeypatch.setattr("vercel.queue._internal.lease._send_lease_extension_start", calls.append)
+
+    _clear_cached_oidc_token()
+    token = "header.eyJleHAiOjk5OTk5OTk5OTl9.signature"
+    set_headers({"x-vercel-oidc-token": token})
+    renewal.start()
+    set_headers(None)
+
+    assert len(calls) == 1
+    assert get_vercel_oidc_token_sync() == token
 
 
 def test_lease_debug_logs_worker_start_extension_success_and_stop(
@@ -1786,7 +1809,6 @@ def _lease_request(
         client=client,
         lease_seconds=lease_seconds,
         next_extension_at=time.monotonic(),
-        headers_context=get_headers_context(),
     )
 
 

--- a/src/vercel-queue/vercel/queue/_internal/client.py
+++ b/src/vercel-queue/vercel/queue/_internal/client.py
@@ -524,14 +524,12 @@ class BaseQueueClient:
         self,
         message: Message[Any],
         lease_duration: Duration | None = None,
-        headers_context: HeadersContext | None = None,
     ) -> LeaseRenewal:
         """Create a context manager that keeps a message lease alive."""
         return LeaseRenewal(
             message,
             client=self,
             lease_duration=lease_duration,
-            headers_context=headers_context,
         )
 
 

--- a/src/vercel-queue/vercel/queue/_internal/lease.py
+++ b/src/vercel-queue/vercel/queue/_internal/lease.py
@@ -46,7 +46,7 @@ from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskGroup
 from anyio.lowlevel import EventLoopToken, current_token
 from anyio.streams.memory import MemoryObjectSendStream
 
-from vercel.headers import HeadersContext, get_headers_context
+from vercel.oidc import get_vercel_oidc_token_sync
 
 from .errors import MessageNotFoundError, QueueError, ThrottledError
 from .log import debug_log
@@ -111,7 +111,6 @@ class _LeaseExtensionRequest:
     client: LeaseAsyncClient
     lease_seconds: int
     next_extension_at: float
-    headers_context: HeadersContext
 
 
 @dataclass(kw_only=True)
@@ -218,12 +217,10 @@ class LeaseRenewal:
         message: Message[Any],
         client: LeaseAsyncClient,
         lease_duration: Duration | None = None,
-        headers_context: HeadersContext | None = None,
     ) -> None:
         self._message = message
         self._client = client
         self._lease_seconds = processing_lease_seconds(lease_duration)
-        self._headers_context = headers_context or get_headers_context()
         self._token: _LeaseRenewalToken | None = None
         self._entered = False
         self._closed = False
@@ -272,6 +269,7 @@ class LeaseRenewal:
         if self._message.metadata.receipt_handle is None:
             return None
         self._entered = True
+        _prime_oidc_token_cache()
         _ensure_lease_renewal_thread()
         self._token = _LeaseRenewalToken(object())
         return _LeaseExtensionRequest(
@@ -280,7 +278,6 @@ class LeaseRenewal:
             client=self._client,
             lease_seconds=self._lease_seconds,
             next_extension_at=_next_extension_at(self._message.metadata, self._lease_seconds),
-            headers_context=self._headers_context,
         )
 
     def _reset_start_after_failure(self) -> None:
@@ -408,6 +405,17 @@ class LeaseRenewal:
         if self._message.metadata.receipt_handle is None:
             return
         retry_message_after_sync(self._message, duration, extend_lease)
+
+
+def _prime_oidc_token_cache() -> None:
+    try:
+        get_vercel_oidc_token_sync()
+    except Exception as exc:  # noqa: BLE001
+        debug_log(
+            "lease.oidc_cache_prime_failed",
+            exception_class=exc.__class__.__name__,
+            exception_message=str(exc),
+        )
 
 
 async def retry_message_after_async(
@@ -897,11 +905,10 @@ async def _run_lease_extension(
         lease_seconds=request.lease_seconds,
     )
     try:
-        with request.headers_context.use():
-            await request.client._renew_lease(  # noqa: SLF001
-                request.message,
-                request.lease_seconds,
-            )
+        await request.client._renew_lease(  # noqa: SLF001
+            request.message,
+            request.lease_seconds,
+        )
     except QueueError as exc:
         if _is_client_error(exc):
             active.pop(request.token, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,9 +39,12 @@ def mock_env_clear(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, Non
         monkeypatch.delenv(var, raising=False)
 
     from vercel.headers import set_headers
+    from vercel.oidc.token import _clear_cached_oidc_token
 
     set_headers(None)
+    _clear_cached_oidc_token()
     yield
+    _clear_cached_oidc_token()
     set_headers(None)
 
 

--- a/tests/integration/test_oidc_sync_async.py
+++ b/tests/integration/test_oidc_sync_async.py
@@ -5,8 +5,15 @@ Tests token retrieval from context, environment, and JWT payload decoding.
 
 import base64
 import json
+import time
 
 import pytest
+
+
+def _oidc_token(exp: float, *, subject: str = "test") -> str:
+    payload_json = json.dumps({"sub": subject, "exp": exp})
+    payload_b64 = base64.urlsafe_b64encode(payload_json.encode()).decode().rstrip("=")
+    return f"header.{payload_b64}.signature"
 
 
 class TestOidcTokenFromContext:
@@ -58,6 +65,65 @@ class TestOidcTokenFromContext:
             assert token == "header_token"
         finally:
             set_headers(None)
+
+    def test_live_unexpired_header_token_is_remembered(self, mock_env_clear):
+        """Test live OIDC headers refresh the process-wide fallback token."""
+        from vercel.headers import set_headers
+        from vercel.oidc import get_vercel_oidc_token_sync
+
+        token = _oidc_token(9999999999, subject="remembered")
+        set_headers({"x-vercel-oidc-token": token})
+        assert get_vercel_oidc_token_sync() == token
+
+        set_headers(None)
+        assert get_vercel_oidc_token_sync() == token
+
+    def test_expired_cached_token_falls_through_to_missing_token_error(self, mock_env_clear):
+        """Test expired OIDC headers are not exposed as fallback credentials."""
+        from vercel.headers import set_headers
+        from vercel.oidc import VercelOidcTokenError, get_vercel_oidc_token_sync
+
+        set_headers({"x-vercel-oidc-token": _oidc_token(1, subject="expired")})
+        with pytest.raises(VercelOidcTokenError, match="x-vercel-oidc-token"):
+            get_vercel_oidc_token_sync()
+
+    def test_header_token_inside_refresh_buffer_is_returned(self, mock_env_clear):
+        """Test currently valid ambient tokens are returned inside the refresh buffer."""
+        from vercel.headers import set_headers
+        from vercel.oidc import get_vercel_oidc_token_sync
+
+        token = _oidc_token(time.time() + 60, subject="inside-buffer")
+        set_headers({"x-vercel-oidc-token": token})
+
+        assert get_vercel_oidc_token_sync() == token
+
+    def test_newer_exp_claim_wins_over_ambient_token(self, mock_env_clear):
+        """Test an older ambient token does not shadow the freshest cached token."""
+        from vercel.headers import set_headers
+        from vercel.oidc import get_vercel_oidc_token_sync
+
+        newer = _oidc_token(9999999999, subject="newer")
+        older = _oidc_token(9999999998, subject="older")
+
+        set_headers({"x-vercel-oidc-token": newer})
+        assert get_vercel_oidc_token_sync() == newer
+        set_headers({"x-vercel-oidc-token": older})
+
+        assert get_vercel_oidc_token_sync() == newer
+
+    def test_expired_ambient_token_does_not_shadow_cached_token(self, mock_env_clear):
+        """Test expired live headers fall back to a newer cached token."""
+        from vercel.headers import set_headers
+        from vercel.oidc import get_vercel_oidc_token_sync
+
+        cached = _oidc_token(9999999999, subject="cached")
+        expired = _oidc_token(1, subject="expired")
+
+        set_headers({"x-vercel-oidc-token": cached})
+        assert get_vercel_oidc_token_sync() == cached
+        set_headers({"x-vercel-oidc-token": expired})
+
+        assert get_vercel_oidc_token_sync() == cached
 
     def test_oidc_standalone_header_context(self, mock_env_clear, monkeypatch):
         """Test the OIDC compatibility header setter."""

--- a/tests/unit/test_headers_context.py
+++ b/tests/unit/test_headers_context.py
@@ -6,9 +6,7 @@ import pytest
 
 from vercel.headers import (
     HeadersContext,
-    context_aware_thread,
     get_headers,
-    get_headers_context,
     headers_from_asgi_scope,
     headers_from_wsgi_environ,
     set_headers,
@@ -26,7 +24,7 @@ def isolated_headers_context() -> Generator[None, None, None]:
 
 def test_headers_context_run_installs_and_restores_headers() -> None:
     set_headers({"x-current": "outer"})
-    context = get_headers_context()
+    context = HeadersContext(dict(get_headers() or {}))
     set_headers({"x-current": "inner"})
 
     def read_headers() -> Mapping[str, str] | None:
@@ -38,7 +36,7 @@ def test_headers_context_run_installs_and_restores_headers() -> None:
 
 def test_headers_context_use_installs_and_restores_headers() -> None:
     set_headers({"x-current": "outer"})
-    context = get_headers_context()
+    context = HeadersContext(dict(get_headers() or {}))
     set_headers({"x-current": "inner"})
 
     with context.use():
@@ -58,7 +56,7 @@ def test_headers_context_use_accepts_explicit_headers() -> None:
 
 def test_headers_context_restores_after_exception() -> None:
     set_headers({"x-current": "outer"})
-    context = get_headers_context()
+    context = HeadersContext(dict(get_headers() or {}))
     set_headers({"x-current": "inner"})
 
     def fail() -> None:
@@ -73,7 +71,7 @@ def test_headers_context_restores_after_exception() -> None:
 
 def test_headers_context_use_restores_after_exception() -> None:
     set_headers({"x-current": "outer"})
-    context = get_headers_context()
+    context = HeadersContext(dict(get_headers() or {}))
     set_headers({"x-current": "inner"})
 
     with pytest.raises(RuntimeError, match="boom"):
@@ -87,27 +85,12 @@ def test_headers_context_use_restores_after_exception() -> None:
 def test_headers_context_is_snapshot_isolated() -> None:
     headers = {"x-current": "initial"}
     set_headers(headers)
-    context = get_headers_context()
+    context = HeadersContext(dict(get_headers() or {}))
 
     headers["x-current"] = "mutated"
     set_headers({"x-current": "latest"})
 
     assert context.run(get_headers) == {"x-current": "initial"}
-    with pytest.raises(TypeError):
-        context.headers["x-current"] = "changed"  # type: ignore[index]
-
-
-def test_context_aware_thread_runs_with_creation_headers() -> None:
-    seen: list[Mapping[str, str] | None] = []
-    set_headers({"x-current": "thread"})
-    thread = context_aware_thread(target=lambda: seen.append(get_headers()))
-    set_headers({"x-current": "main"})
-
-    thread.start()
-    thread.join(timeout=5)
-
-    assert seen == [{"x-current": "thread"}]
-    assert get_headers() == {"x-current": "main"}
 
 
 def test_headers_from_asgi_scope_decodes_latin1_headers() -> None:


### PR DESCRIPTION
Queue auth on Vercel comes from per-request OIDC headers, but SDK work
can run on threads that never had a request context: the queue SDK's
lease renewal thread, and Celery's embedded worker loop and ETA timers.
Instead of capturing and replaying header-context snapshots at every
such call site, remember the freshest live request OIDC token
process-wide in `vercel-oidc` and fall back to it, until its `exp` claim
passes, whenever the ambient context has no token. Lease renewal primes
the fallback on start, while the originating delivery's headers are
still visible, so the renewal thread has credentials before its first
extension fires.

This removes the header-context replay machinery: `LeaseRenewal` no
longer captures a context for the renewal worker thread, the Celery
broker drops per-delivery context tracking, and the unreleased
`context_aware_thread`/`get_headers_context` helpers are dropped from
`vercel-headers`.

Requeue paths now use the queue client's `retry_after()` instead of raw
`extend_lease()`, gaining transient-failure retries and tolerance of an
already-missing lease.

List `TokenResolutionError`, `UnauthorizedError`, and
`CommunicationError` in the Celery transports' `connection_errors` so a
momentary token gap, an expired fallback token, or a network failure
restarts the consumer instead of killing the worker with an
unrecoverable error, which previously wedged the function instance into
endlessly retrying push deliveries.
