### PR TITLE
Add vercel.functions.wait_until()

### DIFF
--- a/changes/vercel/20260730000000.feature.md
+++ b/changes/vercel/20260730000000.feature.md
@@ -1,0 +1,2 @@
+Add `vercel.functions.wait_until()` for post-response asynchronous work that
+remains attached to the current Python Function invocation.

--- a/src/vercel/functions/README.md
+++ b/src/vercel/functions/README.md
@@ -4,11 +4,19 @@
 Functions.
 
 ```python
-from vercel.functions import AsyncRuntimeCache, geolocation, get_env, ip_address, set_headers
+from vercel.functions import (
+    AsyncRuntimeCache,
+    geolocation,
+    get_env,
+    ip_address,
+    set_headers,
+    wait_until,
+)
 
 
 async def handler(request):
     set_headers(request.headers)
+    wait_until(record_request_analytics(request))
 
     env = get_env()
     cache = AsyncRuntimeCache(namespace="api")
@@ -22,4 +30,9 @@ async def handler(request):
 ```
 
 Exports include environment helpers from `vercel.env`, header and geolocation
-helpers from `vercel.headers`, and cache clients from `vercel.cache`.
+helpers from `vercel.headers`, cache clients from `vercel.cache`, and
+`wait_until()` for work that should finish after the response is sent.
+
+`wait_until()` is not a durable task queue. Its work must finish within the
+Function's configured maximum duration, and it is not retried if the
+invocation terminates.

--- a/src/vercel/functions/README.md
+++ b/src/vercel/functions/README.md
@@ -35,4 +35,5 @@ helpers from `vercel.headers`, cache clients from `vercel.cache`, and
 
 `wait_until()` is not a durable task queue. Its work must finish within the
 Function's configured maximum duration, and it is not retried if the
-invocation terminates.
+invocation terminates. It accepts awaitables only; run synchronous work with
+`wait_until(asyncio.to_thread(func))`.

--- a/src/vercel/functions/__init__.py
+++ b/src/vercel/functions/__init__.py
@@ -1,6 +1,7 @@
 from ..cache import AsyncRuntimeCache, RuntimeCache, get_cache
 from ..env import Env, get_env
 from ..headers import Geo, geolocation, get_headers, ip_address, set_headers
+from .wait_until import wait_until
 
 __all__ = [
     "get_env",
@@ -13,4 +14,5 @@ __all__ = [
     "get_cache",
     "RuntimeCache",
     "AsyncRuntimeCache",
+    "wait_until",
 ]

--- a/src/vercel/functions/wait_until.py
+++ b/src/vercel/functions/wait_until.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+
+from vercel.cache.context import get_context
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+
+def wait_until(awaitable: Awaitable[object]) -> None:
+    """Keep the current Function invocation alive for an awaitable.
+
+    The response may be sent before the awaitable completes. Its completion is
+    still bounded by the Function's configured maximum duration.
+    """
+    if not inspect.isawaitable(awaitable):
+        msg = f"wait_until can only be called with an awaitable, got {type(awaitable).__name__}"
+        raise TypeError(msg)
+
+    callback = get_context().wait_until
+    if callback is not None:
+        callback(awaitable)
+    elif inspect.iscoroutine(awaitable):
+        # JavaScript Promises are already active when waitUntil is called, so
+        # its no-context behavior can safely be a no-op. A Python coroutine is
+        # lazy; close it to preserve that no-op without leaking a warning.
+        awaitable.close()

--- a/src/vercel/functions/wait_until.py
+++ b/src/vercel/functions/wait_until.py
@@ -14,9 +14,18 @@ def wait_until(awaitable: Awaitable[object]) -> None:
 
     The response may be sent before the awaitable completes. Its completion is
     still bounded by the Function's configured maximum duration.
+
+    For synchronous work, pass ``asyncio.to_thread(func)``.
     """
     if not inspect.isawaitable(awaitable):
-        msg = f"wait_until can only be called with an awaitable, got {type(awaitable).__name__}"
+        hint = (
+            "; call it first, or wrap synchronous work in asyncio.to_thread(...)"
+            if callable(awaitable)
+            else ""
+        )
+        msg = (
+            f"wait_until can only be called with an awaitable, got {type(awaitable).__name__}{hint}"
+        )
         raise TypeError(msg)
 
     callback = get_context().wait_until

--- a/src/vercel/tests/unit/test_functions_wait_until.py
+++ b/src/vercel/tests/unit/test_functions_wait_until.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vercel.cache.context import set_context
+from vercel.functions import wait_until
+
+
+@pytest.fixture(autouse=True)
+def clear_wait_until_context() -> Any:
+    set_context(wait_until=None)
+    yield
+    set_context(wait_until=None)
+
+
+def test_wait_until_registers_awaitable_with_context() -> None:
+    registered: list[Any] = []
+
+    async def work() -> None:
+        return
+
+    coroutine = work()
+    set_context(wait_until=registered.append)
+    wait_until(coroutine)
+
+    assert registered == [coroutine]
+    coroutine.close()
+
+
+def test_wait_until_is_a_noop_without_context() -> None:
+    async def work() -> None:
+        return
+
+    wait_until(work())
+
+
+@pytest.mark.parametrize("value", [None, 1, False, "work", object()])
+def test_wait_until_rejects_non_awaitables(value: object) -> None:
+    with pytest.raises(TypeError, match="awaitable"):
+        wait_until(value)  # type: ignore[arg-type]

--- a/src/vercel/tests/unit/test_functions_wait_until.py
+++ b/src/vercel/tests/unit/test_functions_wait_until.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
 
 from vercel.cache.context import set_context
 from vercel.functions import wait_until
+
+
+def sync_work() -> str:
+    return "done"
 
 
 @pytest.fixture(autouse=True)
@@ -40,3 +45,23 @@ def test_wait_until_is_a_noop_without_context() -> None:
 def test_wait_until_rejects_non_awaitables(value: object) -> None:
     with pytest.raises(TypeError, match="awaitable"):
         wait_until(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [sync_work, lambda: None])
+def test_wait_until_rejects_uncalled_functions_with_a_hint(value: object) -> None:
+    with pytest.raises(TypeError, match=r"asyncio\.to_thread"):
+        wait_until(value)  # type: ignore[arg-type]
+
+
+def test_wait_until_runs_synchronous_work_through_to_thread() -> None:
+    registered: list[Any] = []
+
+    set_context(wait_until=registered.append)
+    wait_until(asyncio.to_thread(sync_work))
+
+    assert len(registered) == 1
+    assert asyncio.run(_await(registered[0])) == "done"
+
+
+async def _await(awaitable: Any) -> Any:
+    return await awaitable


### PR DESCRIPTION
Expose the runtime's invocation-scoped waitUntil through the SDK: keep the current Function invocation alive for an awaitable that may finish after the response is sent. Outside a Vercel invocation context the call is a safe no-op that closes a lazy coroutine.

Independent of the APScheduler stack (#212–#216); pairs with the runtime support in vercel/vercel (`ricardo/python-wait-until`).