### PR TITLE
[integrations] APScheduler: Activate production schedulers on request traffic

### DIFF
--- a/changes/vercel-apscheduler/queues-adapter.feature.md
+++ b/changes/vercel-apscheduler/queues-adapter.feature.md
@@ -2,4 +2,5 @@ Add Redis-backed APScheduler subscribers for Vercel Queues. The integration
 patches `scheduler.start()`, `scheduler.pause()`, and `scheduler.resume()` with
 durable, deployment-scoped lifecycle transitions and atomic single-chain
 fencing. Paused occurrences are skipped on resume, and interrupted successor
-publication is repaired on retry.
+publication is repaired on retry. Production schedules activate on the first
+request.

--- a/integrations/vercel-apscheduler/README.md
+++ b/integrations/vercel-apscheduler/README.md
@@ -55,9 +55,22 @@ The integration uses that store's configured Redis client for its internal
 lifecycle coordination. A missing `REDIS_URL` fails the import with a
 `KeyError`, which is intended: there is no implicit localhost fallback.
 
-Set explicit socket timeouts on the connection pool, as shown above, so an
-unreachable Redis fails fast instead of stalling lifecycle calls and Queue
-deliveries.
+Set explicit socket timeouts on the connection pool, as shown above. The
+runtime performs its automatic-activation Redis work around request handling,
+bounded by a fixed wait; without socket timeouts an unreachable Redis holds
+that entire bound instead of failing fast.
+
+## Automatic activation
+
+Production deployments activate automatically on their first real request.
+The integration is registered while the application imports, but the Redis
+transition and first Queue send are deferred until the runtime has installed
+that request's OIDC credentials. Builds never enqueue messages.
+
+An explicit `pause()` remains paused across later requests; automatic
+activation never overrides it. A deployment that has never received a request
+cannot start automatically because it has not received request-scoped OIDC
+credentials. Preview deployments do not activate automatically.
 
 ## Start, pause, and resume
 
@@ -111,9 +124,11 @@ heartbeat. `add_job()`, `modify_job()`, `reschedule_job()`, `pause_job()`,
 `resume_job()`, and removals update Redis and rearm the one current wake as
 needed.
 
-Call `scheduler.start()` first in each Function instance that changes jobs;
-before that boundary, `add_job()` calls are treated as module-level
-declarations. The call is idempotent:
+Automatic activation establishes the runtime-mutation boundary before the
+user application handles a production request. In environments without
+automatic activation, call `scheduler.start()` first in each Function
+instance that changes jobs; before that boundary, `add_job()` calls are
+treated as module-level declarations. The call is idempotent:
 
 ```python
 @app.post("/jobs")
@@ -156,6 +171,8 @@ previews. This gives the driver the following guarantees:
   are inert.
 - A wake whose queue message died is presumed lost once it is well past due
   with no live owner, and republished by the owner.
+- Concurrent first requests converge on one automatic generation and one
+  start identity.
 
 The scheduler's durable identity derives from its `RedisJobStore` `jobs_key`,
 so renaming variables or moving modules never orphans state. Two schedulers
@@ -190,8 +207,8 @@ retry without running unfenced work.
 - Jobs declared in code need explicit stable IDs.
 - When the same ID already exists in Redis, declare it with
   `replace_existing=True`. `scheduled_job()` already enables replacement.
-- Runtime mutation APIs require a prior idempotent `scheduler.start()` in
-  that Function instance.
+- Runtime mutation APIs require prior activation in that Function instance,
+  either automatically on the request or through `scheduler.start()`.
 - Job execution is at-least-once.
 
 See [SCHEDULER.md](SCHEDULER.md) for the state machine and failure model. A

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -59,10 +59,11 @@ makes it paused. `resume()` has the same durable transition as starting a
 paused scheduler. Each method is idempotent. The caller must be executing in
 the target deployment; v1 has no cross-deployment control API.
 
-Production additionally registers an automatic activation hook during import.
-The Vercel Python Runtime executes it around the application's first real
-request, after request-scoped OIDC credentials are available. Automatic
-activation never overrides an explicitly paused driver.
+Named environments (production and custom environments) additionally register
+an automatic activation hook during import. The Vercel Python Runtime
+executes it around the application's first real request, after request-scoped
+OIDC credentials are available. Automatic activation never overrides an
+explicitly paused driver.
 
 Outside Vercel, APScheduler's original methods are used.
 
@@ -295,6 +296,14 @@ and acks, it repairs and rearms nothing, its cold starts write no
 declarations, and its mutation APIs refuse loudly. Its queue simply drains.
 A rollback is the same operation in the other direction; the mechanism has
 no notion of old and new, only of who owns the chain now.
+
+Automatic takeover is traffic-driven: it happens on the first request the
+promoted deployment serves through an environment alias. After promoting or
+rolling back a deployment that receives no organic traffic, send one request
+through the environment's domain (or schedule a cron heartbeat) so the chain
+hands over promptly. Alias routing is judged by the request host, so do not
+point a manually created alias at an old deployment of a scheduler project:
+requests through that alias would let the old deployment take the chain.
 
 On takeover the new owner reconciles the
 store against its own declarations, before planning any due jobs: a job the

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -59,6 +59,11 @@ makes it paused. `resume()` has the same durable transition as starting a
 paused scheduler. Each method is idempotent. The caller must be executing in
 the target deployment; v1 has no cross-deployment control API.
 
+Production additionally registers an automatic activation hook during import.
+The Vercel Python Runtime executes it around the application's first real
+request, after request-scoped OIDC credentials are available. Automatic
+activation never overrides an explicitly paused driver.
+
 Outside Vercel, APScheduler's original methods are used.
 
 ## Durable state
@@ -115,6 +120,11 @@ insert-if-absent semantics, so a cold import cannot overwrite a job changed
 through a runtime API. `finish_start` then atomically marks the start active
 and reserves sequence 1 — or, when no job is scheduled, leaves the driver
 dormant with no current wake.
+
+Automatic activation performs the same generation reservation, with one
+important distinction: it never changes an explicitly paused driver. Many cold
+Function instances can attempt activation concurrently, but the Redis
+transition produces one generation and one start identity.
 
 ## One wake
 
@@ -224,9 +234,11 @@ Executing jobs may also mutate the store through the same APIs. An in-job
 persisted job, and the finishing wake reads the store again, so the change is
 reflected in the successor it reserves.
 
-Every cold Function instance that performs a runtime mutation must first call
-the idempotent `scheduler.start()`. Before that boundary, `add_job()` calls
-are treated as module-level declarations. Raw writes to Redis job-store keys
+Automatic activation establishes the boundary before a production request
+reaches the application. Without automatic activation, every cold Function
+instance that performs a runtime mutation must first call the idempotent
+`scheduler.start()`. Before that boundary, `add_job()` calls are treated as
+module-level declarations. Raw writes to Redis job-store keys
 are unsupported because they bypass atomic wake rearming and revision checks.
 
 The no-heartbeat design has one deliberate liveness contract: `start()` and
@@ -275,13 +287,14 @@ that sent it, promoted or not; when the platform enables queue aliasing for a
 project, in-flight messages are instead handed to the environment's current
 deployment. Ownership therefore decides who may act, never who received a
 delivery: `start()` on a non-owner is a takeover that transfers ownership and
-opens a new generation in one atomic step. From that moment the demoted
-deployment is fenced out of the namespace entirely: its deliveries still
-arrive but every claim turns stale and acks, it repairs and rearms nothing,
-its cold starts write no declarations, and its mutation APIs refuse loudly.
-Its queue simply drains. A rollback is the same operation in the other
-direction; the mechanism has no notion of old and new, only of who owns the
-chain now.
+opens a new generation in one atomic step, and a promoted deployment takes
+over automatically on its first request that arrives through an environment
+alias. From that moment the demoted deployment is fenced out of the
+namespace entirely: its deliveries still arrive but every claim turns stale
+and acks, it repairs and rearms nothing, its cold starts write no
+declarations, and its mutation APIs refuse loudly. Its queue simply drains.
+A rollback is the same operation in the other direction; the mechanism has
+no notion of old and new, only of who owns the chain now.
 
 On takeover the new owner reconciles the
 store against its own declarations, before planning any due jobs: a job the
@@ -328,6 +341,8 @@ expiry would make reliable pause semantics impossible.
 | takeover while a wake is in flight | the demoted deployment consumes it and acks it as stale |
 | the owner's wake message dies | the overdue wake is presumed lost and republished by the owner |
 | takeover reconciliation races a demoted deployment's handler | ownership and revision CAS keep exactly one writer per job |
+| concurrent first requests | one automatic generation and one start identity |
+| request arrives after explicit pause | state remains paused |
 
 These properties prevent parallel logical chains. They do not provide
 exactly-once job side effects. If a process dies after an external side effect

--- a/integrations/vercel-apscheduler/examples/cleanup/README.md
+++ b/integrations/vercel-apscheduler/examples/cleanup/README.md
@@ -22,11 +22,11 @@ vc link
 vc deploy --prod
 ```
 
