### PR TITLE
vercel-celery: Settle push deliveries within the push request

### DIFF
--- a/changes/vercel-celery/push-inline-settlement.bugfix.md
+++ b/changes/vercel-celery/push-inline-settlement.bugfix.md
@@ -1,0 +1,7 @@
+Settle push deliveries within the delivering request: drain the embedded
+worker's deferred ACKs/rejects before responding, and wait in-request for the
+handoff lock, consumer readiness, and prefetch capacity (new
+`push_handoff_wait_seconds` transport option) instead of bouncing deliveries
+with `RetryAfter`. On Vercel the worker loop thread is suspended between
+requests, so deferred ACKs never ran, leases silently expired, and every
+message was redelivered and re-executed on a five-minute cycle.

--- a/changes/vercel-queue/lifecycle-nested-retries.bugfix.md
+++ b/changes/vercel-queue/lifecycle-nested-retries.bugfix.md
@@ -1,0 +1,4 @@
+Stop nesting retry wrappers in delivery lifecycle settlement: the RetryAfter
+and ACK paths wrapped the already-retrying `extend_lease()`/`acknowledge()`
+client methods in a second retry layer, multiplying retry attempts and
+logging duplicate `visibility.retry_attempt` events per request.

--- a/integrations/vercel-celery/tests/integration/test_celery_vqs_worker.py
+++ b/integrations/vercel-celery/tests/integration/test_celery_vqs_worker.py
@@ -138,7 +138,9 @@ def test_push_worker_processes_sdk_callback_and_acknowledges_task(
 def test_push_callback_retries_until_worker_channel_is_available(
     isolated_eqs: EmbeddedQueueDevServer,
     push_worker: WorkerApp,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(vqs_celery, "_PUSH_CHANNEL_WAIT_SECONDS", 0.0)
     result = push_worker.add.apply_async((8, 13), queue="emails")
     push_channels = list(vqs_celery._push_channels)
     vqs_celery._push_channels.clear()
@@ -254,6 +256,55 @@ def test_auto_worker_uses_push_on_vercel(
             os.environ.pop("VERCEL", None)
         else:
             os.environ["VERCEL"] = previous_vercel
+        eqs.reset()
+        _clear_celery_broker_state()
+
+
+def test_embedded_worker_settles_push_delivery_inline(
+    eqs: EmbeddedQueueDevServer,
+) -> None:
+    queue_name = "embedded-push-emails"
+    _clear_celery_broker_state()
+    eqs.reset()
+    app = _celery_app(
+        "embedded-push-worker",
+        "vercel-push://localhost//",
+        eqs.base_url,
+        queue_name=queue_name,
+    )
+
+    @app.task(name="embedded-push-worker.add")
+    def add(left: int, right: int) -> int:
+        return left + right
+
+    app.finalize(auto=True)
+    embedded = None
+    try:
+        # The production path on Vercel: the in-process embedded worker owns
+        # consumption, and nothing ever pumps its pending operations between
+        # push requests.
+        vqs_celery.register_celery_app_queues(app)
+        embedded = vqs_celery._embedded_workers.get(app)
+        assert embedded is not None
+
+        result = add.apply_async((2, 40), queue=queue_name)
+        worker_app = WorkerApp(
+            app=app,
+            add=add,
+            worker=embedded.worker,
+            push_channels=tuple(vqs_celery._push_channels),
+        )
+        _deliver_push(eqs, worker_app, queue=queue_name)
+
+        # Settlement must complete inside the push delivery itself: no
+        # perform_pending_operations pumping happens after this point.
+        assert len(eqs.state.messages) == 1
+        assert eqs.state.messages[0].acknowledged is True
+        assert result.get(timeout=10, disable_sync_subtasks=False) == 42
+    finally:
+        if embedded is not None:
+            embedded.worker.stop()
+            embedded.thread.join(timeout=10)
         eqs.reset()
         _clear_celery_broker_state()
 

--- a/integrations/vercel-celery/tests/unit/test_celery_broker.py
+++ b/integrations/vercel-celery/tests/unit/test_celery_broker.py
@@ -1702,7 +1702,10 @@ def test_registered_callback_uses_channel_that_consumes_queue() -> None:
     assert idle_channel._messages_by_tag == {}
 
 
-def test_registered_callback_retries_when_consumer_group_has_no_channel() -> None:
+def test_registered_callback_retries_when_consumer_group_has_no_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vqs_celery, "_PUSH_CHANNEL_WAIT_SECONDS", 0.0)
     app = CeleryApp("callback-group-retry")
     configure_push_broker(app)
     app.conf.broker_transport_options = {"consumer_group": "workers"}
@@ -1721,7 +1724,10 @@ def test_registered_callback_retries_when_consumer_group_has_no_channel() -> Non
     assert channel.connection.delivered == []
 
 
-def test_registered_callback_retries_without_active_channel() -> None:
+def test_registered_callback_retries_without_active_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vqs_celery, "_PUSH_CHANNEL_WAIT_SECONDS", 0.0)
     app = CeleryApp("callback-retry")
     configure_push_broker(app)
     app.conf.task_queues = (Queue("emails"),)
@@ -1841,7 +1847,7 @@ def test_push_queue_callback_uses_registered_queue_name() -> None:
 
 
 def test_push_queue_callback_retries_when_no_consumer_is_registered() -> None:
-    channel = make_push_channel()
+    channel = make_push_channel(push_handoff_wait_seconds=0)
     queued_message = FakeMessage(message())
 
     with pytest.raises(RetryAfter) as exc_info:
@@ -1858,7 +1864,11 @@ def test_push_queue_callback_retries_when_no_consumer_is_registered() -> None:
 
 
 def test_push_queue_callback_retries_when_prefetch_is_exhausted() -> None:
-    channel = make_push_channel(requeue_delay_seconds=8, push_retry_delay_seconds=3)
+    channel = make_push_channel(
+        requeue_delay_seconds=8,
+        push_retry_delay_seconds=3,
+        push_handoff_wait_seconds=0,
+    )
     channel.qos.prefetch_count = 1
     cast("Any", channel.qos._delivered)["existing"] = object()
     queued_message = FakeMessage(message())
@@ -1875,6 +1885,125 @@ def test_push_queue_callback_retries_when_prefetch_is_exhausted() -> None:
     assert FakeSyncQueueClient.instances[0].acknowledged == []
     assert FakeSyncQueueClient.instances[0].visibility_changes == []
     assert channel._messages_by_tag == {}
+
+
+@dataclass
+class _FakeWorkController:
+    consumer: Any
+
+
+def _register_fake_embedded_worker(app: CeleryApp, consumer: Any) -> None:
+    vqs_celery._embedded_workers[app] = vqs_celery._EmbeddedWorker(
+        app=app,
+        worker=_FakeWorkController(consumer),
+        thread=cast("Any", None),
+    )
+
+
+def test_push_queue_delivery_settles_deferred_ack_inline() -> None:
+    app = CeleryApp("inline-settle")
+    channel = make_push_channel()
+    queued_message = FakeMessage(message())
+    pending_operations: list[Any] = []
+    received: list[Any] = []
+
+    def consume(delivered: Any) -> None:
+        received.append(delivered)
+        # Celery consumers defer settlement into the worker's pending
+        # operations; emulate that instead of acking inline.
+        pending_operations.append(lambda: channel.basic_ack(delivered.delivery_tag))
+
+    class FakeConsumer:
+        def perform_pending_operations(self) -> None:
+            while pending_operations:
+                pending_operations.pop()()
+
+    _register_fake_embedded_worker(app, FakeConsumer())
+    channel.basic_consume("emails", no_ack=False, callback=consume, consumer_tag="ctag")
+
+    with pytest.raises(Handoff):
+        channel._handle_queue_delivery(
+            queued_message.payload,
+            queued_message.metadata,
+            queue="emails",
+        )
+
+    assert len(received) == 1
+    assert cast("FakeSyncQueueClient", channel._queue_client).acknowledged == [
+        queued_message.metadata
+    ]
+    assert channel._messages_by_tag == {}
+    assert pending_operations == []
+
+
+def test_push_queue_delivery_waits_for_prefetch_capacity() -> None:
+    app = CeleryApp("capacity-wait")
+    channel = make_push_channel(push_handoff_wait_seconds=5)
+    channel.qos.prefetch_count = 1
+    cast("Any", channel.qos._delivered)["existing"] = object()
+    queued_message = FakeMessage(message())
+    received: list[Any] = []
+
+    def consume(delivered: Any) -> None:
+        received.append(delivered)
+        channel.basic_ack(delivered.delivery_tag)
+
+    class FakeConsumer:
+        def perform_pending_operations(self) -> None:
+            # Emulate the deferred ACK of a previously delivered message
+            # freeing prefetch capacity.
+            cast("Any", channel.qos._delivered).pop("existing", None)
+
+    _register_fake_embedded_worker(app, FakeConsumer())
+    channel.basic_consume("emails", no_ack=False, callback=consume, consumer_tag="ctag")
+
+    with pytest.raises(Handoff):
+        channel._handle_queue_delivery(
+            queued_message.payload,
+            queued_message.metadata,
+            queue="emails",
+        )
+
+    assert len(received) == 1
+
+
+def test_push_queue_delivery_waits_for_handoff_lock() -> None:
+    channel = make_push_channel(push_handoff_wait_seconds=5)
+    queued_message = FakeMessage(message())
+    received: list[Any] = []
+
+    def consume(delivered: Any) -> None:
+        received.append(delivered)
+        channel.basic_ack(delivered.delivery_tag)
+
+    channel.basic_consume("emails", no_ack=False, callback=consume, consumer_tag="ctag")
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with channel._push_handoff_lock:
+            held.set()
+            release.wait(5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert held.wait(5)
+    releaser = threading.Timer(0.1, release.set)
+    releaser.start()
+    try:
+        with pytest.raises(Handoff):
+            channel._handle_queue_delivery(
+                queued_message.payload,
+                queued_message.metadata,
+                queue="emails",
+            )
+    finally:
+        release.set()
+        holder.join(5)
+        releaser.cancel()
+
+    assert len(received) == 1
 
 
 def test_push_accept_releases_lease_when_callback_fails() -> None:

--- a/integrations/vercel-celery/vercel/integrations/celery/_broker.py
+++ b/integrations/vercel-celery/vercel/integrations/celery/_broker.py
@@ -28,6 +28,14 @@ from .version import __version__
 DEFAULT_CONSUMER_GROUP = "celery"
 DEFAULT_REQUEUE_DELAY_SECONDS = 0
 DEFAULT_PUSH_RETRY_DELAY_SECONDS = 1
+# On Vercel, bouncing a push delivery with RetryAfter is expensive: redelivery
+# is paced by the server and can take up to the full remaining visibility
+# deadline. Prefer waiting in-request for the worker to become ready over
+# bouncing, up to this budget.
+DEFAULT_PUSH_HANDOFF_WAIT_SECONDS = 30.0
+_PUSH_CHANNEL_WAIT_SECONDS = 5.0
+_PUSH_WAIT_POLL_INTERVAL_SECONDS = 0.05
+_PUSH_SETTLE_POLL_INTERVAL_SECONDS = 0.01
 _EMBEDDED_WORKER_STARTUP_WAIT_SECONDS = 1.0
 _QUEUE_LOGGER_NAME = "vercel.integrations.celery"
 _DEBUG_ENV = "VERCEL_CELERY_DEBUG"
@@ -54,7 +62,12 @@ PUBLISH_TRANSPORT_OPTIONS = (
     "delay",
     "use_task_id_as_idempotency_key",
 )
-LEASE_TRANSPORT_OPTIONS = ("requeue_delay_seconds", "push_retry_delay_seconds", "lease_duration")
+LEASE_TRANSPORT_OPTIONS = (
+    "requeue_delay_seconds",
+    "push_retry_delay_seconds",
+    "push_handoff_wait_seconds",
+    "lease_duration",
+)
 CONSUMER_TRANSPORT_OPTIONS = ("consumer_group",)
 QUEUE_TRANSPORT_OPTIONS = ("queue_name_prefix",)
 # Celery apps can be short-lived in tests and app factories, so registration
@@ -171,6 +184,7 @@ class _BaseChannel(virtual.Channel):
     timeout: vqs.Duration | None = 10.0
     requeue_delay_seconds: int = DEFAULT_REQUEUE_DELAY_SECONDS
     push_retry_delay_seconds: int = DEFAULT_PUSH_RETRY_DELAY_SECONDS
+    push_handoff_wait_seconds: float = DEFAULT_PUSH_HANDOFF_WAIT_SECONDS
     lease_duration: vqs.Duration | None = None
     retention: vqs.Duration | None = None
     delay: vqs.Duration | None = None
@@ -481,7 +495,13 @@ class _BaseChannel(virtual.Channel):
         *,
         queue: str,
     ) -> None:
-        if not self._push_handoff_lock.acquire(blocking=False):
+        # Bouncing a push delivery with RetryAfter is a last resort: VQS paces
+        # redelivery on its own schedule, which can be far slower than the
+        # requested delay. While this callback runs the function instance is
+        # guaranteed to be executing, so prefer waiting here for the handoff
+        # lock, consumer readiness, and prefetch capacity over bouncing.
+        deadline = time.monotonic() + max(self.push_handoff_wait_seconds, 0.0)
+        if not self._acquire_push_handoff_lock(deadline):
             debug_log(
                 "celery.push_handoff_busy",
                 queue=queue,
@@ -494,7 +514,7 @@ class _BaseChannel(virtual.Channel):
         try:
             # Raising RetryAfter lets the queue SDK update VQS visibility when
             # Kombu has no active callback or its QoS prefetch window is full.
-            if not self._consumes_queue(queue) or not self.qos.can_consume():
+            if not self._wait_for_push_capacity(queue, deadline):
                 debug_log(
                     "celery.push_handoff_unavailable",
                     queue=queue,
@@ -540,6 +560,12 @@ class _BaseChannel(virtual.Channel):
                     push_retry_delay_seconds=self.push_retry_delay_seconds,
                 )
                 raise
+            # Celery queues the ACK/reject for this delivery as a pending
+            # operation drained by the worker consumer loop, but on Vercel that
+            # thread is suspended whenever no request is executing. Settle the
+            # delivery now, while this push invocation still has compute, or
+            # the lease silently expires and the task re-runs on redelivery.
+            self._settle_push_delivery(payload, deadline)
         finally:
             self._push_handoff_lock.release()
         debug_log(
@@ -553,6 +579,41 @@ class _BaseChannel(virtual.Channel):
         # Delivery succeeded into Kombu. Do not let vercel.queue auto-ACK here;
         # Celery/Kombu owns manual ACK/reject semantics from this point onward.
         raise vqs.Handoff
+
+    def _acquire_push_handoff_lock(self, deadline: float) -> bool:
+        timeout = deadline - time.monotonic()
+        if timeout <= 0:
+            return self._push_handoff_lock.acquire(blocking=False)
+        return self._push_handoff_lock.acquire(timeout=timeout)
+
+    def _wait_for_push_capacity(self, queue: str, deadline: float) -> bool:
+        while True:
+            if self._consumes_queue(queue) and self.qos.can_consume():
+                return True
+            # Deferred ACKs are what free prefetch capacity, and consumer
+            # registration happens on the worker startup thread; pump pending
+            # operations because the worker loop may never get scheduled
+            # between push requests.
+            _flush_embedded_worker_operations()
+            if self._consumes_queue(queue) and self.qos.can_consume():
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_PUSH_WAIT_POLL_INTERVAL_SECONDS)
+
+    def _settle_push_delivery(self, payload: dict[str, Any], deadline: float) -> None:
+        delivery_tag = self._delivery_tag(payload)
+        if delivery_tag is None:
+            return
+        while delivery_tag in self._messages_by_tag:
+            if not _flush_embedded_worker_operations():
+                # No embedded worker owns pending operations in this process
+                # (e.g. a standalone `celery worker`); its own consumer loop
+                # keeps running and will settle the delivery.
+                return
+            if delivery_tag not in self._messages_by_tag or time.monotonic() >= deadline:
+                return
+            time.sleep(_PUSH_SETTLE_POLL_INTERVAL_SECONDS)
 
     def _register_push_channel(self) -> None:
         with _push_channels_lock:
@@ -714,7 +775,17 @@ def _make_queue_callback(queue: str) -> Any:
         # This is the real VQS trigger callback. The queue SDK has already
         # accepted/deserialized the delivery and will perform follow-up lease
         # actions according to the directive raised here.
-        channel = _find_push_channel(queue, str(message.metadata.consumer_group))
+        consumer_group = str(message.metadata.consumer_group)
+        channel = _find_push_channel(queue, consumer_group)
+        if channel is None:
+            # A delivery can race worker startup on a cold boot: the embedded
+            # worker opens its push channel moments after the HTTP server
+            # starts accepting push callbacks. Waiting briefly beats bouncing,
+            # because VQS redelivery pacing is far coarser than this window.
+            deadline = time.monotonic() + _PUSH_CHANNEL_WAIT_SECONDS
+            while channel is None and time.monotonic() < deadline:
+                time.sleep(_PUSH_WAIT_POLL_INTERVAL_SECONDS)
+                channel = _find_push_channel(queue, consumer_group)
         if channel is None:
             raise vqs.RetryAfter(DEFAULT_PUSH_RETRY_DELAY_SECONDS)
         channel._handle_queue_delivery(
@@ -725,6 +796,36 @@ def _make_queue_callback(queue: str) -> Any:
 
     handle_queue_delivery.__name__ = f"vercel_celery_{queue}_subscriber"
     return handle_queue_delivery
+
+
+def _flush_embedded_worker_operations() -> bool:
+    """Drain deferred consumer operations (ACKs/rejects) of embedded workers.
+
+    Returns whether any embedded worker consumer was available to drain.
+    Celery consumers defer message settlement to their consuming loop thread,
+    which on Vercel is suspended outside of request handling; push delivery
+    paths call this to run those operations on the delivering thread instead.
+    ``perform_pending_operations`` pops from a plain list and handles each
+    operation's errors, so concurrent draining by the worker loop is safe.
+    """
+    flushed = False
+    with _embedded_workers_lock:
+        embedded_workers = tuple(_embedded_workers.values())
+    for embedded in embedded_workers:
+        consumer = getattr(embedded.worker, "consumer", None)
+        if consumer is None:
+            continue
+        try:
+            consumer.perform_pending_operations()
+        except Exception as exc:  # noqa: BLE001
+            debug_log(
+                "celery.pending_operations_flush_failed",
+                exception_class=exc.__class__.__name__,
+                exception_message=str(exc),
+            )
+            continue
+        flushed = True
+    return flushed
 
 
 def _start_embedded_worker(app: Celery) -> None:

--- a/src/vercel-queue/tests/unit/test_queue_accept_handle.py
+++ b/src/vercel-queue/tests/unit/test_queue_accept_handle.py
@@ -109,7 +109,7 @@ def test_sync_message_lifecycle_ack_stops_renewal_without_wait(
         def acknowledge(self, message: Message[Any]) -> None:
             acknowledged.append(message.metadata.message_id)
 
-        def extend_lease(self, message: Message[Any], duration: int) -> None:
+        def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message, duration
             raise AssertionError("ACK must not extend visibility")
 
@@ -155,7 +155,7 @@ def test_sync_message_lifecycle_retry_after_waits_for_renewal_stop(
             del message
             raise AssertionError("RetryAfter must not acknowledge")
 
-        def extend_lease(self, message: Message[Any], duration: int) -> None:
+        async def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message
             extensions.append(duration)
 
@@ -203,7 +203,7 @@ def test_sync_message_lifecycle_handoff_waits_for_renewal_stop(
             del message
             raise AssertionError("Handoff must not acknowledge")
 
-        def extend_lease(self, message: Message[Any], duration: int) -> None:
+        def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message, duration
             raise AssertionError("Handoff must not extend visibility")
 
@@ -249,7 +249,7 @@ async def test_async_message_lifecycle_ack_stops_renewal_without_wait(
         async def acknowledge(self, message: Message[Any]) -> None:
             acknowledged.append(message.metadata.message_id)
 
-        async def extend_lease(self, message: Message[Any], duration: int) -> None:
+        async def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message, duration
             raise AssertionError("ACK must not extend visibility")
 
@@ -296,7 +296,7 @@ async def test_async_message_lifecycle_retry_after_waits_for_renewal_stop(
             del message
             raise AssertionError("RetryAfter must not acknowledge")
 
-        async def extend_lease(self, message: Message[Any], duration: int) -> None:
+        async def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message
             extensions.append(duration)
 
@@ -344,7 +344,7 @@ async def test_async_message_lifecycle_handoff_waits_for_renewal_stop(
             del message
             raise AssertionError("Handoff must not acknowledge")
 
-        async def extend_lease(self, message: Message[Any], duration: int) -> None:
+        async def _extend_lease(self, message: Message[Any], duration: int) -> None:
             del message, duration
             raise AssertionError("Handoff must not extend visibility")
 

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -118,6 +118,14 @@ class _FakeLeaseClient:
         if inspect.isawaitable(result):
             await result
 
+    async def _extend_lease(
+        self,
+        message: Message[Any] | MessageMetadata,
+        duration: Duration,
+    ) -> None:
+        assert isinstance(message, Message)
+        await self.extend_lease(message, duration)
+
     async def _renew_lease(self, message: Message[Any], duration: Duration) -> None:
         await self.extend_lease(message, duration)
 

--- a/src/vercel-queue/vercel/queue/_internal/client.py
+++ b/src/vercel-queue/vercel/queue/_internal/client.py
@@ -84,7 +84,7 @@ from .push import (
     parse_push_delivery_metadata,
 )
 from .response import queue_response_error, send_response_error
-from .retry import retry_async_follow_up, retry_sync_follow_up
+from .retry import retry_async_follow_up
 from .streams import AsyncStreamPayload, AsyncTextStreamPayload
 from .subscribers import (
     QueueSubscriber,
@@ -607,7 +607,7 @@ class Delivery(Generic[T]):
             debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
-            self._renewal.extend(exc.timeout_seconds, self._client.extend_lease)
+            self._renewal.extend(exc.timeout_seconds)
             debug_log_for_msg(
                 "message.retry_after",
                 self._message,
@@ -615,10 +615,8 @@ class Delivery(Generic[T]):
             )
             return True
         if exc is None:
-            retry_sync_follow_up(
-                lambda: self._client.acknowledge(self._message),
-                event_prefix="acknowledge",
-            )
+            # acknowledge() already retries transient failures internally.
+            self._client.acknowledge(self._message)
             debug_log_for_msg("message.ack", self._message)
         return None
 
@@ -1070,10 +1068,7 @@ class _AsyncMessageLifecycle:
             debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
-            await self._renewal.extend_async(
-                exc.timeout_seconds,
-                self._client.extend_lease,
-            )
+            await self._renewal.extend_async(exc.timeout_seconds)
             debug_log_for_msg(
                 "message.retry_after",
                 self._message,
@@ -1081,10 +1076,8 @@ class _AsyncMessageLifecycle:
             )
             return True
         if exc is None:
-            await retry_async_follow_up(
-                lambda: self._client.acknowledge(self._message),
-                event_prefix="acknowledge",
-            )
+            # acknowledge() already retries transient failures internally.
+            await self._client.acknowledge(self._message)
             debug_log_for_msg("message.ack", self._message)
         return None
 

--- a/src/vercel-queue/vercel/queue/_internal/client_sync.py
+++ b/src/vercel-queue/vercel/queue/_internal/client_sync.py
@@ -414,7 +414,7 @@ class _MessageLifecycle:
             debug_log_for_msg("message.handoff", self._message)
             return True
         if isinstance(exc, RetryAfter):
-            self._renewal.extend(exc.timeout_seconds, self._client.extend_lease)
+            self._renewal.extend(exc.timeout_seconds)
             debug_log_for_msg(
                 "message.retry_after",
                 self._message,
@@ -422,10 +422,8 @@ class _MessageLifecycle:
             )
             return True
         if exc is None:
-            retry_sync_follow_up(
-                lambda: self._client.acknowledge(self._message),
-                event_prefix="acknowledge",
-            )
+            # acknowledge() already retries transient failures internally.
+            self._client.acknowledge(self._message)
             debug_log_for_msg("message.ack", self._message)
         return None
 

--- a/src/vercel-queue/vercel/queue/_internal/lease.py
+++ b/src/vercel-queue/vercel/queue/_internal/lease.py
@@ -48,6 +48,7 @@ from anyio.streams.memory import MemoryObjectSendStream
 
 from vercel.oidc import get_vercel_oidc_token_sync
 
+from .asynctools import iter_coroutine
 from .errors import MessageNotFoundError, QueueError, ThrottledError
 from .log import debug_log
 from .retry import retry_async_follow_up, retry_sync_follow_up
@@ -100,6 +101,12 @@ class LeaseAsyncClient(Protocol):
     def _renew_lease(
         self,
         message: Message[Any],
+        duration: Duration,
+    ) -> Coroutine[Any, Any, None]: ...
+
+    def _extend_lease(
+        self,
+        message: Message[Any] | MessageMetadata,
         duration: Duration,
     ) -> Coroutine[Any, Any, None]: ...
 
@@ -386,25 +393,31 @@ class LeaseRenewal:
         except Exception as exc:  # noqa: BLE001
             _log_best_effort_lease_stop_failure(exc)
 
-    async def extend_async(
-        self,
-        duration: Duration,
-        extend_lease: AsyncExtendMessageLease,
-    ) -> None:
-        """Extend the lease immediately if this message has lease metadata."""
-        if self._message.metadata.receipt_handle is None:
-            return
-        await retry_message_after_async(self._message, duration, extend_lease)
+    async def extend_async(self, duration: Duration) -> None:
+        """Extend the lease immediately if this message has lease metadata.
 
-    def extend(
-        self,
-        duration: Duration,
-        extend_lease: ExtendMessageLease,
-    ) -> None:
-        """Extend the lease immediately if this message has lease metadata."""
+        Applies settlement retry semantics: transient failures are retried
+        and an already-missing lease is tolerated with a warning.
+        """
         if self._message.metadata.receipt_handle is None:
             return
-        retry_message_after_sync(self._message, duration, extend_lease)
+        await retry_message_after_async(
+            self._message,
+            duration,
+            self._client._extend_lease,  # noqa: SLF001
+        )
+
+    def extend(self, duration: Duration) -> None:
+        """Sync flavor of :meth:`extend_async`."""
+        if self._message.metadata.receipt_handle is None:
+            return
+        retry_message_after_sync(
+            self._message,
+            duration,
+            lambda message, duration: iter_coroutine(
+                self._client._extend_lease(message, duration)  # noqa: SLF001
+            ),
+        )
 
 
 def _prime_oidc_token_cache() -> None:


### PR DESCRIPTION
On Vercel, all threads are suspended once the push HTTP response is
sent. The push broker relied on two of them: Celery defers each
delivery's ACK/reject into the worker consumer's pending operations,
drained only by the worker loop thread, and lease renewals run on the
queue SDK's renewal thread. Neither ran between push requests, so
settlement never reached VQS: leases expired and every message was
redelivered and re-executed on a lease-duration cycle, with the stale
ACKs surfacing as 409 errors at the next thaw.

Settle deliveries inline instead: after handing a message into Kombu,
drain the embedded worker's pending operations on the delivering
thread so the ACK lands while the invocation still has compute.

Bouncing with `RetryAfter` is similarly unsafe in push mode because VQS
paces redelivery on its own coarse schedule (observed up to the full
remaining visibility deadline). Wait in-request for the handoff lock,
consumer readiness, and prefetch capacity, bounded by the new
`push_handoff_wait_seconds` transport option, and pump deferred ACKs
while waiting since those are what free prefetch capacity.

Also stop nesting retry wrappers in the queue delivery lifecycles:
the RetryAfter and ACK settlement paths wrapped the already-retrying
`extend_lease()`/`acknowledge()` client methods in a second retry layer,
multiplying worst-case attempts and logging duplicate
`visibility.retry_attempt` events for every visibility update.
