### PR TITLE
[integrations] APScheduler: Idle preview schedulers after a durable deadline

### DIFF
--- a/changes/vercel-apscheduler/queues-adapter.feature.md
+++ b/changes/vercel-apscheduler/queues-adapter.feature.md
@@ -3,4 +3,4 @@ patches `scheduler.start()`, `scheduler.pause()`, and `scheduler.resume()` with
 durable, deployment-scoped lifecycle transitions and atomic single-chain
 fencing. Paused occurrences are skipped on resume, and interrupted successor
 publication is repaired on retry. Production schedules activate on the first
-request.
+request, and opted-in previews stop after a durable idle timeout.

--- a/integrations/vercel-apscheduler/README.md
+++ b/integrations/vercel-apscheduler/README.md
@@ -67,10 +67,31 @@ The integration is registered while the application imports, but the Redis
 transition and first Queue send are deferred until the runtime has installed
 that request's OIDC credentials. Builds never enqueue messages.
 
+Preview deployments are inactive by default. Opt a project into request-driven
+preview scheduling with:
+
+```toml
+[tool.vercel.apscheduler.previews]
+enabled = true
+idle_timeout = "30m"
+```
+
+Each active Function runtime renews the preview's durable Redis activity
+deadline on incoming requests, throttled to at most once every five minutes
+(or one third of a shorter timeout). This is not a background timer and it
+does not emit periodic Queue messages. If no request renews the deadline:
+
+- a queued start or wake becomes stale before it can run;
+- an in-flight wake may finish its current work but cannot publish a
+  successor; and
+- the next request creates one new generation and skips occurrences from the
+  inactive interval.
+
 An explicit `pause()` remains paused across later requests; automatic
-activation never overrides it. A deployment that has never received a request
-cannot start automatically because it has not received request-scoped OIDC
-credentials. Preview deployments do not activate automatically.
+activation never overrides it. Production scheduling has no idle timeout.
+In either environment, a deployment that has never received a request cannot
+start automatically because it has not received request-scoped OIDC
+credentials.
 
 ## Start, pause, and resume
 
@@ -125,7 +146,8 @@ heartbeat. `add_job()`, `modify_job()`, `reschedule_job()`, `pause_job()`,
 needed.
 
 Automatic activation establishes the runtime-mutation boundary before the
-user application handles a production request. In environments without
+user application handles a production request (or an opted-in preview
+request). In environments without
 automatic activation, call `scheduler.start()` first in each Function
 instance that changes jobs; before that boundary, `add_job()` calls are
 treated as module-level declarations. The call is idempotent:
@@ -173,6 +195,9 @@ previews. This gives the driver the following guarantees:
   with no live owner, and republished by the owner.
 - Concurrent first requests converge on one automatic generation and one
   start identity.
+- Preview idle expiry fences both claims and successor publication.
+- A later preview request creates one new generation; concurrent requests
+  converge on that generation.
 
 The scheduler's durable identity derives from its `RedisJobStore` `jobs_key`,
 so renaming variables or moving modules never orphans state. Two schedulers

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -63,7 +63,20 @@ Named environments (production and custom environments) additionally register
 an automatic activation hook during import. The Vercel Python Runtime
 executes it around the application's first real request, after request-scoped
 OIDC credentials are available. Automatic activation never overrides an
-explicitly paused driver.
+explicitly paused driver. Preview deployments register the same hook only
+when enabled in `pyproject.toml`:
+
+```toml
+[tool.vercel.apscheduler.previews]
+enabled = true
+idle_timeout = "30m"
+```
+
+Preview activation is recurring but request-driven. Eligible incoming requests
+renew the durable idle deadline, with process-local throttling capped at five
+minutes. There is no background timer and no activity Queue topic. Idle
+deadlines apply to previews only; a custom environment is a named environment
+and never idles.
 
 Outside Vercel, APScheduler's original methods are used.
 
