### PR TITLE
Add an option to force-bump packages with no changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,14 @@ cmd = "python scripts/release.py lint-towncrier"
 cmd = "python scripts/release.py status"
 
 [tool.poe.tasks.release]
-cmd = "python scripts/release.py release"
+shell = """
+set --
+if [ -n "${force_bump:-}" ]; then
+  set -- "$@" --force-bump "$force_bump"
+fi
+python scripts/release.py release "$@"
+"""
+args = [{ name = "force_bump", options = ["--force-bump"] }]
 
 [tool.poe.tasks.build-packages]
 cmd = "./scripts/build.sh"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ class Release:
     bump: str
     fragments: tuple[Fragment, ...]
     dependency_only: bool = False
+    forced: bool = False
 
 
 def parse_fragments(packages: set[str]) -> list[Fragment]:
@@ -107,7 +108,7 @@ def bump_version(version: str, bump: str) -> str:
     return f"{major}.{minor}.{patch + 1}"
 
 
-def compute_releases() -> list[Release]:
+def compute_releases(*, force_bump: str | None = None) -> list[Release]:
     packages_by_name = workspace.packages()
     versions = {
         name: workspace.read_version(package.version_file)
@@ -120,6 +121,10 @@ def compute_releases() -> list[Release]:
         fragments_by_package[fragment.package].append(fragment)
         bump = _bump_for_fragment(fragment.kind, versions[fragment.package])
         bumps[fragment.package] = _larger(bumps.get(fragment.package, "patch"), bump)
+
+    if force_bump:
+        for name in packages_by_name:
+            bumps[name] = _larger(bumps.get(name, "patch"), force_bump)
 
     reverse_edges = workspace.reverse_dependencies(packages_by_name)
     queue = list(bumps)
@@ -141,7 +146,8 @@ def compute_releases() -> list[Release]:
             new_version=bump_version(versions[name], bumps[name]),
             bump=bumps[name],
             fragments=tuple(fragments_by_package[name]),
-            dependency_only=not fragments_by_package[name],
+            dependency_only=not force_bump and not fragments_by_package[name],
+            forced=force_bump is not None and not fragments_by_package[name],
         )
         for name in ordered
     ]
@@ -150,6 +156,9 @@ def compute_releases() -> list[Release]:
 def _render_changelog_entry(release: Release, *, pr_numbers: dict[Path, int] | None = None) -> str:
     today = date.today().isoformat()
     lines = [f"## {release.new_version} - {today}", ""]
+    if release.forced:
+        lines.extend(["- No changes.", ""])
+        return "\n".join(lines)
     if release.dependency_only:
         lines.extend(["- Update dependencies.", ""])
         return "\n".join(lines)
