### PR TITLE
Change credentials_factory

### DIFF
--- a/src/vercel-internal-core/tests/test_options.py
+++ b/src/vercel-internal-core/tests/test_options.py
@@ -14,12 +14,32 @@ class FirstOptions(ServiceOptions):
     value: str
 
 
+class SharedOptionsKey(ServiceOptions):
+    @classmethod
+    def service_options_key(cls) -> type[ServiceOptions]:
+        return SharedOptionsKey
+
+
+@dataclass(frozen=True, slots=True)
+class SharedOptions(SharedOptionsKey):
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class OtherSharedOptions(SharedOptionsKey):
+    value: str
+
+
 @pytest.mark.parametrize(
     ("options", "message"),
     [
         (
             [FirstOptions("first"), FirstOptions("replacement")],
-            "at most one object per concrete type",
+            "at most one object per logical service",
+        ),
+        (
+            [SharedOptions("first"), OtherSharedOptions("replacement")],
+            "at most one object per logical service",
         ),
         ([object()], "only ServiceOptions instances"),
     ],

--- a/src/vercel-internal-core/vercel/_internal/core/options.py
+++ b/src/vercel-internal-core/vercel/_internal/core/options.py
@@ -10,6 +10,11 @@ class ServiceOptions:
 
     __slots__ = ()
 
+    @classmethod
+    def service_options_key(cls) -> type["ServiceOptions"]:
+        """Return the registry key for the logical service being configured."""
+        return cls
+
 
 ServiceOptionsMap = dict[type[ServiceOptions], ServiceOptions]
 
@@ -17,7 +22,7 @@ ServiceOptionsMap = dict[type[ServiceOptions], ServiceOptions]
 def collect_service_options(
     service_options: Sequence[ServiceOptions] | None,
 ) -> ServiceOptionsMap:
-    """Validate a single service-options list and key it by concrete type."""
+    """Validate a single service-options list and key it by logical service."""
     option_map: ServiceOptionsMap = {}
     if service_options is None:
         return option_map
@@ -28,12 +33,12 @@ def collect_service_options(
                 "service_options must contain only ServiceOptions instances"
             )
 
-        option_type = type(option)
-        if option_type in option_map:
+        option_key = type(option).service_options_key()
+        if option_key in option_map:
             raise VercelServiceOptionsError(
-                "service_options may contain at most one object per concrete type"
+                "service_options may contain at most one object per logical service"
             )
-        option_map[option_type] = option
+        option_map[option_key] = option
 
     return option_map
 
@@ -42,7 +47,7 @@ def merge_service_options(
     inherited: Mapping[type[ServiceOptions], ServiceOptions],
     service_options: Sequence[ServiceOptions] | None,
 ) -> ServiceOptionsMap:
-    """Apply a scoped option list over inherited options by concrete type."""
+    """Apply a scoped option list over inherited options by logical service."""
     merged = dict(inherited)
     merged.update(collect_service_options(service_options))
     return merged

--- a/src/vercel-internal-core/vercel/_internal/core/session.py
+++ b/src/vercel-internal-core/vercel/_internal/core/session.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, ClassVar, TypeVar, cast, overload
 import anyio
 import httpx
 
-from vercel._internal.core.errors import VercelSessionClosedError, VercelSessionError
+from vercel._internal.core.errors import (
+    VercelServiceOptionsError,
+    VercelSessionClosedError,
+    VercelSessionError,
+)
 from vercel._internal.core.options import ServiceOptions, merge_service_options
 from vercel._internal.core.polyfills import Self
 
@@ -58,10 +62,15 @@ class _BaseSdkSession:
 
     def get_service_option(self, option_type: type[ServiceOptionsT]) -> ServiceOptionsT | None:
         self.check_open()
-        option = self._service_options.get(option_type)
+        option = self._service_options.get(option_type.service_options_key())
         if option is None:
             return None
-        return cast(ServiceOptionsT, option)
+        if not isinstance(option, option_type):
+            raise VercelServiceOptionsError(
+                f"{type(option).__name__} cannot configure this session mode; "
+                f"use {option_type.__name__}"
+            )
+        return option
 
     def get_or_create_service(
         self, service_type: type[ServiceT], factory: Callable[[], ServiceT]

--- a/src/vercel-sandbox/tests/sandbox_fixtures.py
+++ b/src/vercel-sandbox/tests/sandbox_fixtures.py
@@ -9,12 +9,12 @@ from vercel.sandbox import SandboxCredentials, SandboxServiceOptions, sync as sa
 def sandbox_service_options(
     *,
     base_url: str = "https://sandbox.test",
-    credential_value: str = "token",
+    token: str = "token",
     team_id: str = "team_123",
     project_id: str = "prj_123",
 ) -> list[ServiceOptions]:
     """Build Sandbox options for the test's current session mode."""
-    credentials = SandboxCredentials(credential_value, team_id, project_id)
+    credentials = SandboxCredentials(token=token, team_id=team_id, project_id=project_id)
 
     try:
         asyncio.get_running_loop()

--- a/src/vercel-sandbox/tests/sandbox_fixtures.py
+++ b/src/vercel-sandbox/tests/sandbox_fixtures.py
@@ -1,5 +1,7 @@
 """Shared helpers for Sandbox tests."""
 
+import asyncio
+
 from vercel._internal.core.options import ServiceOptions
 from vercel.sandbox import SandboxCredentials, SandboxServiceOptions, sync as sandbox_sync
 
@@ -11,22 +13,29 @@ def sandbox_service_options(
     team_id: str = "team_123",
     project_id: str = "prj_123",
 ) -> list[ServiceOptions]:
-    """Build matching async and sync Sandbox options for one test session."""
+    """Build Sandbox options for the test's current session mode."""
     credentials = SandboxCredentials(credential_value, team_id, project_id)
 
-    async def credentials_factory() -> SandboxCredentials:
-        return credentials
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
 
-    def sync_credentials_factory() -> SandboxCredentials:
+        def sync_credentials_factory() -> SandboxCredentials:
+            return credentials
+
+        return [
+            sandbox_sync.SandboxServiceOptions(
+                base_url=base_url,
+                credentials_factory=sync_credentials_factory,
+            )
+        ]
+
+    async def async_credentials_factory() -> SandboxCredentials:
         return credentials
 
     return [
         SandboxServiceOptions(
             base_url=base_url,
-            credentials_factory=credentials_factory,
-        ),
-        sandbox_sync.SandboxServiceOptions(
-            base_url=base_url,
-            credentials_factory=sync_credentials_factory,
-        ),
+            credentials_factory=async_credentials_factory,
+        )
     ]

--- a/src/vercel-sandbox/tests/sandbox_fixtures.py
+++ b/src/vercel-sandbox/tests/sandbox_fixtures.py
@@ -1,0 +1,32 @@
+"""Shared helpers for Sandbox tests."""
+
+from vercel._internal.core.options import ServiceOptions
+from vercel.sandbox import SandboxCredentials, SandboxServiceOptions, sync as sandbox_sync
+
+
+def sandbox_service_options(
+    *,
+    base_url: str = "https://sandbox.test",
+    credential_value: str = "token",
+    team_id: str = "team_123",
+    project_id: str = "prj_123",
+) -> list[ServiceOptions]:
+    """Build matching async and sync Sandbox options for one test session."""
+    credentials = SandboxCredentials(credential_value, team_id, project_id)
+
+    async def credentials_factory() -> SandboxCredentials:
+        return credentials
+
+    def sync_credentials_factory() -> SandboxCredentials:
+        return credentials
+
+    return [
+        SandboxServiceOptions(
+            base_url=base_url,
+            credentials_factory=credentials_factory,
+        ),
+        sandbox_sync.SandboxServiceOptions(
+            base_url=base_url,
+            credentials_factory=sync_credentials_factory,
+        ),
+    ]

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 import respx
 from hypothesis import HealthCheck, given, settings, strategies as st
+from sandbox_fixtures import sandbox_service_options as _session_options
 
 from vercel import sandbox
 from vercel.api import session
@@ -18,11 +19,9 @@ from vercel.sandbox import (
     SandboxFilesystemCommandError,
     SandboxFilesystemWriteError,
     SandboxPathNotFoundError,
-    SandboxServiceOptions,
     SandboxUploadSizeMismatchError,
     sync as sandbox_sync,
 )
-from vercel.sandbox._internal.options import SandboxCredentials
 
 
 async def _read_as_chunks(source: bytes, chunk_size: int) -> AsyncIterator[bytes]:
@@ -100,18 +99,6 @@ def _logs_response(stdout: str = "", stderr: str = "") -> httpx.Response:
     if stderr:
         records.append({"stream": "stderr", "data": stderr})
     return httpx.Response(200, text="".join(json.dumps(item) + "\n" for item in records))
-
-
-def _session_options() -> list[SandboxServiceOptions]:
-    async def credentials_factory() -> SandboxCredentials:
-        return SandboxCredentials(token="token", team_id="team_123", project_id="prj_123")
-
-    return [
-        SandboxServiceOptions(
-            base_url="https://sandbox.test",
-            credentials_factory=credentials_factory,
-        )
-    ]
 
 
 def _tar_entries(content: bytes) -> dict[str, tuple[bytes, int]]:

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -7,11 +7,12 @@ from collections.abc import AsyncIterator, Iterator
 import httpx
 import pytest
 import respx
+from sandbox_fixtures import sandbox_service_options
 
 from vercel import sandbox
+from vercel._internal.core.options import ServiceOptions
 from vercel.api import session
-from vercel.sandbox import SandboxServiceOptions, sync as sandbox_sync
-from vercel.sandbox._internal.options import SandboxCredentials
+from vercel.sandbox import sync as sandbox_sync
 
 
 def _sandbox_response() -> dict[str, object]:
@@ -140,16 +141,11 @@ def _chunked_ndjson(*records: object) -> list[bytes]:
     return [content[offset : offset + 1] for offset in range(len(content))]
 
 
-def _session_options() -> list[SandboxServiceOptions]:
-    async def credentials_factory() -> SandboxCredentials:
-        return SandboxCredentials(token="token", team_id="team_1", project_id="prj_1")
-
-    return [
-        SandboxServiceOptions(
-            base_url="https://sandbox.test",
-            credentials_factory=credentials_factory,
-        )
-    ]
+def _session_options() -> list[ServiceOptions]:
+    return sandbox_service_options(
+        team_id="team_1",
+        project_id="prj_1",
+    )
 
 
 def test_public_process_exports() -> None:
@@ -157,13 +153,17 @@ def test_public_process_exports() -> None:
         "CompletedProcess",
         "Process",
         "ProcessStatus",
+        "SandboxCredentials",
+        "SandboxCredentialsFactory",
         "TextReader",
     ):
         assert name in sandbox.__all__
     for name in (
         "CompletedProcess",
         "ProcessStatus",
+        "SandboxCredentials",
         "SyncProcess",
+        "SyncSandboxCredentialsFactory",
         "SyncTextReader",
     ):
         assert name in sandbox_sync.__all__

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 import respx
 from pydantic import BaseModel, ValidationError