@@ -77,8 +90,9 @@ state stays disposable.
 The driver stores one Redis hash per scope and scheduler:
 
 ```text
-state              running | paused
+state              running | paused | inactive
 generation         monotonically increasing integer
+idle_expires_at    preview idle deadline, when enabled
 start_status       pending | published | processing | active
 current_sequence   monotonically increasing within a generation
 current_logical_time
@@ -177,6 +191,35 @@ Completion is typed. `finish_start` and `finish_wake` atomically distinguish:
 The active-owner lease lasts fifteen minutes and is renewed every minute by
 the processing handler. A claim by a different owner succeeds only after the
 lease lapses.
+
+## Preview idle expiry
+
+An opted-in preview stores `idle_expires_at` in the same Redis driver hash.
+The first request starts the preview generation. Later requests renew the
+deadline without changing the generation.
+
+A manual `start()` renews the deadline in the same atomic transition that
+starts the generation. Without that renewal, a `start()` issued after the
+deadline lapsed would create a generation whose own start message is already
+stale. Outside an opted-in preview, activation clears any stored deadline.
+
+Start and wake claims check the deadline atomically before acquiring
+ownership. Start and wake completion check it again atomically before
+reserving a successor. If it expired, the transition sets the driver to
+`inactive`, clears the current token, and fails closed:
+
+- unclaimed Queue messages do no work;
+- work already in flight may finish, but cannot extend the chain; and
+- no periodic message keeps an abandoned preview alive.
+
+The next real request changes `inactive` to `running`, increments the
+generation, and publishes one start identity. Activation rebases persisted
+jobs to that request time, so the inactive interval is skipped rather than
+replayed as a burst.
+
+`paused` and `inactive` are deliberately distinct. `paused` records an
+explicit operator decision and automatic request activity only renews its
+deadline; it does not resume the scheduler.
 
 ## Pausing and resuming
 
@@ -295,7 +338,9 @@ namespace entirely: its deliveries still arrive but every claim turns stale
 and acks, it repairs and rearms nothing, its cold starts write no
 declarations, and its mutation APIs refuse loudly. Its queue simply drains.
 A rollback is the same operation in the other direction; the mechanism has
-no notion of old and new, only of who owns the chain now.
+no notion of old and new, only of who owns the chain now. An opted-in
+preview activates the same way and remains active only while requests renew
+its deadline.
 
 Automatic takeover is traffic-driven: it happens on the first request the
 promoted deployment serves through an environment alias. After promoting or
@@ -351,7 +396,11 @@ expiry would make reliable pause semantics impossible.
 | the owner's wake message dies | the overdue wake is presumed lost and republished by the owner |
 | takeover reconciliation races a demoted deployment's handler | ownership and revision CAS keep exactly one writer per job |
 | concurrent first requests | one automatic generation and one start identity |
-| request arrives after explicit pause | state remains paused |
+| request arrives after explicit pause | idle deadline renews but state remains paused |
+| preview idle deadline expires before claim | message is stale and no job runs |
+| preview idle deadline expires while work runs | current work may finish; no successor |
+| request arrives after preview expiry | one new generation; inactive time is skipped |
+| `start()` after the preview deadline lapsed | deadline renews; the new generation is claimable |
 
 These properties prevent parallel logical chains. They do not provide
 exactly-once job side effects. If a process dies after an external side effect

--- a/integrations/vercel-apscheduler/examples/cleanup/README.md
+++ b/integrations/vercel-apscheduler/examples/cleanup/README.md
@@ -29,6 +29,15 @@ example:
 curl https://your-deployment.example/
 ```
 
+Previews are inactive by default. To keep a preview active while it is
+receiving traffic, add:
+
+```toml
+[tool.vercel.apscheduler.previews]
+enabled = true
+idle_timeout = "30m"
+```
+
 The example exposes authenticated `/scheduler/start`, `/scheduler/pause`, and
 `/scheduler/resume` routes for operational control. Do not expose these routes
 without authentication.

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -15,8 +15,19 @@ from vercel.integrations.apscheduler import (
 from vercel.integrations.apscheduler._options import is_queue_serving_runtime
 
 
+@pytest.mark.parametrize(
+    ("environment", "timeout", "expected_interval"),
+    [
+        ("production", None, 300.0),
+        ("preview", "1800", 300.0),
+        ("preview", "60", 20.0),
+    ],
+)
 def test_registers_request_driven_automatic_activation(
     monkeypatch: pytest.MonkeyPatch,
+    environment: str,
+    timeout: str | None,
+    expected_interval: float | None,
 ) -> None:
     registered: list[tuple[str, Any, float | None]] = []
     invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
@@ -39,22 +50,27 @@ def test_registers_request_driven_automatic_activation(
         invocation_hooks,
     )
     monkeypatch.setenv("VERCEL", "1")
-    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_ENV", environment)
     monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(
         _automatic.SUBSCRIBERS_ENV,
         '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
     )
+    if timeout is None:
+        monkeypatch.delenv(
+            _automatic.PREVIEW_IDLE_TIMEOUT_ENV,
+            raising=False,
+        )
+    else:
+        monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, timeout)
 
     _automatic.register_automatic_activation()
 
