### PR TITLE
Fix release workflow

### DIFF
--- a/.github/scripts/test_installed_wheel.sh
+++ b/.github/scripts/test_installed_wheel.sh
@@ -14,87 +14,59 @@ if [ ! -f "$wheel_path" ]; then
     printf 'wheel does not exist: %s\n' "$wheel_path" >&2
     exit 1
 fi
+wheel_path=$(python - "$wheel_path" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).resolve())
+PY
+)
 
 wheel_dir=$(dirname "$wheel_path")
 for dependency_wheel in "$wheel_dir"/vercel_*.whl; do
     if [ ! -f "$dependency_wheel" ] || [ "$dependency_wheel" = "$wheel_path" ]; then
         continue
     fi
+    dependency_wheel=$(python - "$dependency_wheel" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).resolve())
+PY
+)
     extra_wheel_args="$extra_wheel_args --with $dependency_wheel"
 done
 
-if [ "$package" = "vercel-internal-shared-vendored-deps" ]; then
-    package_path=
-else
-    package_path=$(python - "$package" <<'PY'
+package_path=$(python - "$package" <<'PY'
 import sys
 
 from scripts import workspace
 
 package = sys.argv[1]
-try:
-    print(workspace.packages()[package].path)
-except KeyError:
-    raise SystemExit(f"unknown package: {package}") from None
+packages = workspace.packages()
+if package in packages:
+    print(packages[package].path)
 PY
 )
-fi
 
 temp_dir=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
 test_root=$(mktemp -d "$temp_dir/vercel-py-installed-package-tests.XXXXXX")
+test_root=$(python - "$test_root" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).resolve())
+PY
+)
 if [ -n "$package_path" ] && [ -d "$package_path/tests" ]; then
     cp -R "$package_path/tests" "$test_root/tests"
+fi
+if [ -n "$package_path" ] && [ -f "$package_path/pyproject.toml" ]; then
+    cp "$package_path/pyproject.toml" "$test_root/pyproject.toml"
 fi
 if [ -n "$package_path" ] && [ -d "$package_path/examples" ]; then
     cp -R "$package_path/examples" "$test_root/examples"
 fi
-
-if [ "$package" = "vercel-cache" ]; then
-    python - "$test_root" <<'PY'
-import sys
-from pathlib import Path
-
-test_root = Path(sys.argv[1])
-for path in (test_root / "tests").rglob("*.py"):
-    text = path.read_text(encoding="utf-8")
-    rewritten = text.replace("import httpx\n", "from vercel.internal._vendor import httpx\n")
-    if rewritten != text:
-        path.write_text(rewritten, encoding="utf-8")
-PY
-fi
-
-case "$package" in
-    vercel-queue)
-        set -- \
-            --with pydantic \
-            --with trio \
-            --with fastapi \
-            --with uvicorn \
-            --with respx \
-            --with pytest-asyncio
-        pytest_args="$test_root/tests/unit/test_queue_typeutils.py $test_root/tests/unit/test_queue_transports.py $test_root/tests/unit/test_queue_config.py"
-        pytest_filter='not test_deployment_resolution_and_opt_out_headers'
-        ;;
-    vercel-celery)
-        set -- --with celery --with respx --with pytest-asyncio
-        pytest_args=''
-        pytest_filter=''
-        ;;
-    vercel-cache)
-        set -- --with respx --with pytest-asyncio
-        pytest_args="$test_root/tests"
-        pytest_filter='not StrictErrors'
-        ;;
-    *)
-        set -- --with respx --with pytest-asyncio
-        if [ -d "$test_root/tests" ]; then
-            pytest_args="$test_root/tests"
-        else
-            pytest_args=''
-        fi
-        pytest_filter=''
-        ;;
-esac
 
 python - "$wheel_path" "$test_root" <<'PY'
 import sys
@@ -114,19 +86,255 @@ with zipfile.ZipFile(wheel) as archive:
             archive.extract(member, test_root)
 PY
 