+from sandbox_fixtures import sandbox_service_options as _session_options
 
 from vercel import sandbox
 from vercel._internal.core.session import get_active_session
@@ -33,7 +34,6 @@ from vercel.sandbox import (
     SandboxQueryByStatusUpdatedAt,
     SandboxResources,
     SandboxResponseError,
-    SandboxServiceOptions,
     SandboxSource,
     SandboxStatus,
     SandboxTerminalStateError,
@@ -45,7 +45,6 @@ from vercel.sandbox import (
     TarballSource,
     sync as sandbox_sync,
 )
-from vercel.sandbox._internal.options import SandboxCredentials
 from vercel.sandbox._internal.service import get_sandbox_service
 from vercel.sandbox._internal.state import SandboxRuntimeSessionState, SandboxState
 
@@ -134,22 +133,6 @@ def _snapshot_response(
             "updatedAt": 2,
         }
     }
-
-
-def _session_options(*, base_url: str = "https://sandbox.test") -> list[SandboxServiceOptions]:
-    async def credentials_factory() -> SandboxCredentials:
-        return SandboxCredentials(
-            token="token",
-            team_id="team_123",
-            project_id="prj_123",
-        )
-
-    return [
-        SandboxServiceOptions(
-            base_url=base_url,
-            credentials_factory=credentials_factory,
-        )
-    ]
 
 
 def _logs_response(*records: object) -> httpx.Response:

