### PR TITLE
Implement changesets-like interactive TUI for changelogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "zizmor>=1.24.1,<2",
     "hatchling>=1.27.0,<2",
     "time-machine>=2.16,<3",
+    "textual>=8.0.0,<9",
     "trio>=0.33.0,<1",
     "poethepoet>=0.48.0",
     "tox>=4",
@@ -180,6 +181,14 @@ fi
 python scripts/release.py release "$@"
 """
 args = [{ name = "force_bump", options = ["--force-bump"] }]
+
+[tool.poe.tasks.changelog]
+cmd = "python scripts/release.py changelog"
+use_exec = true
+
+[tool.poe.tasks.clog]
+cmd = "python scripts/release.py changelog"
+use_exec = true
 
 [tool.poe.tasks.dist]
 cmd = "./scripts/build.sh"

--- a/scripts/clogedit.py
+++ b/scripts/clogedit.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.timer import Timer
+from textual.widget import Widget
+from textual.widgets import (
+    Label,
+    OptionList,
+    SelectionList,
+    Static,
+)
+from textual.widgets.option_list import Option
+from textual.widgets.selection_list import Selection
+
+try:
+    from scripts import release, workspace
+except ImportError:  # pragma: no cover - script execution path
+    import release  # type: ignore[no-redef]
+    import workspace  # type: ignore[no-redef]
+
+NewsFragmentDraft = release.NewsFragmentDraft
+
+
+class WizardStep(Enum):
+    PACKAGES = "packages"
+    TYPES = "types"
+
+
+PACKAGE_STATUS = "packages  arrows move  space toggles  enter next  ctrl-c/ctrl-d exit"
+TYPE_STATUS = "change level  arrows move  space selects  enter edit  esc back  ctrl-c/ctrl-d exit"
+ESC_EXIT_STATUS = "packages  esc again exits  arrows move  space toggles  enter next"
+ESC_EXIT_SECONDS = 0.5
+TYPE_STYLES = {
+    "breaking": "red",
+    "feature": "green",
+    "bugfix": "cyan",
+    "docs": "blue",
+    "internal": "dim",
+}
+
+
+@dataclass(frozen=True)
+class PackageNewsState:
+    name: str
+    changed: bool
+    covered: bool
+    selected: bool
+    kind: str = "bugfix"
+
+
+@dataclass
+class ChangelogSelection:
+    packages: dict[str, PackageNewsState] = field(default_factory=dict)
+
+    def drafts(self) -> list[tuple[str, str]]:
+        return [
+            (state.name, state.kind)
+            for state in self.packages.values()
+            if state.selected and not state.covered
+        ]
+
+
+class ChangeTypeList(OptionList):
+    BINDINGS = [Binding("space", "select", "Select", show=False)]
+
+
+class ChangelogApp(App[list[NewsFragmentDraft]]):
+    CSS = """
+    Screen { padding: 1 2 0 2; }
+    #body { height: 1fr; }
+    #title { height: auto; margin-bottom: 1; }
+    #status { dock: bottom; height: 1; color: $text-muted; }
+    SelectionList, OptionList {
+        height: 1fr;
+        border: none;
+        background: transparent;
+    }
+    """
+    BINDINGS = [
+        Binding("enter", "next", "Next", show=False, priority=True),
+        Binding("escape", "back", "Back", show=False, priority=True),
+        Binding("ctrl+c,ctrl+d", "cancel", "Cancel", show=False, priority=True),
+    ]
+
+    def __init__(
+        self,
+        selection: ChangelogSelection,
+        *,
+        fragment_types: Mapping[str, str],
+        type_bumps: Mapping[str, str],
+        edit_news_fragment: Callable[[str, str], str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.selection = selection
+        self.fragment_types = fragment_types
+        self.type_bumps = type_bumps
+        self.edit_news_fragment = edit_news_fragment
+        self.step = WizardStep.PACKAGES
+        self.type_index = 0
+        self.type_packages: list[str] = []
+        self.package_list: SelectionList[str] | None = None
+        self.type_list: ChangeTypeList | None = None
+        self.status = PACKAGE_STATUS
+        self.draft_texts: dict[str, str] = {}
+        self.escape_exit_timer: Timer | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(id="body")
+        yield Static("", id="status")
+
+    async def on_mount(self) -> None:
+        await self.render_step()
+
+    async def action_next(self) -> None:
+        if self.step is WizardStep.PACKAGES:
+            self.clear_escape_exit()
+            self.save_package_selection()
+            self.type_packages = [package for package, _kind in self.selection.drafts()]
+            if not self.type_packages:
+                self.exit([])
+                return
+            self.type_index = 0
+            self.step = WizardStep.TYPES
+            await self.render_step()
+            return
+
+        self.save_current_type()
+        if self.edit_current_package():
+            await self.advance_after_edit()
+
+    async def action_back(self) -> None:
+        if self.step is WizardStep.PACKAGES:
+            if self.escape_exit_timer is None:
+                self.arm_escape_exit()
+            else:
+                self.exit([])
+            return
+        self.clear_escape_exit()
+        self.save_current_type()
+        if self.type_index > 0:
+            self.type_index -= 1
+        else:
+            self.step = WizardStep.PACKAGES
+        await self.render_step()
+
+    def action_cancel(self) -> None:
+        self.exit([])
+
+    def arm_escape_exit(self) -> None:
+        self.status = ESC_EXIT_STATUS
+        self.update_status()
+        self.escape_exit_timer = self.set_timer(
+            ESC_EXIT_SECONDS,
+            self.clear_escape_exit,
+            name="escape-exit",
+        )
+
+    def clear_escape_exit(self) -> None:
+        if self.escape_exit_timer is not None:
+            self.escape_exit_timer.stop()
+            self.escape_exit_timer = None
+        if self.step is WizardStep.PACKAGES and self.status == ESC_EXIT_STATUS:
+            self.status = PACKAGE_STATUS
+            self.update_status()
+
+    async def render_step(self) -> None:
+        body = self.query_one("#body", Vertical)
+        await body.remove_children()
+        if self.step is WizardStep.PACKAGES:
+            await body.mount(*self.package_widgets())
+            self.status = PACKAGE_STATUS
+            self.focus_packages()
+        else:
+            await body.mount(*self.type_widgets())
+            self.status = TYPE_STATUS
+            self.focus_types()
+        self.update_status()
+
+    def update_status(self) -> None:
+        self.query_one("#status", Static).update(self.status)
+
+    def focus_packages(self) -> None:
+        if self.package_list is not None:
+            self.package_list.focus()
+
+    def focus_types(self) -> None:
+        if self.type_list is not None:
+            self.type_list.focus()
+
+    def package_widgets(self) -> list[Widget]:
+        selections = [
+            Selection(
+                self.package_label(state),
+                state.name,
+                state.selected and not state.covered,
+                disabled=state.covered,
+            )
+            for state in self.selection.packages.values()
+        ]
+        self.package_list = SelectionList[str](*selections)
+        return [
+            Label("Select packages for news fragments"),
+            self.package_list,
+        ]
+
+    def type_widgets(self) -> list[Widget]:
+        package = self.type_packages[self.type_index]
+        state = self.selection.packages[package]
+        progress = f"{self.type_index + 1}/{len(self.type_packages)}"
+        options = [
+            Option(self.type_label(kind, selected=kind == state.kind), id=kind)
+            for kind in self.fragment_types
+        ]
+        self.type_list = ChangeTypeList(*options)
+        self.type_list.highlighted = self.type_list.get_option_index(state.kind)
+        return [
+            Label(Text.assemble("Choose change level for ", (package, "bold"), f" ({progress})")),
+            self.type_list,
+        ]
+
+    def package_label(self, state: PackageNewsState) -> str:
+        flags = []
+        if state.changed:
+            flags.append("changed")
+        if state.covered:
+            flags.append("covered")
+        suffix = f" ({', '.join(flags)})" if flags else ""
+        return f"{state.name}{suffix}"
+
+    def type_label(self, kind: str, *, selected: bool = False) -> Text:
+        title = self.fragment_types[kind]
+        bump = self.type_bumps[kind]
+        marker = "*" if selected else " "
+        style = TYPE_STYLES.get(kind, "")
+        return Text.assemble(
+            f"[{marker}] ",
+            (kind, style),
+            " - ",
+            (title, style),
+            " ",
+            (f"({bump})", "dim"),
+        )
+
+    def save_package_selection(self) -> None:
+        if self.package_list is None:
+            return
+        selected = set(self.package_list.selected)
+        for name, state in list(self.selection.packages.items()):
+            self.replace_state(name, selected=not state.covered and name in selected)
+
+    def save_current_type(self) -> None:
+        if self.step is not WizardStep.TYPES:
+            return
+        if self.type_list is None:
+            return
+        highlighted = self.type_list.highlighted
+        if highlighted is None:
+            return
+        option = self.type_list.get_option_at_index(highlighted)
+        if option.id is None:
+            return
+        self.set_kind(self.type_packages[self.type_index], option.id)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_list is not self.type_list:
+            return
+        event.stop()
+        if event.option_id is None:
+            return
+        self.set_kind(self.type_packages[self.type_index], event.option_id)
+        self.refresh_type_options()
+
+    def on_option_list_option_highlighted(self, event: OptionList.OptionHighlighted) -> None:
+        # Keep the [*] marker in lockstep with the highlight: enter saves the
+        # highlighted kind, so a marker left on another option would lie.
+        if event.option_list is not self.type_list or event.option_id is None:
+            return
+        package = self.type_packages[self.type_index]
+        if self.selection.packages[package].kind == event.option_id:
+            return
+        self.set_kind(package, event.option_id)
+        self.refresh_type_options()
+
+    def refresh_type_options(self) -> None:
+        if self.type_list is None:
+            return
+        package = self.type_packages[self.type_index]
+        selected_kind = self.selection.packages[package].kind
+        for kind in self.fragment_types:
+            self.type_list.replace_option_prompt(
+                kind, self.type_label(kind, selected=kind == selected_kind)
+            )
+
+    def toggle(self, name: str) -> None:
+        state = self.state(name)
+        self.replace_state(name, selected=not state.selected)
+
+    def add(self, name: str) -> None:
+        self.state(name)
+        self.replace_state(name, selected=True)
+
+    def set_kind(self, name: str, kind: str) -> None:
+        if kind not in self.fragment_types:
+            expected = ", ".join(self.fragment_types)
+            raise ValueError(f"invalid news fragment type {kind!r}; expected one of: {expected}")
+        self.state(name)
+        self.replace_state(name, kind=kind)
+
+    def finish(self) -> None:
+        if self.edit_news_fragment is None:
+            self.exit([])
+            return
+        self.exit(self.drafts())
+
+    def edit_current_package(self) -> bool:
+        if self.edit_news_fragment is None:
+            return True
+        package = self.type_packages[self.type_index]
+        kind = self.selection.packages[package].kind
+        with self.suspend():
+            try:
+                text = self.edit_news_fragment(package, kind)
+            except SystemExit as exc:
+                self.status = self.editor_error_status(exc)
+                self.update_status()
+                self.focus_types()
+                return False
+        self.draft_texts[package] = text
+        return True
+
+    async def advance_after_edit(self) -> None:
+        if self.type_index + 1 < len(self.type_packages):
+            self.type_index += 1
+            await self.render_step()
+        else:
+            self.finish()
+
+    def drafts(self) -> list[NewsFragmentDraft]:
+        return [
+            NewsFragmentDraft(package=package, kind=kind, text=self.draft_texts[package])
+            for package, kind in self.selection.drafts()
+        ]
+
+    def editor_error_status(self, error: SystemExit) -> str:
+        message = str(error.code) if error.code not in (None, 1) else "editor failed"
+        return f"{message}  enter retries  esc back  ctrl-c/ctrl-d exit"
+
+    def replace_state(self, name: str, **updates: Any) -> None:
+        self.selection.packages[name] = replace(self.state(name), **updates)
+
+    def state(self, name: str) -> PackageNewsState:
+        try:
+            return self.selection.packages[name]
+        except KeyError as exc:
+            expected = ", ".join(self.selection.packages)
+            raise ValueError(f"Unknown package {name!r}; expected one of: {expected}") from exc
+
+
+def run_changelog_selection_app(
+    selection: ChangelogSelection,
+    *,
+    fragment_types: Mapping[str, str],
+    type_bumps: Mapping[str, str],
+    edit_news_fragment: Callable[[str, str], str],
+) -> list[NewsFragmentDraft]:
+    app = ChangelogApp(
+        selection,
+        fragment_types=fragment_types,
+        type_bumps=type_bumps,
+        edit_news_fragment=edit_news_fragment,
+    )
+    try:
+        result = app.run(mouse=True)
+    except KeyboardInterrupt:
+        return []
+    return result or []
+
+
+def changelog(diff: str = "tracked") -> int:
+    packages_by_name = workspace.packages()
+    changed = release.packages_for_paths(
+        packages_by_name,
+        release.collect_changelog_diff_paths(diff),
+        code_only=True,
+    )
+    fragments = release.parse_fragments(set(packages_by_name))
+    covered = {fragment.package for fragment in fragments}
+    selection = initial_changelog_selection(packages_by_name, changed, covered)
+
+    drafts = run_changelog_ui(selection, packages_by_name=packages_by_name, diff=diff)
+    if not drafts:
+        print("No news fragments selected.")
+        return 0
+
+    for draft in drafts:
+        path = release.write_news_fragment(draft)
+        print(f"Created {path.relative_to(release.ROOT)}")
+    return 0
+
+
+def initial_changelog_selection(
+    packages_by_name: dict[str, workspace.Package], changed: set[str], covered: set[str]
+) -> ChangelogSelection:
+    ordered = workspace.topological_names(packages_by_name)
+    return ChangelogSelection(
+        {
+            name: PackageNewsState(
+                name=name,
+                changed=name in changed,
+                covered=name in covered,
+                selected=name in changed and name not in covered,
+            )
+            for name in ordered
+        }
+    )
+
+
+def run_changelog_ui(
+    selection: ChangelogSelection,
+    *,
+    packages_by_name: dict[str, workspace.Package] | None = None,
+    diff: str = "tracked",
+) -> list[NewsFragmentDraft]:
+    return run_changelog_selection_app(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+        edit_news_fragment=lambda package, kind: release.edit_news_fragment(
+            package,
+            kind,
+            package_path=None if packages_by_name is None else packages_by_name[package].path,
+            diff=diff,
+        ),
+    )

--- a/scripts/githooks/pre-push.checks.sh
+++ b/scripts/githooks/pre-push.checks.sh
@@ -4,7 +4,7 @@ set -eu
 . "$(dirname "$0")/helpers/pre-push-commit.sh"
 
 printf '\n'
-if FORCE_COLOR=1 CLICOLOR_FORCE=1 PY_COLORS=1 uv run poe pre-push; then
+if FORCE_COLOR=1 CLICOLOR_FORCE=1 PY_COLORS=1 POE_VERBOSITY=-1 uv run poe pre-push; then
     status=0
 else
     status=$?

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2,15 +2,17 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
-
 try:
     from scripts import workspace
 except ImportError:  # pragma: no cover - script execution path
@@ -36,7 +38,26 @@ TYPE_BUMPS = {
     "docs": "patch",
     "internal": "patch",
 }
+FRAGMENT_TYPE_ALTERNATION = "|".join(FRAGMENT_TYPES)
+FRAGMENT_FILE_RE = re.compile(rf".+\.({FRAGMENT_TYPE_ALTERNATION})\.md")
 RELEASE_COMMIT_TITLE = "Release Packages"
+CHANGELOG_DIFF_MODES = ("staged", "tracked", "all", "base")
+CUTOFF_MARKER = "# ------------------------ >8 ------------------------"
+FRAGMENT_GUIDANCE = """
+
+# Write a concise news fragment for {package}.
+#
+# Each non-empty, non-comment line becomes changelog text.
+# The release script adds '- ' when a line does not already start with a bullet.
+{package_diff_section}
+"""
+
+
+@dataclass(frozen=True)
+class NewsFragmentDraft:
+    package: str
+    kind: str
+    text: str
 
 
 @dataclass(frozen=True)
@@ -71,11 +92,9 @@ def parse_fragments(packages: set[str]) -> list[Fragment]:
                 continue
             if fragment_path.name in IGNORED_FRAGMENT_FILES:
                 continue
-            match = re.fullmatch(
-                r".+\.(breaking|feature|bugfix|docs|internal)\.md", fragment_path.name
-            )
+            match = FRAGMENT_FILE_RE.fullmatch(fragment_path.name)
             if match is None:
-                expected = "<id>.(breaking|feature|bugfix|docs|internal).md"
+                expected = f"<id>.({FRAGMENT_TYPE_ALTERNATION}).md"
                 raise SystemExit(
                     "invalid news fragment name "
                     f"{fragment_path.relative_to(ROOT)}; expected {expected}"
@@ -272,8 +291,7 @@ def _ensure_clean_tree() -> None:
 
 def _create_release_branch() -> str:
     username = _gh_username()
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    branch = f"{username}/release-{timestamp}"
+    branch = f"{username}/release-{fragment_timestamp()}"
     subprocess.check_call(["git", "switch", "-c", branch], cwd=ROOT)
     return branch
 
@@ -451,6 +469,232 @@ def lint_towncrier() -> int:
     return 0
 
 
+def changelog(diff: str = "tracked") -> int:
+    if diff not in CHANGELOG_DIFF_MODES:
+        expected = ", ".join(CHANGELOG_DIFF_MODES)
+        raise SystemExit(f"invalid diff mode {diff!r}; expected one of: {expected}")
+
+    # Imported lazily: the TUI needs textual, which is not installed in the
+    # environments that run the non-interactive subcommands (e.g. the publish
+    # workflow runs `release.py changed` with a bare system Python).
+    try:
+        from scripts import clogedit
+    except ImportError:  # pragma: no cover - script execution path
+        import clogedit  # type: ignore[no-redef]
+    return clogedit.changelog(diff)
+
+
+def collect_changelog_diff_paths(diff: str) -> set[Path]:
+    paths = _git_name_paths([*changelog_diff_args(diff), "--name-only"])
+    if diff == "all":
+        paths |= _git_name_paths(["ls-files", "--others", "--exclude-standard"])
+    return paths
+
+
+def changelog_diff_args(diff: str) -> list[str]:
+    if diff == "staged":
+        return ["diff", "--cached"]
+    if diff in ("tracked", "all"):
+        return ["diff", "HEAD"]
+    if diff == "base":
+        return ["diff", f"{changelog_base_lower_bound()}..HEAD"]
+    expected = ", ".join(CHANGELOG_DIFF_MODES)
+    raise ValueError(f"invalid diff mode {diff!r}; expected one of: {expected}")
+
+
+@functools.cache
+def changelog_base_lower_bound() -> str:
+    base = _default_base_ref()
+    if base is None:
+        raise SystemExit("could not find origin/main or origin/master for `--diff base`")
+    # `git log --name-only` lists each commit (newest first) followed by the
+    # paths it touched; the NUL prefix cannot appear in a path, so it safely
+    # marks the commit lines.  -m makes merge commits list paths too.
+    commit: str | None = None
+    for line in _git_lines(["log", "-m", "--format=%x00%H", "--name-only", f"{base}..HEAD"]):
+        if line.startswith("\0"):
+            commit = line[1:]
+        elif commit is not None and _is_valid_news_fragment_path(Path(line)):
+            return commit
+    return base
+
+
+def _is_valid_news_fragment_path(path: Path) -> bool:
+    parts = path.parts
+    if len(parts) != 3 or parts[0] != "changes":
+        return False
+    return FRAGMENT_FILE_RE.fullmatch(parts[2]) is not None
+
+
+def _git_name_paths(args: list[str]) -> set[Path]:
+    return {ROOT / line for line in _git_lines(args) if line}
+
+
+def _git_lines(args: list[str]) -> list[str]:
+    # quotepath=off keeps non-ASCII path names literal instead of C-quoted.
+    output = subprocess.check_output(
+        ["git", "-c", "core.quotepath=off", *args], cwd=ROOT, text=True
+    )
+    return [line for line in output.splitlines() if line]
+
+
+def packages_for_paths(
+    packages_by_name: dict[str, workspace.Package], paths: Iterable[Path], *, code_only: bool
+) -> set[str]:
+    changed_paths = set(paths)
+    result: set[str] = set()
+    for name, package in packages_by_name.items():
+        if code_only:
+            if any(_is_package_code_path(path, package.path) for path in changed_paths):
+                result.add(name)
+        elif (
+            package.version_file in changed_paths or package.path / "CHANGELOG.md" in changed_paths
+        ):
+            result.add(name)
+    return result
+
+
+def edit_news_fragment(
+    package: str,
+    kind: str,
+    *,
+    package_path: Path | None = None,
+    diff: str = "tracked",
+    editor_runner: Callable[[Sequence[str]], int] | None = None,
+) -> str:
+    validate_fragment_kind(kind)
+    with tempfile.TemporaryDirectory(prefix=f"{package}-{kind}-") as tmpdir:
+        # Vim detects this basename as gitcommit for commit-message highlighting.
+        tmp_path = Path(tmpdir) / "COMMIT_EDITMSG"
+        tmp_path.write_text(
+            FRAGMENT_GUIDANCE.format(
+                package=package,
+                package_diff_section=package_diff_section(package_path, diff=diff),
+            ),
+            encoding="utf-8",
+        )
+        editor = _select_editor()
+        runner = subprocess.call if editor_runner is None else editor_runner
+        try:
+            result = runner([*editor, str(tmp_path)])
+        except OSError as exc:
+            raise SystemExit(f"could not run editor {editor[0]!r}: {exc}") from exc
+        if result != 0:
+            raise SystemExit(f"editor exited with status {result}")
+        text = clean_news_fragment_text(tmp_path.read_text(encoding="utf-8"))
+    if not text:
+        raise SystemExit(f"empty news fragment for {package}")
+    return text
+
+
+def package_diff_section(package_path: Path | None, *, diff: str) -> str:
+    if package_path is None:
+        return ""
+    diffstat = package_diffstat(package_path, diff=diff).rstrip()
+    diff_text = package_diff(package_path, diff=diff).rstrip()
+    diff_parts = [part for part in (diffstat, diff_text) if part]
+    if not diff_parts:
+        return ""
+    diff_body = "\n\n".join(diff_parts)
+    return (
+        "\n"
+        f"{CUTOFF_MARKER}\n"
+        "# Do not modify or remove the line above.\n"
+        "# Everything below it will be ignored.\n"
+        f"{diff_body}\n"
+    )
+
+
+def package_diffstat(package_path: Path, *, diff: str) -> str:
+    return _package_diff_output(package_path, diff=diff, stat=True)
+
+
+def package_diff(package_path: Path, *, diff: str) -> str:
+    return _package_diff_output(package_path, diff=diff, stat=False)
+
+
+def _package_diff_output(package_path: Path, *, diff: str, stat: bool) -> str:
+    relative_package = package_path.relative_to(ROOT).as_posix()
+    stat_args = ["--stat"] if stat else []
+    tracked = _git_output([*changelog_diff_args(diff), *stat_args, "--", relative_package])
+    if diff != "all":
+        return tracked
+    untracked = "\n".join(
+        _git_untracked_output(path, stat=stat)
+        for path in sorted(_git_name_paths(["ls-files", "--others", "--exclude-standard"]))
+        if path.is_relative_to(package_path)
+    )
+    return "\n".join(part for part in (tracked.rstrip(), untracked.rstrip()) if part)
+
+
+def _git_untracked_output(path: Path, *, stat: bool) -> str:
+    relative_path = path.relative_to(ROOT).as_posix()
+    stat_args = ["--stat"] if stat else []
+    return _git_output(
+        ["diff", "--no-index", *stat_args, "--", "/dev/null", relative_path],
+        check=False,
+    )
+
+
+def _git_output(args: list[str], *, check: bool = True) -> str:
+    return subprocess.run(
+        ["git", "-c", "core.quotepath=off", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        check=check,
+    ).stdout
+
+
+def _select_editor() -> list[str]:
+    for name in ("VISUAL", "EDITOR"):
+        value = os.environ.get(name)
+        if value:
+            return shlex.split(value)
+    return ["vi"]
+
+
+def clean_news_fragment_text(text: str) -> str:
+    text = text.split(CUTOFF_MARKER, 1)[0]
+    lines = [
+        line.rstrip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines).strip()
+
+
+def validate_fragment_kind(kind: str) -> None:
+    if kind not in FRAGMENT_TYPES:
+        expected = ", ".join(FRAGMENT_TYPES)
+        raise ValueError(f"invalid news fragment type {kind!r}; expected one of: {expected}")
+
+
+def write_news_fragment(
+    draft: NewsFragmentDraft, *, timestamp: datetime | None = None, changes: Path | None = None
+) -> Path:
+    validate_fragment_kind(draft.kind)
+    root = CHANGES if changes is None else changes
+    package_dir = root / draft.package
+    package_dir.mkdir(parents=True, exist_ok=True)
+    stem = fragment_timestamp(timestamp)
+    path = package_dir / f"{stem}.{draft.kind}.md"
+    suffix = 1
+    while path.exists():
+        path = package_dir / f"{stem}-{suffix}.{draft.kind}.md"
+        suffix += 1
+    path.write_text(f"{draft.text.rstrip()}\n", encoding="utf-8")
+    return path
+
+
+def fragment_timestamp(value: datetime | None = None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
 def check_fragments(base: str | None = None) -> int:
     packages_by_name = workspace.packages()
     fragments = parse_fragments(set(packages_by_name))
@@ -468,7 +712,10 @@ def check_fragments(base: str | None = None) -> int:
     if missing:
         packages = ", ".join(missing)
         print(f"Missing news fragments for changed packages: {packages}")
-        print("Add changes/<package>/<id>.<type>.md or adjust the changed files.")
+        print(
+            "Run `poe changelog`, add changes/<package>/<id>.<type>.md, "
+            "or adjust the changed files."
+        )
         return 1
     return 0
 
@@ -492,17 +739,11 @@ def _changed_packages(
     head: str | None,
     code_only: bool,
 ) -> set[str]:
-    changed_paths = _changed_paths(base=base, head=head)
-    result: set[str] = set()
-    for name, package in packages_by_name.items():
-        if code_only:
-            if any(_is_package_code_path(path, package.path) for path in changed_paths):
-                result.add(name)
-        elif (
-            package.version_file in changed_paths or package.path / "CHANGELOG.md" in changed_paths
-        ):
-            result.add(name)
-    return result
+    return packages_for_paths(
+        packages_by_name,
+        _changed_paths(base=base, head=head),
+        code_only=code_only,
+    )
 
 
 def _release_prepped_packages(
@@ -566,6 +807,15 @@ def main(argv: list[str] | None = None) -> int:
     github_release_body_parser = subparsers.add_parser("github-release-body")
     github_release_body_parser.add_argument("package")
     github_release_body_parser.set_defaults(func=print_github_release_body)
+
+    changelog_parser = subparsers.add_parser("changelog")
+    changelog_parser.add_argument(
+        "--diff",
+        choices=CHANGELOG_DIFF_MODES,
+        default="tracked",
+        help="changed-path source used to preselect packages",
+    )
+    changelog_parser.set_defaults(func=lambda args: changelog(args.diff))
 
     check_parser = subparsers.add_parser("check-news-fragments")
     check_parser.add_argument("--base")

--- a/tests/unit/test_clogapp.py
+++ b/tests/unit/test_clogapp.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+
+import pytest
+from rich.text import Text
+from textual.widgets import Label
+
+from scripts import clogedit, release
+
+
+def test_clogedit_updates_selection_state() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    app.toggle("pkg")
+    app.set_kind("pkg", "feature")
+    app.add("pkg")
+
+    assert selection.drafts() == [("pkg", "feature")]
+
+
+def test_clogedit_action_next_opens_type_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+    monkeypatch.setattr(app, "save_package_selection", lambda: None)
+
+    async def noop_render() -> None:
+        return None
+
+    monkeypatch.setattr(app, "render_step", noop_render)
+
+    asyncio.run(app.action_next())
+
+    assert app.step is clogedit.WizardStep.TYPES
+    assert app.type_packages == ["pkg"]
+    assert app.type_index == 0
+
+
+def test_clogedit_action_next_finishes_after_type_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+                kind="feature",
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+    app.step = clogedit.WizardStep.TYPES
+    app.type_packages = ["pkg"]
+    monkeypatch.setattr(app, "save_current_type", lambda: None)
+    seen = []
+    monkeypatch.setattr(app, "finish", lambda: seen.append("finished"))
+
+    asyncio.run(app.action_next())
+
+    assert seen == ["finished"]
+
+
+def test_clogedit_statusbar_text_is_minimal() -> None:
+    assert clogedit.PACKAGE_STATUS == (
+        "packages  arrows move  space toggles  enter next  ctrl-c/ctrl-d exit"
+    )
+    assert clogedit.TYPE_STATUS == (
+        "change level  arrows move  space selects  enter edit  esc back  ctrl-c/ctrl-d exit"
+    )
+    assert "Button" not in clogedit.ChangelogApp.CSS
+    assert "Header" not in clogedit.ChangelogApp.CSS
+
+
+def test_clogedit_type_label_is_color_coded() -> None:
+    app = clogedit.ChangelogApp(
+        clogedit.ChangelogSelection(),
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    label = app.type_label("feature", selected=True)
+
+    assert isinstance(label, Text)
+    assert label.plain == "[*] feature - Features (minor)"
+    assert any(span.style == "green" for span in label.spans)
+
+
+def test_clogedit_finish_suspends_for_editor(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+                kind="docs",
+            )
+        }
+    )
+    editor_calls: list[tuple[str, str]] = []
+
+    def edit_news_fragment(package: str, kind: str) -> str:
+        editor_calls.append((package, kind))
+        return f"{package}:{kind}"
+
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+        edit_news_fragment=edit_news_fragment,
+    )
+    monkeypatch.setattr(app, "suspend", lambda: nullcontext())
+    seen: list[list[clogedit.NewsFragmentDraft]] = []
+    monkeypatch.setattr(app, "exit", lambda result: seen.append(result))
+
+    app.type_packages = ["pkg"]
+    assert app.edit_current_package() is True
+    app.finish()
+
+    assert editor_calls == [("pkg", "docs")]
+    assert seen == [[clogedit.NewsFragmentDraft("pkg", "docs", "pkg:docs")]]
+
+
+async def test_clogedit_arrows_drive_widgets(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "first": clogedit.PackageNewsState(
+                name="first",
+                changed=True,
+                covered=False,
+                selected=True,
+            ),
+            "second": clogedit.PackageNewsState(
+                name="second",
+                changed=True,
+                covered=False,
+                selected=False,
+            ),
+        }
+    )
+    editor_calls: list[tuple[str, str]] = []
+
+    def edit_news_fragment(package: str, kind: str) -> str:
+        editor_calls.append((package, kind))
+        return f"{package}:{kind}"
+
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+        edit_news_fragment=edit_news_fragment,
+    )
+    monkeypatch.setattr(app, "suspend", lambda: nullcontext())
+
+    async with app.run_test() as pilot:
+        await pilot.press("down", "space", "enter")
+        assert selection.drafts() == [("first", "bugfix"), ("second", "bugfix")]
+
+        await pilot.press("up", "space", "enter")
+        assert selection.packages["first"].kind == "feature"
+        assert editor_calls == [("first", "feature")]
+        assert app.type_index == 1
+
+        await pilot.press("down", "space", "enter")
+
+    assert pilot.app.return_value == [
+        clogedit.NewsFragmentDraft("first", "feature", "first:feature"),
+        clogedit.NewsFragmentDraft("second", "docs", "second:docs"),
+    ]
+
+
+async def test_clogedit_edits_each_package_after_level_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "first": clogedit.PackageNewsState(
+                name="first",
+                changed=True,
+                covered=False,
+                selected=True,
+            ),
+            "second": clogedit.PackageNewsState(
+                name="second",
+                changed=True,
+                covered=False,
+                selected=True,
+            ),
+        }
+    )
+    events: list[str] = []
+
+    def edit_news_fragment(package: str, kind: str) -> str:
+        events.append(f"edit:{package}:{kind}:index={app.type_index}")
+        return f"{package}:{kind}"
+
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+        edit_news_fragment=edit_news_fragment,
+    )
+    monkeypatch.setattr(app, "suspend", lambda: nullcontext())
+
+    async with app.run_test() as pilot:
+        await pilot.press("enter")
+        assert app.type_index == 0
+        await pilot.press("enter")
+        assert events == ["edit:first:bugfix:index=0"]
+        assert app.type_index == 1
+        await pilot.press("enter")
+
+    assert events == ["edit:first:bugfix:index=0", "edit:second:bugfix:index=1"]
+
+
+async def test_clogedit_type_title_bolds_package_name() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("enter")
+        label = app.query_one(Label)
+        renderable = label.content
+        assert isinstance(renderable, Text)
+        assert renderable.plain == "Choose change level for pkg (1/1)"
+        assert any(span.style == "bold" for span in renderable.spans)
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_kind_marker_follows_highlight() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("enter")
+        assert selection.packages["pkg"].kind == "bugfix"
+        # Selecting one kind and then moving the highlight must not leave a
+        # stale [*] marker: the kind tracks the highlight, which is what
+        # enter saves.
+        await pilot.press("space", "down")
+        assert selection.packages["pkg"].kind == "docs"
+        assert app.type_list is not None
+        marked = app.type_list.get_option("docs").prompt
+        assert isinstance(marked, Text)
+        assert marked.plain.startswith("[*]")
+        unmarked = app.type_list.get_option("bugfix").prompt
+        assert isinstance(unmarked, Text)
+        assert unmarked.plain.startswith("[ ]")
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_covered_packages_are_disabled() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            ),
+            "done": clogedit.PackageNewsState(
+                name="done",
+                changed=True,
+                covered=True,
+                selected=False,
+            ),
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        assert app.package_list is not None
+        assert app.package_list.get_option_at_index(0).disabled is False
+        assert app.package_list.get_option_at_index(1).disabled is True
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_escape_returns_to_previous_step() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("enter")
+        assert app.step is clogedit.WizardStep.TYPES
+        await pilot.press("escape")
+        assert app.step is clogedit.WizardStep.PACKAGES
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_single_escape_on_package_step_arms_exit() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        assert app.step is clogedit.WizardStep.PACKAGES
+        assert app.escape_exit_timer is not None
+        assert app.status == clogedit.ESC_EXIT_STATUS
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_double_escape_on_package_step_exits() -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("escape", "escape")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_escape_exit_timeout_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 0.01)
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        await pilot.pause(0.03)
+        assert app.escape_exit_timer is None
+        assert app.status == clogedit.PACKAGE_STATUS
+        monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 0.5)
+        await pilot.press("escape")
+        assert app.escape_exit_timer is not None
+        await pilot.press("ctrl+d")
+
+    assert pilot.app.return_value == []
+
+
+async def test_clogedit_editor_failure_returns_to_type_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selection = clogedit.ChangelogSelection(
+        {
+            "pkg": clogedit.PackageNewsState(
+                name="pkg",
+                changed=True,
+                covered=False,
+                selected=True,
+            )
+        }
+    )
+    calls = 0
+
+    def edit_news_fragment(package: str, kind: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise SystemExit("editor exited with status 1")
+        return f"{package}:{kind}"
+
+    app = clogedit.ChangelogApp(
+        selection,
+        fragment_types=release.FRAGMENT_TYPES,
+        type_bumps=release.TYPE_BUMPS,
+        edit_news_fragment=edit_news_fragment,
+    )
+    monkeypatch.setattr(app, "suspend", lambda: nullcontext())
+
+    async with app.run_test() as pilot:
+        await pilot.press("enter", "enter")
+        assert app.step is clogedit.WizardStep.TYPES
+        assert app.type_index == 0
+        assert app.status.startswith("editor exited with status 1")
+
+        await pilot.press("enter")
+
+    assert calls == 2
+    assert pilot.app.return_value == [clogedit.NewsFragmentDraft("pkg", "bugfix", "pkg:bugfix")]

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
 import pytest
 
-from scripts import bundle_release, hatch_build, release, workspace
+from scripts import bundle_release, clogedit, hatch_build, release, workspace
 
 
 def _derived_vendoring_config(include: str) -> bundle_release.VendoringConfig:
@@ -580,7 +581,7 @@ def test_fragment_pr_number_reads_subjects_only(
 
 
 def test_check_fragments_requires_changed_package_fragment(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     version_file = tmp_path / "pkg/version.py"
     version_file.parent.mkdir(parents=True)
@@ -599,6 +600,9 @@ def test_check_fragments_requires_changed_package_fragment(
     )
 
     assert release.check_fragments(base="origin/main") == 1
+    output = capsys.readouterr().out
+    assert "Missing news fragments for changed packages: pkg" in output
+    assert "Run `poe changelog`" in output
 
 
 def test_check_fragments_exempts_release_prep_version_bumps(
@@ -663,6 +667,258 @@ def test_changed_packages_accepts_explicit_range(
 
     assert release.changed_packages(base="abc", head="def") == ["pkg"]
     assert seen == {"base": "abc", "head": "def", "code_only": False}
+
+
+def test_collect_changelog_diff_paths_staged_uses_cached_diff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[list[str]] = []
+
+    def fake_git_name_paths(args: list[str]) -> set[Path]:
+        seen.append(args)
+        return {release.ROOT / "src/pkg/module.py"}
+
+    monkeypatch.setattr(release, "_git_name_paths", fake_git_name_paths)
+
+    assert release.collect_changelog_diff_paths("staged") == {release.ROOT / "src/pkg/module.py"}
+    assert seen == [["diff", "--cached", "--name-only"]]
+
+
+def test_collect_changelog_diff_paths_tracked_uses_head_diff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[list[str]] = []
+
+    def fake_git_name_paths(args: list[str]) -> set[Path]:
+        seen.append(args)
+        return {release.ROOT / "src/pkg/module.py"}
+
+    monkeypatch.setattr(release, "_git_name_paths", fake_git_name_paths)
+
+    assert release.collect_changelog_diff_paths("tracked") == {release.ROOT / "src/pkg/module.py"}
+    assert seen == [["diff", "HEAD", "--name-only"]]
+
+
+def test_collect_changelog_diff_paths_all_includes_untracked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values: dict[tuple[str, ...], set[Path]] = {
+        ("diff", "HEAD", "--name-only"): {release.ROOT / "src/pkg/module.py"},
+        ("ls-files", "--others", "--exclude-standard"): {release.ROOT / "src/pkg/new.py"},
+    }
+
+    def fake_git_name_paths(args: list[str]) -> set[Path]:
+        return values[tuple(args)]
+
+    monkeypatch.setattr(release, "_git_name_paths", fake_git_name_paths)
+
+    assert release.collect_changelog_diff_paths("all") == {
+        release.ROOT / "src/pkg/module.py",
+        release.ROOT / "src/pkg/new.py",
+    }
+
+
+def test_collect_changelog_diff_paths_base_uses_lower_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(release, "changelog_base_lower_bound", lambda: "abc123")
+
+    def fake_git_name_paths(args: list[str]) -> set[Path]:
+        seen.append(args)
+        return {release.ROOT / "src/pkg/module.py"}
+
+    monkeypatch.setattr(release, "_git_name_paths", fake_git_name_paths)
+
+    assert release.collect_changelog_diff_paths("base") == {release.ROOT / "src/pkg/module.py"}
+    assert seen == [["diff", "abc123..HEAD", "--name-only"]]
+
+
+def test_changelog_base_lower_bound_uses_newest_news_fragment_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release.changelog_base_lower_bound.cache_clear()
+    monkeypatch.setattr(release, "_default_base_ref", lambda: "origin/main")
+
+    def fake_git_lines(args: list[str]) -> list[str]:
+        assert args == ["log", "-m", "--format=%x00%H", "--name-only", "origin/main..HEAD"]
+        return [
+            "\0new",
+            "src/pkg/module.py",
+            "\0old",
+            "changes/pkg/123.feature.md",
+        ]
+
+    monkeypatch.setattr(release, "_git_lines", fake_git_lines)
+
+    assert release.changelog_base_lower_bound() == "old"
+
+
+def test_changelog_base_lower_bound_defaults_to_base_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release.changelog_base_lower_bound.cache_clear()
+    monkeypatch.setattr(release, "_default_base_ref", lambda: "origin/main")
+    monkeypatch.setattr(release, "_git_lines", lambda _args: [])
+
+    assert release.changelog_base_lower_bound() == "origin/main"
+
+
+def test_changelog_base_lower_bound_requires_base_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release.changelog_base_lower_bound.cache_clear()
+    monkeypatch.setattr(release, "_default_base_ref", lambda: None)
+
+    with pytest.raises(SystemExit, match="could not find origin/main"):
+        release.changelog_base_lower_bound()
+
+
+def test_initial_changelog_selection_marks_changed_uncovered_packages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    packages = {
+        "lib": workspace.Package("lib", tmp_path / "lib", tmp_path / "lib/version.py", ()),
+        "app": workspace.Package("app", tmp_path / "app", tmp_path / "app/version.py", ("lib",)),
+    }
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["lib", "app"])
+
+    selection = clogedit.initial_changelog_selection(packages, {"lib", "app"}, {"app"})
+
+    assert list(selection.packages) == ["lib", "app"]
+    assert selection.packages["lib"].selected is True
+    assert selection.packages["app"].selected is False
+    assert selection.packages["app"].covered is True
+
+
+def test_packages_for_paths_detects_package_code(tmp_path: Path) -> None:
+    package = workspace.Package("pkg", tmp_path / "pkg", tmp_path / "pkg/version.py", ())
+
+    assert release.packages_for_paths(
+        {"pkg": package}, {tmp_path / "pkg/module.py"}, code_only=True
+    ) == {"pkg"}
+    assert (
+        release.packages_for_paths(
+            {"pkg": package}, {tmp_path / "pkg/tests/test_module.py"}, code_only=True
+        )
+        == set()
+    )
+
+
+def test_clean_news_fragment_text_strips_blank_and_comment_lines() -> None:
+    assert release.clean_news_fragment_text(
+        "# template\n\nAdd thing.  \n  # ignored\n- Fix thing.\n"
+    ) == ("Add thing.\n- Fix thing.")
+
+
+def test_clean_news_fragment_text_ignores_cutoff_section() -> None:
+    assert (
+        release.clean_news_fragment_text(
+            "Add thing.\n"
+            f"{release.CUTOFF_MARKER}\n"
+            "# Do not modify or remove the line above.\n"
+            "diff --git a/pkg/module.py b/pkg/module.py\n"
+            "+This is not news.\n"
+        )
+        == "Add thing."
+    )
+
+
+def test_validate_fragment_kind_rejects_unknown_type() -> None:
+    with pytest.raises(ValueError, match="invalid news fragment type"):
+        release.validate_fragment_kind("security")
+
+
+def test_write_news_fragment_uses_utc_timestamp_and_collision_suffix(tmp_path: Path) -> None:
+    timestamp = datetime(2026, 7, 10, 12, 34, 56, tzinfo=timezone.utc)
+    package_dir = tmp_path / "changes/pkg"
+    package_dir.mkdir(parents=True)
+    (package_dir / "20260710123456.bugfix.md").write_text("Existing.\n", encoding="utf-8")
+
+    path = release.write_news_fragment(
+        release.NewsFragmentDraft("pkg", "bugfix", "Fix cleanup."),
+        timestamp=timestamp,
+        changes=tmp_path / "changes",
+    )
+
+    assert path == package_dir / "20260710123456-1.bugfix.md"
+    assert path.read_text(encoding="utf-8") == "Fix cleanup.\n"
+
+
+def test_edit_news_fragment_runs_editor_and_requires_content(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("VISUAL", "test-editor --flag")
+    seen: list[str] = []
+    templates: list[str] = []
+
+    def fake_runner(cmd: Sequence[str]) -> int:
+        seen.extend(cmd[:2])
+        assert Path(cmd[-1]).name == "COMMIT_EDITMSG"
+        templates.append(Path(cmd[-1]).read_text(encoding="utf-8"))
+        Path(cmd[-1]).write_text("# comment\n\nAdd feature.\n", encoding="utf-8")
+        return 0
+
+    assert release.edit_news_fragment("pkg", "feature", editor_runner=fake_runner) == "Add feature."
+    assert seen == ["test-editor", "--flag"]
+    assert templates == [release.FRAGMENT_GUIDANCE.format(package="pkg", package_diff_section="")]
+    assert templates[0].startswith("\n\n# Write a concise news fragment for pkg.")
+
+
+def test_edit_news_fragment_includes_package_diffstat_and_diff(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("VISUAL", "test-editor")
+    package_path = release.ROOT / "src/pkg"
+    seen_args: list[list[str]] = []
+    templates: list[str] = []
+
+    def fake_git_output(args: list[str], *, check: bool = True) -> str:
+        seen_args.append(args)
+        if args == ["diff", "HEAD", "--stat", "--", "src/pkg"]:
+            return " src/pkg/module.py | 2 ++\n 1 file changed, 2 insertions(+)\n"
+        if args == ["diff", "HEAD", "--", "src/pkg"]:
+            return "diff --git a/src/pkg/module.py b/src/pkg/module.py\n+new line\n"
+        raise AssertionError(args)
+
+    def fake_runner(cmd: Sequence[str]) -> int:
+        assert Path(cmd[-1]).name == "COMMIT_EDITMSG"
+        templates.append(Path(cmd[-1]).read_text(encoding="utf-8"))
+        Path(cmd[-1]).write_text("Add feature.\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(release, "_git_output", fake_git_output)
+
+    assert (
+        release.edit_news_fragment(
+            "pkg",
+            "feature",
+            package_path=package_path,
+            editor_runner=fake_runner,
+        )
+        == "Add feature."
+    )
+    assert seen_args == [
+        ["diff", "HEAD", "--stat", "--", "src/pkg"],
+        ["diff", "HEAD", "--", "src/pkg"],
+    ]
+    assert templates[0].startswith("\n\n# Write a concise news fragment for pkg.")
+    assert release.CUTOFF_MARKER in templates[0]
+    assert "# Everything below it will be ignored." in templates[0]
+    assert "src/pkg/module.py | 2 ++" in templates[0]
+    assert "diff --git a/src/pkg/module.py b/src/pkg/module.py" in templates[0]
+
+
+def test_edit_news_fragment_rejects_empty_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    def fake_runner(cmd: Sequence[str]) -> int:
+        Path(cmd[-1]).write_text("# only comments\n\n", encoding="utf-8")
+        return 0
+
+    with pytest.raises(SystemExit, match="empty news fragment"):
+        release.edit_news_fragment("pkg", "docs", editor_runner=fake_runner)
 
 
 def test_package_hatch_build_loader_uses_shared_hook() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ dev = [
     { name = "pytest-xdist", specifier = "<4" },
     { name = "respx", specifier = ">=0.21.0,<1" },
     { name = "ruff", specifier = "==0.15.20" },
+    { name = "textual", specifier = ">=8.0.0,<9" },
     { name = "time-machine", specifier = ">=2.16,<3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0,<3" },
     { name = "tox", specifier = ">=4" },
@@ -923,6 +924,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "lograil"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -945,6 +958,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -1912,6 +1942,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "time-machine"
 version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2220,6 +2267,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes it easier to compose towncrier news fragments.
Invoked with `poe clog` or automatically by `poe release`.