-    assert registered == [
-        (
-            _automatic.ACTIVATION_HOOK_NAME,
-            _automatic._automatic_activation_hook,
-            _automatic.HEAL_SWEEP_INTERVAL_SECONDS,
-        )
-    ]
+    assert len(registered) == 1
+    name, callback, interval = registered[0]
+    assert name == _automatic.ACTIVATION_HOOK_NAME
+    assert callback is _automatic._automatic_activation_hook
+    assert interval == expected_interval
 
 
 @pytest.mark.parametrize(
@@ -119,7 +135,7 @@ def test_malformed_subscriber_entry_fails_loudly(
         _automatic._configured_schedulers()
 
 
-def test_preview_deployments_do_not_activate_automatically(
+def test_preview_automatic_activation_is_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("VERCEL", "1")
@@ -128,6 +144,10 @@ def test_preview_deployments_do_not_activate_automatically(
     monkeypatch.setenv(
         _automatic.SUBSCRIBERS_ENV,
         '[{"id":"scheduler","entrypoint":"scheduler:scheduler"}]',
+    )
+    monkeypatch.delenv(
+        _automatic.PREVIEW_IDLE_TIMEOUT_ENV,
+        raising=False,
     )
 
     assert not _automatic._automatic_environment()
@@ -171,25 +191,53 @@ def test_subscriber_request_does_not_register_automatic_activation(
         invocation_hooks,
     )
     monkeypatch.setenv("VERCEL", "1")
-    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_ENV", "preview")
     monkeypatch.setenv("VERCEL_PYTHON_SUBSCRIBER_ID", "scheduler_scheduler")
     monkeypatch.setenv(
         _automatic.SUBSCRIBERS_ENV,
         '[{"id":"scheduler_scheduler","entrypoint":"scheduler:scheduler"}]',
     )
+    monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "60")
 
     assert is_queue_serving_runtime()
     _automatic.register_automatic_activation()
 
 
+def test_automatic_activation_hook_uses_current_preview_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int | None] = []
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "120")
+
+    def record_activation(timeout: int | None, *, takeover_allowed: bool) -> None:
+        del takeover_allowed
+        calls.append(timeout)
+
+    monkeypatch.setattr(
+        _automatic,
+        "_activate_configured_schedulers",
+        record_activation,
+    )
+
+    _automatic._automatic_activation_hook()
+
+    assert calls == [120]
+
+
 def test_automatic_activation_calls_every_adapter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[bool] = []
+    calls: list[tuple[int | None, bool]] = []
 
     class FakeAdapter:
-        def auto_activate(self, *, takeover_allowed: bool) -> None:
-            calls.append(takeover_allowed)
+        def auto_activate(
+            self,
+            *,
+            idle_timeout_seconds: int | None = None,
+            takeover_allowed: bool = False,
+        ) -> None:
+            calls.append((idle_timeout_seconds, takeover_allowed))
 
     monkeypatch.setattr(
         _automatic,
@@ -198,6 +246,16 @@ def test_automatic_activation_calls_every_adapter(
     )
     monkeypatch.setattr(_adapter, "get_adapter", lambda scheduler: FakeAdapter())
 
-    _automatic._activate_configured_schedulers(takeover_allowed=True)
+    _automatic._activate_configured_schedulers(1800, takeover_allowed=True)
 
-    assert calls == [True, True]
+    assert calls == [(1800, True), (1800, True)]
+
+
+def test_preview_timeout_must_be_positive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "0")
+
+    with pytest.raises(APSchedulerConfigurationError, match="positive integer"):
+        _automatic._preview_idle_timeout()

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -208,6 +208,7 @@ def test_automatic_activation_hook_uses_current_preview_timeout(
 ) -> None:
     calls: list[int | None] = []
     monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "120")
 
     def record_activation(timeout: int | None, *, takeover_allowed: bool) -> None:
@@ -255,7 +256,23 @@ def test_preview_timeout_must_be_positive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "0")
 
     with pytest.raises(APSchedulerConfigurationError, match="positive integer"):
         _automatic._preview_idle_timeout()