--- a/src/vercel-sandbox/tests/test_session.py
+++ b/src/vercel-sandbox/tests/test_session.py
@@ -5,19 +5,70 @@ import pytest
 
 from vercel import sandbox
 from vercel._internal.core.options import ServiceOptions
-from vercel._internal.core.session import get_active_sync_session
+from vercel._internal.core.session import get_active_session, get_active_sync_session
 from vercel.api import session
 from vercel.errors import (
+    VercelServiceOptionsError,
     VercelSessionClosedError,
     VercelSessionError,
 )
 from vercel.sandbox import sync as sync_sandbox
-from vercel.sandbox._internal.service import get_sync_sandbox_service
+from vercel.sandbox._internal.service import get_sandbox_service, get_sync_sandbox_service
 
 
 @dataclass(frozen=True, slots=True)
 class OtherServiceOptions(ServiceOptions):
     value: str
+
+
+def test_sandbox_option_modes_are_mutually_exclusive() -> None:
+    async_options = sandbox.SandboxServiceOptions()
+    sync_options = sync_sandbox.SandboxServiceOptions()
+
+    with pytest.raises(VercelServiceOptionsError, match="one object per logical service"):
+        with session(service_options=[async_options, sync_options]):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_sandbox_option_mode_is_validated_when_service_is_accessed() -> None:
+    async_options = sandbox.SandboxServiceOptions()
+    sync_options = sync_sandbox.SandboxServiceOptions()
+
+    with session(service_options=[async_options]):
+        active = get_active_sync_session()
+        with pytest.raises(
+            VercelServiceOptionsError,
+            match=(
+                "SandboxServiceOptions cannot configure this session mode; "
+                "use SyncSandboxServiceOptions"
+            ),
+        ):
+            get_sync_sandbox_service(active)
+
+    async with session(service_options=[sync_options]):
+        active_async = get_active_session()
+        with pytest.raises(
+            VercelServiceOptionsError,
+            match=(
+                "SyncSandboxServiceOptions cannot configure this session mode; "
+                "use SandboxServiceOptions"
+            ),
+        ):
+            get_sandbox_service(active_async)
+
+
+@pytest.mark.asyncio
+async def test_nested_scope_replaces_sandbox_option_mode() -> None:
+    sync_options = sync_sandbox.SandboxServiceOptions()
+    async_options = sandbox.SandboxServiceOptions()
+
+    async with session(service_options=[sync_options]):
+        async with session(service_options=[async_options]):
+            assert (
+                get_active_session().get_service_option(sandbox.SandboxServiceOptions)
+                is async_options
+            )
 
 
 def test_sandbox_options_inherit_and_service_is_cached_for_session() -> None:

