### PR TITLE
Add Python port of the devalue wire format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
         with:
           node-version: '22'
 
+      # The interop tests fall back to `npm install devalue` when pointed at
+      # nothing, but here we use a pinned checkout: it also carries the test
+      # fixtures the tarball omits, and it keeps npm out of CI. `index.js` and
+      # `src/` are byte-identical to the published package, so this ref is what
+      # the port is actually verified against.
+      - name: Checkout devalue
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: sveltejs/devalue
+          ref: v5.8.2
+          path: .devalue-upstream
+          persist-credentials: false
+
       - name: Sync dependencies
         run: uv sync --all-packages --locked --python ${{ matrix.python-version }}
 
@@ -53,6 +66,8 @@ jobs:
 
       - name: Test
         run: ./scripts/test.sh
+        env:
+          VERCEL_DEVALUE_JS: ${{ github.workspace }}/.devalue-upstream
 
       - name: Build package
         run: ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,14 @@ jobs:
       # fixtures the tarball omits, and it keeps npm out of CI. `index.js` and
       # `src/` are byte-identical to the published package, so this ref is what
       # the port is actually verified against.
+      #
+      # Cloned outside the workspace deliberately. `actions/checkout` can only
+      # write inside it, and a copy there puts devalue's own workflows under
+      # our linters, where zizmor reports findings against them.
       - name: Checkout devalue
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: sveltejs/devalue
-          ref: v5.8.2
-          path: .devalue-upstream
-          persist-credentials: false
+        run: >-
+          git clone --depth 1 --branch v5.9.0
+          https://github.com/sveltejs/devalue.git "$RUNNER_TEMP/devalue"
 
       - name: Sync dependencies
         run: uv sync --all-packages --locked --python ${{ matrix.python-version }}
@@ -67,7 +68,7 @@ jobs:
       - name: Test
         run: ./scripts/test.sh
         env:
-          VERCEL_DEVALUE_JS: ${{ github.workspace }}/.devalue-upstream
+          VERCEL_DEVALUE_JS: ${{ runner.temp }}/devalue
 
       - name: Build package
         run: ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
         with:
           enable-cache: false
 
+      # The devalue interop tests run the real JS package against the Python
+      # port. They skip when node is absent locally, but are mandatory here.
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
       - name: Sync dependencies
         run: uv sync --all-packages --locked --python ${{ matrix.python-version }}
 

--- a/src/vercel/_internal/devalue/__init__.py
+++ b/src/vercel/_internal/devalue/__init__.py
@@ -1,6 +1,6 @@
 """Minimal Python port of the JavaScript *devalue* serialization library.
 
-Wire-format compatible with https://github.com/Rich-Harris/devalue — values
+Wire-format compatible with https://github.com/sveltejs/devalue — values
 serialized by Python ``stringify`` can be parsed by JS ``devalue.parse`` and
 vice-versa.
 """

--- a/src/vercel/_internal/devalue/__init__.py
+++ b/src/vercel/_internal/devalue/__init__.py
@@ -7,10 +7,13 @@ vice-versa.
 
 from .parse import parse, unflatten
 from .stringify import stringify