-if [ -n "$pytest_args" ]; then
+python - "$test_root" <<'PY'
+import sys
+from pathlib import Path
+
+test_root = Path(sys.argv[1])
+uses_vendored_httpx = any(
+    "from vercel.internal._vendor import httpx" in path.read_text(encoding="utf-8")
+    for path in (test_root / "vercel").rglob("*.py")
+)
+(test_root / ".uses-vendored-httpx").write_text(
+    "1\n" if uses_vendored_httpx else "0\n",
+    encoding="utf-8",
+)
+if not uses_vendored_httpx:
+    raise SystemExit
+
+for path in (test_root / "tests").rglob("*.py"):
+    text = path.read_text(encoding="utf-8")
+    rewritten = text.replace("import httpx\n", "from vercel.internal._vendor import httpx\n")
+    if rewritten != text:
+        path.write_text(rewritten, encoding="utf-8")
+PY
+
+python - "$package" "$package_path" "$test_root" <<'PY'
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Any
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from scripts import workspace
+
+ROOT = Path.cwd()
+package_name = sys.argv[1]
+package_path = Path(sys.argv[2]) if sys.argv[2] else None
+test_root = Path(sys.argv[3])
+tests_root = test_root / "tests"
+requirements_path = test_root / "requirements.txt"
+pytest_extra_args_path = test_root / "pytest-extra-args.txt"
+pytest_filter_path = test_root / "pytest-filter.txt"
+uses_vendored_httpx = test_root.joinpath(".uses-vendored-httpx").read_text(
+    encoding="utf-8"
+).strip() == "1"
+
+
+def load_pyproject(path: Path) -> dict[str, Any]:
+    with path.joinpath("pyproject.toml").open("rb") as fp:
+        return tomllib.load(fp)
+
+
+def requirement_name(requirement: str) -> str:
+    return normalize_name(Requirement(requirement).name)
+
+
+def normalize_name(name: str) -> str:
+    return str(canonicalize_name(name))
+
+
+def import_to_distribution(name: str) -> str:
+    return normalize_name(name)
+
+
+def wheel_import_roots() -> set[str]:
+    return {path.name for path in test_root.iterdir() if path.is_dir() and path.name != "tests"}
+
+
+def local_import_roots() -> set[str]:
+    if package_path is None:
+        return set()
+    roots = set()
+    for path in package_path.iterdir():
+        if path.name in {"tests", "examples"}:
+            continue
+        if path.is_file() and path.suffix == ".py":
+            roots.add(path.stem)
+        elif path.is_dir() and path.joinpath("__init__.py").exists():
+            roots.add(path.name)
+    return roots - wheel_import_roots()
+
+
+def imported_modules(path: Path) -> set[str]:
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return set()
+    imports = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def imported_workspace_packages(imports: set[str]) -> set[str]:
+    packages = workspace.packages()
+    result = {package_name} if package_name in packages else set()
+    for name, package in packages.items():
+        data = load_pyproject(package.path)
+        include = data.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {})
+        wheel = include.get("wheel", {})
+        roots = wheel.get("only-include") or []
+        if not roots:
+            roots = [package.version_file.parent.relative_to(package.path).as_posix()]
+        modules = [root.strip("/").replace("/", ".") for root in roots]
+        if any(import_name == module or import_name.startswith(f"{module}.") for import_name in imports for module in modules):
+            result.add(name)
+    return result
+
+
+def project_dependencies(data: dict[str, Any]) -> list[str]:
+    release = data.get("tool", {}).get("vercel", {}).get("release", {})
+    dependencies = release.get("dependencies", data.get("project", {}).get("dependencies", []))
+    if isinstance(dependencies, dict):
+        dependencies = dependencies.get("dependencies", [])
+    return dependencies if isinstance(dependencies, list) else []
+
+
+def root_dev_dependencies() -> dict[str, str]:
+    deps = load_pyproject(ROOT).get("dependency-groups", {}).get("dev", [])
+    result = {}
+    for dependency in deps:
+        if isinstance(dependency, str):
+            result[requirement_name(dependency)] = dependency
+    return result
+
+
+def add_requirement(requirement: str) -> None:
+    requirements[requirement_name(requirement)] = requirement
+
+
+def selected_test_files() -> list[Path]:
+    if not tests_root.exists():
+        return []
+    unavailable_roots = local_import_roots()
+    selected = []
+    for path in sorted(tests_root.rglob("test_*.py")):
+        imports = imported_modules(path)
+        if unavailable_roots.intersection(import_name.split(".", 1)[0] for import_name in imports):
+            continue
+        selected.append(path)
+    return selected
+
+
+def ignored_test_files() -> list[Path]:
+    if not tests_root.exists():
+        return []
+    unavailable_roots = local_import_roots()
+    ignored = []
+    for path in sorted(tests_root.rglob("test_*.py")):
+        imports = imported_modules(path)
+        if unavailable_roots.intersection(import_name.split(".", 1)[0] for import_name in imports):
+            ignored.append(path)
+    return ignored
+
+
+def pytest_filter_for_tests(paths: list[Path], texts: str) -> str:
+    if not uses_vendored_httpx or "respx_mock" not in texts or "httpx.Response" not in texts:
+        return ""
+
+    excluded_names = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        module = ast.parse(text, filename=str(path))
+        for node in module.body:
+            if not isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            source = ast.get_source_segment(text, node) or ""
+            if "respx_mock" in source and "httpx.Response" in source:
+                excluded_names.append(node.name)
+    return " and ".join(f"not {name}" for name in excluded_names)
+
+
+stdlib_modules = sys.stdlib_module_names | {"__future__"}
+test_files = selected_test_files()
+ignored_files = ignored_test_files()
+imports = {module for path in test_files for module in imported_modules(path)}
+texts = "\n".join(path.read_text(encoding="utf-8") for path in test_files)
+requirements: dict[str, str] = {}
+root_dev = root_dev_dependencies()
+requirements.update(root_dev)
+
+for module in imports:
+    root = module.split(".", 1)[0]
+    if root in stdlib_modules or root in {"tests", "vercel"}:
+        continue
+    dependency = root_dev.get(import_to_distribution(root))
+    if dependency is not None:
+        add_requirement(dependency)
+
+pytest_config = load_pyproject(package_path) if package_path is not None else {}
+pytest_options = pytest_config.get("tool", {}).get("pytest", {}).get("ini_options", {})
+
+if "pytest.mark.asyncio" in texts or "asyncio_mode" in pytest_options:
+    dependency = root_dev.get("pytest-asyncio")
+    if dependency is not None:
+        add_requirement(dependency)
+
+packages = workspace.packages()
+for name in imported_workspace_packages(imports):
+    if name not in packages:
+        continue
+    data = load_pyproject(packages[name].path)
+    for dependency in project_dependencies(data):
+        normalized = requirement_name(dependency)
+        if normalized.startswith("vercel-") and normalized in packages:
+            continue
+        add_requirement(root_dev.get(normalized, dependency))
+
+pytest_filter = pytest_filter_for_tests(test_files, texts)
+
+requirements_path.write_text("\n".join(sorted(requirements.values())) + "\n", encoding="utf-8")
+pytest_extra_args_path.write_text(
+    "\n".join(f"--ignore={path}" for path in ignored_files) + "\n",
+    encoding="utf-8",
+)
+pytest_filter_path.write_text(f"{pytest_filter}\n", encoding="utf-8")
+PY
+
+pytest_extra_args=$(cat "$test_root/pytest-extra-args.txt")
+pytest_filter=$(cat "$test_root/pytest-filter.txt")
+set --
+if [ -n "$pytest_filter" ]; then
+    set -- -k "$pytest_filter"
+fi
+
+if [ -d "$test_root/tests" ]; then
     # shellcheck disable=SC2086
     uv run \
         --no-cache \
         --isolated \
+        --no-project \
         --directory "$test_root" \
         --with "$wheel_path" \
         --with pytest \
+        --with-requirements "$test_root/requirements.txt" \
         $extra_wheel_args \
-        "$@" \
         pytest \
         -v \
         --tb=short \
-        -k "$pytest_filter" \
-        $pytest_args
+        "$@" \
+        $pytest_extra_args
 fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: false
         type: boolean
+      force:
+        description: Check every publish candidate, skipping versions that already exist.
+        required: false
+        default: false
+        type: boolean
   push:
     branches:
       - main
@@ -33,11 +38,27 @@ jobs:
         id: packages
         env:
           BASE_REF: ${{ github.event.before || 'HEAD^' }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
         run: |
           packages_json=$(python - <<'PY'
           import os
           import json
           import subprocess
+
+          shared = "vercel-internal-shared-vendored-deps"
+          if os.environ.get("FORCE") == "true":
+              packages = subprocess.check_output(
+                  [
+                      "python",
+                      "scripts/workspace.py",
+                      "list",
+                      "--names",
+                      "--topological",
+                  ],
+                  text=True,
+              ).splitlines()
+              print(json.dumps([shared, *packages]))
+              raise SystemExit
 
           base = os.environ["BASE_REF"]
           if base == "0000000000000000000000000000000000000000":
@@ -55,7 +76,6 @@ jobs:
               ],
               text=True,
           ).splitlines()