--- a/src/vercel-sandbox/tests/test_session.py
+++ b/src/vercel-sandbox/tests/test_session.py
@@ -11,8 +11,8 @@ from vercel.errors import (
     VercelSessionClosedError,
     VercelSessionError,
 )
-from vercel.sandbox import SandboxServiceOptions, sync as sync_sandbox
-from vercel.sandbox._internal.service import get_sandbox_service
+from vercel.sandbox import sync as sync_sandbox
+from vercel.sandbox._internal.service import get_sync_sandbox_service
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,7 +21,7 @@ class OtherServiceOptions(ServiceOptions):
 
 
 def test_sandbox_options_inherit_and_service_is_cached_for_session() -> None:
-    sandbox_outer = SandboxServiceOptions(base_url="https://outer.example.com")
+    sandbox_outer = sync_sandbox.SandboxServiceOptions(base_url="https://outer.example.com")
     other_outer = OtherServiceOptions(value="outer")
 
     def factory() -> httpx.Client:
@@ -29,22 +29,25 @@ def test_sandbox_options_inherit_and_service_is_cached_for_session() -> None:
 
     with session(service_options=[sandbox_outer, other_outer], httpx_client_factory=factory):
         outer_session = get_active_sync_session()
-        assert outer_session.get_service_option(SandboxServiceOptions) is sandbox_outer
+        assert outer_session.get_service_option(sync_sandbox.SandboxServiceOptions) is sandbox_outer
         assert outer_session.get_service_option(OtherServiceOptions) is other_outer
-        service = get_sandbox_service(outer_session)
-        assert get_sandbox_service(outer_session) is service
+        service = get_sync_sandbox_service(outer_session)
+        assert get_sync_sandbox_service(outer_session) is service
 
         with session():
             inner_session = get_active_sync_session()
-            assert inner_session.get_service_option(SandboxServiceOptions) is sandbox_outer
+            assert (
+                inner_session.get_service_option(sync_sandbox.SandboxServiceOptions)
+                is sandbox_outer
+            )
             assert inner_session.get_service_option(OtherServiceOptions) is other_outer
