### PR TITLE
release: catch an uninstallable wheel before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -177,6 +177,13 @@ jobs:
             rm -rf dist-publish
             if [ "$http_status" = "404" ] && [ "$is_shared_vendored_deps" != "true" ]; then
               uv build --package "$package" --no-sources --out-dir dist-publish
+              # Install it before it is uploaded. `dist-verify` accumulates
+              # every wheel built by this run, so a package is resolved
+              # against the sibling versions it is being released with rather
+              # than whatever is already on the index.
+              mkdir -p dist-verify
+              cp dist-publish/*.whl dist-verify/
+              python scripts/verify_dist.py --dist-dir dist-verify --package "$package"
             fi
             if python scripts/bundle_release.py plan --package "$package" > /tmp/bundle-plan.txt 2>/dev/null; then
               cat /tmp/bundle-plan.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,3 +23,7 @@ for package in "${packages[@]}"; do
         uv run python scripts/bundle_release.py build --package "$package" --out-dir "$dist_dir"
     fi
 done
+
+# A wheel's requirements are whatever the build backend wrote; nothing above
+# resolves them. Install each one before it can reach an index.
+uv run python scripts/verify_dist.py --dist-dir "$dist_dir"

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 
 try:
     import tomllib
@@ -29,8 +30,10 @@ class WorkspaceDependenciesMetadataHook(MetadataHookInterface):
         }
         workspace_root = _find_workspace_root(Path(self.root))
 
+        package = pyproject.get("project", {}).get("name", str(self.root))
+
         metadata["dependencies"] = [
-            _rewrite_dependency(requirement, workspace_names, workspace_root)
+            _rewrite_dependency(requirement, workspace_names, workspace_root, package)
             for requirement in dependency_table.get("dependencies", [])
         ]
 
@@ -55,22 +58,54 @@ def _rewrite_dependency(
     requirement: str,
     workspace_names: set[str],
     workspace_root: Path | None,
+    package: str,
 ) -> str:
     parsed = Requirement(requirement)
     normalized = parsed.name.lower().replace("_", "-")
     if normalized not in workspace_names or workspace_root is None:
         return requirement
-    return _with_lower_bound(parsed, _read_workspace_version(workspace_root, normalized))
+    version = _read_workspace_version(workspace_root, normalized)
+    return _with_lower_bound(parsed, version, requirement, package)
 
 
-def _with_lower_bound(requirement: Requirement, version: str) -> str:
+def _with_lower_bound(requirement: Requirement, version: str, declared: str, package: str) -> str:
     extras = f"[{','.join(sorted(requirement.extras))}]" if requirement.extras else ""
     specifiers = [
         str(specifier) for specifier in requirement.specifier if specifier.operator != ">="
     ]
     specifier_text = ",".join([f">={version}", *specifiers])
+    _reject_unsatisfiable(package, requirement.name, declared, specifier_text, version)
     marker = f" ; {requirement.marker}" if requirement.marker else ""
     return f"{requirement.name}{extras}{specifier_text}{marker}"
+
+
+def _reject_unsatisfiable(
+    package: str, dependency: str, declared: str, specifier_text: str, version: str
+) -> None:
+    """Refuse to publish a bound that no version of *dependency* can satisfy.
+
+    The lower bound is generated from the sibling's current version while the
+    rest of the specifier is whatever the package declared, so a hand-written
+    upper bound that the sibling has since reached produces something like
+    ``>=0.3.0,<0.3.0``. Nothing rejects that later: the wheel builds, uploads,
+    and only fails when someone tries to install it. Fail the build instead --
+    CI builds every package, so the bump that crosses the bound is caught by
+    its own pull request.
+
+    The test is that the sibling version *being released* satisfies the bound,
+    which is narrower than the range being non-empty: `>=0.7.1,!=0.7.1` leaves
+    room for a later version, but says the release under way is unusable.
+    """
+    # `prereleases=True` so a workspace version like `0.4.0b1` is judged
+    # against its own bound rather than excluded for being a prerelease.
+    if SpecifierSet(specifier_text).contains(version, prereleases=True):
+        return
+    raise RuntimeError(
+        f"{package} declares {declared!r}, but {dependency} is at {version} in "
+        f"the workspace, so publishing would pin {dependency}{specifier_text} — "
+        f"which excludes {version} itself, the version being released. "
+        f"Raise the upper bound in [tool.vercel.release.dependencies] of {package}."
+    )
 
 
 def _read_workspace_version(workspace_root: Path, package_name: str) -> str:

--- a/scripts/verify_dist.py
+++ b/scripts/verify_dist.py
@@ -1,0 +1,113 @@
+"""Install every built wheel the way a user would, before it is published.
+
+A wheel can be built, uploaded and completely uninstallable: the metadata is
+whatever the build backend wrote, and neither `uv build` nor `uv publish` ever
+resolves it. `vercel` 0.8.0 shipped `vercel-sandbox<0.3.0,>=0.3.0` that way and
+the first person to find out ran `pip install`.
+
+So run the install here instead. Each wheel goes into a throwaway environment
+on its own, because that is the shape of the failure being looked for -- one
+distribution whose own requirements cannot be met. Sibling wheels in the same
+directory are offered to the resolver, so a package released alongside its
+dependencies is testable before any of them exist on the index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Built by `bundle_release.py`, which already installs and tests them through
+# `.github/scripts/test_installed_wheel.sh`. They carry vendored copies of
+# their dependencies and are meant to be installed side by side, so resolving
+# one on its own does not describe how anyone uses them.
+BUNDLE_SUFFIXES = ("_bundle",)
+BUNDLE_NAMES = ("vercel_internal_shared_vendored_deps",)
+
+
+def wheels(dist_dir: Path, *, package: str | None = None) -> list[Path]:
+    found = sorted(p for p in dist_dir.glob("*.whl") if not p.name.endswith(".metadata"))
+    found = [p for p in found if not _is_bundle(p)]
+    if package is None:
+        return found
+    prefix = f"{package.replace('-', '_')}-"
+    return [p for p in found if p.name.startswith(prefix)]
+
+
+def _is_bundle(wheel: Path) -> bool:
+    name = wheel.name.split("-", 1)[0]
+    return name.startswith(BUNDLE_NAMES) or name.endswith(BUNDLE_SUFFIXES)
+
+
+def install(wheel: Path, dist_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Resolve and install *wheel* into a fresh environment."""
+    venv = Path(tempfile.mkdtemp(prefix="vercel-py-verify-dist."))
+    try:
+        subprocess.run(
+            ["uv", "venv", "--no-config", str(venv)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                # `--no-config` so the repo's own resolver settings -- an
+                # `exclude-newer` cutoff in particular -- do not decide whether
+                # a published package is installable.
+                "--no-config",
+                "--python",
+                str(venv),
+                # Siblings from this same build satisfy intra-workspace pins
+                # before they exist on the index.
+                "--find-links",
+                str(dist_dir),
+                str(wheel),
+            ],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        shutil.rmtree(venv, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist-dir", type=Path, default=Path("dist"))
+    parser.add_argument(
+        "--package",
+        help="verify only this distribution; the rest of --dist-dir still "
+        "backs the resolver, which is how a package is checked against "
+        "siblings released in the same run",
+    )
+    args = parser.parse_args(argv)
+
+    found = wheels(args.dist_dir, package=args.package)
+    if not found:
+        target = f"{args.package} in " if args.package else ""
+        print(f"no wheels to verify for {target}{args.dist_dir}", file=sys.stderr)
+        return 1
+
+    failures = []
+    for wheel in found:
+        result = install(wheel, args.dist_dir)
+        status = "ok" if result.returncode == 0 else "FAILED"
+        print(f"{status:>6}  {wheel.name}", flush=True)
+        if result.returncode != 0:
+            failures.append((wheel, result))
+
+    for wheel, result in failures:
+        print(f"\n─── {wheel.name} ───\n{result.stderr.strip()}", file=sys.stderr)
+
+    print(f"\n{len(found) - len(failures)}/{len(found)} wheels install")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -9,7 +9,7 @@ from typing import cast
 
 import pytest
 
-from scripts import bundle_release, clogedit, hatch_build, release, workspace
+from scripts import bundle_release, clogedit, hatch_build, release, verify_dist, workspace
 
 
 def _derived_vendoring_config(include: str) -> bundle_release.VendoringConfig:
@@ -337,6 +337,42 @@ path = "version.py"
     assert metadata["dependencies"] == [
         'lib>=0.8.0,<2 ; python_version >= "3.10"',
         "httpx>=0.27,<1",
+    ]
+
+
+def test_verify_dist_skips_bundles_and_metadata(tmp_path: Path) -> None:
+    """Only the wheels `uv publish` uploads from this directory are checked.
+
+    Bundle wheels carry vendored copies of their dependencies and are meant to
+    be installed side by side, so resolving one alone says nothing; they have
+    their own check in `bundle_release.test-wheel`.
+    """
+    for name in (
+        "vercel-0.8.0-py3-none-any.whl",
+        "vercel-0.8.0-py3-none-any.whl.metadata",
+        "vercel_sandbox-0.3.0-py3-none-any.whl",
+        "vercel_bundle-0.8.0-py3-none-any.whl",
+        "vercel_internal_shared_vendored_deps-1.0.0-py3-none-any.whl",
+        "vercel-0.8.0.tar.gz",
+    ):
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    assert [path.name for path in verify_dist.wheels(tmp_path)] == [
+        "vercel-0.8.0-py3-none-any.whl",
+        "vercel_sandbox-0.3.0-py3-none-any.whl",
+    ]
+
+
+def test_verify_dist_package_filter_matches_the_distribution_name(tmp_path: Path) -> None:
+    # `vercel-sandbox` must not select the `vercel` wheel, and vice versa.
+    for name in ("vercel-0.8.0-py3-none-any.whl", "vercel_sandbox-0.3.0-py3-none-any.whl"):
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    assert [p.name for p in verify_dist.wheels(tmp_path, package="vercel")] == [
+        "vercel-0.8.0-py3-none-any.whl"
+    ]
+    assert [p.name for p in verify_dist.wheels(tmp_path, package="vercel-sandbox")] == [
+        "vercel_sandbox-0.3.0-py3-none-any.whl"
     ]
 
 

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -141,6 +141,80 @@ dependencies = ["vercel-internal-core>=0.1.0,<0.2.0"]
     assert metadata["dependencies"] == ["vercel-internal-core>=0.1.7,<0.2.0"]
 
 
+def _workspace_with_bound(root: Path, *, declared: str, sibling_version: str) -> Path:
+    """A two-package workspace whose dependent declares *declared* on the sibling."""
+    core_root = root / "src/vercel-internal-core"
+    sandbox_root = root / "src/vercel-sandbox"
+    core_root.mkdir(parents=True)
+    sandbox_root.mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = ['src/*']\n", encoding="utf-8"
+    )
+    (core_root / "pyproject.toml").write_text(
+        '[project]\nname = "vercel-internal-core"\n\n[tool.hatch.version]\npath = "version.py"\n',
+        encoding="utf-8",
+    )
+    (core_root / "version.py").write_text(f'__version__ = "{sibling_version}"\n', encoding="utf-8")
+    (sandbox_root / "pyproject.toml").write_text(
+        f"""
+[project]
+name = "vercel-sandbox"
+
+[tool.uv.sources]
+vercel-internal-core = {{ workspace = true }}
+
+[tool.vercel.release.dependencies]
+dependencies = ["{declared}"]
+""".strip(),
+        encoding="utf-8",
+    )
+    return sandbox_root
+
+
+def test_metadata_hook_rejects_a_bound_the_sibling_has_reached(tmp_path: Path) -> None:
+    """The generated lower bound and the declared upper bound can collide.
+
+    `vercel` 0.8.0 shipped `vercel-sandbox<0.3.0,>=0.3.0` this way and could
+    not be installed at all: the sibling reached 0.3.0 while the hand-written
+    upper bound stayed behind. Nothing downstream rejects an empty version
+    range, so the build is the last place to catch it.
+    """
+    package_root = _workspace_with_bound(
+        tmp_path, declared="vercel-internal-core>=0.1.0,<0.2.0", sibling_version="0.2.0"
+    )
+    hook = hatch_build.WorkspaceDependenciesMetadataHook(str(package_root), {})
+
+    with pytest.raises(RuntimeError, match=r"vercel-internal-core>=0.2.0,<0.2.0"):
+        hook.update({})
+
+
+def test_metadata_hook_rejection_says_which_bound_to_raise(tmp_path: Path) -> None:
+    package_root = _workspace_with_bound(
+        tmp_path, declared="vercel-internal-core>=0.1.0,<0.2.0", sibling_version="0.2.0"
+    )
+    hook = hatch_build.WorkspaceDependenciesMetadataHook(str(package_root), {})
+
+    with pytest.raises(RuntimeError) as error:
+        hook.update({})
+
+    message = str(error.value)
+    assert "vercel-sandbox declares" in message
+    assert "is at 0.2.0 in the workspace" in message
+    assert "[tool.vercel.release.dependencies]" in message
+
+
+def test_metadata_hook_accepts_a_prerelease_sibling(tmp_path: Path) -> None:
+    """A prerelease version satisfies its own generated lower bound."""
+    package_root = _workspace_with_bound(
+        tmp_path, declared="vercel-internal-core>=0.1.0,<0.2.0", sibling_version="0.1.9b1"
+    )
+    metadata: dict[str, object] = {}
+
+    hatch_build.WorkspaceDependenciesMetadataHook(str(package_root), {}).update(metadata)
+
+    assert metadata["dependencies"] == ["vercel-internal-core>=0.1.9b1,<0.2.0"]
+
+
 def test_compute_releases_force_bumps_all_packages(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Stacked on #222, which raises the bound that broke `vercel` 0.8.0. That release is on PyPI requiring `vercel-sandbox<0.3.0,>=0.3.0` and cannot be installed at all: `scripts/hatch_build.py` replaces a workspace dependency's lower bound with the sibling's current version and keeps the declared upper bound as written, so when `vercel-sandbox` reached 0.3.0 while `vercel` still said `<0.3.0`, the generated `>=0.3.0` closed the range to nothing. The two bounds had never been
checked against each other, and nothing between `uv build` and `uv publish` resolves a wheel's metadata — so the first resolver to see it belonged to a user.

Two checks close that gap. The metadata hook now refuses to emit a bound the version being released cannot satisfy; it is the only code that sees both bounds, and `scripts/build.sh` runs on every pull request, so the bump that crosses a bound fails on the PR that makes it rather than one release later. And `scripts/verify_dist.py` installs each built wheel into a throwaway environment, resolved against the sibling wheels from the same build so a package is checked against the versions it ships with — `build.sh` runs it over `dist/` in about a second, and the publish workflow runs it per package against the artifacts it is about to upload. Both were verified against a rebuilt copy of the broken 0.8.0 wheel.