-from .utils import DevalueError, Undefined
+from .utils import DevalueError, Hole, JsBigInt, JsRegExp, Undefined
 
 __all__ = [
     "DevalueError",
+    "Hole",
+    "JsBigInt",
+    "JsRegExp",
     "Undefined",
     "parse",
     "stringify",

--- a/src/vercel/_internal/devalue/__init__.py
+++ b/src/vercel/_internal/devalue/__init__.py
@@ -1,0 +1,18 @@
+"""Minimal Python port of the JavaScript *devalue* serialization library.
+
+Wire-format compatible with https://github.com/Rich-Harris/devalue — values
+serialized by Python ``stringify`` can be parsed by JS ``devalue.parse`` and
+vice-versa.
+"""
+
+from .parse import parse, unflatten
+from .stringify import stringify
+from .utils import DevalueError, Undefined
+
+__all__ = [
+    "DevalueError",
+    "Undefined",
+    "parse",
+    "stringify",
+    "unflatten",
+]

--- a/src/vercel/_internal/devalue/constants.py
+++ b/src/vercel/_internal/devalue/constants.py
@@ -1,0 +1,26 @@
+"""Constants matching the JavaScript devalue library wire format."""
+
+UNDEFINED = -1
+HOLE = -2
+NAN = -3
+POSITIVE_INFINITY = -4
+NEGATIVE_INFINITY = -5
+NEGATIVE_ZERO = -6
+SPARSE = -7
+
+# The largest valid value for a JavaScript array's `length` property,
+# and the largest valid array index (one less than the max length).
+MAX_ARRAY_LEN = 2**32 - 1
+MAX_ARRAY_INDEX = MAX_ARRAY_LEN - 1
+
+# The largest exactly-representable integer in a JS `number`.  Python ints
+# beyond this range are serialized as `["BigInt", …]` so that JS `parse`
+# recovers the exact value instead of a rounded float.
+MAX_SAFE_INTEGER = 2**53 - 1
+
+# JS hydrates a sparse array into a dictionary-mode array, so a declared
+# length costs nothing until the slots are populated.  Python lists are
+# dense, so `[Undefined] * length` allocates eagerly and a tiny payload such
+# as `[[-7,4294967295]]` would demand tens of gigabytes.  Reject declared
+# lengths above this bound rather than trying to honour them.
+MAX_SPARSE_ARRAY_LENGTH = 2**22

--- a/src/vercel/_internal/devalue/parse.py
+++ b/src/vercel/_internal/devalue/parse.py
@@ -1,0 +1,349 @@
+"""Parse devalue JSON wire format back into Python values."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re as re_module
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from .constants import (
+    HOLE,
+    MAX_SPARSE_ARRAY_LENGTH,
+    NAN,
+    NEGATIVE_INFINITY,
+    NEGATIVE_ZERO,
+    POSITIVE_INFINITY,
+    SPARSE,
+    UNDEFINED,
+)
+from .utils import Undefined, is_js_integer, is_valid_array_index, is_valid_array_len
+
+
+def parse(serialized: str, revivers: dict[str, Callable] | None = None) -> Any:
+    """Deserialize a string produced by ``devalue.stringify`` (JS or Python).
+
+    *revivers* is an optional dict mapping custom type tags to functions
+    that receive the hydrated inner value and return the final object.
+    """
+    return unflatten(json.loads(serialized), revivers)
+
+
+def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
+    """Hydrate an already-JSON-parsed value produced by ``devalue.stringify``.
+
+    Accepts either a negative integer (for special top-level values such as
+    ``undefined`` or ``NaN``) or a list (the flattened representation).
+
+    Input is untrusted: an index that does not address a slot hydrates to
+    ``Undefined`` (as it does in JS), and a sparse array declaring more than
+    ``MAX_SPARSE_ARRAY_LENGTH`` slots is rejected rather than allocated.
+    """
+    if isinstance(parsed, (int, float)) and not isinstance(parsed, bool):
+        return _hydrate_toplevel(parsed)
+
+    if not isinstance(parsed, list) or len(parsed) == 0:
+        raise ValueError("Invalid input")
+
+    values: list[Any] = parsed
+    hydrated: dict[int, Any] = {}
+    hydrating: set[int] | None = None
+
+    def hydrate(index: Any, standalone: bool = False) -> Any:
+        nonlocal hydrating
+
+        # Special sentinel constants
+        if index == UNDEFINED:
+            return Undefined
+        if index == NAN:
+            return float("nan")
+        if index == POSITIVE_INFINITY:
+            return float("inf")
+        if index == NEGATIVE_INFINITY:
+            return float("-inf")
+        if index == NEGATIVE_ZERO:
+            return -0.0
+
+        if standalone or not isinstance(index, (int, float)) or isinstance(index, bool):
+            raise ValueError("Invalid input")
+
+        # A non-integral index can never address a slot; JS reads `undefined`
+        # from the gap rather than truncating towards one.  Checked before the
+        # cache because such an index resolves to `Undefined` either way.
+        if not is_js_integer(index):
+            return Undefined
+
+        index = int(index)
+
+        if index in hydrated:
+            return hydrated[index]
+
+        # JS reads out-of-range indexes off the end of the array and gets
+        # `undefined`.  Python would wrap a negative index around to a real
+        # element (silently returning the wrong value) or raise IndexError.
+        if index < 0 or index >= len(values):
+            hydrated[index] = Undefined
+            return Undefined
+
+        value = values[index]
+
+        # --- scalar (not a dict or list) → store directly ---
+        if not isinstance(value, (dict, list)):
+            hydrated[index] = value
+        # --- list-encoded values ---
+        elif isinstance(value, list):
+            if len(value) > 0 and isinstance(value[0], str):
+                _hydrate_typed(index, value, hydrate, hydrated, values, revivers, hydrating)
+                # hydrating might have been mutated – re-read from the closure
+            elif len(value) > 0 and value[0] == SPARSE:
+                _hydrate_sparse(index, value, hydrate, hydrated)
+            else:
+                _hydrate_dense(index, value, hydrate, hydrated)
+        # --- plain dict ---
+        else:
+            obj: dict[str, Any] = {}
+            hydrated[index] = obj
+            for key in value:
+                if key == "__proto__":
+                    raise ValueError("Cannot parse an object with a `__proto__` property")
+                obj[key] = hydrate(value[key])
+
+        return hydrated[index]
+
+    # ---------- typed value dispatcher ----------
+
+    def _hydrate_typed(
+        index: int,
+        value: list,
+        hydrate: Callable,
+        hydrated: dict,
+        values: list,
+        revivers: dict | None,
+        outer_hydrating: set | None,
+    ) -> None:
+        nonlocal hydrating
+        type_name: str = value[0]
+
+        # --- custom reviver? ---
+        reviver = revivers.get(type_name) if revivers else None
+        if reviver is not None:
+            i = value[1]
+            if not isinstance(i, (int, float)) or isinstance(i, bool):
+                values.append(value[1])
+                i = len(values) - 1
+
+            # If the payload is already hydrated, its recursion has already
+            # terminated (e.g. a self-referential object cached itself before
+            # following its own back-reference), so revive it directly.
+            # Falling through to the `hydrating` guard here would wrongly
+            # reject a valid cycle.  An actually infinite payload (e.g.
+            # `[["Custom", 0]]`) is never cached, so it still hits the guard.
+            if i in hydrated:
+                hydrated[index] = reviver(hydrated[i])
+                return
+
+            if hydrating is None:
+                hydrating = set()
+
+            if i in hydrating:
+                raise ValueError("Invalid circular reference")
+
+            hydrating.add(i)
+            hydrated[index] = reviver(hydrate(i))
+            hydrating.discard(i)
+            return
+
+        # --- built-in types ---
+        if type_name == "Date":
+            date_str = value[1]
+            if not date_str:
+                hydrated[index] = None
+            else:
+                hydrated[index] = _parse_iso_date(date_str)
+
+        elif type_name == "Set":
+            s: set[Any] = set()
+            hydrated[index] = s
+            for i in range(1, len(value)):
+                s.add(hydrate(value[i]))
+
+        elif type_name == "Map":
+            d: dict[Any, Any] = {}
+            hydrated[index] = d
+            for i in range(1, len(value), 2):
+                k = hydrate(value[i])
+                v = hydrate(value[i + 1])
+                d[k] = v
+
+        elif type_name == "RegExp":
+            pattern = value[1]
+            flags_str = value[2] if len(value) > 2 else ""
+            py_flags = _js_flags_to_py(flags_str)
+            hydrated[index] = re_module.compile(pattern, py_flags)
+
+        elif type_name == "Object":
+            wrapped_index = value[1]
+            wrapped_raw = values[wrapped_index] if isinstance(wrapped_index, int) else None
+            if isinstance(wrapped_raw, (dict, list)) and not (
+                isinstance(wrapped_raw, list)
+                and len(wrapped_raw) > 0
+                and wrapped_raw[0] == "BigInt"
+            ):
+                raise ValueError("Invalid input")
+            hydrated[index] = hydrate(wrapped_index)
+
+        elif type_name == "BigInt":
+            hydrated[index] = int(value[1])
+
+        elif type_name == "null":
+            obj: dict[str, Any] = {}
+            hydrated[index] = obj
+            for i in range(1, len(value), 2):
+                k = value[i]
+                if k == "__proto__":
+                    raise ValueError("Cannot parse an object with a `__proto__` property")
+                obj[k] = hydrate(value[i + 1])
+
+        elif type_name == "ArrayBuffer":
+            b64 = value[1]
+            if not isinstance(b64, str):
+                raise ValueError("Invalid ArrayBuffer encoding")
+            hydrated[index] = base64.b64decode(b64)
+
+        elif type_name in _TYPED_ARRAY_TYPES:
+            ref_idx = value[1]
+            ref_val = (
+                values[ref_idx] if isinstance(ref_idx, int) and 0 <= ref_idx < len(values) else None
+            )
+            if not (isinstance(ref_val, list) and len(ref_val) > 0 and ref_val[0] == "ArrayBuffer"):
+                raise ValueError("Invalid data")
+            buf = hydrate(value[1])
+            if len(value) > 2:
+                byte_offset = value[2]
+                elem_count = value[3]
+                if type_name == "DataView":
+                    hydrated[index] = buf[byte_offset : byte_offset + elem_count]
+                else:
+                    bpe = _BYTES_PER_ELEMENT.get(type_name, 1)
+                    hydrated[index] = buf[byte_offset : byte_offset + elem_count * bpe]
+            else:
+                hydrated[index] = buf
+
+        elif type_name == "URL":
+            hydrated[index] = value[1]
+
+        elif type_name == "URLSearchParams":
+            hydrated[index] = value[1]
+
+        elif type_name.startswith("Temporal."):
+            hydrated[index] = value[1]
+
+        else:
+            raise ValueError(f"Unknown type {type_name}")
+
+    return hydrate(0)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_BYTES_PER_ELEMENT: dict[str, int] = {
+    "Int8Array": 1,
+    "Uint8Array": 1,
+    "Uint8ClampedArray": 1,
+    "Int16Array": 2,
+    "Uint16Array": 2,
+    "Float16Array": 2,
+    "Int32Array": 4,
+    "Uint32Array": 4,
+    "Float32Array": 4,
+    "Float64Array": 8,
+    "BigInt64Array": 8,
+    "BigUint64Array": 8,
+}
+
+_TYPED_ARRAY_TYPES: set[str] = set(_BYTES_PER_ELEMENT) | {"DataView"}
+
+
+def _hydrate_toplevel(n: int | float) -> Any:
+    """Return the Python equivalent for a top-level special constant."""
+    if n == UNDEFINED:
+        return Undefined
+    if n == NAN:
+        return float("nan")
+    if n == POSITIVE_INFINITY:
+        return float("inf")
+    if n == NEGATIVE_INFINITY:
+        return float("-inf")
+    if n == NEGATIVE_ZERO:
+        return -0.0
+    raise ValueError("Invalid input")
+
+
+def _hydrate_sparse(
+    index: int,
+    value: list,
+    hydrate: Callable,
+    hydrated: dict,
+) -> None:
+    """Hydrate a sparse-array encoding ``[SPARSE, length, idx, val, …]``."""
+    raw_length = value[1]
+    if not is_valid_array_len(raw_length):
+        raise ValueError("Invalid input")
+
+    length = int(raw_length)
+    if length > MAX_SPARSE_ARRAY_LENGTH:
+        # `length` comes from the input rather than being bounded by it, so
+        # honouring it would let a few bytes of payload allocate arbitrary
+        # memory.  See MAX_SPARSE_ARRAY_LENGTH for why Python cannot do what
+        # JS does here.
+        raise ValueError(
+            f"Sparse array length {length} exceeds the maximum of {MAX_SPARSE_ARRAY_LENGTH}"
+        )
+
+    array: list[Any] = [Undefined] * length
+    hydrated[index] = array
+    for i in range(2, len(value), 2):
+        idx = value[i]
+        if not is_valid_array_index(idx) or idx >= length:
+            raise ValueError("Invalid input")
+        array[int(idx)] = hydrate(value[i + 1])
+
+
+def _hydrate_dense(
+    index: int,
+    value: list,
+    hydrate: Callable,
+    hydrated: dict,
+) -> None:
+    """Hydrate a dense array (may contain ``HOLE`` sentinels)."""
+    array: list[Any] = [Undefined] * len(value)
+    hydrated[index] = array
+    for i, n in enumerate(value):
+        if n == HOLE:
+            continue  # leave as Undefined
+        array[i] = hydrate(n)
+
+
+def _parse_iso_date(s: str) -> datetime:
+    """Parse a JS ``Date.toISOString()`` string into a Python datetime."""
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def _js_flags_to_py(flags_str: str) -> int:
+    """Convert a JS regex flag string (e.g. ``"gim"``) to Python ``re`` flags."""
+    result = 0
+    for c in flags_str:
+        if c == "i":
+            result |= re_module.IGNORECASE
+        elif c == "m":
+            result |= re_module.MULTILINE
+        elif c == "s":
+            result |= re_module.DOTALL
+        # 'g', 'u', 'y', 'd' have no Python equivalent — silently ignored
+    return result

--- a/src/vercel/_internal/devalue/parse.py
+++ b/src/vercel/_internal/devalue/parse.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import json
-import re as re_module
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -19,7 +18,14 @@ from .constants import (
     SPARSE,
     UNDEFINED,
 )
-from .utils import Undefined, is_js_integer, is_valid_array_index, is_valid_array_len
+from .utils import (
+    Hole,
+    JsBigInt,
+    JsRegExp,
+    Undefined,
+    is_valid_array_index,
+    is_valid_array_len,
+)
 
 
 def parse(serialized: str, revivers: dict[str, Callable] | None = None) -> Any:
@@ -69,13 +75,11 @@ def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
         if standalone or not isinstance(index, (int, float)) or isinstance(index, bool):
             raise ValueError("Invalid input")
 
-        # A non-integral index can never address a slot; JS reads `undefined`
-        # from the gap rather than truncating towards one.  Checked before the
-        # cache because such an index resolves to `Undefined` either way.
-        if not is_js_integer(index):
+        # A float index addresses no slot; JS reads `undefined` from the gap
+        # rather than truncating towards one. Checked before the cache
+        # because such an index resolves to `Undefined` either way.
+        if not isinstance(index, int):
             return Undefined
-
-        index = int(index)
 
         if index in hydrated:
             return hydrated[index]
@@ -180,12 +184,18 @@ def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
         elif type_name == "RegExp":
             pattern = value[1]
             flags_str = value[2] if len(value) > 2 else ""
-            py_flags = _js_flags_to_py(flags_str)
-            hydrated[index] = re_module.compile(pattern, py_flags)
+            hydrated[index] = JsRegExp(pattern, flags_str)
 
         elif type_name == "Object":
             wrapped_index = value[1]
-            wrapped_raw = values[wrapped_index] if isinstance(wrapped_index, int) else None
+            # A boxed special value carries a negative sentinel here (`-3` for
+            # NaN, `-6` for -0, …), and JS reads an out-of-range index as
+            # `undefined` rather than wrapping around to a real element.
+            wrapped_raw = (
+                values[wrapped_index]
+                if isinstance(wrapped_index, int) and 0 <= wrapped_index < len(values)
+                else None
+            )
             if isinstance(wrapped_raw, (dict, list)) and not (
                 isinstance(wrapped_raw, list)
                 and len(wrapped_raw) > 0
@@ -195,7 +205,7 @@ def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
             hydrated[index] = hydrate(wrapped_index)
 
         elif type_name == "BigInt":
-            hydrated[index] = int(value[1])
+            hydrated[index] = JsBigInt(value[1])
 
         elif type_name == "null":
             obj: dict[str, Any] = {}
@@ -290,11 +300,10 @@ def _hydrate_sparse(
     hydrated: dict,
 ) -> None:
     """Hydrate a sparse-array encoding ``[SPARSE, length, idx, val, …]``."""
-    raw_length = value[1]
-    if not is_valid_array_len(raw_length):
+    length = value[1]
+    if not is_valid_array_len(length):
         raise ValueError("Invalid input")
 
-    length = int(raw_length)
     if length > MAX_SPARSE_ARRAY_LENGTH:
         # `length` comes from the input rather than being bounded by it, so
         # honouring it would let a few bytes of payload allocate arbitrary
@@ -304,13 +313,13 @@ def _hydrate_sparse(
             f"Sparse array length {length} exceeds the maximum of {MAX_SPARSE_ARRAY_LENGTH}"
         )
 
-    array: list[Any] = [Undefined] * length
+    array: list[Any] = [Hole] * length
     hydrated[index] = array
     for i in range(2, len(value), 2):
         idx = value[i]
         if not is_valid_array_index(idx) or idx >= length:
             raise ValueError("Invalid input")
-        array[int(idx)] = hydrate(value[i + 1])
+        array[idx] = hydrate(value[i + 1])
 
 
 def _hydrate_dense(
@@ -320,11 +329,11 @@ def _hydrate_dense(
     hydrated: dict,
 ) -> None:
     """Hydrate a dense array (may contain ``HOLE`` sentinels)."""
-    array: list[Any] = [Undefined] * len(value)
+    array: list[Any] = [Hole] * len(value)
     hydrated[index] = array
     for i, n in enumerate(value):
         if n == HOLE:
-            continue  # leave as Undefined
+            continue  # leave as Hole
         array[i] = hydrate(n)
 
 
@@ -333,17 +342,3 @@ def _parse_iso_date(s: str) -> datetime:
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
     return datetime.fromisoformat(s)
-
-
-def _js_flags_to_py(flags_str: str) -> int:
-    """Convert a JS regex flag string (e.g. ``"gim"``) to Python ``re`` flags."""
-    result = 0
-    for c in flags_str:
-        if c == "i":
-            result |= re_module.IGNORECASE
-        elif c == "m":
-            result |= re_module.MULTILINE
-        elif c == "s":
-            result |= re_module.DOTALL
-        # 'g', 'u', 'y', 'd' have no Python equivalent — silently ignored
-    return result

--- a/src/vercel/_internal/devalue/stringify.py
+++ b/src/vercel/_internal/devalue/stringify.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from .constants import (
+    HOLE,
     MAX_SAFE_INTEGER,
     NAN,
     NEGATIVE_INFINITY,
@@ -17,7 +18,16 @@ from .constants import (
     POSITIVE_INFINITY,
     UNDEFINED,
 )
-from .utils import DevalueError, Undefined, stringify_key, stringify_string
+from .utils import (
+    DevalueError,
+    Hole,
+    JsBigInt,
+    JsRegExp,
+    Undefined,
+    py_flags_to_js,
+    stringify_key,
+    stringify_string,
+)
 
 
 def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
@@ -61,6 +71,8 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
             return ("n",)
         if thing is Undefined:
             return ("u",)
+        if isinstance(thing, JsBigInt):
+            return ("bigint", int(thing))
         if isinstance(thing, int):
             return ("i", thing)
         if isinstance(thing, float):
@@ -75,6 +87,9 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
         # --- special values → negative sentinel constants ---
         if thing is Undefined:
             return UNDEFINED
+        if thing is Hole:
+            # Only an array slot can be a hole; the array branch handles it.
+            raise DevalueError("Cannot stringify a hole outside an array", keys, thing, value)
         if isinstance(thing, float):
             if math.isnan(thing):
                 return NAN
@@ -119,6 +134,9 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
             for i, item in enumerate(thing):
                 if i > 0:
                     parts.append(",")
+                if item is Hole:
+                    parts.append(str(HOLE))
+                    continue
                 keys.append(f"[{i}]")
                 parts.append(str(flatten(item)))
                 keys.pop()
@@ -176,10 +194,15 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
             stringified[index] = f'["Date","{iso}"]'
             return index
 
-        # --- re.Pattern → RegExp ---
-        if isinstance(thing, re_module.Pattern):
-            source = thing.pattern
-            flags_str = _py_re_flags_to_js(thing.flags)
+        # --- JsRegExp / re.Pattern → RegExp ---
+        if isinstance(thing, (JsRegExp, re_module.Pattern)):
+            if isinstance(thing, JsRegExp):
+                source, flags_str = thing.source, thing.flags
+            else:
+                # Best effort: a Python pattern is not a JS one, so this can
+                # produce a source the far side refuses to compile.
+                source = thing.pattern
+                flags_str = py_flags_to_js(thing.flags)
             if flags_str:
                 stringified[index] = f'["RegExp",{stringify_string(source)},"{flags_str}"]'
             else:
@@ -236,6 +259,8 @@ def _stringify_primitive(thing: Any) -> str:
     # bool MUST be checked before int (bool is a subclass of int)
     if isinstance(thing, bool):
         return "true" if thing else "false"
+    if isinstance(thing, JsBigInt):
+        return f'["BigInt","{int(thing)}"]'
     if isinstance(thing, int):
         # A JS `number` cannot hold these exactly, so emitting a bare JSON
         # number would silently round-trip as a different value.  Any integer
@@ -247,15 +272,3 @@ def _stringify_primitive(thing: Any) -> str:
         # NaN / Inf / -Inf / -0 are handled before reaching here
         return repr(thing)
     return str(thing)  # pragma: no cover
-
-
-def _py_re_flags_to_js(flags: int) -> str:
-    """Convert Python regex flags to a JS-style flag string (e.g. ``"gim"``)."""
-    result = ""
-    if flags & re_module.IGNORECASE:
-        result += "i"
-    if flags & re_module.MULTILINE:
-        result += "m"
-    if flags & re_module.DOTALL:
-        result += "s"
-    return result

--- a/src/vercel/_internal/devalue/stringify.py
+++ b/src/vercel/_internal/devalue/stringify.py
@@ -1,0 +1,261 @@
+"""Serialize Python values into the devalue JSON wire format."""
+
+from __future__ import annotations
+
+import base64
+import math
+import re as re_module
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from .constants import (
+    MAX_SAFE_INTEGER,
+    NAN,
+    NEGATIVE_INFINITY,
+    NEGATIVE_ZERO,
+    POSITIVE_INFINITY,
+    UNDEFINED,
+)
+from .utils import DevalueError, Undefined, stringify_key, stringify_string
+
+
+def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
+    """Serialize *value* into a JSON string compatible with JS ``devalue.parse``.
+
+    Supports: ``None``, ``bool``, ``int``, ``float`` (including NaN / ±Inf /
+    −0), ``str``, ``list``, ``tuple``, ``dict`` (string keys only), ``set``,
+    ``frozenset``, ``datetime``, ``re.Pattern``, ``bytes``, ``bytearray``,
+    and the ``Undefined`` sentinel.
+
+    Cyclic and repeated references are handled automatically.  Integers
+    outside the JS safe range are emitted as ``["BigInt", …]``, since a bare
+    JSON number would not survive the trip through a JS ``number``.
+
+    *reducers* is an optional dict mapping type tags to functions.  Each
+    function receives a value and should return a replacement value for the
+    values it handles, or a falsy one to decline.  Truthiness follows JS, not
+    Python: ``{}``, ``[]`` and ``set()`` claim the value, while ``NaN`` and
+    ``-0.0`` decline.
+    """
+    stringified: dict[int, str] = {}
+    # Maps a key from `_make_key` to `(index, value)`.  JS keys its index Map
+    # by the value itself, which gives objects reference identity and keeps
+    # them alive.  A dict cannot do that — it would merge distinct-but-equal
+    # objects and reject unhashable ones — so object keys use `id()` instead,
+    # and each entry holds the value so that its address cannot be recycled
+    # while the key is live.
+    indexes: dict[Any, tuple[int, Any]] = {}
+    custom: list[tuple[str, Callable]] = []
+    if reducers:
+        for key in reducers:
+            custom.append((key, reducers[key]))
+    keys: list[str] = []
+    p = 0
+
+    def _make_key(thing: Any) -> Any:
+        """Build a dict key that distinguishes ``bool`` from ``int``."""
+        if isinstance(thing, bool):
+            return ("b", thing)
+        if thing is None:
+            return ("n",)
+        if thing is Undefined:
+            return ("u",)
+        if isinstance(thing, int):
+            return ("i", thing)
+        if isinstance(thing, float):
+            return ("f", thing)
+        if isinstance(thing, str):
+            return ("s", thing)
+        return ("o", id(thing))
+
+    def flatten(thing: Any, index: int | None = None) -> int:
+        nonlocal p
+
+        # --- special values → negative sentinel constants ---
+        if thing is Undefined:
+            return UNDEFINED
+        if isinstance(thing, float):
+            if math.isnan(thing):
+                return NAN
+            if thing == float("inf"):
+                return POSITIVE_INFINITY
+            if thing == float("-inf"):
+                return NEGATIVE_INFINITY
+            if thing == 0.0 and math.copysign(1.0, thing) < 0:
+                return NEGATIVE_ZERO
+
+        # --- already indexed → reuse ---
+        key = _make_key(thing)
+        entry = indexes.get(key)
+        if entry is not None:
+            return entry[0]
+
+        # --- assign a fresh index ---
+        if index is None:
+            index = p
+            p += 1
+        indexes[key] = (index, thing)
+
+        # --- custom reducers ---
+        for reducer_key, fn in custom:
+            reduced = fn(thing)
+            if _is_js_truthy(reduced):
+                stringified[index] = f'["{reducer_key}",{flatten(reduced)}]'
+                return index
+
+        # --- callable (functions, lambdas) ---
+        if callable(thing) and not isinstance(thing, type):
+            raise DevalueError("Cannot stringify a function", keys, thing, value)
+
+        # --- primitives ---
+        if thing is None or isinstance(thing, (bool, int, float, str)):
+            stringified[index] = _stringify_primitive(thing)
+            return index
+
+        # --- list / tuple → Array ---
+        if isinstance(thing, (list, tuple)):
+            parts = ["["]
+            for i, item in enumerate(thing):
+                if i > 0:
+                    parts.append(",")
+                keys.append(f"[{i}]")
+                parts.append(str(flatten(item)))
+                keys.pop()
+            parts.append("]")
+            stringified[index] = "".join(parts)
+            return index
+
+        # --- dict → Object ---
+        if isinstance(thing, dict):
+            for k in thing:
+                if not isinstance(k, str):
+                    raise DevalueError(
+                        "Cannot stringify objects with non-string keys",
+                        keys,
+                        thing,
+                        value,
+                    )
+                if k == "__proto__":
+                    raise DevalueError(
+                        "Cannot stringify objects with __proto__ keys",
+                        keys,
+                        thing,
+                        value,
+                    )
+            parts = ["{"]
+            started = False
+            for k, v in thing.items():
+                if started:
+                    parts.append(",")
+                started = True
+                keys.append(stringify_key(k))
+                parts.append(f"{stringify_string(k)}:{flatten(v)}")
+                keys.pop()
+            parts.append("}")
+            stringified[index] = "".join(parts)
+            return index
+
+        # --- set / frozenset → Set ---
+        if isinstance(thing, (set, frozenset)):
+            parts = ['["Set"']
+            for item in thing:
+                parts.append(f",{flatten(item)}")
+            parts.append("]")
+            stringified[index] = "".join(parts)
+            return index
+
+        # --- datetime → Date ---
+        if isinstance(thing, datetime):
+            if thing.tzinfo is not None:
+                utc_dt = thing.astimezone(timezone.utc)
+            else:
+                utc_dt = thing
+            ms = utc_dt.microsecond // 1000
+            iso = utc_dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{ms:03d}Z"
+            stringified[index] = f'["Date","{iso}"]'
+            return index
+
+        # --- re.Pattern → RegExp ---
+        if isinstance(thing, re_module.Pattern):
+            source = thing.pattern
+            flags_str = _py_re_flags_to_js(thing.flags)
+            if flags_str:
+                stringified[index] = f'["RegExp",{stringify_string(source)},"{flags_str}"]'
+            else:
+                stringified[index] = f'["RegExp",{stringify_string(source)}]'
+            return index
+
+        # --- bytes / bytearray → ArrayBuffer ---
+        if isinstance(thing, (bytes, bytearray, memoryview)):
+            raw = bytes(thing)
+            b64 = base64.b64encode(raw).decode("ascii")
+            stringified[index] = f'["ArrayBuffer","{b64}"]'
+            return index
+
+        raise DevalueError("Cannot stringify arbitrary non-POJOs", keys, thing, value)
+
+    idx = flatten(value)
+
+    # Special value (encoded as a negative number with no array wrapper)
+    if idx < 0:
+        return str(idx)
+
+    parts = [stringified[i] for i in range(p)]
+    return "[" + ",".join(parts) + "]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_js_truthy(thing: Any) -> bool:
+    """Mirror JS truthiness, which decides whether a reducer claimed a value.
+
+    Differs from Python's in both directions: empty containers are truthy in
+    JS, while ``NaN`` and ``-0.0`` are falsy.
+    """
+    if thing is None or thing is Undefined or thing is False:
+        return False
+    if isinstance(thing, str):
+        return thing != ""
+    if isinstance(thing, bool):
+        return thing
+    if isinstance(thing, (int, float)):
+        return not (thing == 0 or (isinstance(thing, float) and math.isnan(thing)))
+    return True
+
+
+def _stringify_primitive(thing: Any) -> str:
+    """Return the JSON-compatible representation of a Python primitive."""
+    if isinstance(thing, str):
+        return stringify_string(thing)
+    if thing is None:
+        return "null"
+    # bool MUST be checked before int (bool is a subclass of int)
+    if isinstance(thing, bool):
+        return "true" if thing else "false"
+    if isinstance(thing, int):
+        # A JS `number` cannot hold these exactly, so emitting a bare JSON
+        # number would silently round-trip as a different value.  Any integer
+        # this large is a `bigint` on the JS side anyway.
+        if not -MAX_SAFE_INTEGER <= thing <= MAX_SAFE_INTEGER:
+            return f'["BigInt","{thing}"]'
+        return str(thing)
+    if isinstance(thing, float):
+        # NaN / Inf / -Inf / -0 are handled before reaching here
+        return repr(thing)
+    return str(thing)  # pragma: no cover
+
+
+def _py_re_flags_to_js(flags: int) -> str:
+    """Convert Python regex flags to a JS-style flag string (e.g. ``"gim"``)."""
+    result = ""
+    if flags & re_module.IGNORECASE:
+        result += "i"
+    if flags & re_module.MULTILINE:
+        result += "m"
+    if flags & re_module.DOTALL:
+        result += "s"
+    return result

--- a/src/vercel/_internal/devalue/utils.py
+++ b/src/vercel/_internal/devalue/utils.py
@@ -1,0 +1,122 @@
+"""Shared utilities for the devalue serialization library."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import TypeGuard
+
+from .constants import MAX_ARRAY_INDEX, MAX_ARRAY_LEN
+
+
+class _UndefinedType:
+    """Singleton sentinel representing JavaScript's ``undefined``."""
+
+    _instance: _UndefinedType | None = None
+
+    def __new__(cls) -> _UndefinedType:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "Undefined"
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return hash("Undefined")
+
+
+Undefined = _UndefinedType()
+
+
+class DevalueError(Exception):
+    """Error raised when a value cannot be serialized by devalue."""
+
+    def __init__(
+        self,
+        message: str,
+        keys: list[str],
+        value: object = None,
+        root: object = None,
+    ) -> None:
+        super().__init__(message)
+        self.name = "DevalueError"
+        self.path = "".join(keys)
+        self.value = value
+        self.root = root
+
+
+def stringify_string(s: str) -> str:
+    """Escape and double-quote a string, matching JS devalue's escaping.
+
+    Escapes ``<``, ``\\``, quotes, control characters, and U+2028/U+2029
+    to produce output safe for embedding in ``<script>`` tags.
+    """
+    parts: list[str] = []
+    for ch in s:
+        cp = ord(ch)
+        if ch == '"':
+            parts.append('\\"')
+        elif ch == "<":
+            parts.append("\\u003C")
+        elif ch == "\\":
+            parts.append("\\\\")
+        elif ch == "\n":
+            parts.append("\\n")
+        elif ch == "\r":
+            parts.append("\\r")
+        elif ch == "\t":
+            parts.append("\\t")
+        elif ch == "\b":
+            parts.append("\\b")
+        elif ch == "\f":
+            parts.append("\\f")
+        elif ch == "\u2028":
+            parts.append("\\u2028")
+        elif ch == "\u2029":
+            parts.append("\\u2029")
+        elif cp < 0x20:
+            parts.append(f"\\u{cp:04x}")
+        else:
+            parts.append(ch)
+    return '"' + "".join(parts) + '"'
+
+
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_$][a-zA-Z_$0-9]*$")
+
+
+def stringify_key(key: str) -> str:
+    """Format an object key for error path display."""
+    if _IDENTIFIER_RE.match(key):
+        return "." + key
+    return "[" + json.dumps(key) + "]"
+
+
+def is_js_integer(n: object) -> TypeGuard[int | float]:
+    """Mirror of JS ``Number.isInteger``.
+
+    JSON numbers reach Python as ``int`` or ``float``, so ``3.0`` must be
+    accepted as an integer the way it is in JS.  ``bool`` is excluded because
+    it is not a number on the JS side.
+    """
+    if isinstance(n, bool):
+        return False
+    if isinstance(n, int):
+        return True
+    if isinstance(n, float):
+        return math.isfinite(n) and n.is_integer()
+    return False
+
+
+def is_valid_array_index(n: object) -> bool:
+    """Mirror of JS ``is_valid_array_index``."""
+    return is_js_integer(n) and 0 <= n <= MAX_ARRAY_INDEX
+
+
+def is_valid_array_len(n: object) -> bool:
+    """Mirror of JS ``is_valid_array_len``."""
+    return is_js_integer(n) and 0 <= n <= MAX_ARRAY_LEN