-            assert get_sandbox_service(inner_session) is not service
+            assert get_sync_sandbox_service(inner_session) is not service
 
         assert inner_session.is_closed
 
     assert outer_session.is_closed
     with pytest.raises(VercelSessionClosedError):
-        get_sandbox_service(outer_session)
+        get_sync_sandbox_service(outer_session)
 
 
 @pytest.mark.asyncio

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -71,7 +71,11 @@ from vercel.sandbox._internal.models import (
     TagFilter,
     TarballSource,
 )
-from vercel.sandbox._internal.options import SandboxServiceOptions
+from vercel.sandbox._internal.options import (
+    SandboxCredentials,
+    SandboxCredentialsFactory,
+    SandboxServiceOptions,
+)
 from vercel.sandbox._internal.service import SandboxService, get_sandbox_service
 from vercel.sandbox._internal.state import SnapshotRetentionState
 from vercel.sandbox._internal.text_reader import TextReader
@@ -374,7 +378,9 @@ __all__ = [
     "ProcessStatus",
     "Process",
     "CompletedProcess",
+    "SandboxCredentials",
     "SandboxCredentialsError",
+    "SandboxCredentialsFactory",
     "SandboxError",
     "SandboxFilesystem",
     "SandboxFilesystemBatch",

--- a/src/vercel-sandbox/vercel/sandbox/_internal/options.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/options.py
@@ -22,7 +22,11 @@ class SandboxCredentialsFactory(Protocol):
     async def __call__(self) -> SandboxCredentials: ...
 
 
-async def _default_sandbox_credentials_factory() -> SandboxCredentials:
+class SyncSandboxCredentialsFactory(Protocol):
+    def __call__(self) -> SandboxCredentials: ...
+
+
+def _resolve_default_sandbox_credentials() -> SandboxCredentials:
     try:
         from vercel.oidc.credentials import get_credentials
 
@@ -35,6 +39,10 @@ async def _default_sandbox_credentials_factory() -> SandboxCredentials:
         team_id=credentials.team_id,
         project_id=credentials.project_id,
     )
+
+
+async def _default_sandbox_credentials_factory() -> SandboxCredentials:
+    return _resolve_default_sandbox_credentials()
 
 
 @dataclass(frozen=True, slots=True, init=False)
@@ -66,6 +74,40 @@ class SandboxServiceOptions(ServiceOptions):
             self,
             "credentials_factory",
             credentials_factory or _default_sandbox_credentials_factory,