+
+
+def test_custom_environments_never_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A custom environment reports VERCEL_ENV=preview but must not idle.
+
+    Its chain is environment-scoped and behaves like production; applying a
+    preview idle deadline would silently stop its jobs between requests.
+    """
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.setenv("VERCEL_TARGET_ENV", "staging")
+    monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "120")
+
+    assert _automatic._preview_idle_timeout() is None

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -161,9 +161,10 @@ class FakeDriver:
         self,
         now: datetime,
         *,
+        idle_timeout_seconds: int | None = None,
         takeover_allowed: bool = False,
     ) -> StartDecision:
-        del now
+        del now, idle_timeout_seconds
         with self.lock:
             foreign = (
                 self.owner_deployment_value is not None

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
@@ -21,7 +21,7 @@ from vercel.integrations.apscheduler import (
     install_vercel_apscheduler_integration,
 )
 from vercel.integrations.apscheduler._adapter import SchedulerAdapter, get_adapter
-from vercel.integrations.apscheduler._driver import RedisDriver
+from vercel.integrations.apscheduler._driver import RedisDriver, StartDecision
 
 UTC = timezone.utc
 REDIS_URL = environ.get("APSCHEDULER_TEST_REDIS_URL")
@@ -781,6 +781,106 @@ def test_real_redis_takeover_reconciles_declared_jobs(
         client.delete(*keys)
 
 
+def test_real_redis_preview_idle_deadline_is_atomic_and_respects_pause() -> None:
+    assert REDIS_URL is not None
+    client = Redis.from_url(REDIS_URL)
+    driver = RedisDriver(
+        client,
+        scope="dpl_preview_idle_test",
+        scheduler_id="scheduler",
+        deployment="dpl_preview_idle_test",
+    )
+    client.delete(driver.key)
+    try:
+        now = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+
+        def activate(_: int) -> StartDecision:
+            return driver.auto_activate(
+                now,
+                idle_timeout_seconds=30 * 60,
+            )
+
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            starts = list(executor.map(activate, range(100)))
+        assert sum(decision.changed for decision in starts) == 1
+        assert {decision.generation for decision in starts} == {1}
+        assert {decision.state for decision in starts} == {"running"}
+
+        renewed = driver.auto_activate(
+            now + timedelta(minutes=5),
+            idle_timeout_seconds=30 * 60,
+        )
+        assert not renewed.changed
+        assert renewed.generation == 1
+
+        assert driver.claim_start(1, "old-owner", now).state == "claimed"
+        assert driver.renew("old-owner", now + timedelta(minutes=25))
+        restarted = driver.auto_activate(
+            now + timedelta(minutes=36),
+            idle_timeout_seconds=30 * 60,
+        )
+        assert restarted.changed
+        assert restarted.generation == 2
+        assert (
+            driver.claim_start(
+                2,
+                "new-owner",
+                now + timedelta(minutes=36),
+            ).state
+            == "busy"
+        )
+        old_finish = driver.finish_start(
+            1,
+            "old-owner",
+            now + timedelta(hours=1),
+            now + timedelta(minutes=36),
+        )
+        assert old_finish.state == "fenced"
+        assert (
+            driver.claim_start(
+                2,
+                "new-owner",
+                now + timedelta(minutes=36),
+            ).state
+            == "claimed"
+        )
+        driver.release("new-owner")
+
+        assert driver.pause(now + timedelta(minutes=37))
+        paused = driver.auto_activate(
+            now + timedelta(hours=2),
+            idle_timeout_seconds=30 * 60,
+        )
+        assert not paused.changed
+        assert paused.state == "paused"
+        assert paused.generation == 2
+        assert driver.snapshot().state == "paused"
+
+        resumed = driver.start(
+            now + timedelta(hours=2),
+            idle_timeout_seconds=30 * 60,
+        )
+        assert resumed.generation == 3
+        assert (
+            driver.claim_start(
+                3,
+                "expiring-owner",
+                now + timedelta(hours=2),
+            ).state
+            == "claimed"
+        )
+        expired_finish = driver.finish_start(
+            3,
+            "expiring-owner",
+            now + timedelta(hours=3),
+            now + timedelta(hours=2, minutes=31),
+        )
+        assert expired_finish.state == "fenced"
+        assert driver.snapshot().state == "inactive"
+    finally:
+        client.delete(driver.key)
+
+
 @pytest.mark.skipif(
     REDIS_URL is None,
     reason="requires a disposable Redis server",
@@ -904,3 +1004,78 @@ def test_real_redis_quarantine_sidelines_unloadable_jobs(
         assert client.hexists(store.jobs_key, "broken")
     finally:
         client.delete(*keys)
+
+
+def test_real_redis_manual_start_renews_a_lapsed_preview_deadline() -> None:
+    assert REDIS_URL is not None
+    client = Redis.from_url(REDIS_URL)
+    driver = RedisDriver(
+        client,
+        scope="dpl_preview_restart_test",
+        scheduler_id="scheduler",
+        deployment="dpl_preview_restart_test",
+    )
+    client.delete(driver.key)
+    try:
+        now = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+        driver.auto_activate(now, idle_timeout_seconds=60)
+
+        # The deadline lapsed; a manual start must renew it, or the new
+        # generation would be demoted before its start message could claim.
+        restarted = driver.start(
+            now + timedelta(minutes=10),
+            idle_timeout_seconds=60,
+        )
+        assert restarted.changed
+        assert restarted.generation == 2
+        assert restarted.state == "running"
+        assert (
+            driver.claim_start(
+                2,
+                "start-owner",
+                now + timedelta(minutes=10),
+            ).state
+            == "claimed"
+        )
+        assert driver.snapshot().state == "running"
+    finally:
+        client.delete(driver.key)
+
+
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
+def test_real_redis_expired_preview_wake_cannot_run() -> None:
+    assert REDIS_URL is not None
+    client = Redis.from_url(REDIS_URL)
+    driver = RedisDriver(
+        client,
+        scope="dpl_preview_wake_test",
+        scheduler_id="scheduler",
+        deployment="dpl_preview_wake_test",
+    )
+    client.delete(driver.key)
+    try:
+        now = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+        driver.auto_activate(now, idle_timeout_seconds=60)
+        assert driver.claim_start(1, "start-owner", now).state == "claimed"
+        finished = driver.finish_start(
+            1,
+            "start-owner",
+            now + timedelta(minutes=5),
+            now,
+        )
+        wake = finished.wake
+        assert wake is not None
+
+        claim = driver.claim_wake(
+            wake,
+            "wake-owner",
+            now + timedelta(minutes=2),
+        )
+        assert claim.state == "stale"
+        assert driver.snapshot().state == "inactive"
+        assert driver.snapshot().current_wake is None
+    finally:
+        client.delete(driver.key)

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
@@ -781,6 +781,10 @@ def test_real_redis_takeover_reconciles_declared_jobs(
         client.delete(*keys)
 
 
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
 def test_real_redis_preview_idle_deadline_is_atomic_and_respects_pause() -> None:
     assert REDIS_URL is not None
     client = Redis.from_url(REDIS_URL)
@@ -1006,6 +1010,10 @@ def test_real_redis_quarantine_sidelines_unloadable_jobs(
         client.delete(*keys)
 
 
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
 def test_real_redis_manual_start_renews_a_lapsed_preview_deadline() -> None:
     assert REDIS_URL is not None
     client = Redis.from_url(REDIS_URL)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -316,14 +316,22 @@ class SchedulerAdapter:
             self.driver.pause(now)
             self._pause_local()
             return
-        decision = self.driver.start(now)
+        decision = self.driver.start(
+            now,
+            idle_timeout_seconds=self._preview_idle_timeout_seconds(),
+        )
         self._reconcile_takeover(now)
         self._publish_start_if_needed(decision, now=now)
         if not decision.changed and decision.start_status == "active":
             self.repair_wakeup(now=now)
         self._resume_local_if_paused()
 
-    def auto_activate(self, *, takeover_allowed: bool = False) -> None:
+    def auto_activate(
+        self,
+        *,
+        idle_timeout_seconds: int | None = None,
+        takeover_allowed: bool = False,
+    ) -> None:
         """Activate on request activity without overriding an explicit pause.
 
         ``takeover_allowed`` is true only when the triggering request arrived