-          shared = "vercel-internal-shared-vendored-deps"
           shared_check = subprocess.run(
               [
                   "python",
@@ -96,6 +116,7 @@ jobs:
         env:
           PACKAGES_JSON: ${{ needs.detect.outputs.packages }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
         run: |
           python - <<'PY' > /tmp/packages.txt
           import json
@@ -122,7 +143,9 @@ jobs:
             fi
             if [ "$is_shared_vendored_deps" = "true" ]; then
               version=$(python scripts/bundle_release.py shared-version)
-              if python scripts/bundle_release.py shared-version --needs-publish >/dev/null; then
+              if [ "$FORCE" = "true" ]; then
+                publish_shared_vendored_deps=true
+              elif python scripts/bundle_release.py shared-version --needs-publish >/dev/null; then
                 publish_shared_vendored_deps=true
               else
                 publish_shared_vendored_deps=false
@@ -199,6 +222,8 @@ jobs:
             if [ "$is_shared_vendored_deps" = "true" ]; then
               if [ "$publish_shared_vendored_deps" != "true" ]; then
                 :
+              elif [ "$http_status" = "200" ]; then
+                :
               elif [ "$DRY_RUN" = "true" ]; then
                 echo "Dry run: would publish $package $version"
               else
@@ -235,7 +260,9 @@ jobs:
                 await github.rest.git.getRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  ref,
                 });
+                core.info(`Tag ${tag} already exists, skipping`);
                 continue;
               } catch (error) {
                 if (error.status !== 404) throw error;
@@ -250,12 +277,22 @@ jobs:
                 object: context.sha,
                 type: 'commit',
               });
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/${ref}`,
-                sha: tagObject.data.sha,
-              });
+              try {
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/${ref}`,
+                  sha: tagObject.data.sha,
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref,
+                });
+                core.info(`Tag ${tag} was created concurrently, skipping`);
+              }
             }
 
       - name: Create GitHub Releases

--- a/scripts/bundle_release.py
+++ b/scripts/bundle_release.py
@@ -60,12 +60,14 @@ SHARED_VENDORED_REQUIREMENTS = tuple(SHARED_VENDORED_LIBS.values())
 SHARED_VENDORED_CONSUMERS = {
     "vercel-cache",
     "vercel-celery",
+    "vercel-dramatiq",
     "vercel-internal-telemetry",
     "vercel-oidc",
     "vercel-queue",
 }
 PEER_DEPENDENCIES = {
     "vercel-celery": {"celery"},
+    "vercel-dramatiq": {"dramatiq"},
 }
 COMMON_DROP_TRANSFORMATIONS = (
     "*.so",
@@ -101,72 +103,9 @@ class VendoringTransformations:
     drops: tuple[str, ...] = COMMON_DROP_TRANSFORMATIONS
 
 
-@dataclass(frozen=True)
-class GeneratedVendoringConfig:
-    config: VendoringConfig
-    transformations: VendoringTransformations = VendoringTransformations()
-
-
-GENERATED_VENDORED_CONFIGS = {
-    "vercel-cache": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/cache/_vendor"),
-            requirements=Path("vercel/cache/_vendor/vendor.txt"),
-            namespace="vercel.cache._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-    ),
-    "vercel-celery": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/integrations/celery/_vendor"),
-            requirements=Path("vercel/integrations/celery/_vendor/vendor.txt"),
-            namespace="vercel.integrations.celery._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-        transformations=VendoringTransformations(
-            substitutions=(ANYIO_FROM_THREAD_SUBSTITUTION,),
-        ),
-    ),
-    "vercel-headers": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/headers/_vendor"),
-            requirements=Path("vercel/headers/_vendor/vendor.txt"),
-            namespace="vercel.headers._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-    ),
-    "vercel-internal-telemetry": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/internal/telemetry/_vendor"),
-            requirements=Path("vercel/internal/telemetry/_vendor/vendor.txt"),
-            namespace="vercel.internal.telemetry._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-    ),
-    "vercel-oidc": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/oidc/_vendor"),
-            requirements=Path("vercel/oidc/_vendor/vendor.txt"),
-            namespace="vercel.oidc._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-    ),
-    "vercel-queue": GeneratedVendoringConfig(
-        config=VendoringConfig(
-            destination=Path("vercel/queue/_vendor"),
-            requirements=Path("vercel/queue/_vendor/vendor.txt"),
-            namespace="vercel.queue._vendor",
-            protected_files=("__init__.py", "vendor.txt"),
-        ),
-        transformations=VendoringTransformations(
-            substitutions=(ANYIO_FROM_THREAD_SUBSTITUTION,),
-        ),
-    ),
-}
-
-
 def is_vendored_eligible(package: workspace.Package) -> bool:
-    return package.name in GENERATED_VENDORED_CONFIGS
+    data = _load_pyproject(package.path)
+    return _vendoring_config_for_package(package, data) is not None
 
 
 def load_plan(package_name: str) -> VendoredPlan:
@@ -182,7 +121,9 @@ def load_plan(package_name: str) -> VendoredPlan:
         raise SystemExit(f"package is not vendored-eligible: {package_name}")
 
     data = _load_pyproject(package.path)
-    config = GENERATED_VENDORED_CONFIGS[package.name].config
+    config = _vendoring_config_for_package(package, data)
+    if config is None:
+        raise SystemExit(f"package is not vendored-eligible: {package_name}")
     requirements = _derive_vendor_requirements(package.name, data)
     return VendoredPlan(
         package=package,
@@ -236,6 +177,49 @@ def _load_pyproject(path: Path) -> dict[str, Any]:
         return tomllib.load(fp)
 
 
+def _vendoring_config_for_package(
+    package: workspace.Package, data: dict[str, Any]
+) -> VendoringConfig | None:
+    package_root = _vendoring_package_root_from_wheel_include(data)
+    if package_root is None:
+        package_root = _vendoring_package_root_from_version_file(package)
+    if package_root is None:
+        return None
+    destination = package_root / "_vendor"
+    return VendoringConfig(
+        destination=destination,
+        requirements=destination / "vendor.txt",
+        namespace=".".join(package_root.parts + ("_vendor",)),
+        protected_files=("__init__.py", "vendor.txt"),
+    )
+
+
+def _vendoring_package_root_from_wheel_include(data: dict[str, Any]) -> Path | None:
+    wheel = (
+        data.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {}).get("wheel", {})
+    )
+    includes = wheel.get("only-include", [])
+    if not isinstance(includes, list) or len(includes) != 1:
+        return None
+    include = includes[0]
+    if not isinstance(include, str):
+        return None
+    package_root = Path(include.lstrip("/"))
+    if package_root.parts[:1] != ("vercel",):
+        return None
+    return package_root
+
+
+def _vendoring_package_root_from_version_file(package: workspace.Package) -> Path | None:
+    try:
+        relative = package.version_file.relative_to(package.path)
+    except ValueError:
+        return None
+    if relative.parts[:1] != ("vercel",):
+        return None
+    return relative.parent
+
+
 def _derive_vendor_requirements(package_name: str, data: dict[str, Any]) -> tuple[str, ...]:
     lock_versions = _lock_versions()
     if package_name == SHARED_VENDORED_PACKAGE:
