### PR TITLE
Fix certifi vendoring for shared deps

### DIFF
--- a/scripts/bundle_release.py
+++ b/scripts/bundle_release.py
@@ -86,6 +86,16 @@ ANYIO_FROM_THREAD_SUBSTITUTION = (
     r"import anyio\.from_thread",
     "from anyio import from_thread",
 )
+# certifi locates cacert.pem with importlib.resources anchored at the literal
+# top-level "certifi" distribution, which does not exist in a bundle install.
+# Rewrite the anchors so the vendored copy resolves its own cacert.pem.
+CERTIFI_RESOURCE_SUBSTITUTION = (
+    r'(files|get_path|read_text)\("certifi"',
+    rf'\1("{SHARED_VENDOR_NAMESPACE}.certifi"',
+)
+# Bump to force a republish of the shared vendored package when the vendoring
+# recipe changes without any change to the pinned requirements.
+SHARED_VENDOR_RECIPE_REVISION = 2
 
 
 @dataclass(frozen=True)
@@ -451,7 +461,11 @@ def _read_json_url(url: str) -> dict[str, Any]:
 
 
 def _shared_deps_fingerprint() -> str:
-    payload = "\n".join(_derive_vendor_requirements(SHARED_VENDORED_PACKAGE, {})) + "\n"
+    lines = (
+        f"recipe-revision={SHARED_VENDOR_RECIPE_REVISION}",
+        *_derive_vendor_requirements(SHARED_VENDORED_PACKAGE, {}),
+    )
+    payload = "\n".join(lines) + "\n"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -560,6 +574,7 @@ path = "vercel/internal/_vendor/version.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/vercel/internal/_vendor/**/*.py",
+    "/vercel/internal/_vendor/certifi/cacert.pem",
     "/vercel/internal/_vendor/{SHARED_DEPS_METADATA}",
     "/vercel/internal/_vendor/py.typed",
     "/README.md",