-Start the scheduler once through the authenticated route:
+Production activates the scheduler automatically on its first request. For
+example:
 
 ```bash
-curl -X POST -H "x-admin-secret: $APSCHEDULER_ADMIN_SECRET" \
-  https://your-deployment.example/scheduler/start
+curl https://your-deployment.example/
 ```
 
 The example exposes authenticated `/scheduler/start`, `/scheduler/pause`, and

--- a/integrations/vercel-apscheduler/pyproject.toml
+++ b/integrations/vercel-apscheduler/pyproject.toml
@@ -44,6 +44,9 @@ extend = "../ruff.toml"
     "SLF001",  # integration relies on APScheduler private extension points.
     "TRY400",  # executor lookup failure is logged with APScheduler context.
 ]
+"vercel/integrations/apscheduler/_automatic.py" = [
+    "PLC0415",  # runtime-only imports avoid a hard runtime dependency and an adapter cycle.
+]
 "vercel/integrations/apscheduler/_jobstore.py" = [
     "S403",  # APScheduler's RedisJobStore persistence format is pickle-based.
     "SLF001",  # coordinated reads must reuse APScheduler's reconstitution hook.

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -56,6 +56,58 @@ def test_registers_request_driven_automatic_activation(
     ]
 
 
+@pytest.mark.parametrize(
+    ("forwarded_host", "expected"),
+    [
+        # Environment aliases route only to the promoted deployment.
+        ("test-app.vercel.app", True),
+        ("www.example.com", True),
+        # The deployment's own URL reaches it forever; proves nothing.
+        ("app-abc123-team.vercel.app", False),
+        # The branch URL tracks the branch's newest deployment, which is
+        # exactly wrong during a rollback.
+        ("app-git-main-team.vercel.app", False),
+        (None, False),
+    ],
+)
+def test_alias_routed_requests_are_the_takeover_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    forwarded_host: str | None,
+    expected: bool,  # noqa: FBT001 - parametrized expectation
+) -> None:
+    invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
+    invocation_hooks.__dict__["current_forwarded_host"] = lambda: forwarded_host
+    runtime = ModuleType("vercel_runtime")
+    runtime.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "vercel_runtime.invocation_hooks",
+        invocation_hooks,
+    )
+    monkeypatch.setenv("VERCEL_URL", "app-abc123-team.vercel.app")
+    monkeypatch.setenv("VERCEL_BRANCH_URL", "app-git-main-team.vercel.app")
+
+    assert _automatic._request_is_alias_routed() is expected
+
+
+def test_runtime_without_host_support_disables_takeover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
+    runtime = ModuleType("vercel_runtime")
+    runtime.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "vercel_runtime.invocation_hooks",
+        invocation_hooks,
+    )
+    monkeypatch.setattr(_automatic, "_takeover_warning_emitted", False)
+
+    assert _automatic._request_is_alias_routed() is False
+
+
 def test_malformed_subscriber_entry_fails_loudly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -112,11 +164,11 @@ def test_subscriber_request_does_not_register_automatic_activation(
 def test_automatic_activation_calls_every_adapter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[str] = []
+    calls: list[bool] = []
 
     class FakeAdapter:
-        def auto_activate(self) -> None:
-            calls.append("activated")
+        def auto_activate(self, *, takeover_allowed: bool) -> None:
+            calls.append(takeover_allowed)
 
     monkeypatch.setattr(
         _automatic,
@@ -125,6 +177,6 @@ def test_automatic_activation_calls_every_adapter(
     )
     monkeypatch.setattr(_adapter, "get_adapter", lambda scheduler: FakeAdapter())
 
-    _automatic._activate_configured_schedulers()
+    _automatic._activate_configured_schedulers(takeover_allowed=True)
 
-    assert calls == ["activated", "activated"]
+    assert calls == [True, True]

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -17,12 +17,12 @@ def test_registers_request_driven_automatic_activation(
     registered: list[tuple[str, Any]] = []
     invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
 
-    def register_invocation_hook(name: str, callback: Any) -> None:
+    def run_on_next_invocation(name: str, callback: Any) -> None:
         registered.append((name, callback))
 
     runtime = ModuleType("vercel_runtime")
     runtime.__path__ = []  # type: ignore[attr-defined]
-    invocation_hooks.__dict__["register_invocation_hook"] = register_invocation_hook
+    invocation_hooks.__dict__["run_on_next_invocation"] = run_on_next_invocation
     monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
     monkeypatch.setitem(
         sys.modules,
@@ -64,13 +64,13 @@ def test_subscriber_request_does_not_register_automatic_activation(
 ) -> None:
     invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
 
-    def register_invocation_hook(*args: Any, **kwargs: Any) -> None:
+    def run_on_next_invocation(*args: Any, **kwargs: Any) -> None:
         del args, kwargs
         pytest.fail("subscriber requests must not register automatic activation")
 
     runtime = ModuleType("vercel_runtime")
     runtime.__path__ = []  # type: ignore[attr-defined]
-    invocation_hooks.__dict__["register_invocation_hook"] = register_invocation_hook
+    invocation_hooks.__dict__["run_on_next_invocation"] = run_on_next_invocation
     monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
     monkeypatch.setitem(
         sys.modules,

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -40,6 +40,7 @@ def test_registers_request_driven_automatic_activation(
     )
     monkeypatch.setenv("VERCEL", "1")
     monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(
         _automatic.SUBSCRIBERS_ENV,
         '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
@@ -123,12 +124,32 @@ def test_preview_deployments_do_not_activate_automatically(
 ) -> None:
     monkeypatch.setenv("VERCEL", "1")
     monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(
         _automatic.SUBSCRIBERS_ENV,
         '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
     )
 
     assert not _automatic._automatic_environment()
+
+
+def test_custom_environments_activate_automatically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A custom environment is a named environment, not a preview.
+
+    It reports ``VERCEL_ENV=preview``, so the gate must resolve the
+    environment exactly the way durable state scoping does.
+    """
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.setenv("VERCEL_TARGET_ENV", "staging")
+    monkeypatch.setenv(
+        _automatic.SUBSCRIBERS_ENV,
+        '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
+    )
+
+    assert _automatic._automatic_environment()
 
 
 def test_subscriber_request_does_not_register_automatic_activation(

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from vercel.integrations.apscheduler import _adapter, _automatic
+from vercel.integrations.apscheduler._options import is_queue_serving_runtime
+
+
+def test_registers_request_driven_automatic_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registered: list[tuple[str, Any]] = []
+    invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
+
+    def register_invocation_hook(name: str, callback: Any) -> None:
+        registered.append((name, callback))
+
+    runtime = ModuleType("vercel_runtime")
+    runtime.__path__ = []  # type: ignore[attr-defined]
+    invocation_hooks.__dict__["register_invocation_hook"] = register_invocation_hook
+    monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "vercel_runtime.invocation_hooks",
+        invocation_hooks,
+    )
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv(
+        _automatic.SUBSCRIBERS_ENV,
+        '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
+    )
+
+    _automatic.register_automatic_activation()
+
+    assert registered == [
+        (
+            _automatic.ACTIVATION_HOOK_NAME,
+            _automatic._automatic_activation_hook,
+        )
+    ]
+
+
+def test_preview_deployments_do_not_activate_automatically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.setenv(
+        _automatic.SUBSCRIBERS_ENV,
+        '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
+    )
+
+    assert not _automatic._automatic_environment()
+
+
+def test_subscriber_request_does_not_register_automatic_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
+
+    def register_invocation_hook(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        pytest.fail("subscriber requests must not register automatic activation")
+
+    runtime = ModuleType("vercel_runtime")
+    runtime.__path__ = []  # type: ignore[attr-defined]
+    invocation_hooks.__dict__["register_invocation_hook"] = register_invocation_hook
+    monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "vercel_runtime.invocation_hooks",
+        invocation_hooks,
+    )
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_PYTHON_SUBSCRIBER_ID", "scheduler_scheduler")
+    monkeypatch.setenv(
+        _automatic.SUBSCRIBERS_ENV,
+        '[{"id":"scheduler_scheduler","entrypoint":"scheduler:scheduler"}]',
+    )
+
+    assert is_queue_serving_runtime()
+    _automatic.register_automatic_activation()
+
+
+def test_automatic_activation_calls_every_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class FakeAdapter:
+        def auto_activate(self) -> None:
+            calls.append("activated")
+
+    monkeypatch.setattr(
+        _automatic,
+        "_configured_schedulers",
+        lambda: [object(), object()],
+    )
+    monkeypatch.setattr(_adapter, "get_adapter", lambda scheduler: FakeAdapter())
+
+    _automatic._activate_configured_schedulers()
+
+    assert calls == ["activated", "activated"]

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -7,7 +7,11 @@ from types import ModuleType
 
 import pytest
 
-from vercel.integrations.apscheduler import _adapter, _automatic
+from vercel.integrations.apscheduler import (
+    APSchedulerConfigurationError,
+    _adapter,
+    _automatic,
+)
 from vercel.integrations.apscheduler._options import is_queue_serving_runtime
 
 
@@ -50,6 +54,16 @@ def test_registers_request_driven_automatic_activation(
             _automatic.HEAL_SWEEP_INTERVAL_SECONDS,
         )
     ]
+
+
+def test_malformed_subscriber_entry_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The builder owns this variable; a bad entry is a regression, not noise."""
+    monkeypatch.setenv(_automatic.SUBSCRIBERS_ENV, '[{"id":"scheduler"}]')
+
+    with pytest.raises(APSchedulerConfigurationError, match="malformed"):
+        _automatic._configured_schedulers()
 
 
 def test_preview_deployments_do_not_activate_automatically(

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -14,11 +14,16 @@ from vercel.integrations.apscheduler._options import is_queue_serving_runtime
 def test_registers_request_driven_automatic_activation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    registered: list[tuple[str, Any]] = []
+    registered: list[tuple[str, Any, float | None]] = []
     invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
 
-    def run_on_next_invocation(name: str, callback: Any) -> None:
-        registered.append((name, callback))
+    def run_on_next_invocation(
+        name: str,
+        callback: Any,
+        *,
+        repeat_after_seconds: float | None = None,
+    ) -> None:
+        registered.append((name, callback, repeat_after_seconds))
 
     runtime = ModuleType("vercel_runtime")
     runtime.__path__ = []  # type: ignore[attr-defined]
@@ -42,6 +47,7 @@ def test_registers_request_driven_automatic_activation(
         (
             _automatic.ACTIVATION_HOOK_NAME,
             _automatic._automatic_activation_hook,
+            _automatic.HEAL_SWEEP_INTERVAL_SECONDS,
         )
     ]
 

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -157,11 +157,29 @@ class FakeDriver:
                 current_wake=self.current,
             )
 
-    def auto_activate(self, now: datetime) -> StartDecision:
+    def auto_activate(
+        self,
+        now: datetime,
+        *,
+        takeover_allowed: bool = False,
+    ) -> StartDecision:
         del now
         with self.lock:
+            foreign = (
+                self.owner_deployment_value is not None
+                and self.owner_deployment_value != self.deployment
+            )
             explicitly_paused = self.state == "paused" and self.generation > 0
-            if not explicitly_paused and self.state != "running":
+            if foreign and (not takeover_allowed or explicitly_paused):
+                return StartDecision(
+                    generation=self.generation,
+                    changed=False,
+                    start_status=self.start_status or "",
+                    current_wake=self.current,
+                    state="paused" if explicitly_paused else "running",
+                    owned=False,
+                )
+            if foreign or (not explicitly_paused and self.state != "running"):
                 self.state = "running"
                 self.generation += 1
                 self.start_status = "pending"
@@ -171,6 +189,7 @@ class FakeDriver:
                 changed = True
             else:
                 changed = False
+            self.owner_deployment_value = self.deployment
             return StartDecision(
                 generation=self.generation,
                 changed=changed,
@@ -780,6 +799,35 @@ def test_takeover_reconciles_declared_jobs_and_keeps_dynamic_ones(
     assert store.jobs["changed"].next_run_time != changed_run_time
     assert store.jobs["changed"].trigger.interval == timedelta(hours=2)
     assert driver.reconciled == "dpl_two"
+
+
+def test_implicit_activation_respects_chain_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deployment-URL traffic never adopts a chain; alias traffic does."""
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_PROJECT_ID", "prj_123")
+    _scheduler, adapter, driver = scheduler_with_driver()
+    driver.owner_deployment_value = "dpl_other"
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg",
+    ) as send:
+        adapter.auto_activate()
+
+    send.assert_not_called()
+    assert driver.owner_deployment_value == "dpl_other"
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg",
+    ) as send:
+        adapter.auto_activate(takeover_allowed=True)
+
+    send.assert_called_once()
+    assert driver.owner_deployment_value == "dpl_test"
+    assert driver.reconciled == "dpl_test"
 
 
 def test_stale_deployment_touches_are_inert(

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -157,6 +157,28 @@ class FakeDriver:
                 current_wake=self.current,
             )
 
+    def auto_activate(self, now: datetime) -> StartDecision:
+        del now
+        with self.lock:
+            explicitly_paused = self.state == "paused" and self.generation > 0
+            if not explicitly_paused and self.state != "running":
+                self.state = "running"
+                self.generation += 1
+                self.start_status = "pending"
+                self.activation_time = None
+                self.current = None
+                self.last_sequence = 0
+                changed = True
+            else:
+                changed = False
+            return StartDecision(
+                generation=self.generation,
+                changed=changed,
+                start_status=self.start_status or "",
+                current_wake=self.current,
+                state="paused" if explicitly_paused else "running",
+            )
+
     def pause(self, now: datetime) -> bool:
         del now
         with self.lock:
@@ -912,6 +934,29 @@ def test_repeated_start_publishes_one_generation() -> None:
     assert driver.state == "running"
     assert driver.generation == 1
     assert StartPayload.from_payload(send.call_args.args[1]).generation == 1
+
+
+def test_automatic_activation_starts_once_and_respects_explicit_pause() -> None:
+    scheduler, adapter, driver = scheduler_with_driver()
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_start",
+    ) as send:
+        adapter.auto_activate()
+        adapter.auto_activate()
+
+        send.assert_called_once()
+        assert driver.state == "running"
+        assert driver.generation == 1
+
+        scheduler.pause()
+        adapter.auto_activate()
+
+    send.assert_called_once()
+    assert driver.state == "paused"
+    assert driver.generation == 1
+    assert scheduler.state == STATE_PAUSED
 
 
 def test_start_paused_waits_for_resume_to_publish() -> None:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -335,13 +335,8 @@ class SchedulerAdapter:
             self._pause_local()
             return
         self._publish_start_if_needed(decision, now=now)
-        if (
-            not decision.changed
-            and decision.start_status == "active"
-            and decision.current_wake is not None
-            and decision.current_wake.status == "pending"
-        ):
-            self.publish_wakeup(decision.current_wake, now=now)
+        if not decision.changed and decision.start_status == "active":
+            self.repair_wakeup(now=now)
         self._resume_local_if_paused()
 
     def pause(self) -> None:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -323,6 +323,27 @@ class SchedulerAdapter:
             self.repair_wakeup(now=now)
         self._resume_local_if_paused()
 
+    def auto_activate(self) -> None:
+        """Activate on request activity without overriding an explicit pause."""
+        self._bind_runtime()
+        self._validate_durable_configuration()
+        self._lifecycle_called = True
+        self.ensure_local_started()
+        now = datetime.now(UTC)
+        decision = self.driver.auto_activate(now)
+        if decision.state != "running":
+            self._pause_local()
+            return
+        self._publish_start_if_needed(decision, now=now)
+        if (
+            not decision.changed
+            and decision.start_status == "active"
+            and decision.current_wake is not None
+            and decision.current_wake.status == "pending"
+        ):
+            self.publish_wakeup(decision.current_wake, now=now)
+        self._resume_local_if_paused()
+
     def pause(self) -> None:
         """Durably fence the current generation."""
         self._lifecycle_called = True
@@ -1159,6 +1180,9 @@ def install_vercel_apscheduler_integration(
         _PATCH_STATE.default_options = VercelAPSchedulerOptions.from_value(options)
     _PATCH_STATE.register_queues = _PATCH_STATE.register_queues or register_queues
     if _PATCH_STATE.installed:
+        from ._automatic import register_automatic_activation
+
+        register_automatic_activation()
         return
 
     _PATCH_STATE.originals = {
@@ -1187,3 +1211,6 @@ def install_vercel_apscheduler_integration(
     BaseScheduler.resume = _patched_lifecycle("resume")  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
     _patch_start_methods()
     _PATCH_STATE.installed = True
+    from ._automatic import register_automatic_activation
+
+    register_automatic_activation()

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -323,12 +323,22 @@ class SchedulerAdapter:
             self.repair_wakeup(now=now)
         self._resume_local_if_paused()
 
-    def auto_activate(self) -> None:
-        """Activate on request activity without overriding an explicit pause."""
+    def auto_activate(self, *, takeover_allowed: bool = False) -> None:
+        """Activate on request activity without overriding an explicit pause.
+
+        ``takeover_allowed`` is true only when the triggering request arrived
+        through an environment alias, which routes exclusively to the
+        currently promoted deployment. Traffic to a deployment's own URL
+        proves nothing about promotion, so it may drive an owned chain but
+        never adopt someone else's.
+        """
         self._lifecycle_called = True
         self.ensure_local_started()
         now = datetime.now(UTC)
-        decision = self.driver.auto_activate(now)
+        decision = self.driver.auto_activate(now, takeover_allowed=takeover_allowed)
+        if not decision.owned:
+            return
+        self._reconcile_takeover(now)
         if decision.state != "running":
             self._pause_local()
             return

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -325,8 +325,6 @@ class SchedulerAdapter:
 
     def auto_activate(self) -> None:
         """Activate on request activity without overriding an explicit pause."""
-        self._bind_runtime()
-        self._validate_durable_configuration()
         self._lifecycle_called = True
         self.ensure_local_started()
         now = datetime.now(UTC)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import importlib
 import json
+import logging
 from os import environ
 
 from ._driver import APSchedulerConfigurationError
@@ -15,6 +16,8 @@ from ._options import (
     is_queue_serving_runtime,
     is_vercel_runtime,
 )
+
+LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
 ENVIRONMENT_ENV = "VERCEL_ENV"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
@@ -49,7 +52,51 @@ def register_automatic_activation() -> None:
 
 
 def _automatic_activation_hook() -> None:
-    _activate_configured_schedulers()
+    _activate_configured_schedulers(takeover_allowed=_request_is_alias_routed())
+
+
+def _request_is_alias_routed() -> bool:
+    """Whether the current request arrived through an environment alias.
+
+    Environment aliases (the production domain and custom domains) route
+    exclusively to the currently promoted deployment, so such a request
+    proves this deployment is current and may take the chain over. The
+    deployment's own URL and its branch URL prove nothing: the branch URL
+    tracks the newest deployment of the branch, which is exactly wrong
+    during a rollback.
+    """
+    try:
+        from vercel_runtime.invocation_hooks import (  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
+            current_forwarded_host,
+        )
+    except ImportError:
+        _warn_takeover_unavailable()
+        return False
+    host = (current_forwarded_host() or "").strip().casefold()
+    if not host:
+        return False
+    own_hosts = {
+        value.strip().casefold()
+        for value in (environ.get("VERCEL_URL"), environ.get("VERCEL_BRANCH_URL"))
+        if value
+    }
+    return host not in own_hosts
+
+
+_takeover_warning_emitted = False
+
+
+def _warn_takeover_unavailable() -> None:
+    global _takeover_warning_emitted  # noqa: PLW0603 - process-lifetime warn-once
+    if _takeover_warning_emitted:
+        return
+    _takeover_warning_emitted = True
+    LOGGER.warning(
+        "This Vercel Python Runtime does not expose the request host; a "
+        "promoted deployment will not take over the scheduler chain "
+        "automatically. Upgrade the runtime or call scheduler.start() "
+        "explicitly after promoting."
+    )
 
 
 def _automatic_environment() -> bool:
@@ -59,7 +106,7 @@ def _automatic_environment() -> bool:
     return environment == "production"
 
 
-def _activate_configured_schedulers() -> None:
+def _activate_configured_schedulers(*, takeover_allowed: bool) -> None:
     from ._adapter import get_adapter
 
     for scheduler in _configured_schedulers():
@@ -68,7 +115,7 @@ def _activate_configured_schedulers() -> None:
             raise APSchedulerConfigurationError(
                 "configured APScheduler subscriber was not adopted by the integration"
             )
-        adapter.auto_activate()
+        adapter.auto_activate(takeover_allowed=takeover_allowed)
 
 
 def _configured_schedulers() -> list[BaseScheduler]:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -19,6 +19,9 @@ from ._options import (
 ENVIRONMENT_ENV = "VERCEL_ENV"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 ACTIVATION_HOOK_NAME = "vercel-apscheduler:auto-activate"
+# Activation is idempotent; the periodic re-run is what notices and heals a
+# wake whose queue message died (for example stranded by a rollback).
+HEAL_SWEEP_INTERVAL_SECONDS = 5 * 60
 
 
 def register_automatic_activation() -> None:
@@ -41,6 +44,7 @@ def register_automatic_activation() -> None:
     run_on_next_invocation(
         ACTIVATION_HOOK_NAME,
         _automatic_activation_hook,
+        repeat_after_seconds=HEAL_SWEEP_INTERVAL_SECONDS,
     )
 
 

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -1,0 +1,106 @@
+"""Request-driven automatic scheduler activation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import importlib
+import json
+from os import environ
+
+from ._driver import APSchedulerConfigurationError
+from ._imports import BaseScheduler
+from ._options import (
+    is_discovery_runtime,
+    is_queue_serving_runtime,
+    is_vercel_runtime,
+)
+
+ENVIRONMENT_ENV = "VERCEL_ENV"
+SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
+ACTIVATION_HOOK_NAME = "vercel-apscheduler:auto-activate"
+
+
+def register_automatic_activation() -> None:
+    """Buffer activation until the runtime has installed request credentials."""
+    if not _automatic_environment():
+        return
+    if is_discovery_runtime() or is_queue_serving_runtime():
+        return
+
+    try:
+        from vercel_runtime.invocation_hooks import (  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
+            register_invocation_hook,
+        )
+    except ImportError as exc:
+        raise APSchedulerConfigurationError(
+            "automatic APScheduler activation requires a Vercel Python Runtime "
+            "with invocation hook support"
+        ) from exc
+
+    register_invocation_hook(
+        ACTIVATION_HOOK_NAME,
+        _automatic_activation_hook,
+    )
+
+
+def _automatic_activation_hook() -> None:
+    _activate_configured_schedulers()
+
+
+def _automatic_environment() -> bool:
+    if not is_vercel_runtime() or not environ.get(SUBSCRIBERS_ENV):
+        return False
+    environment = (environ.get(ENVIRONMENT_ENV) or "").strip().casefold()
+    return environment == "production"
+
+
+def _activate_configured_schedulers() -> None:
+    from ._adapter import get_adapter
+
+    for scheduler in _configured_schedulers():
+        adapter = get_adapter(scheduler)
+        if adapter is None:
+            raise APSchedulerConfigurationError(
+                "configured APScheduler subscriber was not adopted by the integration"
+            )
+        adapter.auto_activate()
+
+
+def _configured_schedulers() -> list[BaseScheduler]:
+    raw = environ.get(SUBSCRIBERS_ENV)
+    if not raw:
+        raise APSchedulerConfigurationError(
+            f"{SUBSCRIBERS_ENV} is not set; declare the scheduler in [[tool.vercel.subscribers]]"
+        )
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise APSchedulerConfigurationError(f"{SUBSCRIBERS_ENV} must contain JSON") from exc
+    if not isinstance(entries, list):
+        raise APSchedulerConfigurationError(f"{SUBSCRIBERS_ENV} must contain a JSON array")
+
+    schedulers: list[BaseScheduler] = []
+    for entry in entries:
+        scheduler = _scheduler_from_entry(entry)
+        if scheduler is not None:
+            schedulers.append(scheduler)
+    if not schedulers:
+        raise APSchedulerConfigurationError(
+            f"{SUBSCRIBERS_ENV} does not contain an APScheduler entrypoint"
+        )
+    return schedulers
+
+
+def _scheduler_from_entry(entry: Any) -> BaseScheduler | None:
+    if not isinstance(entry, dict):
+        return None
+    entrypoint = entry.get("entrypoint")
+    if not isinstance(entrypoint, str):
+        return None
+    module_name, separator, variable_name = entrypoint.partition(":")
+    if not separator or not module_name or not variable_name:
+        return None
+    module = importlib.import_module(module_name)
+    scheduler = getattr(module, variable_name, None)
+    return scheduler if isinstance(scheduler, BaseScheduler) else None

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -15,11 +15,11 @@ from ._options import (
     is_discovery_runtime,
     is_queue_serving_runtime,
     is_vercel_runtime,
+    resolve_environment,
 )
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
-ENVIRONMENT_ENV = "VERCEL_ENV"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 ACTIVATION_HOOK_NAME = "vercel-apscheduler:auto-activate"
 # Activation is idempotent; the periodic re-run is what notices and heals a
@@ -100,10 +100,17 @@ def _warn_takeover_unavailable() -> None:
 
 
 def _automatic_environment() -> bool:
+    """Whether this deployment's environment activates schedulers on traffic.
+
+    Named environments (production and custom environments) share one durable
+    chain that must start and take over without a manual call, so they always
+    activate. The resolution must match ``resolve_state_scope``: a custom
+    environment reports ``VERCEL_ENV=preview`` but is a named environment.
+    """
     if not is_vercel_runtime() or not environ.get(SUBSCRIBERS_ENV):
         return False
-    environment = (environ.get(ENVIRONMENT_ENV) or "").strip().casefold()
-    return environment == "production"
+    environment = resolve_environment().casefold()
+    return environment not in {"", "development", "preview"}
 
 
 def _activate_configured_schedulers(*, takeover_allowed: bool) -> None:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -84,27 +84,34 @@ def _configured_schedulers() -> list[BaseScheduler]:
     if not isinstance(entries, list):
         raise APSchedulerConfigurationError(f"{SUBSCRIBERS_ENV} must contain a JSON array")
 
-    schedulers: list[BaseScheduler] = []
-    for entry in entries:
-        scheduler = _scheduler_from_entry(entry)
-        if scheduler is not None:
-            schedulers.append(scheduler)
-    if not schedulers:
+    if not entries:
         raise APSchedulerConfigurationError(
             f"{SUBSCRIBERS_ENV} does not contain an APScheduler entrypoint"
         )
-    return schedulers
+    return [_scheduler_from_entry(entry) for entry in entries]
 
 
-def _scheduler_from_entry(entry: Any) -> BaseScheduler | None:
-    if not isinstance(entry, dict):
-        return None
-    entrypoint = entry.get("entrypoint")
-    if not isinstance(entrypoint, str):
-        return None
+def _scheduler_from_entry(entry: Any) -> BaseScheduler:
+    """Resolve one builder-written subscriber entry to its scheduler.
+
+    The builder owns this environment variable, so a malformed entry or an
+    entrypoint that does not name a scheduler is a build regression; failing
+    loudly here beats silently skipping a scheduler that should activate.
+    """
+    if not isinstance(entry, dict) or not isinstance(entry.get("entrypoint"), str):
+        raise APSchedulerConfigurationError(
+            f"{SUBSCRIBERS_ENV} contains a malformed subscriber entry"
+        )
+    entrypoint = entry["entrypoint"]
     module_name, separator, variable_name = entrypoint.partition(":")
     if not separator or not module_name or not variable_name:
-        return None
+        raise APSchedulerConfigurationError(
+            f'{SUBSCRIBERS_ENV} entrypoint "{entrypoint}" is not "module:variable"'
+        )
     module = importlib.import_module(module_name)
     scheduler = getattr(module, variable_name, None)
-    return scheduler if isinstance(scheduler, BaseScheduler) else None
+    if not isinstance(scheduler, BaseScheduler):
+        raise APSchedulerConfigurationError(
+            f'{SUBSCRIBERS_ENV} entrypoint "{entrypoint}" does not name an APScheduler scheduler'
+        )
+    return scheduler

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -30,7 +30,7 @@ def register_automatic_activation() -> None:
 
     try:
         from vercel_runtime.invocation_hooks import (  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
-            register_invocation_hook,
+            run_on_next_invocation,
         )
     except ImportError as exc:
         raise APSchedulerConfigurationError(
@@ -38,7 +38,7 @@ def register_automatic_activation() -> None:
             "with invocation hook support"
         ) from exc
 
-    register_invocation_hook(
+    run_on_next_invocation(
         ACTIVATION_HOOK_NAME,
         _automatic_activation_hook,
     )

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
@@ -67,6 +67,10 @@ class StartDecision:
     changed: bool
     start_status: str
     current_wake: WakeToken | None
+    state: LifecycleState = "running"
+    # False when another deployment owns the chain and the caller was not
+    # allowed to take it; every action besides serving must then be skipped.
+    owned: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,28 +107,52 @@ class DriverSnapshot:
     current_wake: WakeToken | None
 
 
-_START_SCRIPT = """
--- vercel-apscheduler-v1:start
--- ARGV[1] now (ISO-8601), ARGV[2] this deployment.
--- A different owner means another deployment drives this chain; starting
--- here is a takeover: one new generation fences every message and handler
--- of the previous owner, exactly like resuming from a pause.
+_ACTIVATE_SCRIPT = """
+-- vercel-apscheduler-v1:activate
+-- ARGV[1] now (ISO-8601), ARGV[2] "1" = manual start, ARGV[3] this
+-- deployment, ARGV[4] "1" = may take the chain from another deployment.
+-- A manual start also activates a paused driver and always may take over.
+-- Taking over opens one new generation, fencing every message and handler
+-- of the previous owner, exactly like resuming from a pause. An automatic
+-- activation never overrides an explicit pause, not even during takeover.
 local state = redis.call("HGET", KEYS[1], "state")
 local owner = redis.call("HGET", KEYS[1], "owner_deployment")
 local generation = tonumber(redis.call("HGET", KEYS[1], "generation") or "0")
 local changed = 0
+local foreign = owner and owner ~= ARGV[3]
 
-if state ~= "running" or (owner and owner ~= ARGV[2]) then
+local function report(owned)
+  return {
+    tostring(changed),
+    tostring(generation),
+    state or "",
+    redis.call("HGET", KEYS[1], "start_status") or "",
+    redis.call("HGET", KEYS[1], "current_sequence") or "",
+    redis.call("HGET", KEYS[1], "current_logical_time") or "",
+    redis.call("HGET", KEYS[1], "current_status") or "",
+    owned
+  }
+end
+
+if foreign and ARGV[4] ~= "1" then
+  return report("")
+end
+if foreign and ARGV[2] ~= "1" and state == "paused" then
+  return report("")
+end
+
+if not state or foreign or (ARGV[2] == "1" and state ~= "running") then
   generation = generation + 1
   changed = 1
+  state = "running"
   redis.call(
     "HSET",
     KEYS[1],
-    "state", "running",
+    "state", state,
     "generation", tostring(generation),
     "start_status", "pending",
     "current_sequence", "0",
-    "owner_deployment", ARGV[2]
+    "owner_deployment", ARGV[3]
   )
   redis.call(
     "HDEL",
@@ -135,18 +163,11 @@ if state ~= "running" or (owner and owner ~= ARGV[2]) then
     "dirty_logical_time"
   )
 elseif not owner then
-  redis.call("HSET", KEYS[1], "owner_deployment", ARGV[2])
+  redis.call("HSET", KEYS[1], "owner_deployment", ARGV[3])
 end
 
 redis.call("HSET", KEYS[1], "updated_at", ARGV[1])
-return {
-  tostring(changed),
-  tostring(generation),
-  redis.call("HGET", KEYS[1], "start_status") or "",
-  redis.call("HGET", KEYS[1], "current_sequence") or "",
-  redis.call("HGET", KEYS[1], "current_logical_time") or "",
-  redis.call("HGET", KEYS[1], "current_status") or ""
-}
+return report("1")
 """
 
 _PAUSE_SCRIPT = """
@@ -510,21 +531,50 @@ class RedisDriver:
 
     def start(self, now: datetime) -> StartDecision:
         """Atomically start, resume, or take over one durable generation."""
+        return self._activate(now, manual=True, takeover_allowed=True)
+
+    def auto_activate(
+        self,
+        now: datetime,
+        *,
+        takeover_allowed: bool = False,
+    ) -> StartDecision:
+        """Start on request activity unless the scheduler was explicitly paused."""
+        return self._activate(now, manual=False, takeover_allowed=takeover_allowed)
+
+    def _activate(
+        self,
+        now: datetime,
+        *,
+        manual: bool,
+        takeover_allowed: bool,
+    ) -> StartDecision:
         now_utc = as_utc(now, name="now")
-        result = self._eval(_START_SCRIPT, now_utc.isoformat(), self.deployment)
-        if not isinstance(result, (list, tuple)) or len(result) != 6:
-            raise RuntimeError("Redis returned an invalid APScheduler start result")
+        result = self._eval(
+            _ACTIVATE_SCRIPT,
+            now_utc.isoformat(),
+            "1" if manual else "",
+            self.deployment,
+            "1" if takeover_allowed else "",
+        )
+        if not isinstance(result, (list, tuple)) or len(result) != 8:
+            raise RuntimeError("Redis returned an invalid APScheduler activation result")
         generation = int(_text(result[1]))
+        state_raw = _text(result[2])
+        if state_raw not in {"running", "paused"}:
+            raise RuntimeError("Redis returned an unknown APScheduler lifecycle state")
         return StartDecision(
             generation=generation,
             changed=bool(int(_text(result[0]))),
-            start_status=_text(result[2]),
+            state=cast("LifecycleState", state_raw),
+            start_status=_text(result[3]),
             current_wake=_wake_from_values(
                 generation,
-                result[3],
                 result[4],
                 result[5],
+                result[6],
             ),
+            owned=bool(_text(result[7])),
         )
 
     def pause(self, now: datetime) -> bool:


### PR DESCRIPTION
Production schedulers now start on their first request; no manual `start()` call needed.

Activation can't happen at import time (builds must not enqueue messages, and publishing needs the request's OIDC credentials), so the integration registers an invocation hook (vercel/vercel-internal#36) that runs the durable start once a real request arrives, off the response path.

- Never overrides an explicit `pause()`.
- Concurrent cold starts converge on one generation.
- Failures retry with backoff on later requests, so recovery after a Redis outage is automatic.
- Previews and dev stay manual (previews opt in via the next PR).

## Takeover follows the platform's own routing

Automatic takeover of the shared production chain is allowed only when the triggering request arrived through an environment alias — hosts that route exclusively to the currently promoted deployment. The deployment's own URL proves nothing, and the branch URL tracks the branch's newest deployment (exactly wrong during a rollback), so neither may adopt the chain. The hook reads the routed host from the runtime (vercel/vercel-internal#36); older runtimes disable automatic takeover with a one-time warning, and explicit `start()` always works.

Activation is idempotent, so the hook re-runs on a 5 minute cadence under traffic. Each sweep also republishes a wake whose queue message is overdue and presumed lost, which is how a chain stranded by a rollback heals without operator action.

Needs the runtime from vercel/vercel-internal#36 released first; older runtimes raise a configuration error.