@@ -283,10 +267,14 @@ def _lock_versions() -> dict[str, str]:
 
 def _release_dependencies(data: dict[str, Any]) -> list[str]:
     release = data.get("tool", {}).get("vercel", {}).get("release", {})
-    dependency_table = release.get("dependencies", {})
-    if isinstance(dependency_table, list):
-        return dependency_table
-    dependencies = dependency_table.get("dependencies", [])
+    if "dependencies" in release:
+        dependency_table = release.get("dependencies", {})
+        if isinstance(dependency_table, list):
+            return dependency_table
+        dependencies = dependency_table.get("dependencies", [])
+        if isinstance(dependencies, list):
+            return dependencies
+    dependencies = data.get("project", {}).get("dependencies", [])
     if isinstance(dependencies, list):
         return dependencies
     return []
@@ -611,7 +599,7 @@ def _strip_vendoring_config(text: str) -> str:
 
 
 def _render_vendoring_config(plan: VendoredPlan) -> str:
-    transformations = _vendoring_transformations(plan.package.name)
+    transformations = _vendoring_transformations(plan)
     lines = [
         "[tool.vendoring]",
         f'destination = "{_toml_path(plan.config.destination)}/"',
@@ -631,12 +619,14 @@ def _render_vendoring_config(plan: VendoredPlan) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _vendoring_transformations(package_name: str) -> VendoringTransformations:
-    if package_name == SHARED_VENDORED_PACKAGE:
+def _vendoring_transformations(plan: VendoredPlan) -> VendoringTransformations:
+    if plan.package.name == SHARED_VENDORED_PACKAGE:
         return VendoringTransformations(
             substitutions=tuple(_shared_h2_substitution_pairs()),
         )
-    return GENERATED_VENDORED_CONFIGS[package_name].transformations
+    if any(_requirement_name(requirement) == "anyio" for requirement in plan.vendored_requirements):
+        return VendoringTransformations(substitutions=(ANYIO_FROM_THREAD_SUBSTITUTION,))
+    return VendoringTransformations()
 
 
 def _shared_h2_substitution_pairs() -> tuple[tuple[str, str], ...]:
@@ -734,12 +724,20 @@ def _rewrite_pyproject(plan: VendoredPlan, generated: Path) -> None:
         count=1,
     )
     deps = _format_toml_string_array(plan.external_dependencies)
