### PR TITLE
workflow: fix against latest workflow server implementation

### DIFF
--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -65,7 +65,7 @@ def get_queue_name(
 
 
 class BaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="forbid", serialize_by_alias=True)
+    model_config = pydantic.ConfigDict(serialize_by_alias=True)
 
 
 class WorkflowInvokePayload(BaseModel):


### PR DESCRIPTION
The workflow server to the EventResult on run_started, and we have
pydantic set up to reject that.

Drop `extra="forbid"` from our pydantic config so we are resilient to
fields being added.
