### PR TITLE
Bind async session clients to the running event loop

### DIFF
--- a/src/vercel-internal-core/tests/test_session_event_loops.py
+++ b/src/vercel-internal-core/tests/test_session_event_loops.py
@@ -1,0 +1,191 @@
+"""The default async session must follow the running event loop.
+
+These tests use a real loopback server rather than `respx`, because the bug they
+guard lives in the keep-alive connection pool: a mocked transport never pools a
+socket, so it cannot reproduce it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import cast
+
+import httpx
+import pytest
+
+from vercel._internal.core.http import AsyncTransport
+from vercel._internal.core.http.transport import ReadResponsePolicy
+from vercel._internal.core.session import SdkSession
+
+
+class _CountingServer(ThreadingHTTPServer):
+    """Loopback server that records how many requests it actually served."""
+
+    daemon_threads = True
+
+    def __init__(self, handler: type[BaseHTTPRequestHandler]) -> None:
+        super().__init__(("127.0.0.1", 0), handler)
+        self.request_count = 0
+
+
+class _KeepAliveHandler(BaseHTTPRequestHandler):
+    # Keep-alive, so the client pools the socket for a later loop to inherit.
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        cast(_CountingServer, self.server).request_count += 1
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Silence the default stderr access log."""
+
+
+@contextlib.contextmanager
+def _keep_alive_server() -> Iterator[_CountingServer]:
+    server = _CountingServer(_KeepAliveHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def isolated_default_session() -> Iterator[None]:
+    """Swap the process-wide default session out for the duration of a test."""
+    previous = SdkSession._default
+    SdkSession._default = None
+    try:
+        yield
+    finally:
+        created = SdkSession._default
+        SdkSession._default = previous
+        if created is not None:
+            # Best effort: its sockets may belong to a loop that already closed.
+            with contextlib.suppress(RuntimeError):
+                asyncio.run(created.aclose())
+
+
+def _url(server: _CountingServer) -> str:
+    return f"http://127.0.0.1:{server.server_address[1]}/mint"
+
+
+async def _post(transport: AsyncTransport, url: str) -> int:
+    response = await transport.send("POST", url, body=None, read_response=ReadResponsePolicy.ALWAYS)
+    return response.status_code
+
+
+def test_default_session_transport_survives_successive_event_loops(
+    isolated_default_session: None,
+) -> None:
+    with _keep_alive_server() as server:
+        url = _url(server)
+
+        async def call() -> int:
+            return await _post(SdkSession.default().get_transport(), url)
+
+        statuses = [asyncio.run(call()) for _ in range(4)]
+
+        assert statuses == [200, 200, 200, 200]
+        # Before the fix half the callers failed *after* the server had processed
+        # their request, so a retry would have duplicated a non-idempotent call.
+        assert server.request_count == 4
+
+
+def test_memoized_service_does_not_keep_a_transport_bound_to_a_dead_loop(
+    isolated_default_session: None,
+) -> None:
+    """Services capture the transport once, so the fix cannot live in `get_transport`.
+
+    `vercel.sandbox` resolves its service per call, but the service keeps the
+    transport it was built with, reaching a stale client without ever asking for
+    a transport again.
+    """
+
+    class CapturingService:
+        def __init__(self, transport: AsyncTransport) -> None:
+            self.transport = transport
+
+    with _keep_alive_server() as server:
+        url = _url(server)
+        services: list[CapturingService] = []
+
+        async def call() -> int:
+            session = SdkSession.default()
+
+            def factory() -> CapturingService:
+                service = CapturingService(session.get_transport())
+                services.append(service)
+                return service
+
+            service = session.get_or_create_service(CapturingService, factory)
+            return await _post(service.transport, url)
+
+        statuses = [asyncio.run(call()) for _ in range(3)]
+
+        assert statuses == [200, 200, 200]
+        assert server.request_count == 3
+        # The service itself is still memoized: only its client changed.
+        assert len(services) == 1
+
+
+def test_concurrent_loops_in_separate_threads_each_get_their_own_client(
+    isolated_default_session: None,
+) -> None:
+    """A session reachable from several threads must not hand a client across loops."""
+    thread_count = 4
+
+    with _keep_alive_server() as server:
+        url = _url(server)
+        barrier = threading.Barrier(thread_count)
+        results: list[object] = []
+        # Held, not just recorded: a dropped client's address can be reused, so
+        # comparing `id()` of released objects would be unsound.
+        clients: list[httpx.AsyncClient] = []
+        lock = threading.Lock()
+
+        async def warm_up() -> int:
+            return await _post(SdkSession.default().get_transport(), url)
+
+        # Memoize the transport first. Otherwise the threads race to create it and
+        # each builds its own client, passing without the per-request lookup.
+        assert asyncio.run(warm_up()) == 200
+
+        async def call() -> int:
+            session = SdkSession.default()
+            transport = session.get_transport()
+            # Overlap the requests so every loop is live at the same time.
+            await asyncio.to_thread(barrier.wait)
+            with lock:
+                clients.append(session._client_for_running_loop())
+            return await _post(transport, url)
+
+        def worker() -> None:
+            try:
+                outcome: object = asyncio.run(call())
+            except BaseException as exc:  # noqa: BLE001
+                outcome = exc
+            with lock:
+                results.append(outcome)
+
+        threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert results == [200] * thread_count
+        assert server.request_count == thread_count + 1
+        # A client each, so no loop is handed sockets opened by another.
+        assert len({id(client) for client in clients}) == thread_count

--- a/src/vercel-internal-core/tests/test_session_event_loops.py
+++ b/src/vercel-internal-core/tests/test_session_event_loops.py
@@ -17,6 +17,7 @@ from typing import cast
 import httpx
 import pytest
 
+from vercel._internal.core.errors import VercelSessionClosedError
 from vercel._internal.core.http import AsyncTransport
 from vercel._internal.core.http.transport import ReadResponsePolicy
 from vercel._internal.core.session import SdkSession
@@ -138,6 +139,25 @@ def test_memoized_service_does_not_keep_a_transport_bound_to_a_dead_loop(
         assert server.request_count == 3
         # The service itself is still memoized: only its client changed.
         assert len(services) == 1
+
+
+async def test_a_closed_session_does_not_build_another_client() -> None:
+    """A request still holding the transport must not outlive its session.
+
+    Closing empties the per-loop registry, so without this the next lookup would
+    treat the session as cold, build a client, and run the request outside the
+    lifecycle that was supposed to end.
+    """
+    with _keep_alive_server() as server:
+        session = SdkSession()
+        transport = session.get_transport()
+        await session.aclose()
+
+        with pytest.raises(VercelSessionClosedError):
+            await _post(transport, _url(server))
+
+        assert server.request_count == 0
+        assert len(session._clients) == 0
 
 
 def test_concurrent_loops_in_separate_threads_each_get_their_own_client(

--- a/src/vercel-internal-core/vercel/_internal/core/http/transport.py
+++ b/src/vercel-internal-core/vercel/_internal/core/http/transport.py
@@ -6,7 +6,7 @@ import abc
 import json
 import queue
 import threading
-from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from datetime import timedelta
@@ -713,8 +713,24 @@ class SyncTransport(BaseTransport):
 class AsyncTransport(BaseTransport):
     _client: httpx.AsyncClient
 
-    def __init__(self, client: httpx.AsyncClient) -> None:
+    def __init__(self, client: httpx.AsyncClient | Callable[[], httpx.AsyncClient]) -> None:
+        """Take a client, or a callable consulted before every request.
+
+        Keep-alive sockets belong to the event loop that opened them, so an owner
+        that outlives a loop passes a callable and gets a client per loop. The
+        transport object itself is memoized by callers and cannot be swapped out.
+        """
+        self._resolve_client: Callable[[], httpx.AsyncClient] = (
+            (lambda: client) if isinstance(client, httpx.AsyncClient) else client
+        )
+        self._client = self._resolve_client()
+
+    def _acquire_client(self) -> httpx.AsyncClient:
+        client = self._resolve_client()
+        # `_client` exists for the inherited `_build_request`, which reads client
+        # defaults; keep it on the client this request is actually sent on.
         self._client = client
+        return client
 
     async def send(
         self,
@@ -730,10 +746,11 @@ class AsyncTransport(BaseTransport):
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
     ) -> httpx.Response:
+        client = self._acquire_client()
         request = self._build_request(
             method, path, token=token, params=params, body=body, headers=headers, timeout=timeout
         )
-        response = await self._client.send(
+        response = await client.send(
             request,
             stream=stream,
             follow_redirects=follow_redirects
@@ -757,6 +774,7 @@ class AsyncTransport(BaseTransport):
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         response_chunk_size: int | None = None,
     ) -> AsyncIterator[StreamingRequest]:
+        client = self._acquire_client()
         send, receive = anyio.create_memory_object_stream[bytes](1)
         request = self._build_request(
             method,
@@ -768,7 +786,7 @@ class AsyncTransport(BaseTransport):
             timeout=timeout,
         )
         streaming_request = _AsyncStreamingRequest(
-            client=self._client,
+            client=client,
             request=request,
             send=send,
             receive=receive,

--- a/src/vercel-internal-core/vercel/_internal/core/http/transport.py
+++ b/src/vercel-internal-core/vercel/_internal/core/http/transport.py
@@ -79,8 +79,6 @@ class TransportOptions:
 
 
 class BaseTransport(abc.ABC):
-    _client: httpx.Client | httpx.AsyncClient
-
     @abc.abstractmethod
     async def send(
         self,
@@ -131,8 +129,9 @@ class BaseTransport(abc.ABC):
         """Open a response whose body is consumed incrementally."""
         raise NotImplementedError()
 
+    @staticmethod
     def _build_request(
-        self,
+        client: httpx.Client | httpx.AsyncClient,
         method: str,
         path: str,
         *,
@@ -158,7 +157,7 @@ class BaseTransport(abc.ABC):
                 content = body.data
 
         if timeout is not None:
-            return self._client.build_request(
+            return client.build_request(
                 method,
                 _normalize_path(path),
                 params=params,
@@ -168,7 +167,7 @@ class BaseTransport(abc.ABC):
                 content=content,
             )
 
-        return self._client.build_request(
+        return client.build_request(
             method,
             _normalize_path(path),
             params=params,
@@ -611,7 +610,14 @@ class SyncTransport(BaseTransport):
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
     ) -> httpx.Response:
         request = self._build_request(
-            method, path, token=token, params=params, body=body, headers=headers, timeout=timeout
+            self._client,
+            method,
+            path,
+            token=token,
+            params=params,
+            body=body,
+            headers=headers,
+            timeout=timeout,
         )
         response = self._client.send(
             request,
@@ -639,6 +645,7 @@ class SyncTransport(BaseTransport):
     ) -> AsyncIterator[StreamingRequest]:
         chunks: queue.Queue[bytes | object] = queue.Queue(maxsize=1)
         request = self._build_request(
+            self._client,
             method,
             path,
             token=token,
@@ -711,8 +718,6 @@ class SyncTransport(BaseTransport):
 
 
 class AsyncTransport(BaseTransport):
-    _client: httpx.AsyncClient
-
     def __init__(self, client: httpx.AsyncClient | Callable[[], httpx.AsyncClient]) -> None:
         """Take a client, or a callable consulted before every request.
 
@@ -723,14 +728,9 @@ class AsyncTransport(BaseTransport):
         self._resolve_client: Callable[[], httpx.AsyncClient] = (
             (lambda: client) if isinstance(client, httpx.AsyncClient) else client
         )
-        self._client = self._resolve_client()
-
-    def _acquire_client(self) -> httpx.AsyncClient:
-        client = self._resolve_client()
-        # `_client` exists for the inherited `_build_request`, which reads client
-        # defaults; keep it on the client this request is actually sent on.
-        self._client = client
-        return client
+        # Resolved once here so a factory that yields the wrong kind of client
+        # fails when the transport is built, as it did before.
+        self._resolve_client()
 
     async def send(
         self,
@@ -746,9 +746,16 @@ class AsyncTransport(BaseTransport):
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
     ) -> httpx.Response:
-        client = self._acquire_client()
+        client = self._resolve_client()
         request = self._build_request(
-            method, path, token=token, params=params, body=body, headers=headers, timeout=timeout
+            client,
+            method,
+            path,
+            token=token,
+            params=params,
+            body=body,
+            headers=headers,
+            timeout=timeout,
         )
         response = await client.send(
             request,
@@ -774,9 +781,10 @@ class AsyncTransport(BaseTransport):
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         response_chunk_size: int | None = None,
     ) -> AsyncIterator[StreamingRequest]:
-        client = self._acquire_client()
+        client = self._resolve_client()
         send, receive = anyio.create_memory_object_stream[bytes](1)
         request = self._build_request(
+            client,
             method,
             path,
             token=token,
@@ -850,7 +858,7 @@ class AsyncTransport(BaseTransport):
         return _AsyncStreamingResponse(response, chunk_size)
 
     async def aclose(self) -> None:
-        await self._client.aclose()
+        await self._resolve_client().aclose()
 
     async def __aenter__(self) -> AsyncTransport:
         return self

--- a/src/vercel-internal-core/vercel/_internal/core/session.py
+++ b/src/vercel-internal-core/vercel/_internal/core/session.py
@@ -155,6 +155,9 @@ class SdkSession(_BaseSdkSession):
         """
         loop = self._running_loop()
         with self._clients_lock:
+            # Under the lock, so a request holding this transport cannot build a
+            # client that outlives the session it belongs to.
+            self.check_open()
             client = self._clients.get(loop)
             if client is not None:
                 return client
@@ -220,11 +223,13 @@ class SdkSession(_BaseSdkSession):
     async def aclose(self) -> None:
         if self._closed:
             return
-        self._closed = True
         self._clear_services()
         self._transport = None
         loop = self._running_loop()
         with self._clients_lock:
+            # Closing and the flag that stops new clients have to be one step, or
+            # a resolver already past the check registers a client nothing closes.
+            self._closed = True
             clients = list(self._clients.items())
             self._clients.clear()
         for owner, client in clients:

--- a/src/vercel-internal-core/vercel/_internal/core/session.py
+++ b/src/vercel-internal-core/vercel/_internal/core/session.py
@@ -1,6 +1,7 @@
 """Mode-specific sessions shared by Vercel Python services."""
 
 import asyncio
+import threading
 import time
 from collections.abc import Callable, Mapping, Sequence
 from contextvars import ContextVar, Token
@@ -102,6 +103,11 @@ class SdkSession(_BaseSdkSession):
         )
         self._transport: AsyncTransport | None = None
         self._staging_file_runtime: AsyncByteStreamRuntime | None = None
+        # Keyed by loop, with `None` for a client built outside one. The default
+        # session is process-wide, so it outlives any loop its sockets belong to.
+        self._clients: dict[asyncio.AbstractEventLoop | None, httpx.AsyncClient] = {}
+        # One session can be reached from threads running loops of their own.
+        self._clients_lock = threading.Lock()
 
     @classmethod
     def default(cls) -> Self:
@@ -131,17 +137,43 @@ class SdkSession(_BaseSdkSession):
             ),
         )
 
-    def get_transport(self) -> "AsyncTransport":
+    @staticmethod
+    def _running_loop() -> "asyncio.AbstractEventLoop | None":
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+    def _client_for_running_loop(self) -> httpx.AsyncClient:
+        """Return the client owned by the loop making this request.
+
+        Reusing a keep-alive socket from a closed loop does not fail early: the
+        request is sent and the response is read, and only then does closing the
+        connection call into the dead loop and raise `RuntimeError: Event loop is
+        closed`. The caller sees an error for work the server already did, so the
+        client is chosen per loop up front rather than repaired afterwards.
+        """
+        loop = self._running_loop()
+        with self._clients_lock:
+            client = self._clients.get(loop)
+            if client is not None:
+                return client
+            for known in [
+                known for known in self._clients if known is not None and known.is_closed()
+            ]:
+                # Dropped, not closed: `aclose` needs the loop that owns the
+                # sockets, and that loop is gone.
+                del self._clients[known]
+            client = self._create_client()
+            self._clients[loop] = client
+            return client
+
+    def _create_client(self) -> httpx.AsyncClient:
         from vercel._internal.core.http import (
             DEFAULT_TIMEOUT,
-            AsyncTransport,
             TransportOptions,
             create_base_async_client,
         )
-
-        self.check_open()
-        if self._transport is not None:
-            return self._transport
 
         if self._httpx_client_factory is None:
             client = create_base_async_client(
@@ -164,7 +196,14 @@ class SdkSession(_BaseSdkSession):
                     "Async SDK sessions require httpx_client_factory to return httpx.AsyncClient"
                 )
             client = candidate
-        self._transport = AsyncTransport(client)
+        return client
+
+    def get_transport(self) -> "AsyncTransport":
+        from vercel._internal.core.http import AsyncTransport
+
+        self.check_open()
+        if self._transport is None:
+            self._transport = AsyncTransport(self._client_for_running_loop)
         return self._transport
 
     def get_staging_file_runtime(self) -> "AsyncByteStreamRuntime":
@@ -183,9 +222,16 @@ class SdkSession(_BaseSdkSession):
             return
         self._closed = True
         self._clear_services()
-        if self._transport is not None:
-            await self._transport.aclose()
-            self._transport = None
+        self._transport = None
+        loop = self._running_loop()
+        with self._clients_lock:
+            clients = list(self._clients.items())
+            self._clients.clear()
+        for owner, client in clients:
+            # Another loop's client is dropped: closing it here would fail the
+            # same way reusing it does.
+            if owner is None or owner is loop:
+                await client.aclose()
 
 
 class SyncSdkSession(_BaseSdkSession):


### PR DESCRIPTION
## Problem

The default async `SdkSession` is a process-wide singleton that held one
`httpx.AsyncClient` for the life of the process. That client pools keep-alive
sockets owned by the event loop that opened them, so a second loop reusing the
session sends the request, reads the response, and then raises
`RuntimeError: Event loop is closed` while closing the connection.

The caller sees an error for work the server already performed, so a retry can
duplicate a non-idempotent operation. From the new test's server, before the fix:

```
client: ok=3 failed=3   server: requests_processed=6
```

It also alternates rather than self-healing: the failed attempt discards the
stale socket, the next call opens a fresh one, and that one goes stale when its
loop closes.

Who hits it: any async API used without an explicit `session()` across more than
one loop. Scripts and CLIs calling `asyncio.run` twice, test suites with a loop
per test, and `vercel.sandbox`, which resolves its service from the default
session. The same root cause was previously worked around in `vercel-cache` by
opening a client per call (#21, #23).

## Fix

Keep one client per event loop on the session, and let the transport resolve it
per request. A check inside `get_transport()` would not be enough: services
capture the transport once at construction and are memoized on the session, so
`get_transport()` is never called again and the stale client is reached through
the cached service. Resolving per request also makes a session shared by threads
that each run their own loop safe, which swapping a single client would not.

Clients for closed loops are dropped when a new one is created, because `aclose`
has to run on the loop that owns the sockets.

## Tests

Three regression tests, all verified failing before the fix and passing after.
They use a loopback keep-alive server rather than `respx`, since a mocked
transport never pools a socket and cannot reproduce this.

1. repeated `asyncio.run` through the default session, asserting no client errors
   and one server-side request per call
2. a memoized service holding the transport across loops, which is what makes the
   `get_transport()`-only fix insufficient
3. four threads with concurrent loops sharing one session, each resolving its own
   client