-    text = re.sub(
-        r"(?ms)^\[tool\.vercel\.release\.dependencies\]\ndependencies = \[.*?\]\n",
-        f"[tool.vercel.release.dependencies]\ndependencies = {deps}\n",
-        text,
-        count=1,
-    )
+    if "[tool.vercel.release.dependencies]" in text:
+        text = re.sub(
+            r"(?ms)^\[tool\.vercel\.release\.dependencies\]\ndependencies = \[.*?\]\n",
+            f"[tool.vercel.release.dependencies]\ndependencies = {deps}\n",
+            text,
+            count=1,
+        )
+    else:
+        text = re.sub(
+            r"(?ms)(^\[project\]\n.*?^dependencies = )\[.*?\]",
+            rf"\1{deps}",
+            text,
+            count=1,
+        )
     text = re.sub(
         r'force-include = \{ "\.\./\.\./scripts/hatch_build\.py" = "/_vercel_hatch_build\.py" \}',
         'force-include = { "_vercel_hatch_build.py" = "/_vercel_hatch_build.py" }',
@@ -1048,7 +1046,7 @@ def test_wheel(package_name: str, *, dist_dir: Path) -> None:
     plan = load_plan(package_name)
     wheel = _single_wheel(dist_dir, plan.variant_name)
     script = ROOT / ".github" / "scripts" / "test_installed_wheel.sh"
-    _run(["sh", str(script), package_name, str(wheel)], cwd=ROOT)
+    _run(["sh", str(script), package_name, str(wheel.resolve())], cwd=ROOT)
 
 
 def shared_github_release_body() -> str:

--- a/src/vercel-queue/tests/unit/helpers.py
+++ b/src/vercel-queue/tests/unit/helpers.py
@@ -11,7 +11,6 @@ from functools import partial
 
 import anyio
 import anyio.lowlevel
-import httpx
 from anyio import to_thread
 
 from vercel.queue import (
@@ -22,6 +21,11 @@ from vercel.queue import (
     SanitizedName,
     Topic,
     subscribe,
+)
+from vercel.queue._internal import (
+    http as queue_http,
+    lease as queue_lease,
+    streams as queue_streams,
 )
 from vercel.queue._internal.constants import (
     CLOUD_EVENT_HEADER_TYPE,
@@ -62,7 +66,19 @@ class EmbeddedDelivery:
 
 
 def mock_response(*args: Any, **kwargs: Any) -> Any:
-    return httpx.Response(*args, **kwargs)
+    return queue_http.httpx.Response(*args, **kwargs)
+
+
+def queue_httpx_module() -> Any:
+    return queue_http.httpx
+
+
+def queue_lease_anyio_module() -> Any:
+    return queue_lease.anyio
+
+
+def queue_streams_anyio_module() -> Any:
+    return queue_streams.anyio
 
 
 def sync_delivery(

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta, timezone
 
 import anyio
 import anyio.from_thread
-import httpx
 import pytest
 from anyio import to_thread
 from anyio.lowlevel import current_token
@@ -66,6 +65,8 @@ from vercel.queue.sync import QueueClient as SyncQueueClient
 from .helpers import (
     CREATED_AT_DT,
     make_leased_metadata,
+    queue_httpx_module,
+    queue_lease_anyio_module,
 )
 
 
@@ -462,14 +463,15 @@ def test_sync_lease_start_reuses_worker_async_client_by_config(
         visibility_deadline=datetime.now(timezone.utc) - timedelta(seconds=1),
     )
     created = 0
-    original_client = httpx.AsyncClient
+    queue_httpx = queue_httpx_module()
+    original_client = queue_httpx.AsyncClient
 
-    def client_factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+    def client_factory(*args: Any, **kwargs: Any) -> Any:
         nonlocal created
         created += 1
         return original_client(*args, **kwargs)
 
-    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    monkeypatch.setattr(queue_httpx, "AsyncClient", client_factory)
     first = client.run_lease_renewal(first_message, lease_duration=30)
     second = client.run_lease_renewal(second_message, lease_duration=45)
     first.start()
@@ -510,14 +512,15 @@ async def test_async_client_reuses_worker_runtime_for_background_lease_extension
         visibility_deadline=datetime.now(timezone.utc) - timedelta(seconds=1),
     )
     created = 0
-    original_client = httpx.AsyncClient
+    queue_httpx = queue_httpx_module()
+    original_client = queue_httpx.AsyncClient
 
-    def client_factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+    def client_factory(*args: Any, **kwargs: Any) -> Any:
         nonlocal created
         created += 1
         return original_client(*args, **kwargs)
 
-    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    monkeypatch.setattr(queue_httpx, "AsyncClient", client_factory)
 
     first = client.run_lease_renewal(first_message, lease_duration=30)
     second = client.run_lease_renewal(second_message, lease_duration=45)
@@ -555,9 +558,7 @@ async def test_retry_async_follow_up_retries_throttled_operation(
         if calls == 1:
             raise ThrottledError(2)
 
-    monkeypatch.setattr(anyio, "sleep", sleep)
-
-    await retry_async_follow_up(operation)
+    await retry_async_follow_up(operation, sleep=sleep)
 
     assert calls == 2
     assert sleeps == [2.0]
@@ -596,10 +597,8 @@ async def test_retry_async_follow_up_does_not_retry_http_error(
         calls += 1
         raise ServerError("server error")
 
-    monkeypatch.setattr(anyio, "sleep", sleep)
-
     with pytest.raises(ServerError):
-        await retry_async_follow_up(operation)
+        await retry_async_follow_up(operation, sleep=sleep)
 
     assert calls == 1
     assert sleeps == []
@@ -845,7 +844,7 @@ async def test_lease_worker_stop_after_start_timeout_cancels_renewal() -> None:
         lease_seconds=30,
         client=_FakeLeaseClient(extend),
     )
-    command_send, command_receive = anyio.create_memory_object_stream(10)
+    command_send, command_receive = queue_lease_anyio_module().create_memory_object_stream(10)
 
     async with anyio.create_task_group() as task_group:
         task_group.start_soon(_lease_worker_async, command_receive)
@@ -893,7 +892,7 @@ async def test_lease_renewal_start_async_does_not_block_caller_loop(
 
 @pytest.mark.anyio
 async def test_send_lease_extension_start_waits_for_real_worker_schedule() -> None:
-    command_send, command_receive = anyio.create_memory_object_stream[Any](10)
+    command_send, command_receive = queue_lease_anyio_module().create_memory_object_stream[Any](10)
     request = _lease_request(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
@@ -948,7 +947,7 @@ def test_signal_lease_start_scheduled_uses_asyncio_native_token(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
     )
-    monkeypatch.setattr(anyio.from_thread, "run_sync", fallback)
+    monkeypatch.setattr(queue_lease_anyio_module().from_thread, "run_sync", fallback)
 
     _signal_lease_start_scheduled(
         _LeaseExtensionStart(
@@ -989,7 +988,7 @@ def test_signal_lease_start_scheduled_uses_trio_native_token(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
     )
-    monkeypatch.setattr(anyio.from_thread, "run_sync", fallback)
+    monkeypatch.setattr(queue_lease_anyio_module().from_thread, "run_sync", fallback)
 
     _signal_lease_start_scheduled(
         _LeaseExtensionStart(
@@ -1027,7 +1026,7 @@ def test_signal_lease_start_scheduled_falls_back_to_anyio_from_thread(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
     )
-    monkeypatch.setattr(anyio.from_thread, "run_sync", fallback)
+    monkeypatch.setattr(queue_lease_anyio_module().from_thread, "run_sync", fallback)
 
     _signal_lease_start_scheduled(
         _LeaseExtensionStart(
@@ -1271,8 +1270,9 @@ async def test_lease_worker_processes_stop_while_extension_is_in_flight() -> Non
                 await after_cancel_release.wait()
             raise
 
-    command_send, command_receive = anyio.create_memory_object_stream(10)
-    done_send, done_receive = anyio.create_memory_object_stream[None](1)
+    queue_lease_anyio = queue_lease_anyio_module()
+    command_send, command_receive = queue_lease_anyio.create_memory_object_stream(10)
+    done_send, done_receive = queue_lease_anyio.create_memory_object_stream[None](1)
     request = _lease_request(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
@@ -1586,7 +1586,7 @@ async def test_signal_lease_stop_complete_failed_send_does_not_block_event_signa
         def set(self) -> None:
             self.signaled = True
 
-    done_send, done_receive = anyio.create_memory_object_stream[None](1)
+    done_send, done_receive = queue_lease_anyio_module().create_memory_object_stream[None](1)
     await done_send.aclose()
     await done_receive.aclose()
     event = Event()
@@ -1667,8 +1667,9 @@ async def test_lease_worker_ignores_registration_after_stop() -> None:
         del message, duration
         calls += 1
 
-    command_send, command_receive = anyio.create_memory_object_stream(10)
-    done_send, done_receive = anyio.create_memory_object_stream[None](1)
+    queue_lease_anyio = queue_lease_anyio_module()
+    command_send, command_receive = queue_lease_anyio.create_memory_object_stream(10)
+    done_send, done_receive = queue_lease_anyio.create_memory_object_stream[None](1)
     request = _lease_request(
         Message(payload=None, metadata=make_leased_metadata("emails")),
         lease_seconds=30,
@@ -1726,7 +1727,7 @@ async def test_lease_worker_bounds_stopped_token_cache(
     )
     second_request.token = second
 
-    command_send, command_receive = anyio.create_memory_object_stream(10)
+    command_send, command_receive = queue_lease_anyio_module().create_memory_object_stream(10)
     async with anyio.create_task_group() as task_group:
         task_group.start_soon(_lease_worker_async, command_receive)
         await command_send.send(_LeaseExtensionStop(token=second))
@@ -1756,7 +1757,7 @@ async def test_lease_worker_one_renewal_in_flight_does_not_block_another_token()
         if message.metadata.message_id == "second":
             second_started.set()
 
-    command_send, command_receive = anyio.create_memory_object_stream(10)
+    command_send, command_receive = queue_lease_anyio_module().create_memory_object_stream(10)
     client = _FakeLeaseClient(extend)
     first = _lease_request(
         Message(payload=None, metadata=make_leased_metadata("emails", message_id="first")),

--- a/src/vercel-queue/tests/unit/test_queue_polling.py
+++ b/src/vercel-queue/tests/unit/test_queue_polling.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta, timezone
 import anyio
 import anyio.lowlevel
 import pytest
-import respx
 import time_machine
 from pydantic import BaseModel
 
@@ -58,6 +57,7 @@ from .helpers import (
     malformed_multipart_body,
     mock_response,
     multipart_body,
+    queue_httpx_module,
 )
 
 
@@ -624,56 +624,69 @@ def test_poll_by_id_uses_default_visibility_timeout(
     )
 
 
-@respx.mock
+def _single_response_client_factory(response: Any) -> Any:
+    queue_httpx = queue_httpx_module()
+
+    def handler(request: Any) -> Any:
+        del request
+        return response
+
+    return lambda **kwargs: queue_httpx.Client(
+        transport=queue_httpx.MockTransport(handler),
+        **kwargs,
+    )
+
+
 def test_poll_raises_on_missing_multipart_receipt_handle() -> None:
     boundary = "queue-boundary"
-    respx.post("https://iad1.vercel-queue.com/api/v3/topic/emails/consumer/test-group").mock(
-        return_value=mock_response(
-            200,
-            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
-            content=malformed_multipart_body(
-                boundary,
-                [
-                    b"Content-Type: application/json",
-                    b"Vqs-Message-Id: msg_1",
-                    f"Vqs-Timestamp: {CREATED_AT}".encode(),
-                ],
-            ),
-        )
+    response = mock_response(
+        200,
+        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        content=malformed_multipart_body(
+            boundary,
+            [
+                b"Content-Type: application/json",
+                b"Vqs-Message-Id: msg_1",
+                f"Vqs-Timestamp: {CREATED_AT}".encode(),
+            ],
+        ),
     )
 
     with pytest.raises(MessageCorruptedError, match="Vqs-Receipt-Handle"):
         list(
-            SyncQueueClient(token="token", deployment=ALL_DEPLOYMENTS).poll(
+            SyncQueueClient(
+                token="token",
+                deployment=ALL_DEPLOYMENTS,
+                http_client_factory=_single_response_client_factory(response),
+            ).poll(
                 "emails",
                 "test-group",
             )
         )
 
 
-@respx.mock
 def test_poll_by_id_raises_on_missing_multipart_message_id() -> None:
     boundary = "queue-boundary"
-    respx.post(
-        "https://iad1.vercel-queue.com/api/v3/topic/emails/consumer/test-group/id/msg_1"
-    ).mock(
-        return_value=mock_response(
-            200,
-            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
-            content=malformed_multipart_body(
-                boundary,
-                [
-                    b"Content-Type: application/json",
-                    b"Vqs-Receipt-Handle: rh_1",
-                    f"Vqs-Timestamp: {CREATED_AT}".encode(),
-                ],
-            ),
-        )
+    response = mock_response(
+        200,
+        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        content=malformed_multipart_body(
+            boundary,
+            [
+                b"Content-Type: application/json",
+                b"Vqs-Receipt-Handle: rh_1",
+                f"Vqs-Timestamp: {CREATED_AT}".encode(),
+            ],
+        ),
     )
 
     with pytest.raises(MessageCorruptedError, match="Vqs-Message-Id"):
         iter_coroutine(
-            SyncQueueClient(token="token", deployment=ALL_DEPLOYMENTS)._poll_by_id(
+            SyncQueueClient(
+                token="token",
+                deployment=ALL_DEPLOYMENTS,
+                http_client_factory=_single_response_client_factory(response),
+            )._poll_by_id(
                 "emails",
                 "test-group",
                 "msg_1",
@@ -681,18 +694,19 @@ def test_poll_by_id_raises_on_missing_multipart_message_id() -> None:
         )
 
 
-@respx.mock
 def test_poll_metadata_allows_missing_expires_at() -> None:
     boundary = "queue-boundary"
-    respx.post("https://iad1.vercel-queue.com/api/v3/topic/emails/consumer/test-group").mock(
-        return_value=mock_response(
-            200,
-            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
-            content=multipart_body(boundary, expires_at=None),
-        )
+    response = mock_response(
+        200,
+        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        content=multipart_body(boundary, expires_at=None),
     )
     delivery: Delivery[Any] = next(
-        SyncQueueClient(token="token", deployment=ALL_DEPLOYMENTS).poll("emails", "test-group")
+        SyncQueueClient(
+            token="token",
+            deployment=ALL_DEPLOYMENTS,
+            http_client_factory=_single_response_client_factory(response),
+        ).poll("emails", "test-group")
     )
     message = delivery.message
 

--- a/src/vercel-queue/tests/unit/test_queue_streams.py
+++ b/src/vercel-queue/tests/unit/test_queue_streams.py
@@ -9,6 +9,7 @@ from vercel.queue._internal.streams import AsyncStreamPayload
 
 from .helpers import (
     one_chunk,
+    queue_streams_anyio_module,
     run_with_anyio_backend,
 )
 
@@ -68,7 +69,7 @@ def test_async_stream_payload_readexactly_reports_partial(anyio_backend: str) ->
     async def check() -> None:
         payload = AsyncStreamPayload(one_chunk(b"abc"))
 
-        with pytest.raises(anyio.IncompleteRead):
+        with pytest.raises(queue_streams_anyio_module().IncompleteRead):
             await payload.readexactly(4)
 
     run_with_anyio_backend(check, anyio_backend)
@@ -79,7 +80,7 @@ def test_async_stream_payload_readuntil_reports_partial(anyio_backend: str) -> N
     async def check() -> None:
         payload = AsyncStreamPayload(one_chunk(b"abc"))
 
-        with pytest.raises(anyio.IncompleteRead):
+        with pytest.raises(queue_streams_anyio_module().IncompleteRead):
             await payload.readuntil(b"--")
 
     run_with_anyio_backend(check, anyio_backend)
@@ -90,7 +91,7 @@ def test_async_stream_payload_readuntil_is_bounded(anyio_backend: str) -> None:
     async def check() -> None:
         payload = AsyncStreamPayload(one_chunk(b"x" * (64 * 1024)))
 
-        with pytest.raises(anyio.DelimiterNotFound):
+        with pytest.raises(queue_streams_anyio_module().DelimiterNotFound):
             await payload.readuntil(b"--")
 
     run_with_anyio_backend(check, anyio_backend)
@@ -134,7 +135,7 @@ def test_async_stream_payload_rejects_concurrent_reads(anyio_backend: str) -> No
             task_group.start_soon(read_all)
             await started.wait()
 
-            with pytest.raises(anyio.BusyResourceError):
+            with pytest.raises(queue_streams_anyio_module().BusyResourceError):
                 await payload.read(1)
 
             release.set()

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -10,6 +10,16 @@ import pytest
 from scripts import bundle_release, hatch_build, release, workspace
 
 
+def _derived_vendoring_config(include: str) -> bundle_release.VendoringConfig:
+    package = workspace.Package("pkg", Path("/tmp/pkg"), Path("/tmp/pkg/version.py"), ())
+    config = bundle_release._vendoring_config_for_package(  # noqa: SLF001
+        package,
+        {"tool": {"hatch": {"build": {"targets": {"wheel": {"only-include": [include]}}}}}},
+    )
+    assert config is not None
+    return config
+
+
 def test_topological_names_orders_dependencies_before_dependents(tmp_path: Path) -> None:
     packages = {
         "app": workspace.Package("app", tmp_path / "app", tmp_path / "app/version.py", ("lib",)),
@@ -539,22 +549,86 @@ def test_package_hatch_build_loader_uses_shared_hook() -> None:
     assert module.get_metadata_hook().__name__ == "WorkspaceDependenciesMetadataHook"
 
 
-def test_vendored_eligibility_uses_generated_config(tmp_path: Path) -> None:
+def test_vendored_eligibility_is_derived_from_package_layout(tmp_path: Path) -> None:
     queue = workspace.Package(
-        "vercel-queue", tmp_path / "src/vercel-queue", tmp_path / "version.py", ()
+        "vercel-queue",
+        tmp_path / "src/vercel-queue",
+        tmp_path / "src/vercel-queue/vercel/queue/version.py",
+        (),
     )
     integration = workspace.Package(
-        "vercel-celery", tmp_path / "integrations/vercel-celery", tmp_path / "version.py", ()
+        "vercel-celery",
+        tmp_path / "integrations/vercel-celery",
+        tmp_path / "integrations/vercel-celery/vercel/integrations/celery/version.py",
+        (),
+    )
+    dramatiq = workspace.Package(
+        "vercel-dramatiq",
+        tmp_path / "integrations/vercel-dramatiq",
+        tmp_path / "integrations/vercel-dramatiq/vercel/integrations/dramatiq/version.py",
+        (),
     )
     headers = workspace.Package(
-        "vercel-headers", tmp_path / "src/vercel-headers", tmp_path / "version.py", ()
+        "vercel-headers",
+        tmp_path / "src/vercel-headers",
+        tmp_path / "src/vercel-headers/vercel/headers/version.py",
+        (),
     )
-    for package in (queue, integration, headers):
+    umbrella = workspace.Package(
+        "vercel", tmp_path / "src/vercel", tmp_path / "src/vercel/version.py", ()
+    )
+    for package in (queue, integration, dramatiq, headers):
         package.path.mkdir(parents=True)
+        include = {
+            "vercel-queue": "/vercel/queue",
+            "vercel-celery": "/vercel/integrations/celery",
+            "vercel-dramatiq": "/vercel/integrations/dramatiq",
+            "vercel-headers": "/vercel/headers",
+        }[package.name]
+        (package.path / "pyproject.toml").write_text(
+            f"""
+[project]
+name = "{package.name}"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["{include}"]
+""".lstrip(),
+            encoding="utf-8",
+        )
+    umbrella.path.mkdir(parents=True)
+    (umbrella.path / "pyproject.toml").write_text(
+        """
+[project]
+name = "vercel"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["/_internal", "/blob"]
+""".lstrip(),
+        encoding="utf-8",
+    )
 
     assert bundle_release.is_vendored_eligible(queue)
     assert bundle_release.is_vendored_eligible(integration)
+    assert bundle_release.is_vendored_eligible(dramatiq)
     assert bundle_release.is_vendored_eligible(headers)
+    assert not bundle_release.is_vendored_eligible(umbrella)
+
+    fallback_path = tmp_path / "src/vercel-fallback"
+    fallback = workspace.Package(
+        "vercel-fallback",
+        fallback_path,
+        fallback_path / "vercel/fallback/version.py",
+        (),
+    )
+    fallback.path.mkdir(parents=True)
+    (fallback.path / "pyproject.toml").write_text(
+        """
+[project]
+name = "vercel-fallback"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    assert bundle_release.is_vendored_eligible(fallback)
 
 
 def test_vendored_external_dependencies_keep_peers_and_side_by_side_vendored_deps(
@@ -597,6 +671,50 @@ def test_vendored_external_dependencies_keep_peers_and_side_by_side_vendored_dep
         (),
     ) == (
         "celery>=5.3,<6",
+        "vercel-cache-bundle>=0.7.0",
+        "vercel-queue-bundle>=0.7.0",
+        "vercel-internal-shared-vendored-deps>=0.7.0",
+    )
+
+
+def test_dramatiq_bundle_keeps_dramatiq_peer_dependency(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bundle_release, "shared_vendored_version", lambda: "0.7.0")
+    cache_version = tmp_path / "vercel-cache/version.py"
+    queue_version = tmp_path / "vercel-queue/version.py"
+    cache_version.parent.mkdir()
+    queue_version.parent.mkdir()
+    cache_version.write_text('__version__ = "0.7.0"\n', encoding="utf-8")
+    queue_version.write_text('__version__ = "0.7.0"\n', encoding="utf-8")
+    monkeypatch.setattr(
+        workspace,
+        "packages",
+        lambda: {
+            "vercel-cache": workspace.Package(
+                "vercel-cache", tmp_path / "vercel-cache", cache_version, ()
+            ),
+            "vercel-queue": workspace.Package(
+                "vercel-queue", tmp_path / "vercel-queue", queue_version, ()
+            ),
+        },
+    )
+    data = {
+        "project": {
+            "dependencies": [
+                "dramatiq>=2.2,<3",
+                "vercel-cache>=0.6.0",
+                "vercel-queue>=0.6.0",
+            ]
+        }
+    }
+
+    assert bundle_release._external_dependencies(  # noqa: SLF001
+        "vercel-dramatiq",
+        data,
+        (),
+    ) == (
+        "dramatiq>=2.2,<3",
         "vercel-cache-bundle>=0.7.0",
         "vercel-queue-bundle>=0.7.0",
         "vercel-internal-shared-vendored-deps>=0.7.0",
@@ -738,7 +856,7 @@ path = "vercel/queue/version.py"
             "vercel-queue", package_path, package_path / "vercel/queue/version.py", ()
         ),
         variant_name="vercel-queue-bundle",
-        config=bundle_release.GENERATED_VENDORED_CONFIGS["vercel-queue"].config,
+        config=_derived_vendoring_config("/vercel/queue"),
         vendored_requirements=("python-multipart==0.0.32",),
         external_dependencies=(),
     )
@@ -750,6 +868,33 @@ path = "vercel/queue/version.py"
     assert 'requirements = "vercel/queue/_vendor/vendor.txt"' in pyproject
     assert 'namespace = "vercel.queue._vendor"' in pyproject
     assert "[tool.vendoring.transformations]" in pyproject
+    assert "import anyio\\\\.from_thread" not in pyproject
+
+
+def test_vendoring_config_includes_anyio_from_thread_transform(tmp_path: Path) -> None:
+    package_path = tmp_path / "pkg"
+    package_path.mkdir()
+    (package_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "pkg"
+
+[tool.hatch.version]
+path = "vercel/pkg/version.py"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    plan = bundle_release.VendoredPlan(
+        package=workspace.Package("pkg", package_path, package_path / "vercel/pkg/version.py", ()),
+        variant_name="pkg-bundle",
+        config=_derived_vendoring_config("/vercel/pkg"),
+        vendored_requirements=("anyio==4.13.0",),
+        external_dependencies=(),
+    )
+
+    bundle_release._write_vendoring_config(plan, package_path)  # noqa: SLF001
+
+    pyproject = (package_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "import anyio\\\\.from_thread" in pyproject
 
 
@@ -759,7 +904,7 @@ def test_vendored_license_files_are_copied_from_dist_info(tmp_path: Path) -> Non
             "vercel-queue", tmp_path / "pkg", tmp_path / "pkg/vercel/queue/version.py", ()
         ),
         variant_name="vercel-queue-bundle",
-        config=bundle_release.GENERATED_VENDORED_CONFIGS["vercel-queue"].config,
+        config=_derived_vendoring_config("/vercel/queue"),
         vendored_requirements=("python-multipart==0.0.32",),
         external_dependencies=(),
     )
@@ -844,7 +989,7 @@ only-include = ["/vercel/queue"]
             "vercel-queue", package_path, package_path / "vercel/queue/version.py", ()
         ),
         variant_name="vercel-queue-bundle",
-        config=bundle_release.GENERATED_VENDORED_CONFIGS["vercel-queue"].config,
+        config=_derived_vendoring_config("/vercel/queue"),
         vendored_requirements=("python-multipart==0.0.32",),
         external_dependencies=(),
     )
@@ -855,6 +1000,58 @@ only-include = ["/vercel/queue"]
     assert 'name = "vercel-queue-bundle"' in pyproject
     assert '"vercel/queue/_vendor/LICEN[CS]E*"' in pyproject
     assert '"/vercel/queue/_vendor/LICEN[CS]E*"' in pyproject
+
+
+def test_bundle_pyproject_rewrites_static_project_dependencies(tmp_path: Path) -> None:
+    package_path = tmp_path / "pkg"
+    package_path.mkdir()
+    (package_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "vercel-dramatiq"
+license = "MIT"
+license-files = ["LICENSE", "LICENSE.*"]
+dependencies = [
+    "dramatiq>=2.2,<3",
+    "vercel-cache>=0.6.0",
+    "vercel-queue>=0.6.0",
+]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/vercel/integrations/dramatiq/**/*.py",
+    "/LICENSE",
+]
+""".lstrip(),
+        encoding="utf-8",
+    )
+    plan = bundle_release.VendoredPlan(
+        package=workspace.Package(
+            "vercel-dramatiq",
+            package_path,
+            package_path / "vercel/integrations/dramatiq/version.py",
+            (),
+        ),
+        variant_name="vercel-dramatiq-bundle",
+        config=_derived_vendoring_config("/vercel/integrations/dramatiq"),
+        vendored_requirements=(),
+        external_dependencies=(
+            "dramatiq>=2.2,<3",
+            "vercel-cache-bundle>=0.7.1",
+            "vercel-queue-bundle>=0.7.1",
+            "vercel-internal-shared-vendored-deps>=0.1.0",
+        ),
+    )
+
+    bundle_release._rewrite_pyproject(plan, package_path)  # noqa: SLF001
+
+    pyproject = (package_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'name = "vercel-dramatiq-bundle"' in pyproject
+    assert '"dramatiq>=2.2,<3"' in pyproject
+    assert '"vercel-cache-bundle>=0.7.1"' in pyproject
+    assert '"vercel-queue-bundle>=0.7.1"' in pyproject
+    assert '"vercel-cache>=0.6.0"' not in pyproject
+    assert '"vercel-queue>=0.6.0"' not in pyproject
 
 
 def test_generated_vendoring_substitutions_escape_newlines() -> None:
@@ -876,7 +1073,7 @@ def test_bundle_readme_recommends_unbundled_package(tmp_path: Path) -> None:
             "vercel-queue", package_path, package_path / "vercel/queue/version.py", ()
         ),
         variant_name="vercel-queue-bundle",
-        config=bundle_release.GENERATED_VENDORED_CONFIGS["vercel-queue"].config,
+        config=_derived_vendoring_config("/vercel/queue"),
         vendored_requirements=("python-multipart==0.0.32",),
         external_dependencies=(),
     )


### PR DESCRIPTION
Unbreak `test_installed_wheel.sh` when called from the publish workflow,
add an option to manually trigger a publish loop.  Derive bundle package
configs from the workspace instead of hardcoding specs in
`bundle_release.py`.
