### PR TITLE
workflow: re-land vercel-queue port, with the naming fixes it needed

### DIFF
--- a/changes/vercel/913e40b.feature.md
+++ b/changes/vercel/913e40b.feature.md
@@ -1,0 +1,1 @@
+Port from vercel-workers to vercel-queue

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import (
     Annotated,
@@ -21,6 +22,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+import httpx
 import pydantic
 
 from vercel._internal.core.polyfills import Self
@@ -639,11 +641,12 @@ class EventResult(BaseModel):
 
 
 class HTTPRequest(metaclass=abc.ABCMeta):
+    @property
     @abc.abstractmethod
-    def get_header(self, name: str) -> str | None: ...
+    def headers(self) -> httpx.Headers: ...
 
     @abc.abstractmethod
-    async def get_body(self) -> bytes: ...
+    def aiter_bytes(self, chunk_size: int | None = None) -> AsyncIterator[bytes]: ...
 
 
 @dataclasses.dataclass

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -26,6 +26,7 @@ import httpx
 import pydantic
 
 from vercel._internal.core.polyfills import Self
+from vercel.queue import SanitizedName
 
 T = TypeVar("T")
 QueueKind: TypeAlias = Literal["workflow", "step"]
@@ -62,6 +63,37 @@ def get_queue_name(
 ) -> str:
     """Build a queue name for an optional namespace."""
     return f"{get_queue_topic_prefix(kind, namespace)}{identifier}"
+
+
+# The consumer group our subscribers register under. The Python builder
+# introspects `get_subscriptions()` and copies this into the queue trigger it
+# writes (vercel/vercel#17236), so the value only has to be stable rather than
+# match anything; `default` keeps it aligned with the trigger
+# `createWorkflowQueueTrigger` writes for the TypeScript SDK on these topics.
+#
+# Dispatch is keyed on `(consumer_group, topic)`, so a subscriber registered
+# under a group the delivery does not name is never called at all.
+QUEUE_CONSUMER_GROUP = SanitizedName("default")
+
+
+def get_physical_topic(queue_name: str) -> SanitizedName:
+    """Map a logical queue name onto the VQS topic it is published to.
+
+    Mirrors `@workflow/world-vercel`: replace anything outside
+    ``[A-Za-z0-9-_]`` with ``-`` and leave the rest — notably the underscores
+    in ``__wkf_workflow_`` — alone. ``sanitize_name()`` must not be used here.
+    Its reversible encoding is meant for arbitrary user-supplied names and
+    doubles underscores; ours are already VQS-safe, and encoding them would
+    put the result outside the ``__wkf_*`` prefix that both the builder's
+    trigger pattern and platform-side service resolution recognize as a
+    workflow topic.
+    """
+    return SanitizedName(
+        "".join(
+            char if char.isascii() and (char.isalnum() or char in "-_") else "-"
+            for char in queue_name
+        )
+    )
 
 
 class BaseModel(pydantic.BaseModel):

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -9,7 +9,7 @@ import threading
 import traceback
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, TypeVar, cast
 from uuid import uuid4
 
@@ -99,6 +99,11 @@ def write_exclusive(path: pathlib.Path, data: str) -> bool:
         return True
 
 
+# Receipt handle marking a delivery that did not come off a real queue lease,
+# so the subscriber knows there is nothing to acknowledge afterwards.
+_LOCAL_RECEIPT_HANDLE = "local"
+
+
 def _json_string(value: str) -> bytes:
     return json.dumps(value).encode("utf-8")
 
@@ -119,6 +124,12 @@ def _local_queue_delivery(
     topic: str,
     consumer_group: str,
 ) -> tuple[AsyncIterator[bytes], dict[str, str]]:
+    """Wrap a `vercel dev` HTTP delivery as if it came off the queue.
+
+    The request body is the bare payload, while subscribers expect the
+    `{payload, queueName, deploymentId}` envelope `queue()` sends, so the
+    envelope is streamed back around it along with synthetic push headers.
+    """
     body = _chain_async_bytes(
         b'{"payload":',
         request.aiter_bytes(),
@@ -131,9 +142,9 @@ def _local_queue_delivery(
         "ce-vqsqueuename": topic,
         "ce-vqsconsumergroup": consumer_group,
         "ce-vqsmessageid": request.headers.get("x-vqs-message-id") or f"msg_{uuid4()}",
-        "ce-vqsreceipthandle": "local",
+        "ce-vqsreceipthandle": _LOCAL_RECEIPT_HANDLE,
         "ce-vqsdeliverycount": request.headers.get("x-vqs-message-attempt") or "1",
-        "ce-vqscreatedat": datetime.now(timezone.utc).isoformat(),
+        "ce-vqscreatedat": datetime.now(UTC).isoformat(),
         "content-type": request.headers.get("content-type") or "application/json",
     }
 
@@ -220,7 +231,7 @@ class LocalWorld(w.World):
         }
         client = await self._get_queue_client()
         message_id = await client.send(
-            vqs.sanitize_name(queue_name),
+            w.get_physical_topic(queue_name),
             payload,
             idempotency_key=idempotency_key,
             delay=max(1, math.ceil(delay_seconds)) if delay_seconds is not None else None,
@@ -230,8 +241,6 @@ class LocalWorld(w.World):
     def create_queue_handler(
         self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
     ) -> w.HTTPHandler:
-        consumer_group = f"local_{queue_name_prefix.rstrip('_')}"
-
         async def async_handler(message: vqs.Message[Any]) -> None:
             try:
                 body = message.payload
@@ -265,7 +274,7 @@ class LocalWorld(w.World):
                         delay_seconds=delay_seconds,
                         idempotency_key=result.idempotency_key,
                     )
-                if message.metadata.receipt_handle == "local":
+                if message.metadata.receipt_handle == _LOCAL_RECEIPT_HANDLE:
                     # Local HTTP deliveries use a synthetic receipt handle so
                     # accept_and_handle can parse them like VQS pushes, but
                     # there is no real queue lease to acknowledge.
@@ -275,18 +284,18 @@ class LocalWorld(w.World):
                     traceback.print_exc()
                 raise
 
-        topic_prefix = vqs.sanitize_name(queue_name_prefix)
-        vqs.subscribe(topic=f"{topic_prefix}*", consumer_group=consumer_group)(async_handler)
+        topic_prefix = w.get_physical_topic(queue_name_prefix)
+        vqs.subscribe(
+            topic=f"{topic_prefix}*",
+            consumer_group=w.QUEUE_CONSUMER_GROUP,
+        )(async_handler)
         self._queue_callbacks.append(async_handler)
 
         async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
-            queue_name_raw = request.headers.get("x-vqs-queue-name")
+            queue_name = request.headers.get("x-vqs-queue-name")
 
-            if not queue_name_raw:
+            if not queue_name:
                 return w.HTTPResponse.json({"error": "Missing required headers"}, status=400)
-
-            queue_name = queue_name_raw
-            topic = str(vqs.sanitize_name(queue_name))
 
             # Validate queue name prefix
             if not queue_name.startswith(queue_name_prefix):
@@ -295,8 +304,8 @@ class LocalWorld(w.World):
             body, headers = _local_queue_delivery(
                 request,
                 queue_name=queue_name,
-                topic=topic,
-                consumer_group=consumer_group,
+                topic=str(w.get_physical_topic(queue_name)),
+                consumer_group=str(w.QUEUE_CONSUMER_GROUP),
             )
 
             try:

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -7,14 +7,18 @@ import pathlib
 import tempfile
 import threading
 import traceback
-from datetime import datetime
-from typing import Any, TypeVar
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
+from datetime import datetime, timezone
+from typing import Any, TypeVar, cast
+from uuid import uuid4
 
 import cbor2
 import pydantic
 
+import vercel.queue as vqs
+import vercel.queue.embedded as vqs_embedded
 from vercel._internal.core.polyfills import UTC
-from vercel.workers import client as vqs_client
 
 from .. import world as w
 from ..ulid import monotonic_factory
@@ -22,10 +26,6 @@ from ..ulid import monotonic_factory
 MAX_DELAY_SECONDS = float(
     os.getenv("VERCEL_QUEUE_MAX_DELAY_SECONDS", "82800")
 )  # 23 hours - leave 1h buffer before 24h retention limit
-LOCAL_QUEUE_MAX_VISIBILITY = int(
-    os.environ.get("WORKFLOW_LOCAL_QUEUE_MAX_VISIBILITY", "0")
-) or float("inf")
-
 T = TypeVar("T", bound=w.BaseModel)
 
 
@@ -99,10 +99,63 @@ def write_exclusive(path: pathlib.Path, data: str) -> bool:
         return True
 
 
+def _json_string(value: str) -> bytes:
+    return json.dumps(value).encode("utf-8")
+
+
+async def _chain_async_bytes(*chunks: bytes | AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        if isinstance(chunk, bytes):
+            yield chunk
+        else:
+            async for part in chunk:
+                yield part
+
+
+def _local_queue_delivery(
+    request: w.HTTPRequest,
+    *,
+    queue_name: str,
+    topic: str,
+    consumer_group: str,
+) -> tuple[AsyncIterator[bytes], dict[str, str]]:
+    body = _chain_async_bytes(
+        b'{"payload":',
+        request.aiter_bytes(),
+        b',"queueName":',
+        _json_string(queue_name),
+        b',"deploymentId":"<local>"}',
+    )
+    return body, {
+        "ce-type": "com.vercel.queue.v2beta",
+        "ce-vqsqueuename": topic,
+        "ce-vqsconsumergroup": consumer_group,
+        "ce-vqsmessageid": request.headers.get("x-vqs-message-id") or f"msg_{uuid4()}",
+        "ce-vqsreceipthandle": "local",
+        "ce-vqsdeliverycount": request.headers.get("x-vqs-message-attempt") or "1",
+        "ce-vqscreatedat": datetime.now(timezone.utc).isoformat(),
+        "content-type": request.headers.get("content-type") or "application/json",
+    }
+
+
 class LocalWorld(w.World):
     def __init__(self) -> None:
         self.monotonic_ulid = monotonic_factory()
         self.data_dir = pathlib.Path(os.getenv("WORKFLOW_LOCAL_DATA_DIR", ".workflow-data"))
+        self._embedded_queue_service_cm: AbstractAsyncContextManager[Any] | None
+        self._embedded_queue_service: Any | None
+        self._queue_client: vqs.QueueClient | None
+        if os.getenv("VERCEL_QUEUE_BASE_URL"):
+            self._queue_mode = "external"
+            self._embedded_queue_service_cm = None
+            self._embedded_queue_service = None
+            self._queue_client = vqs.QueueClient(region="iad1", deployment=vqs.ALL_DEPLOYMENTS)
+        else:
+            self._queue_mode = "embedded"
+            self._embedded_queue_service_cm = vqs_embedded.embedded_queue_service()
+            self._embedded_queue_service = None
+            self._queue_client = None
+        self._queue_callbacks: list[Any] = []
         # Per-run mutex serializing events_create, which does some
         # read-modify-writes in some cases.
         #
@@ -132,6 +185,24 @@ class LocalWorld(w.World):
     async def get_deployment_id(self) -> str:
         return ""
 
+    async def _get_queue_client(self) -> vqs.QueueClient:
+        if self._queue_client is not None:
+            return self._queue_client
+
+        service_cm = cast(
+            "AbstractAsyncContextManager[Any]",
+            self._embedded_queue_service_cm,
+        )
+        self._embedded_queue_service = await service_cm.__aenter__()
+        self._queue_client = self._embedded_queue_service.get_async_client()
+        return self._queue_client
+
+    async def aclose(self) -> None:
+        if self._embedded_queue_service_cm is not None and self._embedded_queue_service is not None:
+            await self._embedded_queue_service_cm.__aexit__(None, None, None)
+            self._embedded_queue_service = None
+            self._queue_client = None
+
     async def queue(
         self,
         queue_name: str,
@@ -147,26 +218,23 @@ class LocalWorld(w.World):
             "queueName": queue_name,
             "deploymentId": "<local>",
         }
-        vqs_delay: int | None = None
-        if delay_seconds is not None:
-            vqs_delay = max(1, math.ceil(delay_seconds))
-        response = await vqs_client.send_async(
-            "".join(char if char.isalnum() or char in "-_" else "-" for char in queue_name),
+        client = await self._get_queue_client()
+        message_id = await client.send(
+            vqs.sanitize_name(queue_name),
             payload,
             idempotency_key=idempotency_key,
-            deployment_id="<local>",
-            delay_seconds=vqs_delay,
+            delay=max(1, math.ceil(delay_seconds)) if delay_seconds is not None else None,
         )
-        return response["messageId"]
+        return message_id or "msg_deferred"
 
     def create_queue_handler(
         self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
     ) -> w.HTTPHandler:
-        @vqs_client.subscribe(
-            topic=(f"{queue_name_prefix}*", lambda t: bool(t and t.startswith(queue_name_prefix)))
-        )
-        async def async_handler(body: Any, meta: vqs_client.MessageMetadata) -> None:
+        consumer_group = f"local_{queue_name_prefix.rstrip('_')}"
+
+        async def async_handler(message: vqs.Message[Any]) -> None:
             try:
+                body = message.payload
                 if not isinstance(body, dict):
                     raise ValueError("Invalid message body: expected a JSON object")
                 if "payload" not in body:
@@ -178,8 +246,8 @@ class LocalWorld(w.World):
                 result = await handler(
                     payload,
                     queue_name=queue_name,
-                    attempt=meta["deliveryCount"],
-                    message_id=meta["messageId"],
+                    attempt=message.metadata.delivery_count,
+                    message_id=message.metadata.message_id,
                 )
                 if result is not None:
                     # Use delaySeconds approach: send new message with delay, then delete current
@@ -197,56 +265,43 @@ class LocalWorld(w.World):
                         delay_seconds=delay_seconds,
                         idempotency_key=result.idempotency_key,
                     )
-            except Exception:
-                traceback.print_exc()
+                if message.metadata.receipt_handle == "local":
+                    # Local HTTP deliveries use a synthetic receipt handle so
+                    # accept_and_handle can parse them like VQS pushes, but
+                    # there is no real queue lease to acknowledge.
+                    raise vqs.Handoff()
+            except Exception as e:
+                if not isinstance(e, vqs.QueueDirective):
+                    traceback.print_exc()
                 raise
 
+        topic_prefix = vqs.sanitize_name(queue_name_prefix)
+        vqs.subscribe(topic=f"{topic_prefix}*", consumer_group=consumer_group)(async_handler)
+        self._queue_callbacks.append(async_handler)
+
         async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
-            # Get request body
-            body = await request.get_body()
+            queue_name_raw = request.headers.get("x-vqs-queue-name")
 
-            if not body:
-                return w.HTTPResponse.json({"error": "Missing request body"}, status=400)
-
-            # Get required headers
-            queue_name = request.get_header("x-vqs-queue-name")
-            message_id = request.get_header("x-vqs-message-id")
-            attempt_str = request.get_header("x-vqs-message-attempt")
-
-            if not queue_name or not message_id or not attempt_str:
+            if not queue_name_raw:
                 return w.HTTPResponse.json({"error": "Missing required headers"}, status=400)
+
+            queue_name = queue_name_raw
+            topic = str(vqs.sanitize_name(queue_name))
 
             # Validate queue name prefix
             if not queue_name.startswith(queue_name_prefix):
                 return w.HTTPResponse.json({"error": "Unhandled queue"}, status=400)
 
-            # Validate attempt number
+            body, headers = _local_queue_delivery(
+                request,
+                queue_name=queue_name,
+                topic=topic,
+                consumer_group=consumer_group,
+            )
+
             try:
-                attempt = int(attempt_str)
-            except ValueError:
-                return w.HTTPResponse.json(
-                    {"error": "Invalid x-vqs-message-attempt header"}, status=400
-                )
-
-            # Deserialize the message body
-            try:
-                message = json.loads(body.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                return w.HTTPResponse.json({"error": f"Invalid JSON body: {e}"}, status=400)
-
-            # Call the handler
-            try:
-                result = await handler(
-                    message, attempt=attempt, queue_name=queue_name, message_id=message_id
-                )
-
-                # Handle timeout response
-                timeout_seconds: float | None = None
-                if result is not None:
-                    timeout_seconds = min(result.delay_seconds, LOCAL_QUEUE_MAX_VISIBILITY)
-                if timeout_seconds:
-                    return w.HTTPResponse.json({"timeoutSeconds": timeout_seconds}, status=503)
-
+                client = await self._get_queue_client()
+                await client.accept_and_handle(body, headers)
                 return w.HTTPResponse.json({"ok": True})
             except Exception as error:
                 return w.HTTPResponse.json({"error": str(error)}, status=500)

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -254,7 +254,7 @@ class VercelWorld(w.World):
         client = self._queue_client(deployment=deployment_id)
         try:
             message_id = await client.send(
-                vqs.sanitize_name(queue_name),
+                w.get_physical_topic(queue_name),
                 payload,
                 idempotency_key=idempotency_key,
                 delay=delay,
@@ -306,12 +306,18 @@ class VercelWorld(w.World):
                 traceback.print_exc()
                 raise
 
-        topic_prefix = vqs.sanitize_name(queue_name_prefix)
-        vqs.subscribe(topic=f"{topic_prefix}*")(async_handler)
+        topic_prefix = w.get_physical_topic(queue_name_prefix)
+        vqs.subscribe(
+            topic=f"{topic_prefix}*",
+            consumer_group=w.QUEUE_CONSUMER_GROUP,
+        )(async_handler)
         self._queue_callbacks.append(async_handler)
 
         async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
             try:
+                # Route follow-up calls (ack, lease renewal) through the same
+                # client the sends use, so they inherit the proxy base URL and
+                # token instead of falling back to an unconfigured default.
                 client = self._queue_client(deployment=vqs.ALL_DEPLOYMENTS)
                 await client.accept_and_handle(request)
             except Exception:

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -1,6 +1,4 @@
-import asyncio
 import datetime
-import json
 import math
 import os
 import platform
@@ -13,9 +11,9 @@ import cbor2
 import httpx
 import pydantic
 
+import vercel.queue as vqs
 from vercel._internal.core.polyfills import UTC
-from vercel.workers import client as vqs_client
-from vercel.workers.exceptions import DuplicateIdempotencyKeyError
+from vercel.oidc.aio import get_vercel_oidc_token
 
 from .. import world as w
 
@@ -81,6 +79,7 @@ class VercelWorld(w.World):
         team_id: str | None = None,
     ) -> None:
         self._token = token
+        self._queue_callbacks: list[Any] = []
 
         # utils.ts, getHttpUrl
         # Use proxy when we have project config (for authentication via Vercel API)
@@ -115,6 +114,25 @@ class VercelWorld(w.World):
         if WORKFLOW_SERVER_URL_OVERRIDE and self._using_proxy:
             self._headers["x-vercel-workflow-api-url"] = WORKFLOW_SERVER_URL_OVERRIDE
 
+        self._queue_clients: dict[object, vqs.QueueClient] = {}
+
+    def _queue_client(
+        self, *, deployment: vqs.DeploymentOption = vqs.CURRENT_DEPLOYMENT
+    ) -> vqs.QueueClient:
+        if deployment not in self._queue_clients:
+            base_url = f"{self._base_url}/queues-proxy" if self._using_proxy else None
+            self._queue_clients[deployment] = vqs.QueueClient(
+                token=self._token if self._using_proxy else None,
+                region=os.getenv("VERCEL_REGION", "iad1"),
+                base_url=base_url,
+                deployment=deployment,
+                headers=self._headers,
+            )
+        return self._queue_clients[deployment]
+
+    async def aclose(self) -> None:
+        self._queue_clients.clear()
+
     async def _cbor_request(
         self,
         method: str,
@@ -125,8 +143,6 @@ class VercelWorld(w.World):
     ) -> T:
         # utils.ts, getHttpConfig, makeRequest
         if self._token is None:
-            from vercel.oidc.aio import get_vercel_oidc_token
-
             token = await get_vercel_oidc_token()
         else:
             token = self._token
@@ -234,43 +250,27 @@ class VercelWorld(w.World):
             # Store deploymentId in the message so it can be preserved when re-enqueueing
             "deploymentId": deployment_id,
         }
-        headers = {}
-        if delay_seconds is not None:
-            headers["Vqs-Delay-Seconds"] = str(max(1, math.ceil(delay_seconds)))
+        delay = max(1, math.ceil(delay_seconds)) if delay_seconds is not None else None
+        client = self._queue_client(deployment=deployment_id)
         try:
-            response = await vqs_client.send_async(
-                "".join(char if char.isalnum() or char in "-_" else "-" for char in queue_name),
+            message_id = await client.send(
+                vqs.sanitize_name(queue_name),
                 payload,
                 idempotency_key=idempotency_key,
-                deployment_id=deployment_id,
-                token=self._token if self._using_proxy else None,
-                base_url=self._base_url if self._using_proxy else None,
-                # The proxy will strip the `/queues-proxy` prefix before forwarding to VQS,
-                # so `/queues-proxy/api/v3/topic` arrives as `/api/v3/topic` at the queue server.
-                base_path="/queues-proxy/api/v3/topic" if self._using_proxy else None,
-                headers=self._headers | headers,
+                delay=delay,
             )
-            return response["messageId"]
-        except DuplicateIdempotencyKeyError:
-            # Silently handle idempotency key conflicts - the message was already queued
-            # This matches the behavior of world-local and world-postgres
-            # Return a placeholder messageId since the original is not available from the error.
-            # Callers using idempotency keys shouldn't depend on the returned messageId.
+        except vqs.DuplicateIdempotencyKeyError:
             return f"msg_duplicate_{idempotency_key or 'unknown'}"
+        if message_id is None:
+            return "msg_deferred"
+        return message_id
 
     def create_queue_handler(
         self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
     ) -> w.HTTPHandler:
-        @vqs_client.subscribe(
-            topic=(f"{queue_name_prefix}*", lambda t: bool(t and t.startswith(queue_name_prefix)))
-        )
-        async def async_handler(body: Any, meta: vqs_client.MessageMetadata) -> None:
+        async def async_handler(message: vqs.Message[Any]) -> None:
             try:
-                if isinstance(body, (bytes, bytearray)):
-                    if body:
-                        body = json.loads(body)
-                    else:
-                        return  # empty body from delayed re-delivery; skip
+                body = message.payload
                 if not isinstance(body, dict):
                     raise ValueError("Invalid message body: expected a JSON object")
                 if "payload" not in body:
@@ -282,18 +282,19 @@ class VercelWorld(w.World):
                 result = await handler(
                     payload,
                     queue_name=queue_name,
-                    attempt=meta["deliveryCount"],
-                    message_id=meta["messageId"],
+                    attempt=message.metadata.delivery_count,
+                    message_id=message.metadata.message_id,
                 )
                 if result is not None:
-                    # Use delaySeconds approach: send new message with delay, then delete current
+                    # Use delaySeconds approach: send new message with delay, then allow the SDK
+                    # to acknowledge current message after this callback returns successfully.
                     # Clamp to max delay (23h) - for longer sleeps, the workflow will chain
-                    # multiple delayed messages until the full sleep duration has elapsed
+                    # multiple delayed messages until the full sleep duration has elapsed.
                     delay_seconds = min(result.delay_seconds, MAX_DELAY_SECONDS)
 
-                    # Send new message with delay BEFORE acknowledging current message
+                    # Send new message with delay BEFORE acknowledging current message.
                     # This ensures crash safety: if process dies after send but before ack,
-                    # we may get a duplicate invocation but won't lose the scheduled wakeup
+                    # we may get a duplicate invocation but won't lose the scheduled wakeup.
                     await self.queue(
                         queue_name,
                         w.QueuePayloadAdaptor.validate_python(payload),
@@ -305,39 +306,18 @@ class VercelWorld(w.World):
                 traceback.print_exc()
                 raise
 
+        topic_prefix = vqs.sanitize_name(queue_name_prefix)
+        vqs.subscribe(topic=f"{topic_prefix}*")(async_handler)
+        self._queue_callbacks.append(async_handler)
+
         async def http_handler(request: w.HTTPRequest) -> w.HTTPResponse:
-            content_type = request.get_header("content-type")
-            if not content_type or "application/cloudevents+json" not in content_type:
-                return w.HTTPResponse.json(
-                    {"error": 'Invalid content type: expected "application/cloudevents+json"'},
-                    status=400,
-                )
-            raw_body = await request.get_body()
-            # Build WSGI-style environ from request headers so that
-            # handle_queue_callback can detect v2beta callbacks correctly.
-            environ: dict[str, Any] = {"CONTENT_TYPE": content_type}
-            for hdr in (
-                "ce-type",
-                "ce-specversion",
-                "ce-source",
-                "ce-id",
-                "ce-time",
-                "ce-vqsmessageid",
-                "ce-vqsqueuename",
-                "ce-vqsconsumergroup",
-                "ce-vqsreceipthandle",
-                "ce-vqsdeliverycount",
-                "ce-vqscreatedat",
-                "ce-vqsexpiresat",
-                "ce-vqsregion",
-            ):
-                val = request.get_header(hdr)
-                if val is not None:
-                    environ["HTTP_" + hdr.upper().replace("-", "_")] = val
-            status_code, headers, body = await asyncio.to_thread(
-                vqs_client.handle_queue_callback, raw_body, environ
-            )
-            return w.HTTPResponse(status_code, body, dict(headers))
+            try:
+                client = self._queue_client(deployment=vqs.ALL_DEPLOYMENTS)
+                await client.accept_and_handle(request)
+            except Exception:
+                traceback.print_exc()
+                raise
+            return w.HTTPResponse(204, b"", {})
 
         return http_handler
 

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -23,12 +23,12 @@ dependencies = [
     "python-dotenv>=1.0.0,<2",
     "websockets>=12.0,<17",
     "cbor2>=6.0,<7",
-    "vercel-workers>=0.0.16,<1 ; python_version >= '3.12'",
     "vercel-cache>=0.6.0",
     "vercel-headers>=0.6.0",
     "vercel-internal-core>=0.1.0,<0.2.0",
     "vercel-internal-telemetry>=0.6.0",
     "vercel-oidc>=0.6.0",
+    "vercel-queue>=0.6.0",
     "vercel-sandbox>=0.2.0,<0.3.0",
 ]
 
@@ -41,6 +41,7 @@ vercel-headers = { workspace = true }
 vercel-internal-core = { workspace = true }
 vercel-internal-telemetry = { workspace = true }
 vercel-oidc = { workspace = true }
+vercel-queue = { workspace = true }
 vercel-sandbox = { workspace = true }
 
 [tool.hatch.version]

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -112,10 +112,6 @@ cache_dir = "../../.mypy_cache/vercel"
 explicit_package_bases = true
 packages = ["vercel"]
 
-[[tool.mypy.overrides]]
-module = ["vercel.workers", "vercel.workers.*"]
-ignore_missing_imports = true
-
 [tool.poe.tasks.lint]
 shell = """
 $RUFF_CHECK

--- a/src/vercel/tests/conftest.py
+++ b/src/vercel/tests/conftest.py
@@ -1,11 +1,9 @@
 """Shared fixtures for all tests."""
 
-import importlib.util
 import os
 import time
 import uuid
 from collections.abc import Generator
-from pathlib import Path
 
 import pytest
 
@@ -100,14 +98,3 @@ requires_blob_credentials = pytest.mark.skipif(
     not has_blob_credentials(),
     reason="Requires BLOB_READ_WRITE_TOKEN environment variable",
 )
-
-# Workflow tests import the workflow worlds, which depend on vercel-workers
-# (installed only on Python >= 3.12; see pyproject). Skip collecting them when the
-# package is unavailable, so collection doesn't error on older interpreters.
-_HAS_VERCEL_WORKERS = importlib.util.find_spec("vercel.workers") is not None
-
-
-def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
-    if not _HAS_VERCEL_WORKERS and collection_path.name.startswith("test_workflow_"):
-        return True
-    return None

--- a/src/vercel/tests/unit/conftest.py
+++ b/src/vercel/tests/unit/conftest.py
@@ -1,0 +1,35 @@
+"""Fixtures shared by the unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+import vercel.queue as vqs
+from vercel.queue.testing import clear_subscriptions
+
+
+@pytest.fixture
+def isolated_subscriptions() -> Iterator[None]:
+    """Keep queue handler registrations out of the global registry.
+
+    ``create_queue_handler`` registers a ``@subscribe`` handler as a side
+    effect, so tests that build a world would otherwise leak subscriptions
+    into every test that runs after them.
+    """
+    saved = vqs.get_subscriptions()
+    clear_subscriptions()
+    try:
+        yield
+    finally:
+        clear_subscriptions()
+        for subscription in saved:
+            vqs.subscribe(
+                topic=subscription.topic,
+                consumer_group=subscription.consumer_group,
+                retry_after=subscription.retry_after_seconds,
+                initial_delay=subscription.initial_delay_seconds,
+                max_concurrency=subscription.max_concurrency,
+                max_attempts=subscription.max_attempts,
+            )(subscription.func)

--- a/src/vercel/tests/unit/test_workflow_queue_namespace.py
+++ b/src/vercel/tests/unit/test_workflow_queue_namespace.py
@@ -119,6 +119,27 @@ def test_queue_names_accept_explicit_namespace() -> None:
     assert w.get_queue_name("step", "example", "python2") == "__python2_wkf_step_example"
 
 
+def test_physical_topic_keeps_the_wkf_prefix_intact() -> None:
+    # `@workflow/world-vercel` publishes the logical queue name with only
+    # non-[A-Za-z0-9-_] characters replaced by "-". Running it through
+    # `vqs.sanitize_name` instead would double the underscores and push the
+    # result outside the `__wkf_*` prefix that the builder's trigger pattern
+    # and platform service resolution key on.
+    assert w.get_physical_topic("__wkf_workflow_") == "__wkf_workflow_"
+    assert w.get_physical_topic("__python2_wkf_step_") == "__python2_wkf_step_"
+    assert (
+        w.get_physical_topic(f"__wkf_workflow_{WORKFLOW_NAME}")
+        == "__wkf_workflow_workflow--tests-example"
+    )
+
+
+def test_queue_consumer_group_is_stable() -> None:
+    # The builder copies this into the generated trigger, and dispatch is keyed
+    # on (consumer_group, topic), so it has to stay put across refactors —
+    # deriving it from the handler's qualname would move it silently.
+    assert str(w.QUEUE_CONSUMER_GROUP) == "default"
+
+
 @pytest.mark.parametrize("namespace", ["", "123abc", "Custom", "my-framework", "my_namespace"])
 def test_invalid_queue_namespaces_are_rejected(namespace: str) -> None:
     with pytest.raises(ValueError, match="Invalid queue namespace"):

--- a/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
@@ -17,17 +17,12 @@ that asks to retry.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import datetime
 
-import pytest
-
-import vercel.queue as vqs
 from vercel._internal.core.polyfills import UTC
 from vercel._internal.workflow import world as w
 from vercel._internal.workflow.worlds.vercel import VercelWorld
-from vercel.queue import Message, MessageMetadata, SanitizedName, Subscription, get_subscriptions
-from vercel.queue.testing import clear_subscriptions
+from vercel.queue import Message, MessageMetadata, SanitizedName, get_subscriptions
 
 CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -46,30 +41,7 @@ class _RecordingWorld(VercelWorld):
         return "msg_test"
 
 
-@pytest.fixture
-def isolated_subscriptions():
-    saved = get_subscriptions()
-    clear_subscriptions()
-    try:
-        yield get_subscriptions
-    finally:
-        clear_subscriptions()
-        for subscription in saved:
-            vqs.subscribe(
-                topic=subscription.topic,
-                consumer_group=subscription.consumer_group,
-                retry_after=subscription.retry_after_seconds,
-                initial_delay=subscription.initial_delay_seconds,
-                max_concurrency=subscription.max_concurrency,
-                max_attempts=subscription.max_attempts,
-            )(subscription.func)
-
-
-def _subscription_list(get_current: Callable[[], tuple[Subscription, ...]]) -> list[Subscription]:
-    return list(get_current())
-
-
-async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> None:
+async def test_step_retry_timeout_reschedules_step(isolated_subscriptions: None) -> None:
     world = _RecordingWorld()
 
     async def handler(
@@ -81,9 +53,10 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> No
 
     # Registers async_handler into the global subscription registry as a side effect.
     world.create_queue_handler("__wkf_step_", handler)
-    subscriptions = _subscription_list(isolated_subscriptions)
+    subscriptions = list(get_subscriptions())
     assert len(subscriptions) == 1
-    assert subscriptions[0].topic == "____wkf__step__*"
+    assert subscriptions[0].topic == "__wkf_step_*"
+    assert subscriptions[0].consumer_group == "default"
     async_handler = subscriptions[0].func
     assert async_handler is not None
 
@@ -118,7 +91,7 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> No
     assert delay == 1.0
 
 
-async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions) -> None:
+async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions: None) -> None:
     """A QueueContinuation return re-enqueues with its idempotency key, so repeated
     suspension passes over the same pending wait dedupe to one delayed wake-up."""
     world = _RecordingWorld()
@@ -131,9 +104,10 @@ async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions
         return w.QueueContinuation(delay_seconds=5.0, idempotency_key="wait_xyz")
 
     world.create_queue_handler("__wkf_workflow_", handler)
-    subscriptions = _subscription_list(isolated_subscriptions)
+    subscriptions = list(get_subscriptions())
     assert len(subscriptions) == 1
-    assert subscriptions[0].topic == "____wkf__workflow__*"
+    assert subscriptions[0].topic == "__wkf_workflow_*"
+    assert subscriptions[0].consumer_group == "default"
     async_handler = subscriptions[0].func
     assert async_handler is not None
 

--- a/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
@@ -17,15 +17,23 @@ that asks to retry.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from datetime import datetime
+
 import pytest
 
+import vercel.queue as vqs
+from vercel._internal.core.polyfills import UTC
 from vercel._internal.workflow import world as w
-from vercel._internal.workflow.worlds.local import LocalWorld
-from vercel.workers._queue.subscribe import subscriptions as _subs_registry
+from vercel._internal.workflow.worlds.vercel import VercelWorld
+from vercel.queue import Message, MessageMetadata, SanitizedName, Subscription, get_subscriptions
+from vercel.queue.testing import clear_subscriptions
+
+CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
 
 
-class _RecordingWorld(LocalWorld):
-    """LocalWorld whose outbound queue is captured instead of sent over the network."""
+class _RecordingWorld(VercelWorld):
+    """VercelWorld whose outbound queue is captured instead of sent over the network."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -40,25 +48,44 @@ class _RecordingWorld(LocalWorld):
 
 @pytest.fixture
 def isolated_subscriptions():
-    saved = list(_subs_registry)
-    _subs_registry.clear()
+    saved = get_subscriptions()
+    clear_subscriptions()
     try:
-        yield _subs_registry
+        yield get_subscriptions
     finally:
-        _subs_registry[:] = saved
+        clear_subscriptions()
+        for subscription in saved:
+            vqs.subscribe(
+                topic=subscription.topic,
+                consumer_group=subscription.consumer_group,
+                retry_after=subscription.retry_after_seconds,
+                initial_delay=subscription.initial_delay_seconds,
+                max_concurrency=subscription.max_concurrency,
+                max_attempts=subscription.max_attempts,
+            )(subscription.func)
+
+
+def _subscription_list(get_current: Callable[[], tuple[Subscription, ...]]) -> list[Subscription]:
+    return list(get_current())
 
 
 async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> None:
     world = _RecordingWorld()
 
-    async def handler(payload, *, queue_name, attempt, message_id):
+    async def handler(
+        message: object, *, queue_name: str, attempt: int, message_id: str
+    ) -> w.QueueContinuation:
         # Stand in for step_handler deciding to retry: a non-None continuation.
+        del message, queue_name, attempt, message_id
         return w.QueueContinuation(delay_seconds=1.0)
 
     # Registers async_handler into the global subscription registry as a side effect.
     world.create_queue_handler("__wkf_step_", handler)
-    assert len(isolated_subscriptions) == 1
-    async_handler = isolated_subscriptions[0].func
+    subscriptions = _subscription_list(isolated_subscriptions)
+    assert len(subscriptions) == 1
+    assert subscriptions[0].topic == "____wkf__step__*"
+    async_handler = subscriptions[0].func
+    assert async_handler is not None
 
     step_payload = w.StepInvokePayload(
         workflowName="wf",
@@ -71,9 +98,15 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions) -> No
         "queueName": "__wkf_step_wf",
         "deploymentId": "<local>",
     }
-    meta = {"deliveryCount": 1, "messageId": "m1", "topic": "__wkf_step_wf"}
+    metadata = MessageMetadata(
+        message_id="m1",
+        delivery_count=1,
+        created_at=CREATED_AT,
+        topic="__wkf_step_wf",
+        consumer_group=SanitizedName("tests"),
+    )
 
-    await async_handler(body, meta)
+    await async_handler(Message(payload=body, metadata=metadata))
 
     assert world.queued, "step retry was not re-enqueued"
     qn, msg, delay, _idem = world.queued[-1]
@@ -90,13 +123,19 @@ async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions
     suspension passes over the same pending wait dedupe to one delayed wake-up."""
     world = _RecordingWorld()
 
-    async def handler(payload, *, queue_name, attempt, message_id):
+    async def handler(
+        message: object, *, queue_name: str, attempt: int, message_id: str
+    ) -> w.QueueContinuation:
         # Stand in for workflow_handler suspending on a wait.
+        del message, queue_name, attempt, message_id
         return w.QueueContinuation(delay_seconds=5.0, idempotency_key="wait_xyz")
 
     world.create_queue_handler("__wkf_workflow_", handler)
-    assert len(isolated_subscriptions) == 1
-    async_handler = isolated_subscriptions[0].func
+    subscriptions = _subscription_list(isolated_subscriptions)
+    assert len(subscriptions) == 1
+    assert subscriptions[0].topic == "____wkf__workflow__*"
+    async_handler = subscriptions[0].func
+    assert async_handler is not None
 
     wf_payload = w.WorkflowInvokePayload(runId="wrun_1").model_dump()
     body = {
@@ -104,9 +143,15 @@ async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions
         "queueName": "__wkf_workflow_wf",
         "deploymentId": "<local>",
     }
-    meta = {"deliveryCount": 1, "messageId": "m1", "topic": "__wkf_workflow_wf"}
+    metadata = MessageMetadata(
+        message_id="m1",
+        delivery_count=1,
+        created_at=CREATED_AT,
+        topic="__wkf_workflow_wf",
+        consumer_group=SanitizedName("tests"),
+    )
 
-    await async_handler(body, meta)
+    await async_handler(Message(payload=body, metadata=metadata))
 
     assert world.queued, "wait continuation was not re-enqueued"
     qn, _msg, delay, idem = world.queued[-1]

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -718,7 +718,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2355,12 +2355,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.11'" },
-    { name = "jsonschema", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "rich", marker = "python_full_version < '3.11'" },
-    { name = "toml", marker = "python_full_version < '3.11'" },
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "toml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/bd/b92bbd4a5e6fb52c05af4fdef86726e05c38e5a36313716cf37e38183c65/vendoring-1.2.0.tar.gz", hash = "sha256:6340a84bf542222c96f22ebc3cb87e4d86932dc04bc8d446e38285594702c00e", size = 21475, upload-time = "2021-10-14T06:18:33.641Z" }
 wheels = [
@@ -2377,13 +2377,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.11'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pip", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "rich", marker = "python_full_version >= '3.11'" },
-    { name = "tomli", marker = "python_full_version >= '3.11'" },
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "packaging" },
+    { name = "pip" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/a6/2ad9ec99117eccf78ba6e69e7c904a3dc08ca2fba50e8869a3f02c1bc518/vendoring-1.4.0.tar.gz", hash = "sha256:48113adfb29db5e5051da823c083219567b9b3405859682cc04400a7743279d9", size = 24761, upload-time = "2026-05-19T14:39:50.773Z" }
 wheels = [
@@ -2405,8 +2405,8 @@ dependencies = [
     { name = "vercel-internal-core" },
     { name = "vercel-internal-telemetry" },
     { name = "vercel-oidc" },
+    { name = "vercel-queue" },
     { name = "vercel-sandbox" },
-    { name = "vercel-workers", marker = "python_full_version >= '3.12'" },
     { name = "websockets" },
 ]
 
@@ -2423,8 +2423,8 @@ requires-dist = [
     { name = "vercel-internal-core", editable = "src/vercel-internal-core" },
     { name = "vercel-internal-telemetry", editable = "src/vercel-internal-telemetry" },
     { name = "vercel-oidc", editable = "src/vercel-oidc" },
+    { name = "vercel-queue", editable = "src/vercel-queue" },
     { name = "vercel-sandbox", editable = "src/vercel-sandbox" },
-    { name = "vercel-workers", marker = "python_full_version >= '3.12'", specifier = ">=0.0.16,<1" },
     { name = "websockets", specifier = ">=12.0,<17" },
 ]
 
@@ -2525,26 +2525,6 @@ requires-dist = [
 ]
 
 [[package]]
-name = "vercel-sandbox"
-source = { editable = "src/vercel-sandbox" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "vercel-internal-core" },
-    { name = "vercel-oidc" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.0.0,<5" },
-    { name = "httpx", specifier = ">=0.27.0,<1" },
-    { name = "pydantic", specifier = ">=2.7.0,<3" },
-    { name = "vercel-internal-core", editable = "src/vercel-internal-core" },
-    { name = "vercel-oidc", editable = "src/vercel-oidc" },
-]
-
-[[package]]
 name = "vercel-queue"
 source = { editable = "src/vercel-queue" }
 dependencies = [
@@ -2582,19 +2562,23 @@ requires-dist = [
 provides-extras = ["devserver", "trio", "typed"]
 
 [[package]]
-name = "vercel-workers"
-version = "0.0.22"
-source = { registry = "https://pypi.org/simple" }
+name = "vercel-sandbox"
+source = { editable = "src/vercel-sandbox" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "vercel-internal-core" },
+    { name = "vercel-oidc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/fb/994dee0f9d2d22dce84c861b62e388b93f19a88b9d5a0bcb2fe6acfe5f29/vercel_workers-0.0.22.tar.gz", hash = "sha256:e189fb0e3c4cabf89e4d38f21c8f13b9dfcd4b1deedd5dc8b43aadbdf145e3a4", size = 62536, upload-time = "2026-05-04T19:17:53.348Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/8c/fb781b58edcb6ced4a6f15392315f88d7021cc2c242638e77f98ee300638/vercel_workers-0.0.22-py3-none-any.whl", hash = "sha256:83cf099a3a3dceb1cd47f8575446fb75a1e7ccbfe1304dbbbc1de3287bd640d6", size = 61175, upload-time = "2026-05-04T19:17:52.332Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0,<5" },
+    { name = "httpx", specifier = ">=0.27.0,<1" },
+    { name = "pydantic", specifier = ">=2.7.0,<3" },
+    { name = "vercel-internal-core", editable = "src/vercel-internal-core" },
+    { name = "vercel-oidc", editable = "src/vercel-oidc" },
 ]
 
 [[package]]


### PR DESCRIPTION
Re-lands #185 (reverted in #189), plus the naming fixes it needs. Local-restart recovery, originally on this branch, moves to a follow-up PR.

**Do not release before vercel/vercel#17236 is deployed**, and ship this as `vercel` 0.8.0 — that PR gates on `MIN_QUEUE_WORKFLOW_SDK_VERSION = '0.8.0'`. Until it lands, the builder serves workflows through the legacy vercel-workers trampoline, which #185 removed. (The release flow already lands on 0.8.0.)

## The fixes

With #17236 the builder introspects `get_subscriptions()` and copies our topic *and* consumer group into the trigger, so both have to be right:

- **Topic.** `sanitize_name()`'s reversible encoding doubles underscores, putting  `__wkf_workflow_` outside the `__wkf_*` prefix the trigger pattern and platform-side service resolution key on. `get_physical_topic()` now does what `@workflow/world-vercel` does: replace non-`[A-Za-z0-9-_]` with `-`, nothing else.
- **Consumer group.** `VercelWorld` passed none and fell back to the handler's qualname, which moves silently on rename. Now an explicit `QUEUE_CONSUMER_GROUP` = `default`, matching what `createWorkflowQueueTrigger` writes for TypeScript.

Both live in `world.py` and are shared by both worlds, so they can't drift.

Also: push callbacks use the world's own queue client, so acks and lease renewals inherit the proxy URL and token instead of a default `QueueClient()`.

## Testing

Contract tests for the topic mapping and consumer group in `test_workflow_queue_namespace.py`, with the reasoning in comments so nobody reaches for `sanitize_name()` again; `test_workflow_step_retry_dispatch.py`
updated to the real topics. Its `isolated_subscriptions` fixture moved to `tests/unit/conftest.py` — `create_queue_handler` registers a subscriber as a side effect that otherwise leaks into later tests.