### PR TITLE
Validate snapshot retention count

### DIFF
--- a/src/vercel-sandbox/tests/test_sandbox_snapshot.py
+++ b/src/vercel-sandbox/tests/test_sandbox_snapshot.py
@@ -4,6 +4,7 @@ import pytest
 
 from vercel.sandbox._internal.models import (
     SnapshotExpiration,
+    SnapshotRetention,
     _parse_snapshot_expiration,
 )
 
@@ -28,6 +29,17 @@ def test_snapshot_expiration_parser_preserves_wrapper() -> None:
     expiration = SnapshotExpiration(timedelta(days=1))
 
     assert _parse_snapshot_expiration(expiration) is expiration
+
+
+@pytest.mark.parametrize("count", [1, 10])
+def test_snapshot_retention_accepts_boundary_counts(count: int) -> None:
+    assert SnapshotRetention(count=count).count == count
+
+
+@pytest.mark.parametrize("count", [0, 11])
+def test_snapshot_retention_rejects_out_of_range_counts(count: int) -> None:
+    with pytest.raises(ValueError):
+        SnapshotRetention(count=count)
 
 
 @pytest.mark.parametrize(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/models.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/models.py
@@ -654,13 +654,13 @@ class SnapshotRetention(_InputModel):
     """Configure automatic snapshot retention.
 
     Attributes:
-        count: Maximum number of retained snapshots, between 1 and 100.
+        count: Maximum number of retained snapshots, between 1 and 10.
         expiration: Lifetime applied to retained snapshots.
         delete_evicted: Whether snapshots removed from the retention window are
             deleted from the project.
     """
 
-    count: int
+    count: int = Field(ge=1, le=10)
     expiration: SnapshotExpirationInput = None
     delete_evicted: bool = Field(default=True, serialization_alias="deleteEvicted")
 


### PR DESCRIPTION
`SnapshotRetention.count` is documented as accepting values from 1 through 100, even though the Sandbox API only supports integers from 1 through 10. Because the model does not currently validate this field, unsupported values can be accepted and serialized into API requests.

This change corrects the documented range and adds Pydantic field constraints so counts outside 1 through 10 are rejected during model construction. It also adds focused boundary coverage for the minimum and maximum valid values and the adjacent invalid values.

Closes #199