### PR TITLE
Fix package release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,11 +84,13 @@ jobs:
               print(package)
           PY
           : > /tmp/tags.txt
+          mkdir -p /tmp/release-bodies
 
           while IFS= read -r package; do
             version=$(python scripts/get-version.py "$package")
             tag="$package-v$version"
             echo "$tag" >> /tmp/tags.txt
+            python scripts/release.py github-release-body "$package" > "/tmp/release-bodies/$tag.md"
 
             http_status=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${package}/${version}/json")
             if [ "$http_status" = "200" ]; then
@@ -112,41 +114,60 @@ jobs:
 
       - name: Create Git Tags
         if: steps.publish.outputs.tags != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAGS: ${{ steps.publish.outputs.tags }}
         with:
           script: |
+            const fs = require('fs');
             const tags = process.env.TAGS.trim().split('\n').filter(Boolean);
             for (const tag of tags) {
+              const ref = `tags/${tag}`;
               try {
-                await github.rest.git.createRef({
+                await github.rest.git.getRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  ref: `refs/tags/${tag}`,
-                  sha: context.sha,
                 });
+                continue;
               } catch (error) {
-                if (error.status !== 422) throw error;
+                if (error.status !== 404) throw error;
               }
+
+              const message = fs.readFileSync(`/tmp/release-bodies/${tag}.md`, 'utf8');
+              const tagObject = await github.rest.git.createTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+                message,
+                object: context.sha,
+                type: 'commit',
+              });
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/${ref}`,
+                sha: tagObject.data.sha,
+              });
             }
 
       - name: Create GitHub Releases
         if: steps.publish.outputs.tags != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAGS: ${{ steps.publish.outputs.tags }}
         with:
           script: |
+            const fs = require('fs');
             const tags = process.env.TAGS.trim().split('\n').filter(Boolean);
             for (const tag of tags) {
+              const body = fs.readFileSync(`/tmp/release-bodies/${tag}.md`, 'utf8');
               try {
                 await github.rest.repos.createRelease({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   tag_name: tag,
                   name: tag,
-                  body: '',
+                  body,
                 });
               } catch (error) {
                 if (error.status !== 422) throw error;

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import os
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -324,10 +324,25 @@ def _release_commit_body(
     lines: list[str] = []
     for item in releases:
         package = packages_by_name[item.package]
-        lines.extend([f"## {item.package}", ""])
-        lines.extend(_demote_markdown_headings(_latest_changelog_entry(package.path)).splitlines())
+        lines.extend([item.package, "-" * len(item.package), ""])
+        lines.extend(_format_commit_markdown(_latest_changelog_entry(package.path)).splitlines())
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _github_release_body(
+    package_name: str, *, packages_by_name: dict[str, workspace.Package]
+) -> str:
+    try:
+        package = packages_by_name[package_name]
+    except KeyError:
+        raise SystemExit(f"unknown package: {package_name}") from None
+    return _latest_changelog_entry(package.path).rstrip() + "\n"
+
+
+def print_github_release_body(args: argparse.Namespace) -> int:
+    sys.stdout.write(_github_release_body(args.package, packages_by_name=workspace.packages()))
+    return 0
 
 
 def _latest_changelog_entry(package_path: Path) -> str:
@@ -343,11 +358,12 @@ def _latest_changelog_entry(package_path: Path) -> str:
     return "\n".join(lines[start:end]).rstrip()
 
 
-def _demote_markdown_headings(text: str) -> str:
+def _format_commit_markdown(text: str) -> str:
     lines = []
     for line in text.splitlines():
         if line.startswith("#"):
-            lines.append(f"#{line}")
+            heading = line.lstrip("#").strip()
+            lines.extend([heading, "-" * len(heading)])
         else:
             lines.append(line)
     return "\n".join(lines)
@@ -513,6 +529,10 @@ def main(argv: list[str] | None = None) -> int:
     changed_parser.add_argument("--base", default="HEAD^")
     changed_parser.add_argument("--head", default="HEAD")
     changed_parser.set_defaults(func=print_changed_packages)
+
+    github_release_body_parser = subparsers.add_parser("github-release-body")
+    github_release_body_parser.add_argument("package")
+    github_release_body_parser.set_defaults(func=print_github_release_body)
 
     check_parser = subparsers.add_parser("check-news-fragments")
     check_parser.add_argument("--base")

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -238,16 +238,73 @@ def test_release_commit_body_uses_latest_changelog_entries(tmp_path: Path) -> No
     assert (
         body
         == """
-## pkg
+pkg
+---
 
-### 0.7.0 - 2026-07-10
+0.7.0 - 2026-07-10
+------------------
 
-#### Features
+Features
+--------
 
 - Add feature.
 """.lstrip()
     )
     assert "Previous release" not in body
+
+
+def test_github_release_body_uses_package_latest_changelog_entry(tmp_path: Path) -> None:
+    package_path = tmp_path / "pkg"
+    other_package_path = tmp_path / "other"
+    package_path.mkdir()
+    other_package_path.mkdir()
+    (package_path / "CHANGELOG.md").write_text(
+        """
+# Changelog
+
+## 0.7.0 - 2026-07-10
+
+### Features
+
+- Add package feature.
+
+## 0.6.0 - 2026-01-01
+
+- Previous package release.
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (other_package_path / "CHANGELOG.md").write_text(
+        """
+# Changelog
+
+## 1.0.0 - 2026-07-10
+
+- Add other package feature.
+""".lstrip(),
+        encoding="utf-8",
+    )
+    packages = {
+        "pkg": workspace.Package("pkg", package_path, package_path / "version.py", ()),
+        "other": workspace.Package(
+            "other", other_package_path, other_package_path / "version.py", ()
+        ),
+    }
+
+    body = release._github_release_body("pkg", packages_by_name=packages)
+
+    assert (
+        body
+        == """
+## 0.7.0 - 2026-07-10
+
+### Features
+
+- Add package feature.
+""".lstrip()
+    )
+    assert "Previous package release" not in body
+    assert "other package" not in body
 
 
 def test_release_stages_commits_pushes_and_opens_pr(
@@ -287,11 +344,13 @@ def test_release_stages_commits_pushes_and_opens_pr(
         if cmd[:3] == ["git", "commit", "-v"]:
             template = Path(cmd[cmd.index("--template") + 1])
             message = template.read_text(encoding="utf-8")
-            assert message.startswith("Release Packages\n\n## pkg\n")
-            assert "### 0.7.0 - 2026-07-10" in message
+            assert message.startswith("Release Packages\n\npkg\n---\n")
+            assert "0.7.0 - 2026-07-10\n------------------" in message
+            assert "#" not in message
         if cmd[:3] == ["gh", "pr", "create"]:
             body = Path(cmd[cmd.index("--body-file") + 1]).read_text(encoding="utf-8")
-            assert body.startswith("## pkg\n")
+            assert body.startswith("pkg\n---\n")
+            assert "#" not in body
 
     def fake_check_output(cmd: list[str], *, cwd: Path, text: bool) -> str:
         assert cwd == root


### PR DESCRIPTION
GitHub releases are created once per package tag, but the publish
workflow did not derive a body for each package. That let package
releases reuse the wrong notes when a release commit covered multiple
packages.

Add a release helper that prints only the latest changelog entry for the
named package, and have the workflow pass that Markdown to each GitHub
release. The release commit and PR body use setext Markdown headings so
Git does not strip hash headings as comments.

Create annotated tags with the same package notes and update
`actions/github-script` to `v9`.
