### PR TITLE
vercel-cache: Make Runtime Cache usable off the request thread

### DIFF
--- a/changes/vercel-cache/runtime-cache-thread-fallback.bugfix.md
+++ b/changes/vercel-cache/runtime-cache-thread-fallback.bugfix.md
@@ -1,0 +1,8 @@
+Remember the last live Runtime Cache client process-wide and fall back to it
+on threads that have no request context, and make `strict=True` raise
+`RuntimeCacheError` when no cache is available instead of silently degrading
+to the in-memory fallback. On Vercel the cache configuration arrives with the
+request context, so background worker threads (such as embedded task-queue
+workers storing results) previously wrote to per-instance memory that readers
+could never see. `prime_runtime_cache()` lets integrations capture the
+request's cache while its context is still visible.

--- a/src/vercel-cache/tests/conftest.py
+++ b/src/vercel-cache/tests/conftest.py
@@ -24,8 +24,11 @@ def mock_env_clear(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, Non
     for var in env_vars_to_clear:
         monkeypatch.delenv(var, raising=False)
 
+    import vercel.cache.runtime_cache as runtime_cache
     from vercel.headers import set_headers
 
     set_headers(None)
+    monkeypatch.setattr(runtime_cache, "_cached_cache_instance", None)
+    monkeypatch.setattr(runtime_cache, "_cached_async_cache_instance", None)
     yield
     set_headers(None)

--- a/src/vercel-cache/tests/integration/test_cache_sync_async.py
+++ b/src/vercel-cache/tests/integration/test_cache_sync_async.py
@@ -80,6 +80,44 @@ class TestRuntimeCacheStrictErrors:
             cache.set("key", {"value": "payload"})
         assert route.called
 
+    def test_strict_runtime_cache_raises_when_unavailable(
+        self,
+        mock_env_clear,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import vercel.cache.runtime_cache as runtime_cache
+        from vercel.cache import RuntimeCache, RuntimeCacheError
+
+        monkeypatch.delenv("RUNTIME_CACHE_ENDPOINT", raising=False)
+        monkeypatch.delenv("RUNTIME_CACHE_HEADERS", raising=False)
+        monkeypatch.setattr(runtime_cache, "_cached_cache_instance", None)
+
+        cache = RuntimeCache(key_hash_function=lambda key: key, strict=True)
+
+        with pytest.raises(RuntimeCacheError, match="Runtime Cache unavailable"):
+            cache.set("key", "value")
+
+    def test_runtime_cache_uses_cached_context_cache_without_request_context(
+        self,
+        mock_env_clear,
+    ) -> None:
+        import vercel.cache.runtime_cache as runtime_cache
+        from vercel.cache import RuntimeCache, context
+        from vercel.cache.cache_in_memory import InMemoryCache
+
+        context_cache = InMemoryCache()
+        context.set_context(cache=context_cache)
+        try:
+            runtime_cache.prime_runtime_cache()
+        finally:
+            context.set_context(cache=None)
+
+        cache = RuntimeCache(key_hash_function=lambda key: key, strict=True)
+        cache.set("key", "value")
+
+        assert context_cache.get("key") == "value"
+        assert cache.get("key") == "value"
+
 
 class TestRuntimeCacheInMemory:
     """Test RuntimeCache with in-memory fallback."""

--- a/src/vercel-cache/vercel/cache/__init__.py
+++ b/src/vercel-cache/vercel/cache/__init__.py
@@ -1,12 +1,13 @@
 from .cache_build import RuntimeCacheError
 from .purge import dangerously_delete_by_tag, invalidate_by_tag
-from .runtime_cache import AsyncRuntimeCache, RuntimeCache, get_cache
+from .runtime_cache import AsyncRuntimeCache, RuntimeCache, get_cache, prime_runtime_cache
 
 __all__ = [
     "RuntimeCache",
     "RuntimeCacheError",
     "AsyncRuntimeCache",
     "get_cache",
+    "prime_runtime_cache",
     "invalidate_by_tag",
     "dangerously_delete_by_tag",
 ]

--- a/src/vercel-cache/vercel/cache/runtime_cache.py
+++ b/src/vercel-cache/vercel/cache/runtime_cache.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Callable, Sequence
 from typing import Literal, cast, overload
 
-from .cache_build import AsyncBuildCache, BuildCache
+from .cache_build import AsyncBuildCache, BuildCache, RuntimeCacheError
 from .cache_in_memory import AsyncInMemoryCache, InMemoryCache
 from .context import get_context
 from .types import AsyncCache, Cache
@@ -13,6 +13,8 @@ _in_memory_cache_instance: InMemoryCache | None = None
 _async_in_memory_cache_instance: AsyncInMemoryCache | None = None
 _build_cache_instance: BuildCache | None = None
 _async_build_cache_instance: AsyncBuildCache | None = None
+_cached_cache_instance: Cache | None = None
+_cached_async_cache_instance: AsyncCache | None = None
 _warned_cache_unavailable = False
 
 
@@ -137,6 +139,8 @@ def _get_cache_implementation(
     if os.getenv("RUNTIME_CACHE_DISABLE_BUILD_CACHE") == "true":
         if debug:
             print("Using InMemoryCache as build cache is disabled")
+        if strict:
+            raise RuntimeCacheError("Runtime Cache unavailable: build cache is disabled")
         return _in_memory_cache_instance if sync else _async_in_memory_cache_instance
 
     endpoint = os.getenv("RUNTIME_CACHE_ENDPOINT")
@@ -149,6 +153,13 @@ def _get_cache_implementation(
         )
 
     if not endpoint or not headers:
+        cached = _cached_cache_instance if sync else _cached_async_cache_instance
+        if cached is not None:
+            return cached
+        if strict:
+            raise RuntimeCacheError(
+                "Runtime Cache unavailable: no request cache context or runtime cache environment"
+            )
         if not _warned_cache_unavailable:
             print("Runtime Cache unavailable in this environment. Falling back to in-memory cache.")
             _warned_cache_unavailable = True
@@ -161,6 +172,10 @@ def _get_cache_implementation(
             raise ValueError("RUNTIME_CACHE_HEADERS must be a JSON object")
     except Exception as e:
         print("Failed to parse RUNTIME_CACHE_HEADERS:", e)
+        if strict:
+            raise RuntimeCacheError(
+                "Runtime Cache unavailable: invalid RUNTIME_CACHE_HEADERS"
+            ) from e
         return _in_memory_cache_instance if sync else _async_in_memory_cache_instance  # type: ignore[return-value]
 
     if sync:
@@ -171,8 +186,11 @@ def _get_cache_implementation(
                 on_error=lambda e: print(e),
             )
         if not strict:
+            remember_cache(_build_cache_instance, sync=True)
             return _build_cache_instance
-        return BuildCache(endpoint=endpoint, headers=parsed_headers, strict=True)
+        cache = BuildCache(endpoint=endpoint, headers=parsed_headers, strict=True)
+        remember_cache(cache, sync=True)
+        return cache
     else:
         if _async_build_cache_instance is None:
             _async_build_cache_instance = AsyncBuildCache(
@@ -180,7 +198,25 @@ def _get_cache_implementation(
                 headers=parsed_headers,
                 on_error=lambda e: print(e),
             )
+        remember_cache(_async_build_cache_instance, sync=False)
         return _async_build_cache_instance
+
+
+def remember_cache(cache: Cache | AsyncCache, *, sync: bool) -> None:
+    """Remember a live Runtime Cache client for background worker threads."""
+    global _cached_cache_instance, _cached_async_cache_instance
+    if sync:
+        _cached_cache_instance = cast(Cache, cache)
+    else:
+        _cached_async_cache_instance = cast(AsyncCache, cache)
+
+
+def prime_runtime_cache() -> None:
+    """Prime process-wide Runtime Cache fallback from the current request context."""
+    try:
+        resolve_cache(sync=True, strict=True)
+    except RuntimeCacheError:
+        return
 
 
 @overload
@@ -196,9 +232,14 @@ def resolve_cache(sync: bool = True, strict: bool = False) -> Cache | AsyncCache
     if sync:
         cache = getattr(ctx, "cache", None)
         if cache is not None:
-            return cast(Cache, cache)
-    else:
-        cache = getattr(ctx, "async_cache", None)
-        if cache is not None:
-            return cast(AsyncCache, cache)
-    return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", sync, strict)
+            resolved = cast(Cache, cache)
+            remember_cache(resolved, sync=True)
+            return resolved
+        return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", True, strict)
+
+    async_cache = getattr(ctx, "async_cache", None)
+    if async_cache is not None:
+        resolved_async = cast(AsyncCache, async_cache)
+        remember_cache(resolved_async, sync=False)
+        return resolved_async
+    return _get_cache_implementation(os.getenv("SUSPENSE_CACHE_DEBUG") == "true", False, strict)


### PR DESCRIPTION
Runtime Cache configuration arrives with the request context: the
client is resolved from a request-scoped context variable or, failing
that, environment variables. Threads that never had a request context,
such as embedded task-queue workers storing results, resolved neither
and silently fell back to the per-instance in-memory cache, so stored
values were invisible to every reader and lookups spun until timeout.

Follow the vercel-oidc freshest-token approach: remember the last cache
client resolved on a live request thread process-wide and fall back to
it whenever the ambient context has no cache. The new
prime_runtime_cache() lets integrations capture the request's cache
while its context is still visible, before handing work to background
threads.

Also make strict=True raise RuntimeCacheError when no cache is
available anywhere instead of degrading to the in-memory fallback;
silent degradation is indistinguishable from data loss for readers on
other instances.
