### PR TITLE
Parallelize workspace Poe checks

### DIFF
--- a/integrations/ruff.toml
+++ b/integrations/ruff.toml
@@ -1,4 +1,5 @@
 extend = "../pyproject.toml"
+cache-dir = "../.ruff_cache"
 preview = true
 
 [lint]

--- a/integrations/vercel-celery/pyproject.toml
+++ b/integrations/vercel-celery/pyproject.toml
@@ -62,3 +62,12 @@ exclude = [
 [tool.poe]
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
+
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-celery"
+explicit_package_bases = true
+packages = ["vercel.integrations.celery"]
+
+[[tool.mypy.overrides]]
+module = ["celery", "celery.*", "kombu", "kombu.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ commands = [["./scripts/test.sh", { replace = "posargs", extend = true }]]
 
 [tool.mypy]
 python_version = "3.10"
+cache_dir = "$MYPY_CONFIG_FILE_DIR/.mypy_cache/root"
 ignore_missing_imports = true
 explicit_package_bases = true
 mypy_path = [
@@ -145,11 +146,29 @@ $RUFF_FORMAT_FIX
 """
 
 [tool.poe.tasks.pre-commit]
+shell = """
+/usr/bin/env bash -c '
+  set -euo pipefail
+  . scripts/poe/workspace-poe.sh
+  workspace_poe_run_color_if_supported "$POE" pre-commit-buffered
+'
+"""
+
+[tool.poe.tasks.pre-commit-buffered]
 parallel = ["lint", "typecheck"]
 output_mode = "buffer"
 ignore_fail = "return_non_zero"
 
 [tool.poe.tasks.pre-push]
+shell = """
+/usr/bin/env bash -c '
+  set -euo pipefail
+  . scripts/poe/workspace-poe.sh
+  workspace_poe_run_color_if_supported "$POE" pre-push-buffered
+'
+"""
+
+[tool.poe.tasks.pre-push-buffered]
 parallel = ["check-news-fragments", "lint", "typecheck", "test"]
 output_mode = "buffer"
 ignore_fail = "return_non_zero"

--- a/scripts/poe/README.md
+++ b/scripts/poe/README.md
@@ -45,15 +45,19 @@ verbosity = -1
 
 The shared include defines these Poe tasks:
 
-- `lint`: runs `$RUFF_CHECK`, then `$RUFF_FORMAT`.
+- `lint`: runs `$RUFF_CHECK` and `$RUFF_FORMAT` in parallel.
 - `fix`: runs `$RUFF_CHECK_FIX`, then `$RUFF_FORMAT_FIX`.
-- `typecheck`: runs `$POE typecheck-mypy`, then `$POE typecheck-ty`.
+- `typecheck`: runs `$POE typecheck-mypy` and `$POE typecheck-ty` in parallel.
 - `typecheck-mypy`: runs `$MYPY`.
 - `typecheck-ty`: runs `$TY`.
-- `test`: runs `$PYTEST`.
+- `test`: runs `$PYTEST` with pytest-xdist `-n auto` by default.
 
 Most packages should not redefine these tasks. Prefer tool configuration in
 `pyproject.toml` and inherit the shared tasks.
+
+Set `WORKSPACE_POE_PARALLEL=0` to run workspace and shared package checks
+sequentially. `false` and `no` are accepted as equivalent opt-outs. This also
+disables the default pytest-xdist worker flag.
 
 ## Tool Wrappers
 
@@ -76,7 +80,12 @@ The wrappers default to the current workspace scope:
 
 The `mypy` wrapper also adds `--config-file <workspace-root>/pyproject.toml`
 unless the caller provides a config file. This keeps package mypy commands
-portable regardless of current working directory.
+portable regardless of current working directory. Unless the caller provides
+`--cache-dir`, the wrapper uses `.mypy_cache/<package-name>` for workspace
+package checks and `.mypy_cache/root` for root checks.
+
+The `pytest` wrapper adds `-n auto` unless the caller provides `-n` or
+`--numprocesses`, or disables parallel mode with `WORKSPACE_POE_PARALLEL=0`.
 
 ## Local Overrides
 

--- a/scripts/poe/poe.toml
+++ b/scripts/poe/poe.toml
@@ -18,15 +18,39 @@ $RUFF_FORMAT_FIX
 [tool.poe.tasks.lint]
 shell = """
 set -e
-$RUFF_CHECK
-$RUFF_FORMAT
+if [ "${WORKSPACE_POE_PARALLEL:-}" = 0 ] || [ "${WORKSPACE_POE_PARALLEL:-}" = false ] || [ "${WORKSPACE_POE_PARALLEL:-}" = no ]; then
+  $RUFF_CHECK
+  $RUFF_FORMAT
+else
+  /usr/bin/env bash -c '
+    set -euo pipefail
+    . "$POE_CONF_DIR/workspace-poe.sh"
+    workspace_poe_reset_jobs
+    workspace_poe_start_job "ruff check" "$RUFF_CHECK"
+    workspace_poe_start_job "ruff format" "$RUFF_FORMAT"
+    workspace_poe_wait_jobs || true
+    workspace_poe_print_jobs
+  '
+fi
 """
 
 [tool.poe.tasks.typecheck]
 shell = """
 set -e
-$POE typecheck-mypy
-$POE typecheck-ty
+if [ "${WORKSPACE_POE_PARALLEL:-}" = 0 ] || [ "${WORKSPACE_POE_PARALLEL:-}" = false ] || [ "${WORKSPACE_POE_PARALLEL:-}" = no ]; then
+  $POE typecheck-mypy
+  $POE typecheck-ty
+else
+  /usr/bin/env bash -c '
+    set -euo pipefail
+    . "$POE_CONF_DIR/workspace-poe.sh"
+    workspace_poe_reset_jobs
+    workspace_poe_start_job mypy "$POE" typecheck-mypy
+    workspace_poe_start_job ty "$POE" typecheck-ty
+    workspace_poe_wait_jobs || true
+    workspace_poe_print_jobs
+  '
+fi
 """
 
 [tool.poe.tasks.typecheck-mypy]

--- a/scripts/poe/tasks/tool
+++ b/scripts/poe/tasks/tool
@@ -5,6 +5,51 @@ task_name="$(basename "$0")"
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 workspace_root="$(cd "$script_dir/../../.." && pwd -P)"
 
+workspace_poe_parallel_enabled() {
+  case "${WORKSPACE_POE_PARALLEL:-}" in
+    0|false|no)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+workspace_poe_mypy_cache_package() {
+  if [[ -n "${WORKSPACE_POE_PACKAGE:-}" ]]; then
+    printf '%s\n' "$WORKSPACE_POE_PACKAGE"
+  elif [[ "$(pwd -P)" == "$workspace_root" ]]; then
+    printf 'root\n'
+  else
+    basename "$(pwd -P)"
+  fi
+}
+
+workspace_poe_drop_duplicate_extra_args() {
+  local start
+  local index
+  local matched
+
+  if ((${#extra_args[@]} == 0 || ${#scope_args[@]} < ${#extra_args[@]})); then
+    return
+  fi
+
+  for ((start = 0; start <= ${#scope_args[@]} - ${#extra_args[@]}; start++)); do
+    matched=1
+    for ((index = 0; index < ${#extra_args[@]}; index++)); do
+      if [[ "${scope_args[start + index]}" != "${extra_args[index]}" ]]; then
+        matched=0
+        break
+      fi
+    done
+    if ((matched)); then
+      extra_args=()
+      return
+    fi
+  done
+}
+
 case "$task_name" in
   pytest)
     command=(pytest)
@@ -42,26 +87,76 @@ if [[ "${extra_args[0]:-}" == -- ]]; then
 fi
 
 scope_args=("$@")
+if [[ "$task_name" == ruff-* && -z "${RUFF_CACHE_DIR:-}" ]]; then
+  export RUFF_CACHE_DIR="$workspace_root/.ruff_cache"
+fi
 if [[ "$task_name" == mypy ]]; then
+  cache_dir=""
   has_config_file=0
+  has_cache_dir=0
   option_value=0
-  for arg in "${scope_args[@]}" "${extra_args[@]}"; do
-    if ((option_value)); then
-      option_value=0
-      continue
-    fi
-    case "$arg" in
-      --config-file)
-        has_config_file=1
-        option_value=1
-        ;;
-      --config-file=*)
-        has_config_file=1
-        ;;
-    esac
-  done
+  if ((${#scope_args[@]})); then
+    for arg in "${scope_args[@]}"; do
+      if ((option_value)); then
+        option_value=0
+        continue
+      fi
+      case "$arg" in
+        --config-file)
+          has_config_file=1
+          option_value=1
+          ;;
+        --config-file=*)
+          has_config_file=1
+          ;;
+        --cache-dir)
+          has_cache_dir=1
+          option_value=1
+          ;;
+        --cache-dir=*)
+          has_cache_dir=1
+          ;;
+      esac
+    done
+  fi
+  if ((${#extra_args[@]})); then
+    for arg in "${extra_args[@]}"; do
+      if ((option_value)); then
+        option_value=0
+        continue
+      fi
+      case "$arg" in
+        --config-file)
+          has_config_file=1
+          option_value=1
+          ;;
+        --config-file=*)
+          has_config_file=1
+          ;;
+        --cache-dir)
+          has_cache_dir=1
+          option_value=1
+          ;;
+        --cache-dir=*)
+          has_cache_dir=1
+          ;;
+      esac
+    done
+  fi
   if ((has_config_file == 0)); then
-    scope_args=(--config-file "$workspace_root/pyproject.toml" "${scope_args[@]}")
+    if ((${#scope_args[@]})); then
+      scope_args=(--config-file "$workspace_root/pyproject.toml" "${scope_args[@]}")
+    else
+      scope_args=(--config-file "$workspace_root/pyproject.toml")
+    fi
+  fi
+  if ((has_cache_dir == 0)); then
+    cache_dir="$workspace_root/.mypy_cache/$(workspace_poe_mypy_cache_package)"
+    if ((${#scope_args[@]})); then
+      scope_args=(--cache-dir "$cache_dir" "${scope_args[@]}")
+    else
+      scope_args=(--cache-dir "$cache_dir")
+    fi
   fi
 fi
 if ((${#scope_args[@]} == 0)) && [[ -n "${WORKSPACE_POE_SCOPE_ARGS:-}" ]]; then
@@ -70,29 +165,76 @@ fi
 if [[ "$task_name" == mypy ]]; then
   has_target=0
   option_value=0
-  for arg in "${scope_args[@]}"; do
-    if ((option_value)); then
-      option_value=0
-      continue
-    fi
-    case "$arg" in
-      --config-file|--python-version)
-        option_value=1
-        ;;
-      --config-file=*|--python-version=*)
-        ;;
-      --*)
-        ;;
-      *)
-        has_target=1
-        ;;
-    esac
-  done
+  if ((${#scope_args[@]})); then
+    for arg in "${scope_args[@]}"; do
+      if ((option_value)); then
+        option_value=0
+        continue
+      fi
+      case "$arg" in
+        --cache-dir|--config-file|--python-version)
+          option_value=1
+          ;;
+        --cache-dir=*|--config-file=*|--python-version=*)
+          ;;
+        --*)
+          ;;
+        *)
+          has_target=1
+          ;;
+      esac
+    done
+  fi
   if ((has_target == 0)); then
     if [[ -n "${WORKSPACE_POE_SCOPE_ARGS:-}" ]]; then
       eval "scope_args+=( ${WORKSPACE_POE_SCOPE_ARGS} )"
     else
       scope_args+=(.)
+    fi
+  fi
+fi
+if [[ "$task_name" == pytest ]]; then
+  has_numprocesses=0
+  option_value=0
+  if ((${#scope_args[@]})); then
+    for arg in "${scope_args[@]}"; do
+      if ((option_value)); then
+        option_value=0
+        continue
+      fi
+      case "$arg" in
+        -n|--numprocesses)
+          has_numprocesses=1
+          option_value=1
+          ;;
+        -n*|--numprocesses=*)
+          has_numprocesses=1
+          ;;
+      esac
+    done
+  fi
+  if ((${#extra_args[@]})); then
+    for arg in "${extra_args[@]}"; do
+      if ((option_value)); then
+        option_value=0
+        continue
+      fi
+      case "$arg" in
+        -n|--numprocesses)
+          has_numprocesses=1
+          option_value=1
+          ;;
+        -n*|--numprocesses=*)
+          has_numprocesses=1
+          ;;
+      esac
+    done
+  fi
+  if ((has_numprocesses == 0)) && workspace_poe_parallel_enabled; then
+    if ((${#scope_args[@]})); then
+      scope_args=(-n auto "${scope_args[@]}")
+    else
+      scope_args=(-n auto)
     fi
   fi
 fi
@@ -104,6 +246,16 @@ if ((${#scope_args[@]} == 0)); then
   fi
 fi
 
-printf '%q ' "${command[@]}" "${scope_args[@]}" "${extra_args[@]}"
+workspace_poe_drop_duplicate_extra_args
+
+run_args=("${command[@]}")
+if ((${#scope_args[@]})); then
+  run_args+=("${scope_args[@]}")
+fi
+if ((${#extra_args[@]})); then
+  run_args+=("${extra_args[@]}")
+fi
+
+printf '%q ' "${run_args[@]}"
 printf '\n'
-exec "${command[@]}" "${scope_args[@]}" "${extra_args[@]}"
+exec "${run_args[@]}"

--- a/scripts/poe/workspace-poe.sh
+++ b/scripts/poe/workspace-poe.sh
@@ -3,7 +3,24 @@
 set -o pipefail
 
 workspace_poe_color_output=0
-if [[ -t 0 || -n "${FORCE_COLOR:-}" || -n "${CLICOLOR_FORCE:-}" || -n "${PY_COLORS:-}" ]]; then
+
+workspace_poe_supports_color() {
+  if [[ -n "${NO_COLOR:-}" && "${NO_COLOR:0:1}" != 0 ]]; then
+    return 1
+  fi
+  if [[ -n "${FORCE_COLOR:-}" && "${FORCE_COLOR:0:1}" != 0 ]]; then
+    return 0
+  fi
+  if [[ -n "${CLICOLOR_FORCE:-}" && "${CLICOLOR_FORCE:0:1}" != 0 ]]; then
+    return 0
+  fi
+  if [[ -n "${PY_COLORS:-}" && "${PY_COLORS:0:1}" != 0 ]]; then
+    return 0
+  fi
+  [[ -t 1 ]]
+}
+
+if workspace_poe_supports_color; then
   workspace_poe_color_output=1
 fi
 workspace_poe_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -12,11 +29,36 @@ workspace_poe_scope_args=()
 workspace_poe_subcommand_args=()
 workspace_poe_poe_args=(-q)
 workspace_poe_snapshot_dir=""
+workspace_poe_jobs_file=""
 
 workspace_poe_cleanup_snapshot() {
   if [[ -n "$workspace_poe_snapshot_dir" ]]; then
     rm -rf "$workspace_poe_snapshot_dir"
+    workspace_poe_snapshot_dir=""
   fi
+}
+
+workspace_poe_cleanup_jobs() {
+  local pid
+  local label
+  local log_file
+  local status_file
+  if [[ -n "$workspace_poe_jobs_file" && -f "$workspace_poe_jobs_file" ]]; then
+    while IFS=$'\t' read -r pid label log_file status_file; do
+      rm -f "$log_file" "$status_file"
+    done < "$workspace_poe_jobs_file"
+    rm -f "$workspace_poe_jobs_file"
+    workspace_poe_jobs_file=""
+  fi
+}
+
+workspace_poe_cleanup() {
+  workspace_poe_cleanup_jobs
+  workspace_poe_cleanup_snapshot
+}
+
+workspace_poe_install_cleanup_trap() {
+  trap workspace_poe_cleanup EXIT INT TERM
 }
 
 workspace_poe_enter_tree() {
@@ -58,11 +100,106 @@ workspace_poe_enter_tree() {
       ;;
   esac
   ln -s "$root/.git" "$workspace_poe_snapshot_dir/.git"
+  mkdir -p "$root/.mypy_cache" "$root/.ruff_cache"
+  ln -s "$root/.mypy_cache" "$workspace_poe_snapshot_dir/.mypy_cache"
+  ln -s "$root/.ruff_cache" "$workspace_poe_snapshot_dir/.ruff_cache"
 
   export WORKSPACE_POE_PROJECT_ROOT="$root"
   export WORKSPACE_POE_GIT_SCOPE_ACTIVE="$mode"
-  trap workspace_poe_cleanup_snapshot EXIT INT TERM
+  workspace_poe_install_cleanup_trap
   cd "$workspace_poe_snapshot_dir" || return
+}
+
+workspace_poe_parallel_enabled() {
+  case "${WORKSPACE_POE_PARALLEL:-}" in
+    0|false|no)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+workspace_poe_reset_jobs() {
+  workspace_poe_cleanup_jobs
+  workspace_poe_jobs_file="$(mktemp "${TMPDIR:-/tmp}/workspace-poe-jobs.XXXXXX")"
+  workspace_poe_install_cleanup_trap
+}
+
+workspace_poe_start_job() {
+  local label="$1"
+  shift
+  local log_file
+  local status_file
+  local pid
+
+  if [[ -z "$workspace_poe_jobs_file" ]]; then
+    workspace_poe_reset_jobs
+  fi
+
+  log_file="$(mktemp "${TMPDIR:-/tmp}/workspace-poe-log.XXXXXX")"
+  status_file="$(mktemp "${TMPDIR:-/tmp}/workspace-poe-status.XXXXXX")"
+  (
+    set +e
+    workspace_poe_jobs_file=""
+    workspace_poe_snapshot_dir=""
+    if ((workspace_poe_color_output)); then
+      FORCE_COLOR=1 CLICOLOR_FORCE=1 PY_COLORS=1 "$@" > "$log_file" 2>&1
+    else
+      "$@" > "$log_file" 2>&1
+    fi
+    printf '%s\n' "$?" > "$status_file"
+  ) &
+  pid=$!
+  printf '%s\t%s\t%s\t%s\n' "$pid" "$label" "$log_file" "$status_file" >> "$workspace_poe_jobs_file"
+}
+
+workspace_poe_wait_jobs() {
+  local pid
+  local label
+  local log_file
+  local status_file
+  local status=0
+
+  if [[ -z "$workspace_poe_jobs_file" || ! -f "$workspace_poe_jobs_file" ]]; then
+    return 0
+  fi
+
+  while IFS=$'\t' read -r pid label log_file status_file; do
+    if ! wait "$pid"; then
+      status=1
+    fi
+  done < "$workspace_poe_jobs_file"
+  return "$status"
+}
+
+workspace_poe_print_jobs() {
+  local pid
+  local label
+  local log_file
+  local status_file
+  local status
+  local failed=0
+
+  if [[ -z "$workspace_poe_jobs_file" || ! -f "$workspace_poe_jobs_file" ]]; then
+    return 0
+  fi
+
+  while IFS=$'\t' read -r pid label log_file status_file; do
+    status=0
+    if [[ -s "$status_file" ]]; then
+      IFS= read -r status < "$status_file"
+    else
+      status=1
+    fi
+    if ((status != 0)); then
+      failed=1
+    fi
+    workspace_poe_print_job "$label" "$status" "$log_file"
+  done < "$workspace_poe_jobs_file"
+  workspace_poe_cleanup_jobs
+  return "$failed"
 }
 
 workspace_poe_uv_no_color() {
@@ -103,6 +240,11 @@ workspace_poe_split_args() {
       passthrough=1
       continue
     fi
+    if [[ "$arg" == -* ]]; then
+      passthrough=1
+      workspace_poe_subcommand_args+=("$arg")
+      continue
+    fi
     workspace_poe_scope_args+=("$arg")
   done
 }
@@ -125,7 +267,9 @@ workspace_poe_join_tab_paths() {
   local path_args=()
   if [[ -n "$paths" ]]; then
     IFS=$'\t' read -r -a path_args <<< "$paths"
-    workspace_poe_join_args "${path_args[@]}"
+    if ((${#path_args[@]})); then
+      workspace_poe_join_args "${path_args[@]}"
+    fi
   fi
 }
 
@@ -179,6 +323,14 @@ workspace_poe_run_scoped_uv() {
   fi
 }
 
+workspace_poe_run_color_if_supported() {
+  if ((workspace_poe_color_output)); then
+    FORCE_COLOR="${FORCE_COLOR:-1}" CLICOLOR_FORCE="${CLICOLOR_FORCE:-1}" PY_COLORS="${PY_COLORS:-1}" "$@"
+  else
+    "$@"
+  fi
+}
+
 workspace_poe_join_args() {
   if (($#)); then
     printf '%q ' "$@"
@@ -214,13 +366,40 @@ workspace_poe_direct_package() {
   IFS=$'\t' read -r package package_path paths < "$scope_file"
   if [[ -n "$paths" ]]; then
     IFS=$'\t' read -r -a path_args <<< "$paths"
-    scope_args="$(workspace_poe_join_args "${path_args[@]}")"
+    if ((${#path_args[@]})); then
+      scope_args="$(workspace_poe_join_args "${path_args[@]}")"
+    fi
   fi
   cd "$package_path" || return
+  export WORKSPACE_POE_PACKAGE="$package"
   if [[ "$package" == root ]]; then
-    workspace_poe_run_scoped_uv "$scope_args" --all-packages poe "${workspace_poe_poe_args[@]}" "$task" "$@"
+    if (($#)); then
+      workspace_poe_run_scoped_uv "$scope_args" --all-packages poe "${workspace_poe_poe_args[@]}" "$task" "$@"
+    else
+      workspace_poe_run_scoped_uv "$scope_args" --all-packages poe "${workspace_poe_poe_args[@]}" "$task"
+    fi
   else
-    workspace_poe_run_scoped_uv "$scope_args" --package "$package" poe "${workspace_poe_poe_args[@]}" "$task" "$@"
+    if (($#)); then
+      workspace_poe_run_scoped_uv "$scope_args" --package "$package" poe "${workspace_poe_poe_args[@]}" "$task" "$@"
+    else
+      workspace_poe_run_scoped_uv "$scope_args" --package "$package" poe "${workspace_poe_poe_args[@]}" "$task"
+    fi
+  fi
+}
+
+workspace_poe_run_resolved_task() {
+  local package_path="$1"
+  local scope_args="$2"
+  local package_task="$3"
+  local uv_scope="$4"
+  local package="$5"
+
+  cd "$package_path" || return
+  export WORKSPACE_POE_PACKAGE="$package"
+  if [[ "$uv_scope" == --all-packages ]]; then
+    workspace_poe_invoke_task "$package_task" workspace_poe_run_scoped_uv "$scope_args" --all-packages
+  else
+    workspace_poe_invoke_task "$package_task" workspace_poe_run_scoped_uv "$scope_args" --package "$package"
   fi
 }
 
@@ -248,6 +427,23 @@ workspace_poe_run_workspace_task() {
     return
   fi
 
+  if workspace_poe_parallel_enabled; then
+    workspace_poe_reset_jobs
+    while IFS=$'\t' read -r package package_path paths; do
+      scope_args="$(workspace_poe_join_tab_paths "$paths")"
+      package_task="$(workspace_poe_task_for_package "$task" "$package")"
+      if [[ "$package" == root ]]; then
+        workspace_poe_start_job root workspace_poe_run_resolved_task "$package_path" "$scope_args" "$package_task" --all-packages root
+      else
+        workspace_poe_start_job "$package" workspace_poe_run_resolved_task "$package_path" "$scope_args" "$package_task" --package "$package"
+      fi
+    done < "$scope_file"
+    rm -f "$scope_file"
+    workspace_poe_wait_jobs || true
+    workspace_poe_print_jobs
+    return
+  fi
+
   while IFS=$'\t' read -r package package_path paths; do
     if [[ "$package" == root ]]; then
       continue
@@ -256,6 +452,7 @@ workspace_poe_run_workspace_task() {
     package_task="$(workspace_poe_task_for_package "$task" "$package")"
     (
       cd "$package_path" || exit
+      export WORKSPACE_POE_PACKAGE="$package"
       workspace_poe_invoke_task "$package_task" workspace_poe_run_scoped_uv "$scope_args" --package "$package"
     ) 2>&1 | workspace_poe_format_output "$package"
   done < "$scope_file"
@@ -268,6 +465,7 @@ workspace_poe_run_workspace_task() {
     package_task="$(workspace_poe_task_for_package "$task" "$package")"
     (
       cd "$package_path" || exit
+      export WORKSPACE_POE_PACKAGE="$package"
       workspace_poe_invoke_task "$package_task" workspace_poe_run_scoped_uv "$scope_args" --all-packages
     ) 2>&1 | workspace_poe_format_output root
   done < "$scope_file"
@@ -291,4 +489,32 @@ workspace_poe_format_output() {
     package_label="$(printf '\033[1;%sm%s\033[0m' "$package_color" "$1")"
   fi
   sed -e "s/^Poe => /${package_label}: /" -e "t" -e "s/^/${package_label}: /"
+}
+
+workspace_poe_print_job() {
+  local label="$1"
+  local status="$2"
+  local log_file="$3"
+  local label_color
+  local display_label="$label"
+
+  if ((workspace_poe_color_output)); then
+    label_color="$(workspace_poe_label_color "$label")"
+    display_label="$(printf '\033[1;%sm%s\033[0m' "$label_color" "$label")"
+  fi
+
+  printf '==> %s\n' "$display_label"
+  if [[ -s "$log_file" ]]; then
+    cat "$log_file"
+    case "$(tail -c 1 "$log_file")" in
+      $'\n'|"")
+        ;;
+      *)
+        printf '\n'
+        ;;
+    esac
+  fi
+  if ((status != 0)); then
+    printf '<== %s failed with exit code %s\n' "$display_label" "$status"
+  fi
 }

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -9,6 +9,7 @@ workspace_poe_enter_tree
 qa_scopes=()
 qa_verbose=0
 qa_quiet=0
+qa_emit_task_header=1
 
 if [[ -n "${POE_EXTRA_ARGS:-}" ]]; then
   echo "qa does not accept tool-specific arguments after --" >&2
@@ -64,7 +65,9 @@ done
 
 qa_run() {
   local task="$1"
-  printf '==> %s\n' "$task"
+  if ((qa_emit_task_header)); then
+    printf '==> %s\n' "$task"
+  fi
   workspace_poe_subcommand_args=()
   workspace_poe_poe_args=(-q)
   if ((${#qa_poe_flags[@]})); then
@@ -78,6 +81,16 @@ workspace_poe_scope_args=()
 if ((${#qa_scopes[@]})); then
   workspace_poe_scope_args+=("${qa_scopes[@]}")
 fi
-qa_run lint
-qa_run typecheck
-qa_run test
+if workspace_poe_parallel_enabled; then
+  qa_emit_task_header=0
+  workspace_poe_reset_jobs
+  workspace_poe_start_job lint qa_run lint
+  workspace_poe_start_job typecheck qa_run typecheck
+  workspace_poe_start_job test qa_run test
+  workspace_poe_wait_jobs || true
+  workspace_poe_print_jobs
+else
+  qa_run lint
+  qa_run typecheck
+  qa_run test
+fi

--- a/src/vercel-cache/pyproject.toml
+++ b/src/vercel-cache/pyproject.toml
@@ -61,5 +61,10 @@ asyncio_mode = "auto"
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
 
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-cache"
+explicit_package_bases = true
+packages = ["vercel.cache"]
+
 [tool.poe.tasks.typecheck]
 cmd = "$MYPY"

--- a/src/vercel-headers/pyproject.toml
+++ b/src/vercel-headers/pyproject.toml
@@ -47,6 +47,11 @@ exclude = [
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
 
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-headers"
+explicit_package_bases = true
+packages = ["vercel.headers"]
+
 [tool.poe.tasks.typecheck]
 cmd = "$MYPY"
 

--- a/src/vercel-internal-telemetry/pyproject.toml
+++ b/src/vercel-internal-telemetry/pyproject.toml
@@ -53,6 +53,11 @@ exclude = [
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
 
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-internal-telemetry"
+explicit_package_bases = true
+packages = ["vercel.internal.telemetry"]
+
 [tool.poe.tasks.typecheck]
 cmd = "$MYPY"
 

--- a/src/vercel-oidc/pyproject.toml
+++ b/src/vercel-oidc/pyproject.toml
@@ -51,6 +51,11 @@ exclude = [
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
 
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-oidc"
+explicit_package_bases = true
+packages = ["vercel.oidc"]
+
 [tool.poe.tasks.typecheck]
 cmd = "$MYPY"
 

--- a/src/vercel-queue/pyproject.toml
+++ b/src/vercel-queue/pyproject.toml
@@ -61,6 +61,7 @@ exclude = [
 
 [tool.ruff]
 extend = "../../pyproject.toml"
+cache-dir = "../../.ruff_cache"
 preview = true
 
 [tool.ruff.lint]
@@ -200,3 +201,8 @@ testpaths = ["tests"]
 [tool.poe]
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
+
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel-queue"
+explicit_package_bases = true
+packages = ["vercel.queue"]

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -90,6 +90,15 @@ exclude = [
 include = "../../scripts/poe/poe.toml"
 verbosity = -1
 
+[tool.mypy]
+cache_dir = "../../.mypy_cache/vercel"
+explicit_package_bases = true
+packages = ["vercel"]
+
+[[tool.mypy.overrides]]
+module = ["vercel.workers", "vercel.workers.*"]
+ignore_missing_imports = true
+
 [tool.poe.tasks.lint]
 shell = """
 $RUFF_CHECK


### PR DESCRIPTION
Make poe tasks run in parallel by default (opt out via
`WORKSPACE_POE_PARALLEL=0`).  Makes `pre-commit` check run in ~2s and
`pre-push` in ~10s.  This also enables `pytest-xdist`.