--- a/src/vercel/_internal/devalue/utils.py
+++ b/src/vercel/_internal/devalue/utils.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json
-import math
 import re
-from typing import TypeGuard
 
 from .constants import MAX_ARRAY_INDEX, MAX_ARRAY_LEN
 
@@ -31,6 +29,115 @@ class _UndefinedType:
 
 
 Undefined = _UndefinedType()
+
+
+class _HoleType:
+    """Singleton sentinel for a missing array slot.
+
+    JS distinguishes an array *hole* from a slot holding ``undefined`` — the
+    former is absent from ``Object.keys`` and devalue gives it its own wire
+    sentinel — so collapsing both onto ``Undefined`` would silently rewrite
+    ``[, 1]`` as ``[undefined, 1]`` on the way back out.
+    """
+
+    _instance: _HoleType | None = None
+
+    def __new__(cls) -> _HoleType:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "Hole"
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return hash("Hole")
+
+
+Hole = _HoleType()
+
+
+class JsBigInt(int):
+    """A JavaScript ``bigint``.
+
+    Subclasses ``int`` so it compares and computes like one; the distinct type
+    only records that the far side used ``bigint`` rather than ``number``.
+    Without it every small ``bigint`` would come back as a plain ``number``,
+    because the port can otherwise only infer "must be a bigint" from an
+    integer being too large for a JS ``number``.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return f"JsBigInt({int(self)})"
+
+
+class JsRegExp:
+    """A JavaScript regular expression, kept as source plus flags.
+
+    Deliberately *not* compiled with ``re``. The two flavours are neither
+    syntax- nor semantics-compatible: patterns JS accepts can fail to compile
+    in Python (``(?<name>…)``, ``\\p{…}``, ``\\cX``, ``[]``), and some that do
+    compile mean different things (``\\d`` is ASCII-only in JS, ``a{,3}`` is a
+    literal in JS but a quantifier in Python). Holding the source verbatim
+    keeps the value round-trippable and keeps ``parse`` from raising on input
+    the far side considers valid.
+
+    Call :meth:`compile` to opt into a Python pattern, accepting those caveats.
+    """
+
+    __slots__ = ("flags", "source")
+
+    def __init__(self, source: str, flags: str = "") -> None:
+        self.source = source
+        self.flags = flags
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, JsRegExp)
+            and other.source == self.source
+            and other.flags == self.flags
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.source, self.flags))
+
+    def __repr__(self) -> str:
+        return f"JsRegExp({self.source!r}, {self.flags!r})"
+
+    def compile(self) -> re.Pattern[str]:
+        """Compile to a Python pattern; may raise ``re.error``, may differ."""
+        return re.compile(self.source, js_flags_to_py(self.flags))
+
+
+def js_flags_to_py(flags: str) -> int:
+    """Map the JS flags that have a Python equivalent; ignore the rest."""
+    result = 0
+    for char in flags:
+        if char == "i":
+            result |= re.IGNORECASE
+        elif char == "m":
+            result |= re.MULTILINE
+        elif char == "s":
+            result |= re.DOTALL
+        # 'g', 'u', 'v', 'y', 'd' have no Python counterpart.
+    return result
+
+
+def py_flags_to_js(flags: int) -> str:
+    """Map Python regex flags to the JS flag string."""
+    result = ""
+    if flags & re.IGNORECASE:
+        result += "i"
+    if flags & re.MULTILINE:
+        result += "m"
+    if flags & re.DOTALL:
+        result += "s"
+    return result
 
 
 class DevalueError(Exception):
@@ -96,27 +203,19 @@ def stringify_key(key: str) -> str:
     return "[" + json.dumps(key) + "]"
 
 
-def is_js_integer(n: object) -> TypeGuard[int | float]:
-    """Mirror of JS ``Number.isInteger``.
-
-    JSON numbers reach Python as ``int`` or ``float``, so ``3.0`` must be
-    accepted as an integer the way it is in JS.  ``bool`` is excluded because
-    it is not a number on the JS side.
-    """
-    if isinstance(n, bool):
-        return False
-    if isinstance(n, int):
-        return True
-    if isinstance(n, float):
-        return math.isfinite(n) and n.is_integer()
-    return False
-
-
 def is_valid_array_index(n: object) -> bool:
-    """Mirror of JS ``is_valid_array_index``."""
-    return is_js_integer(n) and 0 <= n <= MAX_ARRAY_INDEX
+    """Mirror of JS ``is_valid_array_index``.
+
+    JS goes through ``Number.isInteger``, which also accepts an integral
+    float such as ``3.0``. Nothing emits that — devalue and
+    ``JSON.stringify`` format via ``String(number)``, and an index is
+    bounded far below where JS switches to exponent notation — and upstream
+    only ever tests that non-integers are *rejected*, so accepting it is an
+    accident of the implementation rather than part of the format.
+    """
+    return isinstance(n, int) and not isinstance(n, bool) and 0 <= n <= MAX_ARRAY_INDEX
 
 
 def is_valid_array_len(n: object) -> bool:
-    """Mirror of JS ``is_valid_array_len``."""
-    return is_js_integer(n) and 0 <= n <= MAX_ARRAY_LEN
+    """Mirror of JS ``is_valid_array_len``; see is_valid_array_index."""
+    return isinstance(n, int) and not isinstance(n, bool) and 0 <= n <= MAX_ARRAY_LEN

--- a/src/vercel/tests/integration/test_devalue.py
+++ b/src/vercel/tests/integration/test_devalue.py
@@ -59,7 +59,7 @@ _TYPED_ARRAY_TAGS = frozenset(_BYTES_PER_ELEMENT)
 # Pins the npm fallback used when VERCEL_DEVALUE_JS is not set. It has no
 # bearing on an explicit checkout, which is deliberately free to be any
 # version — testing against a different one is the point of the override.
-DEVALUE_VERSION = "5.8.2"
+DEVALUE_VERSION = "5.9.0"
 
 _IS_CI = bool(os.getenv("CI"))
 

--- a/src/vercel/tests/integration/test_devalue.py
+++ b/src/vercel/tests/integration/test_devalue.py
@@ -41,10 +41,24 @@ from typing import Any
 
 import pytest
 
-from vercel._internal.devalue import Undefined, parse, stringify
+from vercel._internal.devalue import Hole, JsBigInt, JsRegExp, Undefined, parse, stringify
+from vercel._internal.devalue.constants import (
+    HOLE,
+    NAN,
+    NEGATIVE_INFINITY,
+    NEGATIVE_ZERO,
+    POSITIVE_INFINITY,
+    SPARSE,
+    UNDEFINED,
+)
+from vercel._internal.devalue.parse import _BYTES_PER_ELEMENT
 
-# The version fetched from npm when VERCEL_DEVALUE_JS is not set.  Keep this in
-# step with the upstream release the port is written against.
+# Every tag devalue uses for an array view; all of them land as plain bytes.
+_TYPED_ARRAY_TAGS = frozenset(_BYTES_PER_ELEMENT)
+
+# Pins the npm fallback used when VERCEL_DEVALUE_JS is not set. It has no
+# bearing on an explicit checkout, which is deliberately free to be any
+# version — testing against a different one is the point of the override.
 DEVALUE_VERSION = "5.8.2"
 
 _IS_CI = bool(os.getenv("CI"))
@@ -314,22 +328,48 @@ ROUND_TRIP_CASES: list[Case] = [
         'new Date("1970-01-01T00:00:00.000Z")',
         datetime(1970, 1, 1, tzinfo=timezone.utc),
     ),
-    Case("regex_no_flags", "/a+b/", re.compile("a+b")),
-    Case("regex_ignorecase", "/a+b/i", re.compile("a+b", re.IGNORECASE)),
+    # A Python pattern is accepted going out, but lands as the container.
+    Case("regex_no_flags", "/a+b/", re.compile("a+b"), expected=JsRegExp("a+b", "")),
+    Case(
+        "regex_ignorecase",
+        "/a+b/i",
+        re.compile("a+b", re.IGNORECASE),
+        expected=JsRegExp("a+b", "i"),
+    ),
     Case(
         "regex_multiline_dotall",
         "/a.b/ms",
         re.compile("a.b", re.MULTILINE | re.DOTALL),
+        expected=JsRegExp("a.b", "ms"),
     ),
+    # Flags and syntax with no Python counterpart: compiling these would
+    # drop `gu` and raise outright on the named group and \p{...}.
+    Case("regex_js_only_flags", "/a+/gu", JsRegExp("a+", "gu")),
+    Case("regex_named_group", r"/(?<y>\d{4})/", JsRegExp(r"(?<y>\d{4})", "")),
+    Case("regex_unicode_property", r"/\p{Letter}/u", JsRegExp(r"\p{Letter}", "u")),
     Case("bytes", "new Uint8Array([0,1,255]).buffer", b"\x00\x01\xff"),
     Case("bytes_empty", "new Uint8Array([]).buffer", b""),
     Case("bytearray", "new Uint8Array([1,2]).buffer", bytearray(b"\x01\x02"), expected=b"\x01\x02"),
     # ── integers across the JS safe boundary ───────────────────────────────
     Case("safe_int_max", "9007199254740991", 2**53 - 1),
     Case("safe_int_min", "-9007199254740991", -(2**53) + 1),
-    Case("unsafe_int_positive", "9007199254740993n", 2**53 + 1),
-    Case("unsafe_int_negative", "-9007199254740993n", -(2**53) - 1),
-    Case("unsafe_int_huge", "123456789012345678901234567890n", 123456789012345678901234567890),
+    # A plain int beyond the safe range has to come back as a bigint.
+    Case("unsafe_int_positive", "9007199254740993n", 2**53 + 1, expected=JsBigInt(2**53 + 1)),
+    Case(
+        "unsafe_int_negative",
+        "-9007199254740993n",
+        -(2**53) - 1,
+        expected=JsBigInt(-(2**53) - 1),
+    ),
+    Case(
+        "unsafe_int_huge",
+        "123456789012345678901234567890n",
+        123456789012345678901234567890,
+        expected=JsBigInt(123456789012345678901234567890),
+    ),
+    # An explicit bigint keeps its tag however small it is.
+    Case("bigint_small", "1n", JsBigInt(1)),
+    Case("bigint_zero", "0n", JsBigInt(0)),
     # ── graph shape ────────────────────────────────────────────────────────
     Case(
         "cycle_dict",
@@ -398,14 +438,19 @@ JS_ORIGIN_CASES: list[Case] = [
     Case(
         "js_array_with_holes",
         '(() => { const a = [, "a", ,]; return a; })()',
-        expected=[Undefined, "a", Undefined],
+        expected=[Hole, "a", Hole],
     ),
     Case(
         "js_sparse_array",
         '(() => { const a = []; a[5] = "x"; return a; })()',
-        expected=[Undefined] * 5 + ["x"],
+        expected=[Hole] * 5 + ["x"],
     ),
-    Case("js_bigint", "123456789012345678901234567890n", expected=123456789012345678901234567890),
+    Case("js_explicit_undefined", "[undefined, 1]", expected=[Undefined, 1]),
+    Case(
+        "js_bigint",
+        "123456789012345678901234567890n",
+        expected=JsBigInt(123456789012345678901234567890),
+    ),
     Case("js_negative_zero_nested", "[0, -0]", expected=[0, -0.0]),
 ]
 
@@ -590,7 +635,306 @@ class TestHarness:
         assert not deep_equal(True, 1)
         assert not deep_equal(1, 1.0)
         assert not deep_equal(Undefined, None)
+        assert not deep_equal(Hole, Undefined)
+        assert not deep_equal([Hole], [Undefined])
+        assert not deep_equal(JsBigInt(1), 1)
+        assert not deep_equal(JsRegExp("a", "g"), JsRegExp("a", ""))
+        assert deep_equal(JsBigInt(1), JsBigInt(1))
+        assert deep_equal([Hole], [Hole])
         assert not deep_equal(re.compile("a"), re.compile("a", re.I))
         assert not deep_equal([1, 2], [1, 3])
         assert deep_equal(float("nan"), float("nan"))
         assert deep_equal(_cyclic_dict(), _cyclic_dict())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# upstream's own corpus
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# The cases above are ones we thought of. Upstream's fixtures encode edge cases
+# someone else thought of, which is the more valuable half. Each fixture ships
+# the exact wire string devalue produces, so the assertion is: parse it, encode
+# it again, and have JS confirm the two strings denote the same value.
+#
+# The npm tarball ships no `test/`, so this needs a devalue *checkout* via
+# VERCEL_DEVALUE_JS and skips otherwise. Nothing is lost by running the whole
+# suite against a checkout: every file the tarball actually ships for execution
+# (`index.js` and `src/`) is byte-identical to the tag.
+
+# Constants upstream interpolates into its expected wire strings.
+_CORPUS_SUBSTITUTIONS = {
+    "consts.UNDEFINED": str(UNDEFINED),
+    "consts.HOLE": str(HOLE),
+    "consts.NAN": str(NAN),
+    "consts.POSITIVE_INFINITY": str(POSITIVE_INFINITY),
+    "consts.NEGATIVE_INFINITY": str(NEGATIVE_INFINITY),
+    "consts.NEGATIVE_ZERO": str(NEGATIVE_ZERO),
+    "consts.SPARSE": str(SPARSE),
+    "JSON.stringify('\U0001d306')": '"\U0001d306"',
+}
+
+# Wire tags whose value cannot survive a Python round trip, and why. Anything
+# NOT matching one of these must round-trip exactly; anything matching one must
+# still fail. Both directions are asserted so the inventory cannot go stale —
+# closing a gap here breaks the test until the entry is removed.
+_KNOWN_LOSSY: dict[str, str] = {
+    '["Object"': "boxed primitives are unboxed",
+    '["Map"': "Map becomes dict",
+    '["URL"': "URL becomes str",
+    '["URLSearchParams"': "URLSearchParams becomes str",
+    '["null"': "null-prototype object becomes dict",
+    '["Date",""': "an invalid Date becomes None",
+    '["DataView"': "DataView becomes bytes",
+    '["Temporal.': "Temporal values become str",
+    **{f'["{tag}"': f"{tag} becomes bytes" for tag in _TYPED_ARRAY_TAGS},
+}
+
+# Needs revivers we deliberately do not supply, or a Python container that
+# cannot hold the key at all.
+_CORPUS_SKIP = {
+    "Custom type": "exercises caller-supplied revivers",
+    "Function wrapped in custom type": "exercises caller-supplied revivers",
+    "Function in nested structure": "exercises caller-supplied revivers",
+    "Set (cyclical)": "a Python set cannot contain a set",
+    "Map key (repetition)": "Python dict cannot hold an unhashable key",
+    "Map keys (interlinked)": "Python dict cannot hold an unhashable key",
+}
+
+
+def _unescape_js_literal(text: str, quote: str) -> str:
+    """Resolve the escapes a JS source-level string literal used."""
+    if quote == "`":
+        return text
+    simple = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f", "0": "\0"}
+
+    def replace(match: re.Match[str]) -> str:
+        body = match.group(1)
+        if body[0] in "ux" and len(body) > 1:
+            return chr(int(body[1:], 16))
+        return simple.get(body, body)
+
+    return re.sub(r"\\(u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|.)", replace, text)
+
+
+@dataclass(frozen=True)
+class _UpstreamCase:
+    name: str
+    wire: str
+    """The exact devalue output upstream expects."""
+
+    expects_error: bool = False
+    """Upstream expects `parse` to reject this."""
+
+    message: str | None = None
+    """The expected message, when upstream states it on one line."""
+
+    needs_reviver: bool = False
+
+
+def _load_upstream_cases(test_file: Path) -> list[_UpstreamCase]:
+    """Pull every `{name, json, …}` case out of upstream's test file.
+
+    Deliberately indentation-agnostic: cases live at several depths (some
+    fixtures are built inside an IIFE, and the error array sits a level
+    shallower than `fixtures`), and keying off a fixed indent silently skipped
+    whole groups.
+    """
+    field = re.compile(r"^(\t+)(name|json|message|revivers):\s*(.*)$")
+    literal = re.compile(r"""(['"`])(.*)\1,?$""")
+
+    cases: list[_UpstreamCase] = []
+    pending: dict[str, str | bool] = {}
+    depth: str | None = None
+
+    def flush() -> None:
+        name, wire = pending.get("name"), pending.get("json")
+        if isinstance(name, str) and isinstance(wire, str):
+            for token, replacement in _CORPUS_SUBSTITUTIONS.items():
+                wire = wire.replace("${" + token + "}", replacement)
+            assert "${" not in wire, (
+                f"unmodelled interpolation in upstream case {name!r}: {wire} — add "
+                "it to _CORPUS_SUBSTITUTIONS rather than skipping the case"
+            )
+            message = pending.get("message")
+            cases.append(
+                _UpstreamCase(
+                    name=name,
+                    wire=wire,
+                    expects_error=bool(pending.get("has_message")),
+                    message=message if isinstance(message, str) else None,
+                    needs_reviver=bool(pending.get("revivers")),
+                )
+            )
+        pending.clear()
+
+    for line in test_file.read_text().split("\n"):
+        match = field.match(line)
+        if match is None:
+            continue
+        indent, key, rest = match.groups()
+        if key == "name" or indent != depth:
+            flush()
+            depth = indent
+        if key == "revivers":
+            pending["revivers"] = True
+            continue
+        if key == "message":
+            # Upstream sometimes builds the message across several lines (it
+            # varies by Node version), so presence is what marks an error case.
+            pending["has_message"] = True
+        value = literal.match(rest.rstrip())
+        if value is not None:
+            pending[key] = _unescape_js_literal(value.group(2), value.group(1))
+    flush()
+    return cases
+
+
+@pytest.fixture(scope="session")
+def upstream_corpus(devalue_entry: Path) -> list[tuple[str, str]]:
+    checkout = _corpus_checkout(devalue_entry)
+    if checkout is None:
+        pytest.skip(
+            "upstream fixtures need a devalue checkout (the npm tarball ships no "
+            "tests); point VERCEL_DEVALUE_JS at one"
+        )
+    cases = _load_upstream_cases(checkout / "test" / "index.test.js")
+    corpus = [(c.name, c.wire) for c in cases if not c.expects_error]
+    assert len(corpus) > 90, f"suspiciously few fixtures extracted: {len(corpus)}"
+    return corpus
+
+
+def _corpus_checkout(devalue_entry: Path) -> Path | None:
+    """The checkout the fixtures live in, if we are running against one."""
+    checkout = devalue_entry.parent
+    return checkout if (checkout / "test" / "index.test.js").is_file() else None
+
+
+@pytest.fixture(scope="session")
+def upstream_invalid(devalue_entry: Path) -> list[tuple[str, str, str | None, bool]]:
+    checkout = _corpus_checkout(devalue_entry)
+    if checkout is None:
+        pytest.skip("upstream error cases need a devalue checkout")
+    cases = _load_upstream_cases(checkout / "test" / "index.test.js")
+    invalid = [
+        # An error from the JSON layer rather than from devalue: the wording
+        # is language-specific, so only require that it is rejected.
+        (c.name, c.wire, None if _is_json_level(c.wire) else c.message, c.needs_reviver)
+        for c in cases
+        if c.expects_error
+    ]
+    assert len(invalid) > 25, f"suspiciously few error cases extracted: {len(invalid)}"
+    return invalid
+
+
+def _is_json_level(wire: str) -> bool:
+    try:
+        json.loads(wire)
+    except json.JSONDecodeError:
+        return True
+    return False
+
+
+@pytest.fixture(scope="session")
+def corpus_results(
+    devalue_entry: Path, upstream_corpus: list[tuple[str, str]]
+) -> dict[str, dict[str, Any]]:
+    """Re-encode each fixture, then have JS compare the two wire strings."""
+    pairs, outcomes = [], {}
+    for name, wire in upstream_corpus:
+        if name in _CORPUS_SKIP:
+            continue
+        try:
+            outcomes[name] = {"wire": wire, "reencoded": stringify(parse(wire))}
+            pairs.append({"name": name, "a": wire, "b": outcomes[name]["reencoded"]})
+        except Exception as exc:
+            outcomes[name] = {"wire": wire, "py_error": f"{type(exc).__name__}: {exc}"}
+
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", _CORPUS_HARNESS],
+        input=json.dumps(pairs),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env={**os.environ, "DEVALUE_ENTRY": str(devalue_entry)},
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"Node corpus harness failed (exit {proc.returncode}):\n{proc.stderr}")
+    for entry in json.loads(proc.stdout):
+        outcomes[entry["name"]].update(entry)
+    return outcomes
+
+
+_CORPUS_HARNESS = """
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const { parse } = await import(pathToFileURL(process.env.DEVALUE_ENTRY).href);
+const results = [];
+
+for (const { name, a, b } of JSON.parse(readFileSync(0, 'utf8'))) {
+  const result = { name };
+  try {
+    assert.deepStrictEqual(parse(b), parse(a));
+    result.equal = true;
+  } catch (error) {
+    result.equal = false;
+    result.detail = (error.message || String(error)).split('\\n').slice(0, 4).join(' | ');
+  }
+  results.push(result);
+}
+
+process.stdout.write(JSON.stringify(results));
+"""
+
+
+def _lossy_reason(wire: str) -> str | None:
+    for tag, reason in _KNOWN_LOSSY.items():
+        if tag in wire:
+            return reason
+    return None
+
+
+class TestUpstreamCorpus:
+    def test_corpus_was_extracted(self, upstream_corpus):
+        assert len(upstream_corpus) > 50
+
+    def test_every_fixture_round_trips_unless_known_lossy(self, corpus_results):
+        unexpected_loss, unexpected_success, errors = [], [], []
+        for name, outcome in corpus_results.items():
+            reason = _lossy_reason(outcome["wire"])
+            if "py_error" in outcome:
+                if reason is None:
+                    errors.append(f"{name}: {outcome['py_error']}  ({outcome['wire'][:60]})")
+                continue
+            if outcome["equal"] and reason is not None:
+                unexpected_success.append(f"{name}: no longer lossy ({reason}) — drop it")
+            elif not outcome["equal"] and reason is None:
+                unexpected_loss.append(
+                    f"{name}: {outcome['wire'][:52]} -> {outcome['reencoded'][:52]}"
+                    f"  [{outcome.get('detail', '')[:70]}]"
+                )
+        assert not errors, "parse/stringify raised on upstream fixtures:\n  " + "\n  ".join(errors)
+        assert not unexpected_loss, "fixtures stopped round-tripping:\n  " + "\n  ".join(
+            unexpected_loss
+        )
+        assert not unexpected_success, "_KNOWN_LOSSY is stale:\n  " + "\n  ".join(
+            unexpected_success
+        )
+
+    def test_upstream_error_cases_are_rejected(self, upstream_invalid):
+        """Rejecting malformed input the same way matters as much as accepting
+        well-formed input: several of these cases came from upstream security
+        fixes, so the list grows and is worth tracking rather than copying."""
+        wrong = []
+        for name, wire, message, needs_reviver in upstream_invalid:
+            revivers = {"Custom": lambda value: value} if needs_reviver else None
+            try:
+                parse(wire, revivers)
+            except Exception as exc:  # noqa: BLE001 - any rejection is enough
+                if message is not None and message not in str(exc):
+                    wrong.append(f"{name}: expected {message!r}, got {str(exc)[:60]!r}")
+                continue
+            wrong.append(f"{name}: accepted {wire[:50]!r} but upstream rejects it")
+        assert not wrong, "upstream error cases handled differently:\n  " + "\n  ".join(wrong)

--- a/src/vercel/tests/integration/test_devalue.py
+++ b/src/vercel/tests/integration/test_devalue.py
@@ -58,13 +58,11 @@ _NO_PY = object()
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def _npm_install_devalue() -> Path | None:
-    """Install the pinned devalue into a version-keyed temp dir, and reuse it."""
-    prefix = Path(tempfile.gettempdir()) / f"vercel-py-devalue-{DEVALUE_VERSION}"
-    entry = prefix / "node_modules" / "devalue" / "index.js"
-    if entry.is_file():
-        return entry
+def _entry_in(prefix: Path) -> Path:
+    return prefix / "node_modules" / "devalue" / "index.js"
 
+
+def _npm_install_into(prefix: Path) -> bool:
     prefix.mkdir(parents=True, exist_ok=True)
     result = subprocess.run(
         [
@@ -82,9 +80,42 @@ def _npm_install_devalue() -> Path | None:
         timeout=300,
         check=False,
     )
-    if result.returncode != 0 or not entry.is_file():
+    return result.returncode == 0 and _entry_in(prefix).is_file()
+
+
+def _npm_install_devalue() -> Path | None:
+    """Install the pinned devalue into a version-keyed temp dir, and reuse it.
+
+    pytest-xdist gives every worker its own session fixture, so several
+    processes reach this at once. npm rebuilds ``node_modules`` in place and
+    non-atomically, so installing straight into the shared directory lets one
+    worker observe ``index.js`` and then have it vanish underneath a running
+    node. Each worker therefore installs into a private staging directory and
+    publishes it with a single atomic rename; losers of that race reuse the
+    winner's copy.
+    """
+    shared = Path(tempfile.gettempdir()) / f"vercel-py-devalue-{DEVALUE_VERSION}"
+    if _entry_in(shared).is_file():
+        return _entry_in(shared)
+
+    staging = Path(tempfile.mkdtemp(prefix=f"vercel-py-devalue-{DEVALUE_VERSION}-"))
+    if not _npm_install_into(staging):
+        shutil.rmtree(staging, ignore_errors=True)
         return None
-    return entry
+
+    try:
+        # Atomic when `shared` does not exist; raises if another worker won.
+        staging.rename(shared)
+    except OSError:
+        if _entry_in(shared).is_file():
+            shutil.rmtree(staging, ignore_errors=True)
+            return _entry_in(shared)
+        # `shared` exists but holds no usable install (e.g. a partial tree from
+        # an interrupted run). Keep our own copy rather than deleting a path
+        # another process may be reading.
+        return _entry_in(staging)
+
+    return _entry_in(shared)
 
 
 def _resolve_devalue_entry() -> tuple[Path | None, str]:

--- a/src/vercel/tests/integration/test_devalue.py
+++ b/src/vercel/tests/integration/test_devalue.py
@@ -1,0 +1,565 @@
+"""Interop tests that run the real JavaScript ``devalue`` package.
+
+``vercel._internal.devalue`` exists to speak the same wire format as the JS
+package, so the unit tests assert against hand-written wire strings.  Those
+literals can only ever encode what their author believed JS does; they cannot
+catch a divergence.  These tests execute the actual package instead.
+
+Each round-trip case makes a full circle::
+
+    Python stringify ─→ JS parse ─→ assert.deepStrictEqual vs the expected JS value
+                                 └→ JS stringify ─→ Python parse ─→ compare to expected
+
+Only *values* are compared, never wire strings: `1.0` vs `1` and set iteration
+order legitimately differ between the two implementations while remaining
+perfectly interoperable.
+
+A second family covers values Python cannot construct (``Map``, ``URL``,
+``Uint8Array``, boxed primitives, sparse arrays, …).  Those have no Python
+encode leg, so they assert the documented Python landing type instead.
+
+The whole suite needs Node.  Following the precedent in ``tests/test_examples.py``
+it is optional locally and mandatory on CI, so a developer without Node is not
+blocked but a real divergence cannot merge green.  Set ``VERCEL_DEVALUE_JS`` to a
+devalue checkout to test against something other than the pinned npm release.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vercel._internal.devalue import Undefined, parse, stringify
+
+# The version fetched from npm when VERCEL_DEVALUE_JS is not set.  Keep this in
+# step with the upstream release the port is written against.
+DEVALUE_VERSION = "5.8.2"
+
+_IS_CI = bool(os.getenv("CI"))
+
+# Marks a case as JS-origin: there is no Python value to encode.
+_NO_PY = object()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# locating the JavaScript package
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _npm_install_devalue() -> Path | None:
+    """Install the pinned devalue into a version-keyed temp dir, and reuse it."""
+    prefix = Path(tempfile.gettempdir()) / f"vercel-py-devalue-{DEVALUE_VERSION}"
+    entry = prefix / "node_modules" / "devalue" / "index.js"
+    if entry.is_file():
+        return entry
+
+    prefix.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [
+            "npm",
+            "install",
+            f"devalue@{DEVALUE_VERSION}",
+            "--no-save",
+            "--no-audit",
+            "--no-fund",
+            "--prefix",
+            str(prefix),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    if result.returncode != 0 or not entry.is_file():
+        return None
+    return entry
+
+
+def _resolve_devalue_entry() -> tuple[Path | None, str]:
+    """Return the devalue entry point, or ``None`` plus the reason it is missing."""
+    override = os.getenv("VERCEL_DEVALUE_JS")
+    if override:
+        candidate = Path(override).expanduser()
+        if candidate.is_dir():
+            candidate = candidate / "index.js"
+        if not candidate.is_file():
+            return None, f"VERCEL_DEVALUE_JS does not point at a devalue package: {override}"
+        return candidate, ""
+
+    if shutil.which("node") is None:
+        return None, "node is not installed"
+    if shutil.which("npm") is None:
+        return None, "npm is not installed"
+
+    entry = _npm_install_devalue()
+    if entry is None:
+        return None, f"could not npm install devalue@{DEVALUE_VERSION}"
+    return entry, ""
+
+
+@pytest.fixture(scope="session")
+def devalue_entry() -> Path:
+    entry, reason = _resolve_devalue_entry()
+    if entry is None:
+        message = (
+            f"JS devalue unavailable ({reason}). Install node, or point "
+            f"VERCEL_DEVALUE_JS at a devalue checkout."
+        )
+        if _IS_CI:
+            pytest.fail(message)
+        pytest.skip(message)
+    return entry
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the Node harness
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Reads `[{name, js, pyJson, jsReducers, jsRevivers}, …]` on stdin and writes
+# `[{name, jsVerifyError, jsJson, harnessError}, …]` on stdout.
+_JS_HARNESS = """
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const { parse, stringify } = await import(pathToFileURL(process.env.DEVALUE_ENTRY).href);
+const evaluate = (src) => (0, eval)(`(${src})`);
+
+const cases = JSON.parse(readFileSync(0, 'utf8'));
+const results = [];
+
+for (const testCase of cases) {
+  const result = { name: testCase.name };
+  let expected;
+
+  try {
+    expected = evaluate(testCase.js);
+  } catch (error) {
+    result.harnessError = `building expected value: ${error.message}`;
+    results.push(result);
+    continue;
+  }
+
+  // Leg 1 — decode what Python encoded and verify it in JS.
+  if (testCase.pyJson !== null) {
+    try {
+      const revivers = testCase.jsRevivers ? evaluate(testCase.jsRevivers) : undefined;
+      assert.deepStrictEqual(parse(testCase.pyJson, revivers), expected);
+    } catch (error) {
+      result.jsVerifyError = error.message;
+    }
+  }
+
+  // Leg 2 — encode the JS value for Python to decode.
+  try {
+    const reducers = testCase.jsReducers ? evaluate(testCase.jsReducers) : undefined;
+    result.jsJson = stringify(expected, reducers);
+  } catch (error) {
+    result.harnessError = `stringify: ${error.message}`;
+  }
+
+  results.push(result);
+}
+
+process.stdout.write(JSON.stringify(results));
+"""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class Custom:
+    """Stand-in for a caller type handled by a reducer/reviver pair."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Custom) and other.value == self.value
+
+    def __repr__(self) -> str:
+        return f"Custom({self.value!r})"
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    js: str
+    """JS expression producing the value equivalent to ``value``."""
+
+    value: Any = _NO_PY
+    """The Python value to encode, or ``_NO_PY`` for JS-origin cases."""
+
+    expected: Any = _NO_PY
+    """What Python should decode back to; defaults to ``value``."""
+
+    py_reducers: dict[str, Callable] | None = None
+    py_revivers: dict[str, Callable] | None = None
+    js_reducers: str | None = None
+    js_revivers: str | None = None
+    extra: Callable[[Any], None] | None = None
+    """Extra assertions on the Python-decoded value (identity, sharing, …)."""
+
+    def expected_value(self) -> Any:
+        return self.value if self.expected is _NO_PY else self.expected
+
+
+def _cyclic_dict() -> dict:
+    value: dict = {"x": 1}
+    value["self"] = value
+    return value
+
+
+def _cyclic_list() -> list:
+    value: list = [1, 2]
+    value.append(value)
+    return value
+
+
+_SHARED = {"x": 1}
+
+_AWARE = datetime(2024, 1, 2, 3, 4, 5, 678000, tzinfo=timezone.utc)
+
+ROUND_TRIP_CASES: list[Case] = [
+    # ── scalars ────────────────────────────────────────────────────────────
+    Case("int", "42", 42),
+    Case("negative_int", "-5", -5),
+    Case("zero", "0", 0),
+    Case("float", "0.1", 0.1),
+    # JSON has no int/float distinction, so an integral float lands as an int.
+    Case("float_integral", "2", 2.0, expected=2),
+    Case("nan", "NaN", float("nan")),
+    Case("infinity", "Infinity", float("inf")),
+    Case("negative_infinity", "-Infinity", float("-inf")),
+    Case("negative_zero", "-0", -0.0),
+    Case("true", "true", True),
+    Case("false", "false", False),
+    Case("none", "null", None),
+    Case("undefined", "undefined", Undefined),
+    # ── strings ────────────────────────────────────────────────────────────
+    Case("string", '"hello world"', "hello world"),
+    Case("string_empty", '""', ""),
+    Case("string_xss", '"<script>alert(1)</script>"', "<script>alert(1)</script>"),
+    Case("string_line_separators", '"a\\u2028b\\u2029c"', "a b c"),
+    Case("string_control_chars", '"a\\u0000b\\u001fc"', "a\x00b\x1fc"),
+    Case("string_quotes_backslash", '"he said \\"hi\\" \\\\ ok"', 'he said "hi" \\ ok'),
+    Case("string_unicode", '"héllo 😀 中文"', "héllo 😀 中文"),
+    # ── containers ─────────────────────────────────────────────────────────
+    Case("list", '[1,"two",null,true]', [1, "two", None, True]),
+    Case("list_empty", "[]", []),
+    Case("tuple", "[1,2]", (1, 2), expected=[1, 2]),
+    Case("dict", '{"a":1,"b":"c"}', {"a": 1, "b": "c"}),
+    Case("dict_empty", "{}", {}),
+    Case("nested", '{"a":[1,{"b":2}]}', {"a": [1, {"b": 2}]}),
+    Case("dict_non_identifier_keys", '{"x-y":1,"":2}', {"x-y": 1, "": 2}),
+    Case("set", "new Set([1,2,3])", {1, 2, 3}),
+    Case("set_empty", "new Set()", set()),
+    Case("frozenset", "new Set([1,2])", frozenset({1, 2}), expected={1, 2}),
+    # ── rich types ─────────────────────────────────────────────────────────
+    Case("datetime_aware", 'new Date("2024-01-02T03:04:05.678Z")', _AWARE),
+    # A naive datetime is serialized as UTC, so it comes back tz-aware.
+    Case(
+        "datetime_naive",
+        'new Date("2024-01-02T03:04:05.678Z")',
+        datetime(2024, 1, 2, 3, 4, 5, 678000),
+        expected=_AWARE,
+    ),
+    Case(
+        "datetime_epoch",
+        'new Date("1970-01-01T00:00:00.000Z")',
+        datetime(1970, 1, 1, tzinfo=timezone.utc),
+    ),
+    Case("regex_no_flags", "/a+b/", re.compile("a+b")),
+    Case("regex_ignorecase", "/a+b/i", re.compile("a+b", re.IGNORECASE)),
+    Case(
+        "regex_multiline_dotall",
+        "/a.b/ms",
+        re.compile("a.b", re.MULTILINE | re.DOTALL),
+    ),
+    Case("bytes", "new Uint8Array([0,1,255]).buffer", b"\x00\x01\xff"),
+    Case("bytes_empty", "new Uint8Array([]).buffer", b""),
+    Case("bytearray", "new Uint8Array([1,2]).buffer", bytearray(b"\x01\x02"), expected=b"\x01\x02"),
+    # ── integers across the JS safe boundary ───────────────────────────────
+    Case("safe_int_max", "9007199254740991", 2**53 - 1),
+    Case("safe_int_min", "-9007199254740991", -(2**53) + 1),
+    Case("unsafe_int_positive", "9007199254740993n", 2**53 + 1),
+    Case("unsafe_int_negative", "-9007199254740993n", -(2**53) - 1),
+    Case("unsafe_int_huge", "123456789012345678901234567890n", 123456789012345678901234567890),
+    # ── graph shape ────────────────────────────────────────────────────────
+    Case(
+        "cycle_dict",
+        "(() => { const o = { x: 1 }; o.self = o; return o; })()",
+        _cyclic_dict(),
+        extra=lambda v: _assert(v["self"] is v, "cycle not preserved"),
+    ),
+    Case(
+        "cycle_list",
+        "(() => { const a = [1, 2]; a.push(a); return a; })()",
+        _cyclic_list(),
+        extra=lambda v: _assert(v[2] is v, "cycle not preserved"),
+    ),
+    Case(
+        "shared_reference",
+        "(() => { const o = { x: 1 }; return [o, o]; })()",
+        [_SHARED, _SHARED],
+        extra=lambda v: _assert(v[0] is v[1], "sharing not preserved"),
+    ),
+    Case(
+        "repeated_string",
+        '(() => { const s = "abc"; return [s, s]; })()',
+        ["abc", "abc"],
+    ),
+    # ── custom types via reducers/revivers ─────────────────────────────────
+    Case(
+        "custom_type",
+        "({ tag: 'custom', v: 42 })",
+        Custom(42),
+        py_reducers={"Custom": lambda x: {"v": x.value} if isinstance(x, Custom) else None},
+        py_revivers={"Custom": lambda d: Custom(d["v"])},
+        js_reducers="{ Custom: (x) => (x && x.tag === 'custom') ? { v: x.v } : null }",
+        js_revivers="{ Custom: (d) => ({ tag: 'custom', v: d.v }) }",
+    ),
+]
+
+JS_ORIGIN_CASES: list[Case] = [
+    # Python has no Map; devalue lands it as a dict.
+    Case("js_map_string_keys", 'new Map([["a","b"],["c","d"]])', expected={"a": "b", "c": "d"}),
+    Case("js_map_number_keys", 'new Map([[1,"a"],[2,"b"]])', expected={1: "a", 2: "b"}),
+    Case("js_map_empty", "new Map()", expected={}),
+    # URL-ish and typed arrays land as their string / bytes payload.
+    Case(
+        "js_url", 'new URL("https://vercel.com/docs?a=1")', expected="https://vercel.com/docs?a=1"
+    ),
+    Case(
+        "js_url_search_params",
+        'new URLSearchParams("foo=1&foo=2&baz=%3C+%3E")',
+        expected="foo=1&foo=2&baz=%3C+%3E",
+    ),
+    Case("js_uint8array", "new Uint8Array([1,2,3])", expected=b"\x01\x02\x03"),
+    Case("js_uint16array", "new Uint16Array([1,2])", expected=b"\x01\x00\x02\x00"),
+    Case("js_arraybuffer", "new Uint8Array([9,8]).buffer", expected=b"\x09\x08"),
+    # Boxed primitives are unboxed.
+    Case("js_boxed_number", "Object(42)", expected=42),
+    Case("js_boxed_string", 'Object("woo!!!")', expected="woo!!!"),
+    Case("js_boxed_boolean", "Object(true)", expected=True),
+    # null-prototype objects land as plain dicts.
+    Case(
+        "js_null_prototype",
+        'Object.assign(Object.create(null), { foo: "bar" })',
+        expected={"foo": "bar"},
+    ),
+    Case("js_null_prototype_empty", "Object.create(null)", expected={}),
+    # Holes and sparse arrays pad with Undefined.
+    Case(
+        "js_array_with_holes",
+        '(() => { const a = [, "a", ,]; return a; })()',
+        expected=[Undefined, "a", Undefined],
+    ),
+    Case(
+        "js_sparse_array",
+        '(() => { const a = []; a[5] = "x"; return a; })()',
+        expected=[Undefined] * 5 + ["x"],
+    ),
+    Case("js_bigint", "123456789012345678901234567890n", expected=123456789012345678901234567890),
+    Case("js_negative_zero_nested", "[0, -0]", expected=[0, -0.0]),
+]
+
+ALL_CASES: list[Case] = ROUND_TRIP_CASES + JS_ORIGIN_CASES
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# comparison
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def deep_equal(a: Any, b: Any, seen: set[tuple[int, int]] | None = None) -> bool:
+    """Structural equality with JS-comparable strictness.
+
+    Plain ``==`` is wrong here in several ways: ``nan != nan``, ``-0.0 == 0.0``,
+    ``True == 1``, ``1 == 1.0``, cyclic structures raise ``RecursionError``, and
+    ``re.Pattern`` equality is really identity via ``re.compile``'s cache.
+    """
+    if seen is None:
+        seen = set()
+
+    if a is Undefined or b is Undefined:
+        return a is b
+    if a is None or b is None:
+        return a is b
+    if type(a) is not type(b):
+        return False
+
+    if isinstance(a, bool):
+        return a is b
+    if isinstance(a, float):
+        if math.isnan(a):
+            return math.isnan(b)
+        if a == 0.0:
+            return math.copysign(1.0, a) == math.copysign(1.0, b)
+        return a == b
+    if isinstance(a, (int, str, bytes, bytearray, datetime)):
+        return a == b
+    if isinstance(a, re.Pattern):
+        return a.pattern == b.pattern and a.flags == b.flags
+    if isinstance(a, (set, frozenset)):
+        return a == b
+
+    pair = (id(a), id(b))
+    if pair in seen:
+        # Already comparing this pair further up the stack — a cycle.
+        return True
+    seen = seen | {pair}
+
+    if isinstance(a, (list, tuple)):
+        return len(a) == len(b) and all(deep_equal(x, y, seen) for x, y in zip(a, b, strict=True))
+    if isinstance(a, dict):
+        return a.keys() == b.keys() and all(deep_equal(a[k], b[k], seen) for k in a)
+
+    return a == b
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# running the harness
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class _Outcome:
+    py_json: str | None = None
+    py_encode_error: str | None = None
+    js_verify_error: str | None = None
+    js_json: str | None = None
+    harness_error: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@pytest.fixture(scope="session")
+def interop(devalue_entry: Path) -> dict[str, _Outcome]:
+    """Push every case through a single Node process and index the results."""
+    outcomes = {case.name: _Outcome() for case in ALL_CASES}
+    payload = []
+
+    for case in ALL_CASES:
+        py_json = None
+        if case.value is not _NO_PY:
+            try:
+                py_json = stringify(case.value, case.py_reducers)
+            except Exception as exc:  # surfaced by the individual test
+                outcomes[case.name].py_encode_error = f"{type(exc).__name__}: {exc}"
+        outcomes[case.name].py_json = py_json
+        payload.append(
+            {
+                "name": case.name,
+                "js": case.js,
+                "pyJson": py_json,
+                "jsReducers": case.js_reducers,
+                "jsRevivers": case.js_revivers,
+            }
+        )
+
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", _JS_HARNESS],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env={**os.environ, "DEVALUE_ENTRY": str(devalue_entry)},
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"Node harness failed (exit {proc.returncode}):\n{proc.stderr}")
+
+    for entry in json.loads(proc.stdout):
+        outcome = outcomes[entry["name"]]
+        outcome.js_verify_error = entry.get("jsVerifyError")
+        outcome.js_json = entry.get("jsJson")
+        outcome.harness_error = entry.get("harnessError")
+
+    return outcomes
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestJsAcceptsPythonOutput:
+    """Leg 1 — JS `parse` must accept what Python `stringify` produced."""
+
+    @pytest.mark.parametrize("case", ROUND_TRIP_CASES, ids=lambda c: c.name)
+    def test_js_decodes_python_output(self, case: Case, interop: dict[str, _Outcome]):
+        outcome = interop[case.name]
+        assert outcome.py_encode_error is None, (
+            f"Python stringify failed: {outcome.py_encode_error}"
+        )
+        assert outcome.harness_error is None, f"harness: {outcome.harness_error}"
+        assert outcome.js_verify_error is None, (
+            f"JS decoded Python's output to the wrong value.\n"
+            f"  Python emitted: {outcome.py_json}\n"
+            f"  {outcome.js_verify_error}"
+        )
+
+
+class TestPythonAcceptsJsOutput:
+    """Leg 2 — Python `parse` must recover the value from JS `stringify`."""
+
+    @pytest.mark.parametrize("case", ALL_CASES, ids=lambda c: c.name)
+    def test_python_decodes_js_output(self, case: Case, interop: dict[str, _Outcome]):
+        outcome = interop[case.name]
+        assert outcome.harness_error is None, f"harness: {outcome.harness_error}"
+        assert outcome.js_json is not None, "Node produced no output for this case"
+
+        decoded = parse(outcome.js_json, case.py_revivers)
+        expected = case.expected_value()
+
+        assert deep_equal(decoded, expected), (
+            f"round trip changed the value.\n"
+            f"  JS emitted: {outcome.js_json}\n"
+            f"  Python decoded: {decoded!r}\n"
+            f"  expected: {expected!r}"
+        )
+        if case.extra is not None:
+            case.extra(decoded)
+
+
+class TestHarness:
+    """Guard rails on the harness itself, so a silent no-op cannot pass."""
+
+    def test_every_case_ran(self, interop: dict[str, _Outcome]):
+        missing = [
+            name for name, o in interop.items() if o.js_json is None and o.harness_error is None
+        ]
+        assert not missing, f"Node returned no result for: {missing}"
+
+    def test_round_trip_cases_exercise_both_legs(self, interop: dict[str, _Outcome]):
+        no_python_leg = [c.name for c in ROUND_TRIP_CASES if interop[c.name].py_json is None]
+        assert not no_python_leg, f"round-trip cases with no Python output: {no_python_leg}"
+
+    def test_deep_equal_rejects_the_differences_that_matter(self):
+        assert not deep_equal(0.0, -0.0)
+        assert not deep_equal(True, 1)
+        assert not deep_equal(1, 1.0)
+        assert not deep_equal(Undefined, None)
+        assert not deep_equal(re.compile("a"), re.compile("a", re.I))
+        assert not deep_equal([1, 2], [1, 3])
+        assert deep_equal(float("nan"), float("nan"))
+        assert deep_equal(_cyclic_dict(), _cyclic_dict())

--- a/src/vercel/tests/unit/test_devalue.py
+++ b/src/vercel/tests/unit/test_devalue.py
@@ -1,0 +1,1111 @@
+"""Tests for vercel._internal.devalue — Python port of JS devalue.
+
+Test cases are modelled after the JS test suite at
+https://github.com/Rich-Harris/devalue/blob/main/test/index.test.js
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from vercel._internal.devalue import (
+    DevalueError,
+    Undefined,
+    parse,
+    stringify,
+    unflatten,
+)
+from vercel._internal.devalue.constants import (
+    HOLE,
+    MAX_ARRAY_LEN,
+    MAX_SAFE_INTEGER,
+    MAX_SPARSE_ARRAY_LENGTH,
+    NAN,
+    NEGATIVE_INFINITY,
+    NEGATIVE_ZERO,
+    POSITIVE_INFINITY,
+    SPARSE,
+    UNDEFINED,
+)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – primitives
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyPrimitives:
+    def test_positive_integer(self):
+        assert stringify(42) == "[42]"
+
+    def test_negative_integer(self):
+        assert stringify(-5) == "[-5]"
+
+    def test_positive_decimal(self):
+        assert stringify(0.1) == "[0.1]"
+
+    def test_negative_decimal(self):
+        assert stringify(-0.1) == "[-0.1]"
+
+    def test_nan(self):
+        assert stringify(float("nan")) == str(NAN)
+
+    def test_positive_infinity(self):
+        assert stringify(float("inf")) == str(POSITIVE_INFINITY)
+
+    def test_negative_infinity(self):
+        assert stringify(float("-inf")) == str(NEGATIVE_INFINITY)
+
+    def test_zero(self):
+        assert stringify(0) == "[0]"
+
+    def test_negative_zero(self):
+        assert stringify(-0.0) == str(NEGATIVE_ZERO)
+
+    def test_string(self):
+        assert stringify("woo!!!") == '["woo!!!"]'
+
+    def test_boolean_true(self):
+        assert stringify(True) == "[true]"
+
+    def test_boolean_false(self):
+        assert stringify(False) == "[false]"
+
+    def test_undefined(self):
+        assert stringify(Undefined) == str(UNDEFINED)
+
+    def test_none(self):
+        assert stringify(None) == "[null]"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – basic complex types
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyBasics:
+    def test_regex_with_flags(self):
+        p = re.compile("regexp", re.IGNORECASE | re.MULTILINE)
+        result = stringify(p)
+        assert result == '[["RegExp","regexp","im"]]'
+
+    def test_regex_no_flags(self):
+        p = re.compile("regexp")
+        result = stringify(p)
+        assert result == '[["RegExp","regexp"]]'
+
+    def test_date(self):
+        dt = datetime(2001, 9, 9, 1, 46, 40, tzinfo=timezone.utc)
+        assert stringify(dt) == '[["Date","2001-09-09T01:46:40.000Z"]]'
+
+    def test_list(self):
+        assert stringify(["a", "b", "c"]) == '[[1,2,3],"a","b","c"]'
+
+    def test_empty_list(self):
+        assert stringify([]) == "[[]]"
+
+    def test_dict(self):
+        assert stringify({"foo": "bar", "x-y": "z"}) == '[{"foo":1,"x-y":2},"bar","z"]'
+
+    def test_empty_dict(self):
+        assert stringify({}) == "[{}]"
+
+    def test_set(self):
+        result = stringify({1, 2, 3})
+        parsed = parse(result)
+        assert parsed == {1, 2, 3}
+
+    def test_bytes(self):
+        assert stringify(b"\x01\x02\x03") == '[["ArrayBuffer","AQID"]]'
+
+    def test_bytearray(self):
+        assert stringify(bytearray(b"\x01\x02\x03")) == '[["ArrayBuffer","AQID"]]'
+
+    def test_tuple_as_array(self):
+        assert stringify(("a", "b")) == '[[1,2],"a","b"]'
+
+    def test_nested_structure(self):
+        val = {"list": [1, 2], "flag": True}
+        result = stringify(val)
+        assert parse(result) == val
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – strings (escaping)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyStrings:
+    def test_newline(self):
+        assert stringify("a\nb") == '["a\\nb"]'
+
+    def test_double_quotes(self):
+        assert stringify('"yar"') == '["\\"yar\\""]'
+
+    def test_nul(self):
+        assert stringify("\0") == '["\\u0000"]'
+
+    def test_control_character(self):
+        assert stringify("\u0001") == '["\\u0001"]'
+
+    def test_control_character_extremum(self):
+        assert stringify("\u001f") == '["\\u001f"]'
+
+    def test_backslash(self):
+        assert stringify("\\") == '["\\\\"]'
+
+    def test_tab(self):
+        assert stringify("\t") == '["\\t"]'
+
+    def test_carriage_return(self):
+        assert stringify("\r") == '["\\r"]'
+
+    def test_unicode_2028(self):
+        assert stringify("\u2028") == '["\\u2028"]'
+
+    def test_unicode_2029(self):
+        assert stringify("\u2029") == '["\\u2029"]'
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – XSS prevention
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyXSS:
+    def test_dangerous_string(self):
+        value = "</script><script src='https://evil.com/script.js'>alert('pwned')</script><script>"
+        result = stringify(value)
+        assert "\\u003C" in result
+        assert "<script" not in result
+
+    def test_dangerous_key(self):
+        value = {'<svg onload=alert("xss_works")>': "bar"}
+        result = stringify(value)
+        assert "\\u003C" in result
+        assert "<svg" not in result
+
+    def test_dangerous_regex(self):
+        pattern = re.compile("[</script><script>alert('xss')//]")
+        result = stringify(pattern)
+        assert "\\u003C" in result
+        assert "<script" not in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – cycles
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyCycles:
+    def test_dict_cycle(self):
+        obj: dict = {}
+        obj["self"] = obj
+        result = stringify(obj)
+        assert result == '[{"self":0}]'
+
+    def test_list_cycle(self):
+        arr: list = [None]
+        arr[0] = arr
+        result = stringify(arr)
+        assert result == "[[0]]"
+
+    def test_mutual_cycle(self):
+        first: dict = {}
+        second: dict = {}
+        first["second"] = second
+        second["first"] = first
+        result = stringify([first, second])
+        assert result == '[[1,2],{"second":2},{"first":1}]'
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – repetition / deduplication
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyRepetition:
+    def test_string_repetition(self):
+        assert stringify(["a string", "a string"]) == '[[1,1],"a string"]'
+
+    def test_none_repetition(self):
+        assert stringify([None, None]) == "[[1,1],null]"
+
+    def test_nan_repetition(self):
+        assert stringify([float("nan"), float("nan")]) == f"[[{NAN},{NAN}]]"
+
+    def test_dict_repetition(self):
+        obj: dict = {}
+        assert stringify([obj, obj]) == "[[1,1],{}]"
+
+    def test_regex_repetition(self):
+        p = re.compile("regexp")
+        result = stringify([p, p])
+        assert result == '[[1,1],["RegExp","regexp"]]'
+
+    def test_date_repetition(self):
+        dt = datetime(2001, 9, 9, 1, 46, 40, tzinfo=timezone.utc)
+        result = stringify([dt, dt])
+        assert result == '[[1,1],["Date","2001-09-09T01:46:40.000Z"]]'
+
+    def test_bytes_repetition(self):
+        buf = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"
+        result = stringify([buf, buf])
+        assert result == '[[1,1],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – custom reducers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class Foo:
+    def __init__(self, value):
+        self.value = value
+
+
+class Bar:
+    def __init__(self, value):
+        self.value = value
+
+
+class TestStringifyCustom:
+    def test_custom_type(self):
+        instance = Foo({"bar": Bar({"answer": 42})})
+        reducers = {
+            "Foo": lambda x: x.value if isinstance(x, Foo) else None,
+            "Bar": lambda x: x.value if isinstance(x, Bar) else None,
+        }
+        result = stringify([instance, instance], reducers)
+        assert result == '[[1,1],["Foo",2],{"bar":3},["Bar",4],{"answer":5},42]'
+
+    def test_custom_round_trip(self):
+        instance = Foo({"bar": Bar({"answer": 42})})
+        reducers = {
+            "Foo": lambda x: x.value if isinstance(x, Foo) else None,
+            "Bar": lambda x: x.value if isinstance(x, Bar) else None,
+        }
+        revivers = {
+            "Foo": lambda x: Foo(x),
+            "Bar": lambda x: Bar(x),
+        }
+        result = parse(stringify([instance, instance], reducers), revivers)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] is result[1]
+        assert isinstance(result[0], Foo)
+        assert isinstance(result[0].value["bar"], Bar)
+        assert result[0].value["bar"].value["answer"] == 42
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# stringify – errors
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStringifyErrors:
+    def test_function_raises(self):
+        with pytest.raises(DevalueError, match="Cannot stringify a function"):
+            stringify(lambda x: x)
+
+    def test_non_string_dict_key_raises(self):
+        with pytest.raises(DevalueError, match="non-string keys"):
+            stringify({1: "value"})
+
+    def test_proto_key_raises(self):
+        obj = json.loads('{"__proto__": 1}')
+        root = {"foo": obj}
+        with pytest.raises(DevalueError, match="__proto__") as exc_info:
+            stringify(root)
+        assert exc_info.value.path == ".foo"
+        assert exc_info.value.name == "DevalueError"
+
+    def test_non_pojo_raises(self):
+        class Custom:
+            pass
+
+        with pytest.raises(DevalueError, match="non-POJOs"):
+            stringify(Custom())
+
+    def test_error_path_nested(self):
+        with pytest.raises(DevalueError) as exc_info:
+            stringify({"foo": {"array": [lambda: None]}})
+        assert exc_info.value.path == ".foo.array[0]"
+
+    def test_error_path_map_then_object(self):
+        with pytest.raises(DevalueError) as exc_info:
+            stringify({"aset": {1, 2}, "object": {"invalid": lambda: None}})
+        assert exc_info.value.path == ".object.invalid"
+
+    def test_error_value_attribute(self):
+        fn = lambda: None  # noqa: E731
+        with pytest.raises(DevalueError) as exc_info:
+            stringify({"foo": {"array": [fn]}})
+        assert exc_info.value.value is fn
+
+    def test_error_root_attribute(self):
+        root = {"foo": {"array": [lambda: None]}}
+        with pytest.raises(DevalueError) as exc_info:
+            stringify(root)
+        assert exc_info.value.root is root
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – primitives
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParsePrimitives:
+    def test_positive_integer(self):
+        assert parse("[42]") == 42
+
+    def test_negative_integer(self):
+        assert parse("[-5]") == -5
+
+    def test_positive_decimal(self):
+        assert parse("[0.1]") == pytest.approx(0.1)
+
+    def test_negative_decimal(self):
+        assert parse("[-0.1]") == pytest.approx(-0.1)
+
+    def test_nan(self):
+        assert math.isnan(parse(str(NAN)))
+
+    def test_positive_infinity(self):
+        assert parse(str(POSITIVE_INFINITY)) == float("inf")
+
+    def test_negative_infinity(self):
+        assert parse(str(NEGATIVE_INFINITY)) == float("-inf")
+
+    def test_zero(self):
+        assert parse("[0]") == 0
+
+    def test_negative_zero(self):
+        result = parse(str(NEGATIVE_ZERO))
+        assert result == 0.0
+        assert math.copysign(1, result) < 0
+
+    def test_string(self):
+        assert parse('["woo!!!"]') == "woo!!!"
+
+    def test_boolean(self):
+        assert parse("[true]") is True
+
+    def test_undefined(self):
+        assert parse(str(UNDEFINED)) is Undefined
+
+    def test_null(self):
+        assert parse("[null]") is None
+
+    def test_bigint(self):
+        assert parse('[["BigInt","12345678901234567890"]]') == 12345678901234567890
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – basic complex types
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParseBasics:
+    def test_date(self):
+        result = parse('[["Date","2001-09-09T01:46:40.000Z"]]')
+        assert isinstance(result, datetime)
+        assert result == datetime(2001, 9, 9, 1, 46, 40, tzinfo=timezone.utc)
+
+    def test_invalid_date(self):
+        result = parse('[["Date",""]]')
+        assert result is None
+
+    def test_regex(self):
+        result = parse('[["RegExp","regexp","gim"]]')
+        assert isinstance(result, re.Pattern)
+        assert result.pattern == "regexp"
+        assert result.flags & re.IGNORECASE
+        assert result.flags & re.MULTILINE
+
+    def test_regex_no_flags(self):
+        result = parse('[["RegExp","test"]]')
+        assert isinstance(result, re.Pattern)
+        assert result.pattern == "test"
+
+    def test_array(self):
+        assert parse('[[1,2,3],"a","b","c"]') == ["a", "b", "c"]
+
+    def test_empty_array(self):
+        assert parse("[[]]") == []
+
+    def test_sparse_array(self):
+        json_str = f'[[{HOLE},1,{HOLE}],"b"]'
+        result = parse(json_str)
+        assert len(result) == 3
+        assert result[0] is Undefined
+        assert result[1] == "b"
+        assert result[2] is Undefined
+
+    def test_very_sparse_array(self):
+        json_str = f'[[{SPARSE},1000001,1000000,1],"x"]'
+        result = parse(json_str)
+        assert len(result) == 1000001
+        assert result[1000000] == "x"
+        assert result[0] is Undefined
+
+    def test_object(self):
+        assert parse('[{"foo":1,"x-y":2},"bar","z"]') == {
+            "foo": "bar",
+            "x-y": "z",
+        }
+
+    def test_set(self):
+        assert parse('[["Set",1,2,3],1,2,3]') == {1, 2, 3}
+
+    def test_map_as_dict(self):
+        assert parse('[["Map",1,2],"a","b"]') == {"a": "b"}
+
+    def test_arraybuffer(self):
+        result = parse('[["ArrayBuffer","AQID"]]')
+        assert result == b"\x01\x02\x03"
+
+    def test_typed_array(self):
+        result = parse('[["Uint8Array",1],["ArrayBuffer","AQID"]]')
+        assert result == b"\x01\x02\x03"
+
+    def test_url_as_string(self):
+        result = parse('[["URL","https://example.com/path"]]')
+        assert result == "https://example.com/path"
+
+    def test_url_search_params_as_string(self):
+        result = parse('[["URLSearchParams","foo=1&bar=2"]]')
+        assert result == "foo=1&bar=2"
+
+    def test_temporal_as_string(self):
+        result = parse('[["Temporal.Duration","P1Y2M3D"]]')
+        assert result == "P1Y2M3D"
+
+    def test_null_prototype_object(self):
+        result = parse('[["null"]]')
+        assert result == {}
+
+    def test_null_prototype_object_with_keys(self):
+        result = parse('[["null","key",1],"value"]')
+        assert result == {"key": "value"}
+
+    def test_object_wrapper_returns_inner_value(self):
+        # ["Object", idx] → unwrap to the inner value
+        assert parse('[["Object",1],42]') == 42
+
+    def test_object_wrapper_bigint(self):
+        assert parse('[["Object",1],["BigInt","1"]]') == 1
+
+    def test_sliced_typed_array(self):
+        # Uint16Array with byteOffset=2, length=2 from an 8-byte buffer
+        result = parse('[["Uint16Array",1,2,2],["ArrayBuffer","CgAUAB4AKAA="]]')
+        assert isinstance(result, bytes)
+        assert len(result) == 4  # 2 elements × 2 bytes each
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – cycles
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParseCycles:
+    def test_dict_cycle(self):
+        result = parse('[{"self":0}]')
+        assert result["self"] is result
+
+    def test_list_cycle(self):
+        result = parse("[[0]]")
+        assert result[0] is result
+
+    def test_mutual_cycle(self):
+        result = parse('[[1,2],{"second":2},{"first":1}]')
+        assert result[0]["second"] is result[1]
+        assert result[1]["first"] is result[0]
+
+    def test_map_cycle(self):
+        result = parse('[["Map",1,0],"self"]')
+        assert isinstance(result, dict)
+        assert result["self"] is result
+
+    def test_null_proto_cycle(self):
+        result = parse('[["null","self",0]]')
+        assert result["self"] is result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – repetition / deduplication
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParseRepetition:
+    def test_string_repetition(self):
+        result = parse('[[1,1],"a string"]')
+        assert result == ["a string", "a string"]
+
+    def test_null_repetition(self):
+        result = parse("[[1,1],null]")
+        assert result == [None, None]
+
+    def test_nan_repetition(self):
+        result = parse(f"[[{NAN},{NAN}]]")
+        assert len(result) == 2
+        assert all(math.isnan(x) for x in result)
+
+    def test_object_repetition(self):
+        result = parse("[[1,1],{}]")
+        assert result[0] is result[1]
+
+    def test_regex_repetition(self):
+        result = parse('[[1,1],["RegExp","regexp"]]')
+        assert result[0] is result[1]
+        assert isinstance(result[0], re.Pattern)
+
+    def test_date_repetition(self):
+        result = parse('[[1,1],["Date","2001-09-09T01:46:40.000Z"]]')
+        assert result[0] is result[1]
+        assert isinstance(result[0], datetime)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – custom revivers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParseCustom:
+    def test_custom_reviver(self):
+        revivers = {
+            "Foo": lambda x: Foo(x),
+            "Bar": lambda x: Bar(x),
+        }
+        result = parse(
+            '[[1,1],["Foo",2],{"bar":3},["Bar",4],{"answer":5},42]',
+            revivers,
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] is result[1]
+        assert isinstance(result[0], Foo)
+        assert isinstance(result[0].value["bar"], Bar)
+        assert result[0].value["bar"].value["answer"] == 42
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# parse – error cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestParseErrors:
+    def test_empty_string(self):
+        with pytest.raises(json.JSONDecodeError):
+            parse("")
+
+    def test_invalid_json(self):
+        with pytest.raises(json.JSONDecodeError):
+            parse("][")
+
+    def test_hole_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(str(HOLE))
+
+    def test_string_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse('"hello"')
+
+    def test_number_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse("42")
+
+    def test_boolean_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse("true")
+
+    def test_null_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse("null")
+
+    def test_object_standalone(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse("{}")
+
+    def test_empty_array(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse("[]")
+
+    def test_prototype_pollution(self):
+        with pytest.raises(ValueError, match="__proto__"):
+            parse('[{"__proto__":1},{}]')
+
+    def test_prototype_pollution_null_proto(self):
+        with pytest.raises(ValueError, match="__proto__"):
+            parse('[["null","__proto__",1],{}]')
+
+    def test_nested_prototype_pollution_null_proto(self):
+        with pytest.raises(ValueError, match="__proto__"):
+            parse('[{"data":1},["null","__proto__",2],{"polluted":3},true]')
+
+    def test_prototype_pollution_via_object_wrapper(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse('[["Object",{"__proto__":1}],{}]')
+
+    def test_typed_array_with_non_arraybuffer(self):
+        with pytest.raises(ValueError, match="Invalid data"):
+            parse('[["Int8Array", 1], { "length": 2 }, 1000000000]')
+
+    def test_arraybuffer_with_non_string(self):
+        with pytest.raises(ValueError, match="Invalid ArrayBuffer encoding"):
+            parse('[["ArrayBuffer", { "length": 100 }]]')
+
+    def test_sparse_array_proto_pollution(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 1, "__proto__", {"polluted": True}]]))
+
+    def test_sparse_array_non_integer_index(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 5, "foo", 1]]))
+
+    def test_sparse_array_negative_index(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 5, -1, 1]]))
+
+    def test_sparse_array_out_of_bounds(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 2, 5, 1]]))
+
+    def test_sparse_array_non_integer_length(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, "abc"]]))
+
+    def test_sparse_array_negative_length(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, -3]]))
+
+    def test_sparse_array_float_length(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 1.5]]))
+
+    def test_sparse_array_float_index(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, 5, 1.5, 1]]))
+
+    def test_sparse_array_length_above_max_array_len(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(json.dumps([[SPARSE, MAX_ARRAY_LEN + 1]]))
+
+    def test_typed_array_self_reference(self):
+        with pytest.raises(ValueError, match="Invalid data"):
+            parse('[["Uint8Array", 0]]')
+
+    def test_custom_reviver_self_reference(self):
+        with pytest.raises(ValueError, match="Invalid circular reference"):
+            parse('[["Custom", 0]]', revivers={"Custom": lambda v: v})
+
+    def test_mutual_typed_array_reference(self):
+        with pytest.raises(ValueError, match="Invalid data"):
+            parse('[["Uint8Array", 1], ["Uint8Array", 0]]')
+
+    def test_unknown_type(self):
+        with pytest.raises(ValueError, match="Unknown type"):
+            parse('[["NoSuchType","data"]]')
+
+    def test_bad_index(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse('[{"0":1,"toString":"push"},"hello"]')
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# unflatten (direct, without JSON.parse step)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestUnflatten:
+    def test_special_constants(self):
+        assert unflatten(UNDEFINED) is Undefined
+        assert math.isnan(unflatten(NAN))
+        assert unflatten(POSITIVE_INFINITY) == float("inf")
+        assert unflatten(NEGATIVE_INFINITY) == float("-inf")
+        result = unflatten(NEGATIVE_ZERO)
+        assert result == 0.0 and math.copysign(1, result) < 0
+
+    def test_array(self):
+        assert unflatten([[1, 2, 3], "a", "b", "c"]) == ["a", "b", "c"]
+
+    def test_object(self):
+        assert unflatten([{"foo": 1}, "bar"]) == {"foo": "bar"}
+
+    def test_rejects_standalone_number(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            unflatten(42)
+
+    def test_rejects_empty_list(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            unflatten([])
+
+    def test_rejects_non_list(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            unflatten("hello")
+
+    def test_sparse_proto_pollution_unflatten(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            unflatten([[SPARSE, 1, "__proto__", {"polluted": True}]])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# round-trip tests (stringify → parse)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRoundTrip:
+    """Verify that stringify → parse produces an equivalent value."""
+
+    def test_integer(self):
+        assert parse(stringify(42)) == 42
+
+    def test_negative_integer(self):
+        assert parse(stringify(-5)) == -5
+
+    def test_float(self):
+        assert parse(stringify(0.1)) == pytest.approx(0.1)
+
+    def test_nan(self):
+        assert math.isnan(parse(stringify(float("nan"))))
+
+    def test_infinity(self):
+        assert parse(stringify(float("inf"))) == float("inf")
+
+    def test_neg_infinity(self):
+        assert parse(stringify(float("-inf"))) == float("-inf")
+
+    def test_neg_zero(self):
+        result = parse(stringify(-0.0))
+        assert result == 0.0
+        assert math.copysign(1, result) < 0
+
+    def test_string(self):
+        assert parse(stringify("hello world")) == "hello world"
+
+    def test_none(self):
+        assert parse(stringify(None)) is None
+
+    def test_true(self):
+        assert parse(stringify(True)) is True
+
+    def test_false(self):
+        assert parse(stringify(False)) is False
+
+    def test_undefined(self):
+        assert parse(stringify(Undefined)) is Undefined
+
+    def test_list(self):
+        assert parse(stringify([1, "two", None])) == [1, "two", None]
+
+    def test_dict(self):
+        assert parse(stringify({"a": 1, "b": "c"})) == {"a": 1, "b": "c"}
+
+    def test_set(self):
+        assert parse(stringify({1, 2, 3})) == {1, 2, 3}
+
+    def test_date(self):
+        dt = datetime(2024, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
+        result = parse(stringify(dt))
+        assert isinstance(result, datetime)
+        assert result == dt
+
+    def test_regex(self):
+        p = re.compile("foo.*bar", re.IGNORECASE)
+        result = parse(stringify(p))
+        assert isinstance(result, re.Pattern)
+        assert result.pattern == p.pattern
+        assert result.flags & re.IGNORECASE
+
+    def test_bytes(self):
+        data = b"\x00\x01\x02\xff"
+        assert parse(stringify(data)) == data
+
+    def test_nested(self):
+        val = {
+            "users": [
+                {"name": "Alice", "age": 30},
+                {"name": "Bob", "age": 25},
+            ],
+            "count": 2,
+        }
+        assert parse(stringify(val)) == val
+
+    def test_cycle_dict(self):
+        obj: dict = {"x": 1}
+        obj["self"] = obj
+        result = parse(stringify(obj))
+        assert result["x"] == 1
+        assert result["self"] is result
+
+    def test_cycle_list(self):
+        arr: list = [1, 2]
+        arr.append(arr)
+        result = parse(stringify(arr))
+        assert result[0] == 1
+        assert result[1] == 2
+        assert result[2] is result
+
+    def test_shared_reference(self):
+        inner = {"x": 1}
+        outer = [inner, inner]
+        result = parse(stringify(outer))
+        assert result[0] is result[1]
+        assert result[0] == {"x": 1}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# valid sparse array
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSparseArray:
+    def test_valid_sparse_array(self):
+        payload = json.dumps([[SPARSE, 3, 0, 1, 2, 2], "a", "c"])
+        result = parse(payload)
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0] == "a"
+        assert result[1] is Undefined
+        assert result[2] == "c"
+
+    def test_very_sparse_multiple_values(self):
+        payload = json.dumps([[SPARSE, 21, 10, 1, 20, 2], "a", "b"])
+        result = parse(payload)
+        assert len(result) == 21
+        assert result[10] == "a"
+        assert result[20] == "b"
+        assert result[0] is Undefined
+
+    def test_array_with_negative_zero_after_zero(self):
+        result = parse(f"[[1,{NEGATIVE_ZERO}],0]")
+        assert result[0] == 0
+        assert result[1] == 0.0
+        assert math.copysign(1, result[1]) < 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# cross-format: verify Python can parse JSON produced by JS devalue
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestJSCompat:
+    """Verify that JSON wire-format strings from JS devalue can be parsed."""
+
+    def test_js_boxed_number(self):
+        # JS: new Number(42) → '["Object",1],42]'
+        assert parse('[["Object",1],42]') == 42
+
+    def test_js_boxed_string(self):
+        assert parse('[["Object",1],"woo!!!"]') == "woo!!!"
+
+    def test_js_boxed_boolean(self):
+        assert parse('[["Object",1],true]') is True
+
+    def test_js_set(self):
+        assert parse('[["Set",1,2,3],1,2,3]') == {1, 2, 3}
+
+    def test_js_map(self):
+        assert parse('[["Map",1,2],"a","b"]') == {"a": "b"}
+
+    def test_js_url(self):
+        url = "https://user:password@example.com/%3Cscript%3E/path?foo=bar#hash"
+        assert parse(f'[["URL","{url}"]]') == url
+
+    def test_js_url_search_params(self):
+        assert parse('[["URLSearchParams","foo=1&foo=2&baz=%3C+%3E"]]') == "foo=1&foo=2&baz=%3C+%3E"
+
+    def test_js_temporal_duration(self):
+        assert parse('[["Temporal.Duration","P1Y2M3D"]]') == "P1Y2M3D"
+
+    def test_js_temporal_instant(self):
+        assert parse('[["Temporal.Instant","1999-09-29T05:30:00Z"]]') == "1999-09-29T05:30:00Z"
+
+    def test_js_null_prototype_empty(self):
+        assert parse('[["null"]]') == {}
+
+    def test_js_null_prototype_with_data(self):
+        result = parse('[{"foo":1,"self":0},"bar"]')
+        assert result["foo"] == "bar"
+        assert result["self"] is result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# regressions — places where the port used to diverge from JS devalue
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _caching_reviver(cls, cache):
+    """Reviver that returns one instance per payload.
+
+    Stands in for the ``WeakMap`` the JS suite uses; the payload is kept
+    alive by the parser for the duration of the call, so ``id`` is stable.
+    """
+
+    def revive(payload):
+        instance = cache.get(id(payload))
+        if instance is None:
+            instance = cls.__new__(cls)
+            cache[id(payload)] = instance
+        instance.value = payload
+        return instance
+
+    return revive
+
+
+class TestCircularRevivers:
+    """Ported from the JS suite's `circular references through custom types`.
+
+    A payload that already finished hydrating must be revived directly rather
+    than tripping the in-progress guard.
+    """
+
+    def test_resolves_circular_reference_through_two_custom_types(self):
+        foo = Foo({"name": "outer"})
+        bar = Bar({"name": "inner", "ref": foo})
+        foo.value["ref"] = bar
+
+        reducers = {
+            "Foo": lambda x: x.value if isinstance(x, Foo) else None,
+            "Bar": lambda x: x.value if isinstance(x, Bar) else None,
+        }
+        revivers = {
+            "Foo": _caching_reviver(Foo, {}),
+            "Bar": _caching_reviver(Bar, {}),
+        }
+
+        result = parse(stringify(foo, reducers), revivers)
+
+        assert isinstance(result, Foo)
+        assert isinstance(result.value["ref"], Bar)
+        assert result.value["ref"].value["ref"] is result
+
+    def test_resolves_self_referencing_custom_type(self):
+        foo = Foo({"name": "self"})
+        foo.value["ref"] = foo
+
+        reducers = {"Foo": lambda x: x.value if isinstance(x, Foo) else None}
+        revivers = {"Foo": _caching_reviver(Foo, {})}
+
+        result = parse(stringify(foo, reducers), revivers)
+
+        assert isinstance(result, Foo)
+        assert result.value["ref"] is result
+
+    def test_uncached_reviver_still_resolves_the_cycle(self):
+        result = parse('[["C",1],{"self":0}]', {"C": lambda v: {"wrapped": v}})
+        assert result["wrapped"]["self"]["wrapped"] is result["wrapped"]
+
+    def test_genuinely_infinite_payload_still_rejected(self):
+        with pytest.raises(ValueError, match="Invalid circular reference"):
+            parse('[["C",0]]', {"C": lambda v: v})
+
+
+class TestOutOfRangeIndex:
+    """JS reads past the end of the array and gets `undefined`.
+
+    Python would wrap a negative index around to a real element, silently
+    yielding the wrong value, or raise IndexError.
+    """
+
+    def test_negative_index_does_not_wrap_around(self):
+        assert parse("[[-8],1,2,3,4,5,6,7,8]") == [Undefined]
+
+    def test_index_past_end(self):
+        assert parse("[[9],1]") == [Undefined]
+
+    def test_non_integral_index(self):
+        assert parse("[[1.5],1]") == [Undefined]
+
+    def test_integral_float_index_still_resolves(self):
+        assert parse('[[1.0],"a"]') == ["a"]
+
+
+class TestSparseArrayLimits:
+    def test_integral_float_length_accepted(self):
+        # JSON `3.0` is an integer to `Number.isInteger`, so JS accepts it.
+        assert parse(f'[[{SPARSE},3.0,0,1],"a"]') == ["a", Undefined, Undefined]
+
+    def test_length_at_materialization_cap_allocates(self):
+        result = parse(f"[[{SPARSE},{MAX_SPARSE_ARRAY_LENGTH},0,1],1]")
+        assert len(result) == MAX_SPARSE_ARRAY_LENGTH
+
+    def test_oversized_length_is_rejected_without_allocating(self):
+        # A 15-byte payload must not be able to demand gigabytes.
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            parse(f"[[{SPARSE},{MAX_ARRAY_LEN}]]")
+
+
+class TestReducerTruthiness:
+    """A reducer claims a value by returning something JS-truthy.
+
+    Empty containers are truthy in JS but falsy in Python, so the two
+    disagree about whether the reducer handled the value.
+    """
+
+    # Expected strings are what JS devalue emits for the same reducer.
+    @pytest.mark.parametrize(
+        ("reduced", "expected"),
+        [
+            ({}, '[["Foo",1],{}]'),
+            ([], '[["Foo",1],[]]'),
+            (set(), '[["Foo",1],["Set"]]'),
+            ("0", '[["Foo",1],"0"]'),
+            (-1, '[["Foo",1],-1]'),
+            (float("inf"), '[["Foo",-4]]'),
+        ],
+    )
+    def test_js_truthy_results_claim_the_value(self, reduced, expected):
+        reducers = {"Foo": lambda x: reduced if isinstance(x, Foo) else None}
+        assert stringify(Foo(1), reducers) == expected
+
+    @pytest.mark.parametrize("reduced", [None, False, 0, 0.0, -0.0, "", float("nan")])
+    def test_js_falsy_results_decline(self, reduced):
+        reducers = {"Foo": lambda x: reduced if isinstance(x, Foo) else None}
+        with pytest.raises(DevalueError, match="Cannot stringify arbitrary non-POJOs"):
+            stringify(Foo(1), reducers)
+
+
+class TestIndexIdentity:
+    """`indexes` is keyed by `id()`, which is only unique among live objects.
+
+    Without a strong reference a reducer's temporary can be collected and its
+    address reused, aliasing a later value onto the earlier one's index.
+    """
+
+    def test_reducer_temporaries_do_not_alias(self):
+        boxes = [Foo(1), Foo(2), Foo(3)]
+        reducers = {"Foo": lambda x: {"v": x.value} if isinstance(x, Foo) else None}
+
+        serialized = stringify(boxes, reducers)
+        assert serialized == '[[1,4,7],["Foo",2],{"v":3},1,["Foo",5],{"v":6},2,["Foo",8],{"v":9},3]'
+
+        revived = parse(serialized, {"Foo": lambda x: Foo(x["v"])})
+        assert [f.value for f in revived] == [1, 2, 3]
+
+
+class TestLargeIntegers:
+    """Python ints are unbounded; JS `number` is not.
+
+    Anything outside the safe range is a `bigint` on the JS side, so emitting
+    a bare JSON number would silently round-trip as a different value.
+    """
+
+    @pytest.mark.parametrize("value", [MAX_SAFE_INTEGER, -MAX_SAFE_INTEGER, 0, 1, -1])
+    def test_safe_integers_stay_bare_numbers(self, value):
+        assert stringify(value) == f"[{value}]"
+
+    @pytest.mark.parametrize(
+        "value",
+        [MAX_SAFE_INTEGER + 1, -MAX_SAFE_INTEGER - 1, 2**64, 123456789012345678901234567890],
+    )
+    def test_unsafe_integers_use_the_bigint_tag(self, value):
+        assert stringify(value) == f'[["BigInt","{value}"]]'
+        assert parse(stringify(value)) == value
+
+    def test_nested_large_integer(self):
+        assert parse(stringify({"n": 2**70})) == {"n": 2**70}

--- a/src/vercel/tests/unit/test_devalue.py
+++ b/src/vercel/tests/unit/test_devalue.py
@@ -15,6 +15,9 @@ import pytest
 
 from vercel._internal.devalue import (
     DevalueError,
+    Hole,
+    JsBigInt,
+    JsRegExp,
     Undefined,
     parse,
     stringify,
@@ -422,15 +425,14 @@ class TestParseBasics:
 
     def test_regex(self):
         result = parse('[["RegExp","regexp","gim"]]')
-        assert isinstance(result, re.Pattern)
-        assert result.pattern == "regexp"
-        assert result.flags & re.IGNORECASE
-        assert result.flags & re.MULTILINE
+        assert result == JsRegExp("regexp", "gim")
+        # `g` has no Python counterpart but survives the round trip.
+        assert result.flags == "gim"
+        assert result.compile().flags & re.IGNORECASE
 
     def test_regex_no_flags(self):
         result = parse('[["RegExp","test"]]')
-        assert isinstance(result, re.Pattern)
-        assert result.pattern == "test"
+        assert result == JsRegExp("test", "")
 
     def test_array(self):
         assert parse('[[1,2,3],"a","b","c"]') == ["a", "b", "c"]
@@ -442,16 +444,16 @@ class TestParseBasics:
         json_str = f'[[{HOLE},1,{HOLE}],"b"]'
         result = parse(json_str)
         assert len(result) == 3
-        assert result[0] is Undefined
+        assert result[0] is Hole
         assert result[1] == "b"
-        assert result[2] is Undefined
+        assert result[2] is Hole
 
     def test_very_sparse_array(self):
         json_str = f'[[{SPARSE},1000001,1000000,1],"x"]'
         result = parse(json_str)
         assert len(result) == 1000001
         assert result[1000000] == "x"
-        assert result[0] is Undefined
+        assert result[0] is Hole
 
     def test_object(self):
         assert parse('[{"foo":1,"x-y":2},"bar","z"]') == {
@@ -562,7 +564,7 @@ class TestParseRepetition:
     def test_regex_repetition(self):
         result = parse('[[1,1],["RegExp","regexp"]]')
         assert result[0] is result[1]
-        assert isinstance(result[0], re.Pattern)
+        assert isinstance(result[0], JsRegExp)
 
     def test_date_repetition(self):
         result = parse('[[1,1],["Date","2001-09-09T01:46:40.000Z"]]')
@@ -815,11 +817,12 @@ class TestRoundTrip:
         assert result == dt
 
     def test_regex(self):
+        # A Python pattern is accepted on the way out but lands as the
+        # lossless container, not as a `re.Pattern` again.
         p = re.compile("foo.*bar", re.IGNORECASE)
         result = parse(stringify(p))
-        assert isinstance(result, re.Pattern)
-        assert result.pattern == p.pattern
-        assert result.flags & re.IGNORECASE
+        assert result == JsRegExp("foo.*bar", "i")
+        assert result.compile().flags & re.IGNORECASE
 
     def test_bytes(self):
         data = b"\x00\x01\x02\xff"
@@ -870,7 +873,7 @@ class TestSparseArray:
         assert isinstance(result, list)
         assert len(result) == 3
         assert result[0] == "a"
-        assert result[1] is Undefined
+        assert result[1] is Hole
         assert result[2] == "c"
 
     def test_very_sparse_multiple_values(self):
@@ -879,7 +882,7 @@ class TestSparseArray:
         assert len(result) == 21
         assert result[10] == "a"
         assert result[20] == "b"
-        assert result[0] is Undefined
+        assert result[0] is Hole
 
     def test_array_with_negative_zero_after_zero(self):
         result = parse(f"[[1,{NEGATIVE_ZERO}],0]")
@@ -1018,17 +1021,27 @@ class TestOutOfRangeIndex:
     def test_index_past_end(self):
         assert parse("[[9],1]") == [Undefined]
 
-    def test_non_integral_index(self):
-        assert parse("[[1.5],1]") == [Undefined]
-
-    def test_integral_float_index_still_resolves(self):
-        assert parse('[[1.0],"a"]') == ["a"]
+    @pytest.mark.parametrize("index", ["1.5", "1.0"])
+    def test_float_index_addresses_no_slot(self, index):
+        # JS would resolve `1.0` (it has no int/float split) but nothing emits
+        # a float index, and upstream only ever tests that floats are refused.
+        assert parse(f'[[{index}],"a"]') == [Undefined]
 
 
 class TestSparseArrayLimits:
-    def test_integral_float_length_accepted(self):
-        # JSON `3.0` is an integer to `Number.isInteger`, so JS accepts it.
-        assert parse(f'[[{SPARSE},3.0,0,1],"a"]') == ["a", Undefined, Undefined]
+    # `[[SPARSE,1.5]]` and `[[SPARSE,5,1.5,1]]` are upstream's own cases and
+    # live in TestParseErrors. These are the integral-float forms, where the
+    # port is deliberately stricter: `Number.isInteger(3.0)` is true so JS
+    # happens to accept them, but nothing emits a float here and upstream only
+    # ever asserts the rejections, so accepting it would be matching an
+    # implementation accident.
+    @pytest.mark.parametrize(
+        "payload",
+        [f'[[{SPARSE},3.0,0,1],"a"]', f'[[{SPARSE},5,3.0,1],"a"]'],
+    )
+    def test_integral_float_length_and_index_are_rejected(self, payload):
+        with pytest.raises(ValueError, match="Invalid input"):
+            parse(payload)
 
     def test_length_at_materialization_cap_allocates(self):
         result = parse(f"[[{SPARSE},{MAX_SPARSE_ARRAY_LENGTH},0,1],1]")
@@ -1109,3 +1122,140 @@ class TestLargeIntegers:
 
     def test_nested_large_integer(self):
         assert parse(stringify({"n": 2**70})) == {"n": 2**70}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# lossless containers for JS-only distinctions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestJsRegExp:
+    """A JS RegExp is kept as source + flags rather than compiled.
+
+    `re` rejects patterns JS accepts, and silently changes the meaning of
+    others, so compiling would both crash on valid payloads and misrepresent
+    them.
+    """
+
+    @pytest.mark.parametrize(
+        "source",
+        [r"(?<year>\d{4})", r"\p{Letter}", r"\cJ", "[]", r"\u{1F600}"],
+    )
+    def test_patterns_python_cannot_compile_still_parse(self, source):
+        payload = json.dumps([["RegExp", source]])
+        assert parse(payload) == JsRegExp(source, "")
+        with pytest.raises(re.error):
+            parse(payload).compile()
+
+    def test_js_only_flags_survive(self):
+        result = parse('[["RegExp","a+","gimsuy"]]')
+        assert result.flags == "gimsuy"
+        # Only i/m/s have Python counterparts; g/u/y are dropped on compile.
+        assert result.compile().flags & (re.IGNORECASE | re.MULTILINE | re.DOTALL)
+
+    def test_round_trips_verbatim(self):
+        original = JsRegExp(r"(?<y>\d+)", "gu")
+        assert parse(stringify(original)) == original
+
+    def test_equality_is_by_source_and_flags(self):
+        assert JsRegExp("a", "g") == JsRegExp("a", "g")
+        assert JsRegExp("a", "g") != JsRegExp("a", "")
+        assert JsRegExp("a", "g") != JsRegExp("b", "g")
+
+
+class TestJsBigInt:
+    """`bigint` is a distinct JS type, not just a large integer."""
+
+    def test_parses_to_jsbigint(self):
+        assert parse('[["BigInt","1"]]') == JsBigInt(1)
+        assert isinstance(parse('[["BigInt","1"]]'), JsBigInt)
+
+    def test_behaves_like_an_int(self):
+        assert JsBigInt(6) + 1 == 7
+        assert isinstance(JsBigInt(6), int)
+
+    def test_small_bigint_keeps_its_tag(self):
+        # A plain `1` would come back as a JS number, losing the distinction.
+        assert stringify(JsBigInt(1)) == '[["BigInt","1"]]'
+        assert stringify(1) == "[1]"
+
+    def test_not_deduplicated_against_a_plain_int(self):
+        # JS Map keys use SameValueZero, where `1n !== 1`.
+        assert stringify([JsBigInt(1), 1]) == '[[1,2],["BigInt","1"],1]'
+
+
+class TestHole:
+    """An array hole is distinct from a slot holding `undefined`."""
+
+    def test_hole_and_undefined_parse_differently(self):
+        assert parse(f"[[{HOLE},1],1]") == [Hole, 1]
+        assert parse(f"[[{UNDEFINED},1],1]") == [Undefined, 1]
+
+    def test_hole_round_trips_as_a_hole(self):
+        assert stringify([Hole, 1]) == f"[[{HOLE},1],1]"
+        assert stringify([Undefined, 1]) == f"[[{UNDEFINED},1],1]"
+
+    def test_hole_outside_an_array_is_rejected(self):
+        with pytest.raises(DevalueError, match="hole outside an array"):
+            stringify(Hole)
+        with pytest.raises(DevalueError, match="hole outside an array"):
+            stringify({"a": Hole})
+
+
+class TestBoxedSentinels:
+    """`["Object", <negative sentinel>]` is a valid payload.
+
+    Regression: the Object branch did its own raw `values[...]` lookup, so a
+    boxed NaN/Infinity/-0 raised IndexError instead of unboxing. Found by
+    running upstream's own fixtures.
+    """
+
+    @pytest.mark.parametrize(
+        ("payload", "check"),
+        [
+            (f'[["Object",{NAN}]]', lambda v: math.isnan(v)),
+            (f'[["Object",{POSITIVE_INFINITY}]]', lambda v: v == float("inf")),
+            (f'[["Object",{NEGATIVE_INFINITY}]]', lambda v: v == float("-inf")),
+            (f'[["Object",{NEGATIVE_ZERO}]]', lambda v: math.copysign(1, v) < 0),
+            (f'[["Object",{UNDEFINED}]]', lambda v: v is Undefined),
+        ],
+    )
+    def test_boxed_sentinel_unboxes(self, payload, check):
+        assert check(parse(payload))
+
+
+class TestMapLimitations:
+    """A JS ``Map`` lands as a ``dict``, which is lossier than it looks.
+
+    Insertion order is fine — ``dict`` has preserved it since 3.7 — but key
+    identity is not: ``dict`` uses ``__hash__``/``__eq__`` where JS uses
+    SameValueZero, and it cannot hold an unhashable key at all. Recorded here
+    because two of these lose data with no error at all.
+    """
+
+    def test_string_keys_lose_only_the_map_tag(self):
+        result = parse('[["Map",1,2,3,4],"a",1,"b",2]')
+        assert result == {"a": 1, "b": 2}
+        # Re-encodes as a plain object, so the far side no longer sees a Map.
+        assert stringify(result) == '[{"a":1,"b":2},1,2]'
+
+    def test_insertion_order_is_preserved(self):
+        assert list(parse('[["Map",1,2,3,4],"z",1,"a",2]')) == ["z", "a"]
+
+    def test_bool_and_int_keys_collapse_silently(self):
+        # `Map([[1, "one"], [true, "true"]])` has two entries in JS, but
+        # `True == 1` and `hash(True) == hash(1)`, so one value is destroyed
+        # without any error being raised.
+        result = parse('[["Map",1,2,3,4],1,"one",true,"true"]')
+        assert result == {1: "true"}
+        assert "one" not in result.values()
+
+    def test_non_string_keys_cannot_be_re_encoded(self):
+        result = parse('[["Map",1,2],1,"a"]')
+        assert result == {1: "a"}
+        with pytest.raises(DevalueError, match="non-string keys"):
+            stringify(result)
+
+    def test_unhashable_keys_cannot_be_parsed(self):
+        with pytest.raises(TypeError, match="unhashable"):
+            parse('[["Map",1,3],{"id":2},1,"v"]')

--- a/src/vercel/tests/unit/test_devalue.py
+++ b/src/vercel/tests/unit/test_devalue.py
@@ -1,7 +1,7 @@
 """Tests for vercel._internal.devalue — Python port of JS devalue.
 
 Test cases are modelled after the JS test suite at
-https://github.com/Rich-Harris/devalue/blob/main/test/index.test.js
+https://github.com/sveltejs/devalue/blob/main/test/index.test.js
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Python port of the JS [`devalue`](https://github.com/sveltejs/devalue) wire format, pinned to upstream **5.9.0**, so the workflow SDK can exchange payloads with the TypeScript SDK. Compatible both directions, including cycles, shared references, and custom reducers/revivers.

Four types carry distinctions Python lacks: `Undefined`, `Hole` (an array hole ≠ a slot holding `undefined`), `JsBigInt(int)` (a `bigint` at any size, `int` subclass so it still computes normally), and `JsRegExp(source, flags)` — kept verbatim rather than compiled, because `re` raises on patterns JS accepts (`(?<n>…)`, `\p{…}`) and silently redefines others (`\d` is ASCII-only in JS).

Untrusted input: an out-of-range index hydrates to `Undefined` rather than wrapping to a real element, and an oversized sparse array is rejected rather than allocated (JS gets this free from dictionary-mode arrays; a Python list is dense).

## Tests

371, in two layers. Unit tests (239) pin exact wire bytes offline. Interop tests (132) run the real JS package via Node — our own values full-circle (Python encode → JS `deepStrictEqual` → JS encode → Python decode), plus **upstream's 106 fixtures and 28 error cases**. Comparison is semantic, not byte-exact; byte equality would need ordered sets and JS number formatting, neither related to correctness.

Worth it: this found a crash where `[["Object",-3]]` (boxed `NaN`) raised `IndexError`.

## Known lossiness

46 upstream fixtures don't round-trip — boxed primitives, typed arrays, `Temporal.*`, `Map`, `URL`, null-prototype objects, invalid `Date`. Recorded as `_KNOWN_LOSSY` and asserted **both** ways, so closing a gap or regressing one each fail until the list is updated. Wrappers get added as we need them.

Most lose only the type tag. **`Map` is the exception**: a `dict` keeps insertion order but not JS key identity, so `1` and `true` collapse into one entry with no error. Pinned separately.

Not ported: `uneval`, `stringifyAsync`, pluggable `operations` — nothing in workflow needs them.

## CI

Adds Node and clones devalue at `v5.9.0` into `RUNNER_TEMP` (upstream's fixtures aren't in the npm tarball). Interop tests skip without Node locally, mandatory in CI, per the `tests/test_examples.py` precedent.