@@ -335,7 +343,11 @@ class SchedulerAdapter:
         self._lifecycle_called = True
         self.ensure_local_started()
         now = datetime.now(UTC)
-        decision = self.driver.auto_activate(now, takeover_allowed=takeover_allowed)
+        decision = self.driver.auto_activate(
+            now,
+            idle_timeout_seconds=idle_timeout_seconds,
+            takeover_allowed=takeover_allowed,
+        )
         if not decision.owned:
             return
         self._reconcile_takeover(now)
@@ -357,6 +369,13 @@ class SchedulerAdapter:
     def resume(self) -> None:
         """Resume by creating one new durable generation."""
         self.start()
+
+    def _preview_idle_timeout_seconds(self) -> int | None:
+        # _automatic imports this module for the adapter registry; resolving
+        # at call time keeps the modules from importing each other at load.
+        from ._automatic import _preview_idle_timeout
+
+        return _preview_idle_timeout()
 
     def _publish_start_if_needed(
         self,

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -20,10 +20,12 @@ from ._options import (
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
+PREVIEW_IDLE_TIMEOUT_ENV = "VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 ACTIVATION_HOOK_NAME = "vercel-apscheduler:auto-activate"
-# Activation is idempotent; the periodic re-run is what notices and heals a
-# wake whose queue message died (for example stranded by a rollback).
+MAX_PREVIEW_RENEW_INTERVAL_SECONDS = 5 * 60
+# Activation is idempotent; the periodic re-run renews preview deadlines and
+# heals a wake whose queue message died (for example stranded by a rollback).
 HEAL_SWEEP_INTERVAL_SECONDS = 5 * 60
 
 
@@ -34,6 +36,15 @@ def register_automatic_activation() -> None:
     if is_discovery_runtime() or is_queue_serving_runtime():
         return
 
+    timeout = _preview_idle_timeout()
+    interval = (
+        min(
+            float(MAX_PREVIEW_RENEW_INTERVAL_SECONDS),
+            timeout / 3,
+        )
+        if timeout is not None
+        else float(HEAL_SWEEP_INTERVAL_SECONDS)
+    )
     try:
         from vercel_runtime.invocation_hooks import (  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
             run_on_next_invocation,
@@ -47,12 +58,15 @@ def register_automatic_activation() -> None:
     run_on_next_invocation(
         ACTIVATION_HOOK_NAME,
         _automatic_activation_hook,
-        repeat_after_seconds=HEAL_SWEEP_INTERVAL_SECONDS,
+        repeat_after_seconds=interval,
     )
 
 
 def _automatic_activation_hook() -> None:
-    _activate_configured_schedulers(takeover_allowed=_request_is_alias_routed())
+    _activate_configured_schedulers(
+        _preview_idle_timeout(),
+        takeover_allowed=_request_is_alias_routed(),
+    )
 
 
 def _request_is_alias_routed() -> bool:
@@ -104,16 +118,46 @@ def _automatic_environment() -> bool:
 
     Named environments (production and custom environments) share one durable
     chain that must start and take over without a manual call, so they always
-    activate. The resolution must match ``resolve_state_scope``: a custom
-    environment reports ``VERCEL_ENV=preview`` but is a named environment.
+    activate. Previews activate only when idling is configured, so a preview
+    chain cannot outlive its usefulness. The resolution must match
+    ``resolve_state_scope``: a custom environment reports
+    ``VERCEL_ENV=preview`` but is a named environment.
     """
     if not is_vercel_runtime() or not environ.get(SUBSCRIBERS_ENV):
         return False
     environment = resolve_environment().casefold()
-    return environment not in {"", "development", "preview"}
+    if environment in {"", "development"}:
+        return False
+    if environment == "preview":
+        return PREVIEW_IDLE_TIMEOUT_ENV in environ
+    return True
 
 
-def _activate_configured_schedulers(*, takeover_allowed: bool) -> None:
+def _preview_idle_timeout() -> int | None:
+    """The idle deadline for previews; named environments never idle."""
+    if resolve_environment().casefold() != "preview":
+        return None
+    raw = environ.get(PREVIEW_IDLE_TIMEOUT_ENV)
+    if raw is None:
+        return None
+    try:
+        timeout = int(raw)
+    except ValueError as exc:
+        raise APSchedulerConfigurationError(
+            f"{PREVIEW_IDLE_TIMEOUT_ENV} must be a positive integer"
+        ) from exc
+    if timeout <= 0:
+        raise APSchedulerConfigurationError(
+            f"{PREVIEW_IDLE_TIMEOUT_ENV} must be a positive integer"
+        )
+    return timeout
+
+
+def _activate_configured_schedulers(
+    idle_timeout_seconds: int | None,
+    *,
+    takeover_allowed: bool,
+) -> None:
     from ._adapter import get_adapter
 
     for scheduler in _configured_schedulers():
@@ -122,7 +166,10 @@ def _activate_configured_schedulers(*, takeover_allowed: bool) -> None:
             raise APSchedulerConfigurationError(
                 "configured APScheduler subscriber was not adopted by the integration"
             )
-        adapter.auto_activate(takeover_allowed=takeover_allowed)
+        adapter.auto_activate(
+            idle_timeout_seconds=idle_timeout_seconds,
+            takeover_allowed=takeover_allowed,
+        )
 
 
 def _configured_schedulers() -> list[BaseScheduler]:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -134,7 +134,7 @@ def _automatic_environment() -> bool:
 
 
 def _preview_idle_timeout() -> int | None:
-    """The idle deadline for previews; named environments never idle."""
+    """Return the idle deadline for previews; named environments never idle."""
     if resolve_environment().casefold() != "preview":
         return None
     raw = environ.get(PREVIEW_IDLE_TIMEOUT_ENV)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
@@ -25,7 +25,7 @@ _SCOPE_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]+$")
 
 ClaimState = Literal["claimed", "busy", "stale"]
 FinishState = Literal["advanced", "fenced", "lost"]
-LifecycleState = Literal["running", "paused"]
+LifecycleState = Literal["running", "paused", "inactive"]
 
 __all__ = [
     "APSchedulerConfigurationError",
@@ -107,10 +107,48 @@ class DriverSnapshot:
     current_wake: WakeToken | None
 
 
+def _idle_demotion_block(*, now_ts: str, updated_at: str, clear_owner: bool, result: str) -> str:
+    """Lua that atomically demotes a running driver whose idle deadline lapsed."""
+    owner_fields = (
+        """,
+    "active_owner",
+    "active_kind",
+    "active_generation",
+    "active_sequence",
+    "active_lease_until\""""
+        if clear_owner
+        else ""
+    )
+    return f"""local idle_expiry = tonumber(redis.call("HGET", KEYS[1], "idle_expires_at") or "")
+if redis.call("HGET", KEYS[1], "state") == "running"
+  and idle_expiry
+  and idle_expiry <= tonumber({now_ts})
+then
+  redis.call(
+    "HSET",
+    KEYS[1],
+    "state", "inactive",
+    "current_sequence", "0",
+    "updated_at", {updated_at}
+  )
+  redis.call(
+    "HDEL",
+    KEYS[1],
+    "start_status",
+    "activation_time",
+    "current_logical_time",
+    "current_status",
+    "dirty_logical_time"{owner_fields}
+  )
+  return {result}
+end"""
+
+
 _ACTIVATE_SCRIPT = """
 -- vercel-apscheduler-v1:activate
 -- ARGV[1] now (ISO-8601), ARGV[2] "1" = manual start, ARGV[3] this
--- deployment, ARGV[4] "1" = may take the chain from another deployment.
+-- deployment, ARGV[4] "1" = may take the chain from another deployment,
+-- ARGV[5] now (unix timestamp), ARGV[6] idle deadline (unix ts, "" = none).
 -- A manual start also activates a paused driver and always may take over.
 -- Taking over opens one new generation, fencing every message and handler
 -- of the previous owner, exactly like resuming from a pause. An automatic
@@ -141,7 +179,29 @@ if foreign and ARGV[2] ~= "1" and state == "paused" then
   return report("")
 end
 
-if not state or foreign or (ARGV[2] == "1" and state ~= "running") then
+if ARGV[6] ~= "" then
+  local prior_expiry = tonumber(redis.call("HGET", KEYS[1], "idle_expires_at") or "")
+  if state == "running" and prior_expiry and prior_expiry <= tonumber(ARGV[5]) then
+    state = "inactive"
+    redis.call(
+      "HDEL",
+      KEYS[1],
+      "start_status",
+      "activation_time",
+      "current_logical_time",
+      "current_status",
+      "dirty_logical_time"
+    )
+    redis.call("HSET", KEYS[1], "current_sequence", "0")
+  end
+  redis.call("HSET", KEYS[1], "idle_expires_at", ARGV[6])
+else
+  redis.call("HDEL", KEYS[1], "idle_expires_at")
+end
+
+if not state or state == "inactive" or foreign
+  or (ARGV[2] == "1" and state ~= "running")
+then
   generation = generation + 1
   changed = 1
   state = "running"
@@ -205,8 +265,17 @@ end
 return 1
 """
 
-_CLAIM_START_SCRIPT = """
+_CLAIM_START_SCRIPT = (
+    """
 -- vercel-apscheduler-v1:claim-start
+"""
+    + _idle_demotion_block(
+        now_ts="ARGV[3]",
+        updated_at="ARGV[5]",
+        clear_owner=False,
+        result='{"stale", ""}',
+    )
+    + """
 if redis.call("HGET", KEYS[1], "state") ~= "running" then
   return {"stale", ""}
 end
@@ -243,8 +312,10 @@ redis.call(
 )
 return {"claimed", activation_time}
 """
+)
 
-_FINISH_START_SCRIPT = """
+_FINISH_START_SCRIPT = (
+    """
 -- vercel-apscheduler-v1:finish-start
 local owner = redis.call("HGET", KEYS[1], "active_owner")
 if owner ~= ARGV[2] then
@@ -257,6 +328,14 @@ if owner ~= ARGV[2] then
   return {"fenced", "", ""}
 end
 
+"""
+    + _idle_demotion_block(
+        now_ts="ARGV[5]",
+        updated_at="ARGV[4]",
+        clear_owner=True,
+        result='{"fenced", "", ""}',
+    )
+    + """
 if redis.call("HGET", KEYS[1], "state") ~= "running"
   or tonumber(redis.call("HGET", KEYS[1], "generation") or "-1") ~= tonumber(ARGV[1])
 then
@@ -305,6 +384,7 @@ redis.call(
 )
 return {"advanced", logical_time ~= "" and "1" or "", logical_time}
 """
+)
 
 _MARK_WAKE_PUBLISHED_SCRIPT = """
 -- vercel-apscheduler-v1:mark-wake-published
@@ -328,8 +408,17 @@ end
 return 1
 """
 
-_CLAIM_WAKE_SCRIPT = """
+_CLAIM_WAKE_SCRIPT = (
+    """
 -- vercel-apscheduler-v1:claim-wake
+"""
+    + _idle_demotion_block(
+        now_ts="ARGV[5]",
+        updated_at="ARGV[7]",
+        clear_owner=False,
+        result='"stale"',
+    )
+    + """
 if redis.call("HGET", KEYS[1], "state") ~= "running" then
   return "stale"
 end
@@ -365,8 +454,10 @@ redis.call(
 )
 return "claimed"
 """
+)
 
-_FINISH_WAKE_SCRIPT = """
+_FINISH_WAKE_SCRIPT = (
+    """
 -- vercel-apscheduler-v1:finish-wake
 if redis.call("HGET", KEYS[1], "active_owner") ~= ARGV[3] then
   if redis.call("HGET", KEYS[1], "state") == "running"
@@ -379,6 +470,14 @@ if redis.call("HGET", KEYS[1], "active_owner") ~= ARGV[3] then
   return {"fenced", "", ""}
 end
 
+"""
+    + _idle_demotion_block(
+        now_ts="ARGV[7]",
+        updated_at="ARGV[6]",
+        clear_owner=True,
+        result='{"fenced", "", ""}',
+    )
+    + """
 if redis.call("HGET", KEYS[1], "state") ~= "running"
   or tonumber(redis.call("HGET", KEYS[1], "generation") or "-1") ~= tonumber(ARGV[1])
   or tonumber(redis.call("HGET", KEYS[1], "current_sequence") or "-1") ~= tonumber(ARGV[2])
@@ -437,6 +536,7 @@ return {
   logical_time
 }
 """
+)
 
 _REPAIR_OVERDUE_WAKE_SCRIPT = """
 -- vercel-apscheduler-v1:repair-overdue-wake
@@ -529,39 +629,68 @@ class RedisDriver:
         self.deployment = deployment
         self.key = f"vercel:apscheduler:{{{scope}:{scheduler_id}}}:driver"
 
-    def start(self, now: datetime) -> StartDecision:
-        """Atomically start, resume, or take over one durable generation."""
-        return self._activate(now, manual=True, takeover_allowed=True)
+    def start(
+        self,
+        now: datetime,
+        *,
+        idle_timeout_seconds: int | None = None,
+    ) -> StartDecision:
+        """Atomically start, resume, or take over one durable generation.
+
+        A manual start also renews the preview idle deadline; otherwise a
+        deadline that lapsed before the start could make the new generation
+        immediately stale.
+        """
+        return self._activate(
+            now,
+            idle_timeout_seconds=idle_timeout_seconds,
+            manual=True,
+            takeover_allowed=True,
+        )
 
     def auto_activate(
         self,
         now: datetime,
         *,
+        idle_timeout_seconds: int | None = None,
         takeover_allowed: bool = False,
     ) -> StartDecision:
-        """Start on request activity unless the scheduler was explicitly paused."""
-        return self._activate(now, manual=False, takeover_allowed=takeover_allowed)
+        """Renew activity and start unless the scheduler was explicitly paused."""
+        return self._activate(
+            now,
+            idle_timeout_seconds=idle_timeout_seconds,
+            manual=False,
+            takeover_allowed=takeover_allowed,
+        )
 
     def _activate(
         self,
         now: datetime,
         *,
+        idle_timeout_seconds: int | None,
         manual: bool,
         takeover_allowed: bool,
     ) -> StartDecision:
+        if idle_timeout_seconds is not None and idle_timeout_seconds <= 0:
+            raise ValueError("idle_timeout_seconds must be a positive integer")
         now_utc = as_utc(now, name="now")
+        expires_at = (
+            now_utc.timestamp() + idle_timeout_seconds if idle_timeout_seconds is not None else None
+        )
         result = self._eval(
             _ACTIVATE_SCRIPT,
             now_utc.isoformat(),
             "1" if manual else "",
             self.deployment,
             "1" if takeover_allowed else "",
+            str(now_utc.timestamp()),
+            str(expires_at) if expires_at is not None else "",
         )
         if not isinstance(result, (list, tuple)) or len(result) != 8:
             raise RuntimeError("Redis returned an invalid APScheduler activation result")
         generation = int(_text(result[1]))
         state_raw = _text(result[2])
-        if state_raw not in {"running", "paused"}:
+        if state_raw not in {"running", "paused", "inactive"}:
             raise RuntimeError("Redis returned an unknown APScheduler lifecycle state")
         return StartDecision(
             generation=generation,
@@ -637,12 +766,14 @@ class RedisDriver:
             if next_logical_time is not None
             else None
         )
+        now_utc = as_utc(now, name="now")
         result = self._eval(
             _FINISH_START_SCRIPT,
             str(generation),
             owner,
             logical_time.isoformat() if logical_time is not None else "",
-            as_utc(now, name="now").isoformat(),
+            now_utc.isoformat(),
+            str(now_utc.timestamp()),
         )
         return _finish_result(
             result,
@@ -699,6 +830,7 @@ class RedisDriver:
             if next_logical_time is not None
             else None
         )
+        now_utc = as_utc(now, name="now")
         result = self._eval(
             _FINISH_WAKE_SCRIPT,
             str(token.generation),
@@ -706,7 +838,8 @@ class RedisDriver:
             owner,
             token.logical_time.isoformat(),
             logical_time.isoformat() if logical_time is not None else "",
-            as_utc(now, name="now").isoformat(),
+            now_utc.isoformat(),
+            str(now_utc.timestamp()),
         )
         return _finish_result(
             result,
@@ -726,7 +859,11 @@ class RedisDriver:
         if not isinstance(values, (list, tuple)) or len(values) != 6:
             raise RuntimeError("Redis returned an invalid APScheduler driver state")
         state_raw = _text(values[0])
-        state: LifecycleState = "running" if state_raw == "running" else "paused"
+        state: LifecycleState
+        if state_raw in {"running", "paused", "inactive"}:
+            state = cast("LifecycleState", state_raw)
+        else:
+            state = "paused"
         generation_raw = _text(values[1])
         generation = int(generation_raw) if generation_raw else 0
         return DriverSnapshot(


### PR DESCRIPTION
Top of the stack: an opted-in preview schedules only while it receives traffic.

```toml
[tool.vercel.apscheduler.previews]
enabled = true
idle_timeout = "30m"
```

Requests renew a durable deadline in Redis (throttled, at most every 5 minutes). When it lapses, every claim and finish atomically demotes the chain to `inactive` and fails closed; the next request starts a fresh generation and skips the idle gap instead of replaying it.

- Manual `start()` renews the deadline too, so it can't create an instantly-stale generation.
- `paused` stays paused; request activity never resumes it.
- Production is untouched (no deadline, never idles out).

Builder half: vercel/vercel-internal#39.