@@ -161,12 +170,26 @@ def _render_changelog_entry(release: Release, *, pr_numbers: dict[Path, int] | N
         lines.extend([f"### {title}", ""])
         for fragment in fragments:
             pr_number = pr_numbers.get(fragment.path) if pr_numbers is not None else None
-            for item in fragment.text.splitlines():
-                item = item.strip()
-                if item:
-                    lines.append(_render_changelog_bullet(item, pr_number=pr_number))
+            for item in _fragment_changelog_items(fragment.text):
+                lines.append(_render_changelog_bullet(item, pr_number=pr_number))
         lines.append("")
     return "\n".join(lines)
+
+
+def _fragment_changelog_items(text: str) -> list[str]:
+    items: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if current:
+                items.append(" ".join(current))
+                current = []
+            continue
+        current.append(stripped)
+    if current:
+        items.append(" ".join(current))
+    return items
 
 
 def _render_changelog_bullet(item: str, *, pr_number: int | None) -> str:
@@ -197,8 +220,10 @@ def write_changelog(
     path.write_text(content, encoding="utf-8")
 
 
-def prepare_release_files() -> tuple[list[Release], dict[Path, int]]:
-    releases = compute_releases()
+def prepare_release_files(
+    *, force_bump: str | None = None
+) -> tuple[list[Release], dict[Path, int]]:
+    releases = compute_releases(force_bump=force_bump)
     if not releases:
         print("No news fragments found.")
         return [], {}
@@ -224,10 +249,10 @@ def prepare() -> int:
     return 0
 
 
-def release() -> int:
+def release(*, force_bump: str | None = None) -> int:
     _ensure_clean_tree()
     branch = _create_release_branch()
-    releases, _pr_numbers = prepare_release_files()
+    releases, _pr_numbers = prepare_release_files(force_bump=force_bump)
     if not releases:
         return 0
 
@@ -276,7 +301,9 @@ def _stage_all() -> None:
 def _commit_release(body: str) -> None:
     message_path = _write_temp_text(_release_commit_message(body), prefix="release-commit-")
     try:
-        subprocess.check_call(["git", "commit", "-v", "--template", str(message_path)], cwd=ROOT)
+        subprocess.check_call(
+            ["git", "commit", "-v", "--file", str(message_path), "--edit"], cwd=ROOT
+        )
     finally:
         message_path.unlink(missing_ok=True)
 
@@ -524,7 +551,13 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("status").set_defaults(func=lambda _args: status())
     subparsers.add_parser("prepare").set_defaults(func=lambda _args: prepare())
-    subparsers.add_parser("release").set_defaults(func=lambda _args: release())
+    release_parser = subparsers.add_parser("release")
+    release_parser.add_argument(
+        "--force-bump",
+        choices=tuple(BUMP_ORDER),
+        help="bump every package by this amount and write No changes changelog entries",
+    )
+    release_parser.set_defaults(func=lambda args: release(force_bump=args.force_bump))
     changed_parser = subparsers.add_parser("changed")
     changed_parser.add_argument("--base", default="HEAD^")
     changed_parser.add_argument("--head", default="HEAD")

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -50,6 +50,84 @@ def test_compute_releases_cascades_dependency_only_patch(
     ]
 
 
+def test_compute_releases_force_bumps_all_packages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    changes.mkdir()
+
+    lib_version = tmp_path / "lib/version.py"
+    app_version = tmp_path / "app/version.py"
+    lib_version.parent.mkdir()
+    app_version.parent.mkdir()
+    lib_version.write_text('__version__ = "0.6.0"\n', encoding="utf-8")
+    app_version.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+
+    packages = {
+        "lib": workspace.Package("lib", tmp_path / "lib", lib_version, ()),
+        "app": workspace.Package("app", tmp_path / "app", app_version, ("lib",)),
+    }
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["lib", "app"])
+
+    releases = release.compute_releases(force_bump="minor")
+
+    assert [
+        (item.package, item.new_version, item.bump, item.dependency_only, item.forced)
+        for item in releases
+    ] == [
+        ("lib", "0.7.0", "minor", False, True),
+        ("app", "1.3.0", "minor", False, True),
+    ]
+
+
+def test_compute_releases_force_accepts_patch_bump(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    changes.mkdir()
+
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["pkg"])
+
+    releases = release.compute_releases(force_bump="patch")
+
+    assert [(item.package, item.new_version, item.bump, item.forced) for item in releases] == [
+        ("pkg", "1.2.4", "patch", True)
+    ]
+
+
+def test_compute_releases_force_preserves_larger_fragment_bump(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    fragment_dir = changes / "pkg"
+    fragment_dir.mkdir(parents=True)
+    (fragment_dir / "123.breaking.md").write_text("Break API.\n", encoding="utf-8")
+
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["pkg"])
+
+    releases = release.compute_releases(force_bump="minor")
+
+    assert [(item.package, item.new_version, item.bump, item.forced) for item in releases] == [
+        ("pkg", "2.0.0", "major", False)
+    ]
+
+
 def test_workspace_dependency_hook_rewrites_lower_bound(tmp_path: Path) -> None:
     workspace_root = tmp_path
     package_root = workspace_root / "src/app"
@@ -161,6 +239,38 @@ def test_render_changelog_entry_does_not_duplicate_pr_number(tmp_path: Path) -> 
     assert entry.count("#42") == 1
 
 
+def test_render_changelog_entry_treats_paragraphs_as_items(tmp_path: Path) -> None:
+    fragment = release.Fragment(
+        package="pkg",
+        path=tmp_path / "123.bugfix.md",
+        kind="bugfix",
+        text=(
+            "Remember the last live Runtime Cache client process-wide and fall back to it\n"
+            "on threads that have no request context, and make strict=True raise\n"
+            "RuntimeCacheError when no cache is available.\n"
+            "\n"
+            "Prime the cache while request context is still visible.\n"
+        ),
+    )
+    item = release.Release(
+        package="pkg",
+        old_version="0.6.0",
+        new_version="0.6.1",
+        bump="patch",
+        fragments=(fragment,),
+    )
+
+    entry = release._render_changelog_entry(item, pr_numbers={fragment.path: 178})
+
+    assert (
+        "- Remember the last live Runtime Cache client process-wide and fall back to it "
+        "on threads that have no request context, and make strict=True raise "
+        "RuntimeCacheError when no cache is available. (#178)"
+    ) in entry
+    assert "- Prime the cache while request context is still visible. (#178)" in entry
+    assert entry.count("#178") == 2
+
+
 def test_dependency_only_changelog_omits_pr_number() -> None:
     item = release.Release(
         package="pkg",
@@ -175,6 +285,22 @@ def test_dependency_only_changelog_omits_pr_number() -> None:
 
     assert "- Update dependencies." in entry
     assert "#42" not in entry
+
+
+def test_forced_changelog_entry_uses_no_changes() -> None:
+    item = release.Release(
+        package="pkg",
+        old_version="0.6.0",
+        new_version="0.7.0",
+        bump="minor",
+        fragments=(),
+        forced=True,
+    )
+
+    entry = release._render_changelog_entry(item, pr_numbers={})
+
+    assert "- No changes." in entry
+    assert "- Update dependencies." not in entry
 
 
 def test_write_changelog_separates_prepended_entry(tmp_path: Path) -> None:
@@ -336,14 +462,14 @@ def test_release_stages_commits_pushes_and_opens_pr(
 
     monkeypatch.setattr(release, "ROOT", root)
     monkeypatch.setattr(release, "datetime", FakeDatetime)
-    monkeypatch.setattr(release, "prepare_release_files", lambda: ([item], {}))
+    monkeypatch.setattr(release, "prepare_release_files", lambda *, force_bump=None: ([item], {}))
     monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
 
     def fake_check_call(cmd: list[str], *, cwd: Path) -> None:
         calls.append(cmd)
         if cmd[:3] == ["git", "commit", "-v"]:
-            template = Path(cmd[cmd.index("--template") + 1])
-            message = template.read_text(encoding="utf-8")
+            message_file = Path(cmd[cmd.index("--file") + 1])
+            message = message_file.read_text(encoding="utf-8")
             assert message.startswith("Release Packages\n\npkg\n---\n")
             assert "0.7.0 - 2026-07-10\n------------------" in message
             assert "#" not in message
@@ -367,7 +493,8 @@ def test_release_stages_commits_pushes_and_opens_pr(
     assert release.release() == 0
     assert calls[0] == ["git", "switch", "-c", "octocat/release-20260710123456"]
     assert calls[1] == ["git", "add", "-A"]
-    assert calls[2][:4] == ["git", "commit", "-v", "--template"]
+    assert calls[2][:4] == ["git", "commit", "-v", "--file"]
+    assert calls[2][-1] == "--edit"
     assert calls[3] == ["git", "push", "--set-upstream", "origin", "HEAD"]
     assert calls[4][:3] == ["gh", "pr", "create"]
     assert "--title" in calls[4]


### PR DESCRIPTION
In some cases we might want to push a new package release even when
there were no code changes since the last release (such as when there
are release/packaging changes), so add an option to `poe release`:
`--force-bump={patch,minor,major}`.