@@ -636,7 +651,7 @@ def _render_vendoring_config(plan: VendoredPlan) -> str:
 def _vendoring_transformations(plan: VendoredPlan) -> VendoringTransformations:
     if plan.package.name == SHARED_VENDORED_PACKAGE:
         return VendoringTransformations(
-            substitutions=tuple(_shared_h2_substitution_pairs()),
+            substitutions=(*_shared_h2_substitution_pairs(), CERTIFI_RESOURCE_SUBSTITUTION),
         )
     vendored_names = {_requirement_name(requirement) for requirement in plan.vendored_requirements}
     substitutions = (ANYIO_FROM_THREAD_SUBSTITUTION,) if "anyio" in vendored_names else ()

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1334,6 +1335,7 @@ def test_shared_bundle_package_is_generated(
     pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     metadata = (tmp_path / "vercel/internal/_vendor/_shared_deps.json").read_text(encoding="utf-8")
     assert 'name = "vercel-internal-shared-vendored-deps"' in pyproject
+    assert '"/vercel/internal/_vendor/certifi/cacert.pem",' in pyproject
     assert "[tool.vendoring]" not in pyproject
     assert (tmp_path / "vercel/internal/_vendor/version.py").read_text(
         encoding="utf-8"
@@ -1400,6 +1402,39 @@ path = "vercel/pkg/version.py"
 
     pyproject = (package_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "import anyio\\\\.from_thread" in pyproject
+
+
+def test_shared_vendoring_config_rewrites_certifi_resource_anchors(tmp_path: Path) -> None:
+    plan = bundle_release._shared_vendored_plan()  # noqa: SLF001
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "vercel-internal-shared-vendored-deps"\n',
+        encoding="utf-8",
+    )
+
+    bundle_release._write_vendoring_config(plan, tmp_path)  # noqa: SLF001
+
+    pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    match, replace = bundle_release.CERTIFI_RESOURCE_SUBSTITUTION
+    assert json.dumps(match) in pyproject
+    assert json.dumps(replace) in pyproject
+    assert "vercel.internal._vendor.certifi" in replace
+
+
+def test_shared_deps_fingerprint_includes_recipe_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bundle_release,
+        "_derive_vendor_requirements",
+        lambda _package, _data: ("httpx==0.28.1",),
+    )
+    before = bundle_release._shared_deps_fingerprint()  # noqa: SLF001
+    monkeypatch.setattr(
+        bundle_release,
+        "SHARED_VENDOR_RECIPE_REVISION",
+        bundle_release.SHARED_VENDOR_RECIPE_REVISION + 1,
+    )
+    assert bundle_release._shared_deps_fingerprint() != before  # noqa: SLF001
 
 
 def test_vendored_license_files_are_copied_from_dist_info(tmp_path: Path) -> None:


### PR DESCRIPTION
Currently our vendoring skips `cacert.pem` from `certifi` for `vercel-internal-shared-vendored-deps` and also doesn't update how `ceritfi` imports the cert, so when vendored `httpx` tries to use `certify` it fails: https://github.com/vercel/vercel/actions/runs/30350836367/job/90247791318#step:14:12895

This PR will fix vendoring of `cerifi`

<details>
  <summary>Logs</summary>

```
vercel:test:  │ ERROR:    Exception in ASGI application
vercel:test:  │ Traceback (most recent call last):
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel_runtime/_vendor/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
vercel:test:  │     result = await app(  # type: ignore[func-returns-value]
vercel:test:  │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel_runtime/_vendor/uvicorn/middleware/proxy_headers.py", line 60, in __call__
vercel:test:  │     return await self.app(scope, receive, send)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel_runtime/dev.py", line 307, in asgi_app
vercel:test:  │     await _asgi_user_app(effective_scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1163, in __call__
vercel:test:  │     await super().__call__(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/applications.py", line 90, in __call__
vercel:test:  │     await self.middleware_stack(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 186, in __call__
vercel:test:  │     raise exc
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
vercel:test:  │     await self.app(scope, receive, _send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
vercel:test:  │     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
vercel:test:  │     raise exc
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
vercel:test:  │     await app(scope, receive, sender)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
vercel:test:  │     await self.app(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/routing.py", line 660, in __call__
vercel:test:  │     await self.middleware_stack(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 2691, in app
vercel:test:  │     await route.handle(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 1273, in handle
vercel:test:  │     await super().handle(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/routing.py", line 276, in handle
vercel:test:  │     await self.app(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 156, in app
vercel:test:  │     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
vercel:test:  │     raise exc
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
vercel:test:  │     await app(scope, receive, sender)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 142, in app
vercel:test:  │     response = await f(request)
vercel:test:  │                ^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 698, in app
vercel:test:  │     raw_response = await run_endpoint_function(
vercel:test:  │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
vercel:test:  │     return await run_in_threadpool(dependant.call, **values)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/starlette/concurrency.py", line 34, in run_in_threadpool
vercel:test:  │     return await anyio.to_thread.run_sync(func)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/anyio/to_thread.py", line 65, in run_sync
vercel:test:  │     return await get_async_backend().run_sync_in_worker_thread(
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2641, in run_sync_in_worker_thread
vercel:test:  │     return await future
vercel:test:  │            ^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1033, in run
vercel:test:  │     result = context.run(func, *args)
vercel:test:  │              ^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/main.py", line 18, in enqueue
vercel:test:  │     process_high.apply_async(args=("dev-celery-high", 19, 23), queue=HIGH_QUEUE)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/celery/app/task.py", line 627, in apply_async
vercel:test:  │     return app.send_task(
vercel:test:  │            ^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/celery/app/base.py", line 969, in send_task
vercel:test:  │     amqp.send_task_message(P, name, message, **options)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/celery/app/amqp.py", line 559, in send_task_message
vercel:test:  │     ret = producer.publish(
vercel:test:  │           ^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/kombu/messaging.py", line 190, in publish
vercel:test:  │     return _publish(
vercel:test:  │            ^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/kombu/connection.py", line 558, in _ensured
vercel:test:  │     return fun(*args, **kwargs)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/kombu/messaging.py", line 214, in _publish
vercel:test:  │     return channel.basic_publish(
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/kombu/transport/virtual/base.py", line 614, in basic_publish
vercel:test:  │     return self._put(routing_key, message, **kwargs)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/integrations/celery/_broker.py", line 230, in _put
vercel:test:  │     self._queue_client.send(
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/client_sync.py", line 107, in send
vercel:test:  │     return iter_coroutine(
vercel:test:  │            ^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/asynctools.py", line 17, in iter_coroutine
vercel:test:  │     coro.send(None)
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/client.py", line 261, in _send
vercel:test:  │     response = await self._runtime.post(
vercel:test:  │                ^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/http.py", line 386, in post
vercel:test:  │     return await self.request(
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/http.py", line 367, in request
vercel:test:  │     return await self._request(
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/http.py", line 452, in _request
vercel:test:  │     client = self._acquire_client()
vercel:test:  │              ^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/http.py", line 437, in _acquire_client
vercel:test:  │     return _sync_http_client_pool.acquire(
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/queue/_internal/http.py", line 170, in acquire
vercel:test:  │     entry = _HttpClientPoolEntry(client=factory())
vercel:test:  │                                         ^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/internal/_vendor/httpx/_client.py", line 688, in __init__
vercel:test:  │     self._transport = self._init_transport(
vercel:test:  │                       ^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/internal/_vendor/httpx/_client.py", line 731, in _init_transport
vercel:test:  │     return HTTPTransport(
vercel:test:  │            ^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/internal/_vendor/httpx/_transports/default.py", line 153, in __init__
vercel:test:  │     ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
vercel:test:  │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/internal/_vendor/httpx/_config.py", line 40, in create_ssl_context
vercel:test:  │     ctx = ssl.create_default_context(cafile=certifi.where())
vercel:test:  │                                             ^^^^^^^^^^^^^^^
vercel:test:  │   File "/home/runner/work/vercel/vercel/packages/cli/test/dev/fixtures/pyproject-subscriber/.vercel/python/vercel/internal/_vendor/certifi/core.py", line 40, in where
vercel:test:  │     _CACERT_CTX = as_file(files("certifi").joinpath("cacert.pem"))
vercel:test:  │                           ^^^^^^^^^^^^^^^^
vercel:test:  │   File "/usr/lib/python3.12/importlib/resources/_common.py", line 46, in wrapper
vercel:test:  │     return func(anchor)
vercel:test:  │            ^^^^^^^^^^^^
vercel:test:  │   File "/usr/lib/python3.12/importlib/resources/_common.py", line 56, in files
vercel:test:  │     return from_package(resolve(anchor))
vercel:test:  │                         ^^^^^^^^^^^^^^^
vercel:test:  │   File "/usr/lib/python3.12/functools.py", line 909, in wrapper
vercel:test:  │     return dispatch(args[0].__class__)(*args, **kw)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/usr/lib/python3.12/importlib/resources/_common.py", line 82, in _
vercel:test:  │     return importlib.import_module(cand)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
vercel:test:  │     return _bootstrap._gcd_import(name[level:], package, level)
vercel:test:  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vercel:test:  │   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
vercel:test:  │   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
vercel:test:  │   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
vercel:test:  │ ModuleNotFoundError: No module named 'certifi'
vercel:test:  ╰ 
```


</details>