+        )
+        object.__setattr__(
+            self,
+            "file_transfer_timeout",
+            file_transfer_timeout
+            if file_transfer_timeout is not None
+            else _DEFAULT_FILE_TRANSFER_TIMEOUT,
+        )
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SyncSandboxServiceOptions(ServiceOptions):
+    """Configuration for synchronous `vercel.sandbox` calls in an SDK session."""
+
+    base_url: str
+    credentials_factory: SyncSandboxCredentialsFactory
+    file_transfer_timeout: timedelta
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        credentials_factory: SyncSandboxCredentialsFactory | None = None,
+        file_transfer_timeout: timedelta | None = None,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "base_url",
+            base_url or DEFAULT_SANDBOX_API_BASE_URL,
+        )
+        object.__setattr__(
+            self,
+            "credentials_factory",
+            credentials_factory or _resolve_default_sandbox_credentials,
         )
         object.__setattr__(
             self,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/options.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/options.py
@@ -45,8 +45,18 @@ async def _default_sandbox_credentials_factory() -> SandboxCredentials:
     return _resolve_default_sandbox_credentials()
 
 
+class _SandboxServiceOptionsKey(ServiceOptions):
+    """Shared registry key for sync and async Sandbox service options."""
+
+    __slots__ = ()
+
+    @classmethod
+    def service_options_key(cls) -> type[ServiceOptions]:
+        return _SandboxServiceOptionsKey
+
+
 @dataclass(frozen=True, slots=True, init=False)
-class SandboxServiceOptions(ServiceOptions):
+class SandboxServiceOptions(_SandboxServiceOptionsKey):
     """Configuration for `vercel.sandbox` calls in an SDK session.
 
     A session that does not receive this option still constructs one with the
@@ -85,7 +95,7 @@ class SandboxServiceOptions(ServiceOptions):
 
 
 @dataclass(frozen=True, slots=True, init=False)
-class SyncSandboxServiceOptions(ServiceOptions):
+class SyncSandboxServiceOptions(_SandboxServiceOptionsKey):
     """Configuration for synchronous `vercel.sandbox` calls in an SDK session."""
 
     base_url: str

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -38,7 +38,13 @@ from vercel.sandbox._internal.models import (
     SnapshotRetentionUpdate,
     TagFilter,
 )
-from vercel.sandbox._internal.options import SandboxServiceOptions
+from vercel.sandbox._internal.options import (
+    SandboxCredentials,
+    SandboxCredentialsFactory,
+    SandboxServiceOptions,
+    SyncSandboxCredentialsFactory,
+    SyncSandboxServiceOptions,
+)
 from vercel.sandbox._internal.process_output import ProcessOutputRouter
 from vercel.sandbox._internal.runtime_common import (
     _StreamUploadFileEntry,
@@ -1033,9 +1039,44 @@ class SandboxArchiveUpload:
         await self._writer.abort()
 
 
-def get_sandbox_service(session: "SdkSession | SyncSdkSession") -> SandboxService:
+def _adapt_sync_credentials_factory(
+    factory: SyncSandboxCredentialsFactory,
+) -> SandboxCredentialsFactory:
+    async def credentials_factory() -> SandboxCredentials:
+        return factory()
+
+    return credentials_factory
+
+
+def get_sandbox_service(session: "SdkSession") -> SandboxService:
     def factory() -> SandboxService:
         options = session.get_service_option(SandboxServiceOptions) or SandboxServiceOptions()
+        return SandboxService(
+            api_client=SandboxApiClient(
+                base_url=options.base_url,
+                credentials_factory=options.credentials_factory,
+                transport=session.get_transport(),
+                file_transfer_timeout=options.file_transfer_timeout,
+            ),
+            options=options,
+            ensure_open=session.check_open,
+            sleep=session.sleep,
+            staging_file_runtime=session.get_staging_file_runtime(),
+        )
+
+    return session.get_or_create_service(SandboxService, factory)
+
+
+def get_sync_sandbox_service(session: "SyncSdkSession") -> SandboxService:
+    def factory() -> SandboxService:
+        sync_options = (
+            session.get_service_option(SyncSandboxServiceOptions) or SyncSandboxServiceOptions()
+        )
+        options = SandboxServiceOptions(
+            base_url=sync_options.base_url,
+            credentials_factory=_adapt_sync_credentials_factory(sync_options.credentials_factory),
+            file_transfer_timeout=sync_options.file_transfer_timeout,
+        )
         return SandboxService(
             api_client=SandboxApiClient(
                 base_url=options.base_url,

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -47,8 +47,12 @@ from vercel.sandbox._internal.models import (
     TagFilter,
     TarballSource,
 )
-from vercel.sandbox._internal.options import SandboxServiceOptions
-from vercel.sandbox._internal.service import SandboxService, get_sandbox_service
+from vercel.sandbox._internal.options import (
+    SandboxCredentials,
+    SyncSandboxCredentialsFactory,
+    SyncSandboxServiceOptions as SandboxServiceOptions,
+)
+from vercel.sandbox._internal.service import SandboxService, get_sync_sandbox_service
 from vercel.sandbox._internal.state import SnapshotRetentionState
 from vercel.sandbox._internal.sync_filesystem_handle import (
     SyncSandboxBinaryReader,
@@ -77,7 +81,7 @@ from vercel.sandbox._internal.text_reader import SyncTextReader
 
 
 def _service() -> SandboxService:
-    return get_sandbox_service(get_active_sync_session())
+    return get_sync_sandbox_service(get_active_sync_session())
 
 
 def create_sandbox(
@@ -363,7 +367,9 @@ __all__ = [
     "SandboxCleanupError",
     "ProcessStatus",
     "CompletedProcess",
+    "SandboxCredentials",
     "SandboxCredentialsError",
+    "SyncSandboxCredentialsFactory",
     "SandboxError",
     "SandboxFilesystemCommandError",
     "SandboxFilesystemError",


### PR DESCRIPTION
For sync usage, we should take a normal sync function instead of requiring that you give us an async shaped, non-suspending function that we pass through iter_coroutine.

Also export the required types here so consumers can properly type their usage.