### PR TITLE
Fix the unsatisfiable `vercel-sandbox` bound

### DIFF
--- a/changes/vercel/20260801133000.bugfix.md
+++ b/changes/vercel/20260801133000.bugfix.md
@@ -1,0 +1,3 @@
+Fix the `vercel-sandbox` dependency bound, which `vercel` 0.8.0 published as
+`vercel-sandbox<0.3.0,>=0.3.0` — a range no version can satisfy, so that
+release could not be installed at all.

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "vercel-internal-telemetry>=0.6.0",
     "vercel-oidc>=0.6.0",
     "vercel-queue>=0.6.0",
-    "vercel-sandbox>=0.2.0,<0.3.0",
+    "vercel-sandbox>=0.2.0,<0.4.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
`vercel` 0.8.0 published `vercel-sandbox<0.3.0,>=0.3.0`, a range no version can satisfy, so the release cannot be installed:

    $ uv pip install "vercel==0.8.0"
      × No solution found when resolving dependencies:
      ╰─▶ Because vercel==0.8.0 depends on vercel-sandbox<0.3.0 and
          vercel-sandbox>=0.3.0, which are incompatible …

The two halves come from different places. The release metadata hook replaces the declared lower bound with the sibling's current workspace version and keeps the rest of the specifier as written, so when `vercel-sandbox` reached 0.3.0 while this file still said `<0.3.0`, the generated `>=0.3.0` closed the range to nothing.

Raise the upper bound to the next one that has room.