### PR TITLE
workflow: make payloads interchangeable with the TypeScript SDK

### DIFF
--- a/changes/vercel/20260731134500.breaking.md
+++ b/changes/vercel/20260731134500.breaking.md
@@ -1,0 +1,11 @@
+Workflow payloads — run and step inputs, step results, workflow outputs and
+hook payloads — now use the devalue wire format of the TypeScript
+`@workflow/core` package: a `devl` prefix, and a single value per field where
+this SDK wrote a one-element list. Workflows and steps are also called with
+keyword arguments only, and their parameters have to be declared keyword-only
+(a positional one is rejected when the function is registered). Together those
+make a Python call record byte-identically to the TypeScript one, so payloads
+written by either SDK are readable by the other. Runs recorded by an earlier
+version cannot be replayed. `BaseHook.resume()` now passes its keyword
+arguments to `model_dump()`, in `"python"` mode, rather than to
+`model_dump_json()`.

--- a/changes/vercel/20260731134500.breaking.md
+++ b/changes/vercel/20260731134500.breaking.md
@@ -1,11 +1,3 @@
-Workflow payloads — run and step inputs, step results, workflow outputs and
-hook payloads — now use the devalue wire format of the TypeScript
-`@workflow/core` package: a `devl` prefix, and a single value per field where
-this SDK wrote a one-element list. Workflows and steps are also called with
-keyword arguments only, and their parameters have to be declared keyword-only
-(a positional one is rejected when the function is registered). Together those
-make a Python call record byte-identically to the TypeScript one, so payloads
-written by either SDK are readable by the other. Runs recorded by an earlier
-version cannot be replayed. `BaseHook.resume()` now passes its keyword
-arguments to `model_dump()`, in `"python"` mode, rather than to
-`model_dump_json()`.
+Workflow payloads now use the devalue wire format of the TypeScript
+`@workflow/core` package, and workflows and steps are called with keyword
+arguments only.

--- a/changes/vercel/20260731152000.feature.md
+++ b/changes/vercel/20260731152000.feature.md
@@ -1,0 +1,8 @@
+Workflow payloads can carry `Decimal`, `UUID`, `date`, `time`, `timedelta` and
+`Path`, and `@serializable` (or `register_serializable()`) puts your own
+classes on the wire through `__workflow_serialize__` /
+`__workflow_deserialize__` — an `Enum` needs neither. These ride
+`@workflow/core`'s `Instance` tag, so a JavaScript reader that has never heard
+of the class still renders the value (`workflow inspect` shows
+`Decimal@decimal '1.50'`), and a TypeScript peer can reconstruct the object by
+registering the same `class_id`.

--- a/changes/vercel/20260731152000.feature.md
+++ b/changes/vercel/20260731152000.feature.md
@@ -1,7 +1,7 @@
 Workflow payloads can carry `Decimal`, `UUID`, `date`, `time`, `timedelta` and
 `Path`, and `@serializable` (or `register_serializable()`) puts your own
-classes on the wire through `__workflow_serialize__` /
-`__workflow_deserialize__` — an `Enum` needs neither. These ride
+classes on the wire through `_workflow_serialize` /
+`_workflow_deserialize` — an `Enum` needs neither. These ride
 `@workflow/core`'s `Instance` tag, so a JavaScript reader that has never heard
 of the class still renders the value (`workflow inspect` shows
 `Decimal@decimal '1.50'`), and a TypeScript peer can reconstruct the object by

--- a/changes/vercel/20260731152000.feature.md
+++ b/changes/vercel/20260731152000.feature.md
@@ -1,8 +1,3 @@
-Workflow payloads can carry `Decimal`, `UUID`, `date`, `time`, `timedelta` and
-`Path`, and `@serializable` (or `register_serializable()`) puts your own
-classes on the wire through `_workflow_serialize` /
-`_workflow_deserialize` — an `Enum` needs neither. These ride
-`@workflow/core`'s `Instance` tag, so a JavaScript reader that has never heard
-of the class still renders the value (`workflow inspect` shows
-`Decimal@decimal '1.50'`), and a TypeScript peer can reconstruct the object by
-registering the same `class_id`.
+Workflow payloads can now carry native `Decimal`, `UUID`, `date`, `time`,
+`timedelta` and `Path`, and `@serializable` (or `register_serializable()`)
+is offered for custom classes.

--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import functools
-import json
 import random as _random
 from collections.abc import AsyncIterator, Callable, Coroutine, Generator
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, overload
@@ -174,14 +173,13 @@ class BaseHook:
             raise RuntimeError("cannot call resume() inside workflow")
 
         if isinstance(self, pydantic.BaseModel):
-            json_str = self.model_dump_json(**kwargs)
+            payload = self.model_dump(**{"mode": "python", **kwargs})
         elif dataclasses.is_dataclass(self):
-            obj = dataclasses.asdict(self, dict_factory=kwargs.pop("dict_factory", dict))
-            json_str = json.dumps(obj, **kwargs)
+            payload = dataclasses.asdict(self, **kwargs)
         else:
             raise TypeError("resume only supports pydantic models or dataclasses")
 
-        return await runtime.resume_hook(token_or_hook, json_str)
+        return await runtime.resume_hook(token_or_hook, payload)
 
 
 class Workflows:

--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import functools
+import inspect
 import random as _random
 from collections.abc import AsyncIterator, Callable, Coroutine, Generator
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, overload
@@ -22,6 +23,32 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 DEFAULT_MAX_RETRIES = 3
+
+
+def _require_keyword_only(func: Callable[..., Any], kind: str) -> None:
+    """Reject a workflow or step whose parameters could be passed positionally.
+
+    Calls are recorded as the single object `@workflow/core` records for a
+    call with one argument, so there is nowhere for a positional argument to
+    go. Declaring the parameters keyword-only is what makes that visible in the
+    signature -- and it lets the type checker reject a positional call, since
+    `start()` and `Step.__call__` forward a `ParamSpec`.
+
+    Raised at registration rather than at call time so the whole codebase
+    reports at import, each error pointing at its own definition.
+    """
+    positional = [
+        name
+        for name, param in inspect.signature(func).parameters.items()
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD, param.VAR_POSITIONAL)
+    ]
+    if positional:
+        raise TypeError(
+            f"{kind} {func.__qualname__} takes positional parameter(s) "
+            f"{', '.join(positional)}; workflows and steps are called with keyword "
+            f"arguments only. Declare them keyword-only: "
+            f"async def {func.__name__}(*, {positional[0]}: ...)"
+        )
 
 
 class Workflow(Generic[P, T]):
@@ -52,6 +79,11 @@ class Step(Generic[P, T]):
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         from . import runtime
+
+        if args:
+            raise TypeError(
+                f"{self.name} takes keyword arguments only; got {len(args)} positional argument(s)"
+            )
 
         try:
             ctx = runtime.WorkflowOrchestratorContext.current()
@@ -210,6 +242,7 @@ class Workflows:
         return self._namespace
 
     def workflow(self, func: Callable[P, Coroutine[Any, Any, T]]) -> Workflow[P, T]:
+        _require_keyword_only(func, "workflow")
         rv = Workflow(func, registry=self)
         assert rv.workflow_id not in self._workflows, f"Duplicate workflow ID: {rv.workflow_id}"
         self._workflows[rv.workflow_id] = rv
@@ -233,6 +266,7 @@ class Workflows:
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> Step[P, T] | Callable[[Callable[P, Coroutine[Any, Any, T]]], Step[P, T]]:
         def register(f: Callable[P, Coroutine[Any, Any, T]]) -> Step[P, T]:
+            _require_keyword_only(f, "step")
             rv = Step(f, max_retries=max_retries)
             assert rv.name not in self._steps, f"Duplicate step name: {rv.name}"
             self._steps[rv.name] = rv

--- a/src/vercel/_internal/workflow/py_sandbox.py
+++ b/src/vercel/_internal/workflow/py_sandbox.py
@@ -950,10 +950,10 @@ class SandboxPolicy:
 def workflow_sandbox(*, policy: SandboxPolicy | None = None) -> Iterator[None]:
     """Activate the workflow sandbox for the current context.
 
-    Gives this context its own private ``sys.modules`` table and marks it
-    as in-sandbox so proxy modules enforce restrictions. Both are
-    ContextVars, so concurrent runs are isolated without touching any
-    shared global.
+    Gives this context its own private ``sys.modules`` table, its own
+    serializable-class registrations, and marks it as in-sandbox so proxy
+    modules enforce restrictions. All are ContextVars, so concurrent runs
+    are isolated without touching any shared global.
     """
     if policy is None:
         policy = SandboxPolicy()
@@ -963,8 +963,13 @@ def workflow_sandbox(*, policy: SandboxPolicy | None = None) -> Iterator[None]:
     table_token = _sandbox_sys_modules.set(table)
     sandbox_token = _in_sandbox.set(True)
     passthrough_token = _policy_passthroughs.set(frozenset(policy.passthrough_modules))
+    # Imported here rather than at module scope: `serde` is a leaf, but this
+    # module is imported by `core` before the rest of the package exists.
+    from . import serde
+
     try:
-        yield
+        with serde.sandboxed_registrations():
+            yield
     finally:
         _policy_passthroughs.reset(passthrough_token)
         _in_sandbox.reset(sandbox_token)

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -254,12 +254,11 @@ class WorkflowOrchestratorContext:
     def current(cls) -> Self:
         return cls._ctx.get()
 
-    def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> Any:
+    def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> bytes:
+        """Run the body inside the sandbox, returning its result serialized there."""
         wf = self.registry._get_workflow(workflow_run.workflow_name)
         if not workflow_run.input:
             raise RuntimeError(f"Invalid workflow input for run {workflow_run.run_id}")
-        what = f"the input of run {workflow_run.run_id}"
-        kwargs = ser.keyword_arguments(ser.hydrate(workflow_run.input, what=what), what=what)
 
         with workflow_sandbox(policy=self.registry._sandbox_policy):
             mod = importlib.import_module(wf.module)
@@ -269,6 +268,9 @@ class WorkflowOrchestratorContext:
             obj: Any = mod
             for attr in wf.qualname.split("."):
                 obj = getattr(obj, attr)
+
+            what = f"the input of run {workflow_run.run_id}"
+            kwargs = ser.keyword_arguments(ser.hydrate(workflow_run.input, what=what), what=what)
 
             async def inner():
                 self._fut = asyncio.ensure_future(obj.func(**kwargs))
@@ -281,7 +283,7 @@ class WorkflowOrchestratorContext:
             finally:
                 self._ctx.reset(token)
             assert self._fut
-            return self._fut.result()
+            return ser.dehydrate(self._fut.result())
 
     # `args` is always empty: `Step.__call__` refuses a positional call before
     # forwarding, and only spells one because a ParamSpec has to carry both
@@ -653,8 +655,7 @@ async def workflow_handler(
         events, seed=run_id, started_at=workflow_started_at, registry=registry
     )
     try:
-        result = context.run_workflow(workflow_run)
-        output = ser.dehydrate(result)
+        output = context.run_workflow(workflow_run)
     except BaseException as e:
         if isinstance(e, asyncio.CancelledError) and e.args and e.args[0] == SUSPENDED_MESSAGE:
             # Workflow suspended, continue outside the try..except block

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -258,9 +258,8 @@ class WorkflowOrchestratorContext:
         wf = self.registry._get_workflow(workflow_run.workflow_name)
         if not workflow_run.input:
             raise RuntimeError(f"Invalid workflow input for run {workflow_run.run_id}")
-        args, kwargs = ser.hydrate(
-            workflow_run.input, what=f"the input of run {workflow_run.run_id}"
-        )
+        what = f"the input of run {workflow_run.run_id}"
+        kwargs = ser.keyword_arguments(ser.hydrate(workflow_run.input, what=what), what=what)
 
         with workflow_sandbox(policy=self.registry._sandbox_policy):
             mod = importlib.import_module(wf.module)
@@ -272,7 +271,7 @@ class WorkflowOrchestratorContext:
                 obj = getattr(obj, attr)
 
             async def inner():
-                self._fut = asyncio.ensure_future(obj.func(*args, **kwargs))
+                self._fut = asyncio.ensure_future(obj.func(**kwargs))
                 self.resume_wrapper()  # arm the resume callback
                 await self._fut
 
@@ -284,8 +283,11 @@ class WorkflowOrchestratorContext:
             assert self._fut
             return self._fut.result()
 
+    # `args` is always empty: `Step.__call__` refuses a positional call before
+    # forwarding, and only spells one because a ParamSpec has to carry both
+    # halves.
     async def run_step(self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-        input_data = ser.dehydrate([list(args), kwargs])
+        input_data = ser.dehydrate(ser.step_arguments(kwargs))
         sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
         return await sus.future
@@ -887,7 +889,8 @@ async def step_handler(
         # Deserialize step input
         if not step_run.input:
             raise RuntimeError(f"Step '{req.step_id}' has no input")
-        args, kwargs = ser.hydrate(step_run.input, what=f"the input of step {req.step_id}")
+        what = f"the input of step {req.step_id}"
+        kwargs = ser.step_keyword_arguments(ser.hydrate(step_run.input, what=what), what=what)
 
         logger.debug(
             "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
@@ -906,7 +909,7 @@ async def step_handler(
         )
         # Execute the step function
         try:
-            result = await step.func(*args, **kwargs)
+            result = await step.func(**kwargs)
         finally:
             _step_ctx.reset(token)
 
@@ -1126,10 +1129,15 @@ class Run:
 
 
 async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> Run:
+    # See `Step.__call__` on why a keyword-only call still spells `*args`.
+    if args:
+        raise TypeError(
+            f"{wf.workflow_id} takes keyword arguments only; got {len(args)} positional argument(s)"
+        )
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
     namespace = wf._resolve_queue_namespace()
-    input_data = ser.dehydrate([list(args), kwargs])
+    input_data = ser.dehydrate(ser.argument_array(kwargs))
     data = w.RunCreatedEventData(
         deploymentId=deployment_id,
         workflowName=wf.workflow_id,

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -3,7 +3,6 @@ import contextvars
 import dataclasses
 import functools
 import importlib
-import json
 import logging
 import math
 import random
@@ -20,7 +19,7 @@ import pydantic
 
 from vercel._internal.core.polyfills import UTC, Self
 
-from . import core, nanoid, ulid, world as w
+from . import core, nanoid, serialization as ser, ulid, world as w
 from .py_sandbox import workflow_sandbox
 
 P = ParamSpec("P")
@@ -257,11 +256,11 @@ class WorkflowOrchestratorContext:
 
     def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> Any:
         wf = self.registry._get_workflow(workflow_run.workflow_name)
-        if not workflow_run.input or not isinstance(workflow_run.input, list):
+        if not workflow_run.input:
             raise RuntimeError(f"Invalid workflow input for run {workflow_run.run_id}")
-        if not workflow_run.input[0].startswith(b"json"):
-            raise RuntimeError(f"Unsupported workflow input encoding for run {workflow_run.run_id}")
-        args, kwargs = json.loads(workflow_run.input[0][len(b"json") :].decode())
+        args, kwargs = ser.hydrate(
+            workflow_run.input, what=f"the input of run {workflow_run.run_id}"
+        )
 
         with workflow_sandbox(policy=self.registry._sandbox_policy):
             mod = importlib.import_module(wf.module)
@@ -286,7 +285,7 @@ class WorkflowOrchestratorContext:
             return self._fut.result()
 
     async def run_step(self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-        input_data = b"json" + json.dumps((args, kwargs), sort_keys=True).encode()
+        input_data = ser.dehydrate([list(args), kwargs])
         sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
         return await sus.future
@@ -466,7 +465,7 @@ class WorkflowOrchestratorContext:
                     # The recorded step at this (positional) correlation ID must be
                     # the same call the body just issued; a mismatch means the body
                     # is non-deterministic.
-                    if sus.step.name != name or [sus.input] != recorded_input:
+                    if sus.step.name != name or sus.input != recorded_input:
                         self._fail_suspension(
                             sus,
                             NondeterminismError(
@@ -487,13 +486,12 @@ class WorkflowOrchestratorContext:
                 case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
                     sus = self.suspensions.pop(event.correlation_id)
                     assert isinstance(sus, Suspension)
-                    if data[0].startswith(b"json"):
-                        result = json.loads(data[0][len(b"json") :].decode())
-                    else:
-                        self._fut.cancel(
-                            f"Unsupported step result encoding for "
-                            f"correlation ID {event.correlation_id}"
+                    try:
+                        result = ser.hydrate(
+                            data, what=f"the result of step {event.correlation_id}"
                         )
+                    except ser.SerializationError as error:
+                        self._fut.cancel(str(error))
                         return
                     sus.future.set_result(result)
 
@@ -521,13 +519,12 @@ class WorkflowOrchestratorContext:
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]
                     assert isinstance(hook, Hook)
-                    if data[0].startswith(b"json"):
-                        result = json.loads(data[0][len(b"json") :].decode())
-                    else:
-                        self._fut.cancel(
-                            f"Unsupported step result encoding for "
-                            f"correlation ID {event.correlation_id}"
+                    try:
+                        result = ser.hydrate(
+                            data, what=f"the payload of hook {event.correlation_id}"
                         )
+                    except ser.SerializationError as error:
+                        self._fut.cancel(str(error))
                         return
                     hook.set_result(result)
                     if not hook.futures:
@@ -655,7 +652,7 @@ async def workflow_handler(
     )
     try:
         result = context.run_workflow(workflow_run)
-        output = b"json" + json.dumps(result).encode()
+        output = ser.dehydrate(result)
     except BaseException as e:
         if isinstance(e, asyncio.CancelledError) and e.args and e.args[0] == SUSPENDED_MESSAGE:
             # Workflow suspended, continue outside the try..except block
@@ -680,7 +677,7 @@ async def workflow_handler(
         try:
             await world.events_create(
                 run_id,
-                w.RunCompletedEventData(output=[output]).into_event(),
+                w.RunCompletedEventData(output=output).into_event(),
             )
         except w.EntityConflictError:
             logger.warning(f"Workflow run {run_id} was already completed")
@@ -696,7 +693,7 @@ async def workflow_handler(
             elif isinstance(sus, Suspension):
 
                 async def create_step(s=sus):
-                    step_data = w.StepCreatedEventData(stepName=s.step.name, input=[s.input])
+                    step_data = w.StepCreatedEventData(stepName=s.step.name, input=s.input)
                     try:
                         await world.events_create(run_id, step_data.into_event(s.correlation_id))
                     except w.EntityConflictError:
@@ -890,9 +887,7 @@ async def step_handler(
         # Deserialize step input
         if not step_run.input:
             raise RuntimeError(f"Step '{req.step_id}' has no input")
-        if not step_run.input[0].startswith(b"json"):
-            raise RuntimeError(f"Unsupported step input encoding for step {req.step_id}")
-        args, kwargs = json.loads(step_run.input[0][len(b"json") :].decode())
+        args, kwargs = ser.hydrate(step_run.input, what=f"the input of step {req.step_id}")
 
         logger.debug(
             "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
@@ -916,12 +911,12 @@ async def step_handler(
             _step_ctx.reset(token)
 
         # Serialize the result
-        output = b"json" + json.dumps(result).encode()
+        output = ser.dehydrate(result)
 
         # Complete the step via event
         await world.events_create(
             req.workflow_run_id,
-            w.StepCompletedEventData(result=[output]).into_event(req.step_id),
+            w.StepCompletedEventData(result=output).into_event(req.step_id),
         )
 
     except Exception as e:
@@ -1118,9 +1113,7 @@ class Run:
             if run.status == "completed":
                 if not run.output:
                     raise RuntimeError(f"Completed workflow {run.run_id} has no output")
-                if not run.output[0].startswith(b"json"):
-                    raise RuntimeError(f"Unsupported workflow output encoding for {run.run_id}")
-                return json.loads(run.output[0][len(b"json") :].decode())
+                return ser.hydrate(run.output, what=f"the output of run {run.run_id}")
 
             elif run.status == "cancelled":
                 raise RuntimeError("workflow cancelled")
@@ -1136,11 +1129,11 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
     namespace = wf._resolve_queue_namespace()
-    input_data = b"json" + json.dumps([args, kwargs], sort_keys=True).encode()
+    input_data = ser.dehydrate([list(args), kwargs])
     data = w.RunCreatedEventData(
         deploymentId=deployment_id,
         workflowName=wf.workflow_id,
-        input=[input_data],
+        input=input_data,
         executionContext={"queueNamespace": namespace} if namespace is not None else None,
     )
     result = await world.events_create(None, data.into_event())
@@ -1159,15 +1152,14 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     return Run(run_id)
 
 
-async def resume_hook(token_or_hook: str | w.Hook, payload_json: str) -> w.Hook:
+async def resume_hook(token_or_hook: str | w.Hook, payload: Any) -> w.Hook:
     world = w.get_world()
     if isinstance(token_or_hook, str):
         hook = await world.hooks_get_by_token(token_or_hook)
     else:
         hook = token_or_hook
     run = await world.runs_get(hook.run_id)
-    payload = b"json" + payload_json.encode()
-    data = w.HookReceivedEventData(payload=[payload])
+    data = w.HookReceivedEventData(payload=ser.dehydrate(payload))
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}
     namespace = execution_context.get("queueNamespace")

--- a/src/vercel/_internal/workflow/serde.py
+++ b/src/vercel/_internal/workflow/serde.py
@@ -28,14 +28,12 @@ TypeScript compiler plugin generates.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import dataclasses
-import datetime
-import decimal
 import enum
 import operator
-import pathlib
-import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Any, TypeVar
 
 CLASS_ID_PREFIX = "class//"
@@ -50,14 +48,44 @@ class _Registration:
     deserialize: Callable[[Any], Any]
 
 
-_by_class_id: dict[str, _Registration] = {}
-_by_class: dict[type, _Registration] = {}
-# Types devalue already carries that a registration on a base class would
-# otherwise capture. Walking the MRO stops here, declining the value.
-_NATIVE: set[type] = {datetime.datetime}
-# `type(value)` -> the registration that applies to it, or None. Cleared
-# whenever a registration lands, since a new one can change the answer.
-_resolved: dict[type, _Registration | None] = {}
+@dataclasses.dataclass
+class _Registry:
+    """The registrations one side of the sandbox boundary can see.
+
+    A sandbox gets its own, holding the classes it imported itself and nothing
+    else -- see :func:`sandboxed_registrations`.
+    """
+
+    by_class_id: dict[str, _Registration] = dataclasses.field(default_factory=dict)
+    by_class: dict[type, str] = dataclasses.field(default_factory=dict)
+    # `type(value)` -> the classId that applies to it, or None. Dropped
+    # whenever a registration lands here, since a new one can change the
+    # answer.
+    resolved: dict[type, str | None] = dataclasses.field(default_factory=dict)
+    # Types devalue carries itself, which a registration on a base class would
+    # otherwise capture. The MRO walk stops here and declines the value.
+    native: set[type] = dataclasses.field(default_factory=set)
+
+    def registration(self, class_id: str) -> _Registration | None:
+        return self.by_class_id.get(class_id)
+
+    def add(self, cls: type, registration: _Registration) -> None:
+        self.by_class_id[registration.class_id] = registration
+        self.by_class[cls] = registration.class_id
+        self.resolved.clear()
+
+
+# What the host registers, at import and afterwards.
+_HOST = _Registry()
+# The registry in effect. Unset outside a sandbox, where there is one registry
+# and it is the host's; `sandboxed_registrations` sets one for the sandbox.
+_registry: contextvars.ContextVar[_Registry | None] = contextvars.ContextVar(
+    "_registry", default=None
+)
+
+
+def _current() -> _Registry:
+    return _registry.get() or _HOST
 
 
 def default_class_id(cls: type) -> str:
@@ -110,14 +138,14 @@ def register_serializable(
                 f"or a deserialize= function, to be read back"
             )
 
-    registration = _Registration(
-        class_id=class_id or default_class_id(cls),
-        serialize=serialize,
-        deserialize=deserialize,
+    _current().add(
+        cls,
+        _Registration(
+            class_id=class_id or default_class_id(cls),
+            serialize=serialize,
+            deserialize=deserialize,
+        ),
     )
-    _by_class_id[registration.class_id] = registration
-    _by_class[cls] = registration
-    _resolved.clear()
 
 
 def serializable(cls: type[T] | None = None, *, class_id: str | None = None) -> Any:
@@ -146,6 +174,35 @@ def serializable(cls: type[T] | None = None, *, class_id: str | None = None) -> 
     return decorate if cls is None else decorate(cls)
 
 
+def _registration(class_id: str) -> _Registration | None:
+    return _current().registration(class_id)
+
+
+@contextlib.contextmanager
+def sandboxed_registrations() -> Iterator[None]:
+    """Give this context a registry of its own, holding only the built-ins.
+
+    Entered by `workflow_sandbox`. The sandbox re-imports the workflow's
+    module, so the `@serializable` classes it needs are registered again here;
+    what the host registered elsewhere is deliberately not visible, which is
+    what keeps the sandbox from being handed a class its own code never
+    imported -- and through that class's `__globals__`, the host's module
+    graph.
+
+    Nothing shared is mutated, so there is nothing to restore and concurrent
+    runs do not interfere. The registry is dropped whole when the scope closes,
+    taking the sandbox's classes with it, which is why none of this needs weak
+    keys: no payload of this run crosses the boundary un-serialized.
+    """
+    sandboxed = _Registry()
+    token = _registry.set(sandboxed)
+    try:
+        _register_builtins(sandboxed)
+        yield
+    finally:
+        _registry.reset(token)
+
+
 def _resolve(tp: type) -> _Registration | None:
     """The registration that applies to *tp*, by method resolution order.
 
@@ -154,17 +211,19 @@ def _resolve(tp: type) -> _Registration | None:
     which of several applicable registrations wins without any ordering rule
     of our own.
     """
-    if tp in _resolved:
-        return _resolved[tp]
-    found: _Registration | None = None
+    registry = _current()
+    if tp in registry.resolved:
+        class_id = registry.resolved[tp]
+        return registry.registration(class_id) if class_id is not None else None
+    found: str | None = None
     for base in tp.__mro__:
-        if base in _NATIVE:
+        if base in registry.native:
             break
-        if base in _by_class:
-            found = _by_class[base]
+        found = registry.by_class.get(base)
+        if found is not None:
             break
-    _resolved[tp] = found
-    return found
+    registry.resolved[tp] = found
+    return registry.registration(found) if found is not None else None
 
 
 def reduce_instance(value: Any) -> Any:
@@ -193,7 +252,7 @@ def revive_instance(value: Any) -> Any:
     if not isinstance(value, dict) or not isinstance(value.get("classId"), str):
         raise ValueError(f"malformed Instance payload: {value!r}")
     class_id = value["classId"]
-    registration = _by_class_id.get(class_id)
+    registration = _registration(class_id)
     if registration is None:
         raise ValueError(
             f"unknown class {class_id!r}; register it with @serializable to read "
@@ -242,44 +301,80 @@ REVIVERS: dict[str, Callable[[Any], Any]] = {"Instance": revive_instance}
 #
 # An `enum.Enum` cannot be covered here because the class is the user's; it is
 # one `@serializable` away, and `registration_hint` says so.
+#
+# These are registered per registry rather than once, for the reason
+# `_register_builtins` gives.
 
-register_serializable(
-    decimal.Decimal,
-    serialize=str,
-    deserialize=decimal.Decimal,
-)
-register_serializable(
-    uuid.UUID,
-    serialize=str,
-    deserialize=uuid.UUID,
-)
-register_serializable(
-    # `datetime` is a `date` subclass and devalue carries it as a JS `Date`
-    # already; `_NATIVE` is what keeps this registration off it.
-    datetime.date,
-    serialize=lambda value: value.isoformat(),
-    deserialize=datetime.date.fromisoformat,
-)
-register_serializable(
-    datetime.time,
-    serialize=lambda value: value.isoformat(),
-    deserialize=datetime.time.fromisoformat,
-)
-register_serializable(
-    datetime.timedelta,
-    # Exact rather than `total_seconds()`, which is a float and rounds.
-    serialize=lambda value: {
-        "days": value.days,
-        "seconds": value.seconds,
-        "microseconds": value.microseconds,
-    },
-    deserialize=lambda data: datetime.timedelta(**data),
-)
-register_serializable(
-    pathlib.PurePath,
-    # The concrete class is host-dependent (`PosixPath` / `WindowsPath`), so
-    # the id names the portable one and reading picks the local flavour.
-    class_id=f"{CLASS_ID_PREFIX}pathlib//Path",
-    serialize=str,
-    deserialize=pathlib.Path,
-)
+
+def _register_builtins(registry: _Registry) -> None:
+    """Register the stdlib types this module carries into *registry*.
+
+    Called for the host at import, and again for each sandbox. Each needs its
+    own: a sandbox re-imports `uuid`, so its `uuid.UUID` is a different class
+    object, and a registration made against the host's does not apply to it.
+
+    Reading a payload then builds the sandbox's own class, which is the point
+    for `datetime.date` -- inside a sandbox that is `_RestrictedDate`, there to
+    keep `date.today()` out of a workflow body.
+    """
+
+    def add(
+        cls: type,
+        class_id: str,
+        *,
+        serialize: Callable[[Any], Any],
+        deserialize: Callable[[Any], Any],
+    ) -> None:
+        # The id is spelled out rather than derived from the class, which inside
+        # a sandbox would put `_RestrictedDate` on the wire.
+        registry.add(cls, _Registration(class_id, serialize, deserialize))
+
+    import datetime  # noqa: PLC0415
+    import decimal  # noqa: PLC0415
+    import pathlib  # noqa: PLC0415
+    import uuid  # noqa: PLC0415
+
+    add(
+        decimal.Decimal,
+        f"{CLASS_ID_PREFIX}decimal//Decimal",
+        serialize=str,
+        deserialize=decimal.Decimal,
+    )
+    add(uuid.UUID, f"{CLASS_ID_PREFIX}uuid//UUID", serialize=str, deserialize=uuid.UUID)
+    add(
+        # `datetime` is a `date` subclass and devalue carries it as a JS `Date`
+        # already; `registry.native` keeps this registration off it.
+        datetime.date,
+        f"{CLASS_ID_PREFIX}datetime//date",
+        serialize=lambda value: value.isoformat(),
+        deserialize=datetime.date.fromisoformat,
+    )
+    add(
+        datetime.time,
+        f"{CLASS_ID_PREFIX}datetime//time",
+        serialize=lambda value: value.isoformat(),
+        deserialize=datetime.time.fromisoformat,
+    )
+    add(
+        datetime.timedelta,
+        f"{CLASS_ID_PREFIX}datetime//timedelta",
+        # Exact rather than `total_seconds()`, which is a float and rounds.
+        serialize=lambda value: {
+            "days": value.days,
+            "seconds": value.seconds,
+            "microseconds": value.microseconds,
+        },
+        deserialize=lambda data: datetime.timedelta(**data),
+    )
+    registry.native.add(datetime.datetime)
+    add(
+        pathlib.PurePath,
+        # The concrete class is host-dependent (`PosixPath` / `WindowsPath`), so
+        # the id names the portable one and reading picks the local one.
+        f"{CLASS_ID_PREFIX}pathlib//Path",
+        serialize=str,
+        deserialize=pathlib.Path,
+    )
+
+
+_register_builtins(_HOST)

--- a/src/vercel/_internal/workflow/serde.py
+++ b/src/vercel/_internal/workflow/serde.py
@@ -1,0 +1,285 @@
+"""Custom value types on the wire, on `@workflow/core`'s ``Instance`` rail.
+
+devalue encodes a value it has no built-in form for as a tagged pair,
+``["<tag>", payload]``, and both ends have to agree on the tag. That tag set
+belongs to `@workflow/core`, which composes it internally — so adding a tag is
+a change to *that package*, not something either SDK can do on its own. The one
+tag it leaves open is ``Instance``, carrying ``{classId, data}``, where the
+class is found by ``classId`` in a registry each side keeps.
+
+Riding that rail rather than minting a Python-only tag buys two things.
+
+A JavaScript reader that has never heard of the class still renders the
+payload: the CLI and the dashboard revive ``Instance`` through
+``observabilityRevivers``, which builds a display reference instead of
+consulting the registry, so `workflow inspect` shows ``Decimal@decimal '1.50'``
+and the fields beside it survive. An unknown *tag*, by contrast, makes
+`devalue.parse` throw, and o11y hydration catches that per payload — one
+unreadable value would cost the whole run input.
+
+And when a JavaScript peer does want the real object back, it registers the
+same ``classId`` from userland — no change to `@workflow/core`, and no change
+to the bytes.
+
+``classId`` is ``class//<module>//<qualname>``, matching the ``step//`` and
+``workflow//`` ids this SDK already mints, and the ``class//`` ids the
+TypeScript compiler plugin generates.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import decimal
+import enum
+import operator
+import pathlib
+import uuid
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+CLASS_ID_PREFIX = "class//"
+
+T = TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True)
+class _Registration:
+    class_id: str
+    serialize: Callable[[Any], Any]
+    deserialize: Callable[[Any], Any]
+
+
+_by_class_id: dict[str, _Registration] = {}
+_by_class: dict[type, _Registration] = {}
+# Types devalue already carries that a registration on a base class would
+# otherwise capture. Walking the MRO stops here, declining the value.
+_NATIVE: set[type] = {datetime.datetime}
+# `type(value)` -> the registration that applies to it, or None. Cleared
+# whenever a registration lands, since a new one can change the answer.
+_resolved: dict[type, _Registration | None] = {}
+
+
+def default_class_id(cls: type) -> str:
+    """The ``classId`` a class gets when none is given."""
+    return f"{CLASS_ID_PREFIX}{cls.__module__}//{cls.__qualname__}"
+
+
+def register_serializable(
+    cls: type[T],
+    *,
+    class_id: str | None = None,
+    serialize: Callable[[T], Any] | None = None,
+    deserialize: Callable[[Any], T] | None = None,
+) -> None:
+    """Teach the wire format about *cls*.
+
+    *serialize* turns an instance into something devalue can already carry;
+    *deserialize* turns that back into an instance. Both default to the
+    ``__workflow_serialize__`` / ``__workflow_deserialize__`` methods on the
+    class, and for an `enum.Enum` subclass to its member value and back.
+
+    Pass *class_id* to pin the id — necessary when pairing with a class on the
+    TypeScript side, and when the concrete type varies (`pathlib.Path` is
+    `PosixPath` or `WindowsPath` depending on the host).
+
+    Re-registering a ``classId`` replaces the previous entry. That is not a
+    guard against collisions but a requirement: the sandbox re-imports the
+    workflow's module, so a decorated class is registered once per import with
+    a fresh class object each time.
+    """
+    if serialize is None:
+        if hasattr(cls, "__workflow_serialize__"):
+            serialize = operator.methodcaller("__workflow_serialize__")
+        elif issubclass(cls, enum.Enum):
+            serialize = operator.attrgetter("value")
+        else:
+            raise TypeError(
+                f"{cls.__qualname__} needs a __workflow_serialize__ method, or a "
+                f"serialize= function, to be put on the wire"
+            )
+    if deserialize is None:
+        hook = getattr(cls, "__workflow_deserialize__", None)
+        if hook is not None:
+            deserialize = hook
+        elif issubclass(cls, enum.Enum):
+            deserialize = cls
+        else:
+            raise TypeError(
+                f"{cls.__qualname__} needs a __workflow_deserialize__ classmethod, "
+                f"or a deserialize= function, to be read back"
+            )
+
+    registration = _Registration(
+        class_id=class_id or default_class_id(cls),
+        serialize=serialize,
+        deserialize=deserialize,
+    )
+    _by_class_id[registration.class_id] = registration
+    _by_class[cls] = registration
+    _resolved.clear()
+
+
+def serializable(cls: type[T] | None = None, *, class_id: str | None = None) -> Any:
+    """Register a class for the wire, as a decorator.
+
+    Usable bare or with a ``class_id``::
+
+        @serializable
+        class Point:
+            def __workflow_serialize__(self) -> dict[str, int]:
+                return {"x": self.x, "y": self.y}
+
+            @classmethod
+            def __workflow_deserialize__(cls, data: dict[str, int]) -> "Point":
+                return cls(**data)
+
+        @serializable
+        class Tier(enum.Enum):   # an Enum needs no methods
+            PRO = "pro"
+    """
+
+    def decorate(target: type[T]) -> type[T]:
+        register_serializable(target, class_id=class_id)
+        return target
+
+    return decorate if cls is None else decorate(cls)
+
+
+def _resolve(tp: type) -> _Registration | None:
+    """The registration that applies to *tp*, by method resolution order.
+
+    The MRO is what makes a base-class registration cover its subclasses —
+    `pathlib.Path` is registered once and matches `PosixPath` — and it settles
+    which of several applicable registrations wins without any ordering rule
+    of our own.
+    """
+    if tp in _resolved:
+        return _resolved[tp]
+    found: _Registration | None = None
+    for base in tp.__mro__:
+        if base in _NATIVE:
+            break
+        if base in _by_class:
+            found = _by_class[base]
+            break
+    _resolved[tp] = found
+    return found
+
+
+def reduce_instance(value: Any) -> Any:
+    """devalue reducer for the ``Instance`` tag. Falsy declines the value."""
+    registration = _resolve(type(value))
+    if registration is None:
+        return False
+    try:
+        data = registration.serialize(value)
+    except Exception as error:
+        # A registered serializer is code this module does not own, so its
+        # failure is attributed here rather than surfacing from inside the
+        # codec with nothing naming the class that caused it.
+        raise ValueError(f"{registration.class_id} could not be written: {error}") from error
+    return {"classId": registration.class_id, "data": data}
+
+
+def revive_instance(value: Any) -> Any:
+    """devalue reviver for the ``Instance`` tag.
+
+    Raises `ValueError` for a class this side has not registered, which
+    :func:`vercel._internal.workflow.serialization.hydrate` reports with the
+    name of the payload it came from. Returning a stand-in instead would hand
+    the workflow something that is not the value it was sent.
+    """
+    if not isinstance(value, dict) or not isinstance(value.get("classId"), str):
+        raise ValueError(f"malformed Instance payload: {value!r}")
+    class_id = value["classId"]
+    registration = _by_class_id.get(class_id)
+    if registration is None:
+        raise ValueError(
+            f"unknown class {class_id!r}; register it with @serializable to read "
+            f"a payload that carries one"
+        )
+    try:
+        return registration.deserialize(value.get("data"))
+    except Exception as error:
+        # Payload data is untrusted, and a registered deserializer may raise
+        # anything at all -- `Decimal("garbage")` raises `InvalidOperation`,
+        # which is not even an error the codec would recognize.
+        raise ValueError(f"{class_id} could not be read back: {error}") from error
+
+
+def registration_hint(value: Any) -> str:
+    """A sentence naming the way out, for a value nothing can serialize."""
+    if isinstance(value, enum.Enum):
+        # The class is user-defined, so no built-in registration can cover it.
+        # `StrEnum`/`IntEnum` need none: they are `str`/`int` on the wire.
+        return (
+            f" Register {type(value).__qualname__} with @serializable, or derive it "
+            f"from enum.StrEnum / enum.IntEnum to send the bare member value."
+        )
+    # A class object rather than an instance is a different thing to send --
+    # TypeScript has a separate `Class` tag for it -- so no hint applies.
+    if value is not None and not isinstance(value, type):
+        return f" Register {type(value).__qualname__} with @serializable to send it."
+    return ""
+
+
+REDUCERS: dict[str, Callable[[Any], Any]] = {"Instance": reduce_instance}
+REVIVERS: dict[str, Callable[[Any], Any]] = {"Instance": revive_instance}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# built-in registrations
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Standard-library types that devalue rejects outright and that turn up in
+# ordinary payloads. Types it already carries are left alone -- `datetime` is
+# a `Date`, `bytes` an `ArrayBuffer`, `set` a `Set` -- as are the ones it
+# narrows rather than rejects (`tuple` to a list, `frozenset` to a set,
+# `OrderedDict` to an object): those already cross the wire, and wrapping them
+# would take a plain JavaScript array or Set away from a JavaScript reader for
+# the sake of a Python distinction.
+#
+# An `enum.Enum` cannot be covered here because the class is the user's; it is
+# one `@serializable` away, and `registration_hint` says so.
+
+register_serializable(
+    decimal.Decimal,
+    serialize=str,
+    deserialize=decimal.Decimal,
+)
+register_serializable(
+    uuid.UUID,
+    serialize=str,
+    deserialize=uuid.UUID,
+)
+register_serializable(
+    # `datetime` is a `date` subclass and devalue carries it as a JS `Date`
+    # already; `_NATIVE` is what keeps this registration off it.
+    datetime.date,
+    serialize=lambda value: value.isoformat(),
+    deserialize=datetime.date.fromisoformat,
+)
+register_serializable(
+    datetime.time,
+    serialize=lambda value: value.isoformat(),
+    deserialize=datetime.time.fromisoformat,
+)
+register_serializable(
+    datetime.timedelta,
+    # Exact rather than `total_seconds()`, which is a float and rounds.
+    serialize=lambda value: {
+        "days": value.days,
+        "seconds": value.seconds,
+        "microseconds": value.microseconds,
+    },
+    deserialize=lambda data: datetime.timedelta(**data),
+)
+register_serializable(
+    pathlib.PurePath,
+    # The concrete class is host-dependent (`PosixPath` / `WindowsPath`), so
+    # the id names the portable one and reading picks the local flavour.
+    class_id=f"{CLASS_ID_PREFIX}pathlib//Path",
+    serialize=str,
+    deserialize=pathlib.Path,
+)

--- a/src/vercel/_internal/workflow/serde.py
+++ b/src/vercel/_internal/workflow/serde.py
@@ -76,7 +76,7 @@ def register_serializable(
 
     *serialize* turns an instance into something devalue can already carry;
     *deserialize* turns that back into an instance. Both default to the
-    ``__workflow_serialize__`` / ``__workflow_deserialize__`` methods on the
+    ``_workflow_serialize`` / ``_workflow_deserialize`` methods on the
     class, and for an `enum.Enum` subclass to its member value and back.
 
     Pass *class_id* to pin the id — necessary when pairing with a class on the
@@ -89,24 +89,24 @@ def register_serializable(
     a fresh class object each time.
     """
     if serialize is None:
-        if hasattr(cls, "__workflow_serialize__"):
-            serialize = operator.methodcaller("__workflow_serialize__")
+        if hasattr(cls, "_workflow_serialize"):
+            serialize = operator.methodcaller("_workflow_serialize")
         elif issubclass(cls, enum.Enum):
             serialize = operator.attrgetter("value")
         else:
             raise TypeError(
-                f"{cls.__qualname__} needs a __workflow_serialize__ method, or a "
+                f"{cls.__qualname__} needs a _workflow_serialize method, or a "
                 f"serialize= function, to be put on the wire"
             )
     if deserialize is None:
-        hook = getattr(cls, "__workflow_deserialize__", None)
+        hook = getattr(cls, "_workflow_deserialize", None)
         if hook is not None:
             deserialize = hook
         elif issubclass(cls, enum.Enum):
             deserialize = cls
         else:
             raise TypeError(
-                f"{cls.__qualname__} needs a __workflow_deserialize__ classmethod, "
+                f"{cls.__qualname__} needs a _workflow_deserialize classmethod, "
                 f"or a deserialize= function, to be read back"
             )
 
@@ -127,11 +127,11 @@ def serializable(cls: type[T] | None = None, *, class_id: str | None = None) -> 
 
         @serializable
         class Point:
-            def __workflow_serialize__(self) -> dict[str, int]:
+            def _workflow_serialize(self) -> dict[str, int]:
                 return {"x": self.x, "y": self.y}
 
             @classmethod
-            def __workflow_deserialize__(cls, data: dict[str, int]) -> "Point":
+            def _workflow_deserialize(cls, data: dict[str, int]) -> "Point":
                 return cls(**data)
 
         @serializable

--- a/src/vercel/_internal/workflow/serde.py
+++ b/src/vercel/_internal/workflow/serde.py
@@ -7,7 +7,7 @@ a change to *that package*, not something either SDK can do on its own. The one
 tag it leaves open is ``Instance``, carrying ``{classId, data}``, where the
 class is found by ``classId`` in a registry each side keeps.
 
-Riding that rail rather than minting a Python-only tag buys two things.
+Using that tag rather than adding a Python-only one has two advantages.
 
 A JavaScript reader that has never heard of the class still renders the
 payload: the CLI and the dashboard revive ``Instance`` through
@@ -100,7 +100,7 @@ def register_serializable(
     serialize: Callable[[T], Any] | None = None,
     deserialize: Callable[[Any], T] | None = None,
 ) -> None:
-    """Teach the wire format about *cls*.
+    """Register *cls* so its instances can be serialized.
 
     *serialize* turns an instance into something devalue can already carry;
     *deserialize* turns that back into an instance. Both default to the
@@ -206,10 +206,10 @@ def sandboxed_registrations() -> Iterator[None]:
 def _resolve(tp: type) -> _Registration | None:
     """The registration that applies to *tp*, by method resolution order.
 
-    The MRO is what makes a base-class registration cover its subclasses —
-    `pathlib.Path` is registered once and matches `PosixPath` — and it settles
-    which of several applicable registrations wins without any ordering rule
-    of our own.
+    Using the MRO makes a base-class registration cover its subclasses --
+    `pathlib.PurePath` is registered once and matches `PosixPath` -- and
+    decides between several applicable registrations without this module
+    needing an ordering rule of its own.
     """
     registry = _current()
     if tp in registry.resolved:
@@ -227,7 +227,11 @@ def _resolve(tp: type) -> _Registration | None:
 
 
 def reduce_instance(value: Any) -> Any:
-    """devalue reducer for the ``Instance`` tag. Falsy declines the value."""
+    """devalue reducer for the ``Instance`` tag.
+
+    Returns a falsy value for a type nothing has registered, which is how a
+    devalue reducer declines.
+    """
     registration = _resolve(type(value))
     if registration is None:
         return False
@@ -244,10 +248,10 @@ def reduce_instance(value: Any) -> Any:
 def revive_instance(value: Any) -> Any:
     """devalue reviver for the ``Instance`` tag.
 
-    Raises `ValueError` for a class this side has not registered, which
-    :func:`vercel._internal.workflow.serialization.hydrate` reports with the
-    name of the payload it came from. Returning a stand-in instead would hand
-    the workflow something that is not the value it was sent.
+    Raises `ValueError` for a class this side has not registered;
+    :func:`vercel._internal.workflow.serialization.hydrate` reports it with
+    the name of the payload it came from. Returning a stand-in instead would
+    give the workflow a value it was not sent.
     """
     if not isinstance(value, dict) or not isinstance(value.get("classId"), str):
         raise ValueError(f"malformed Instance payload: {value!r}")
@@ -268,7 +272,7 @@ def revive_instance(value: Any) -> Any:
 
 
 def registration_hint(value: Any) -> str:
-    """A sentence naming the way out, for a value nothing can serialize."""
+    """The suggestion to append when a value cannot be serialized."""
     if isinstance(value, enum.Enum):
         # The class is user-defined, so no built-in registration can cover it.
         # `StrEnum`/`IntEnum` need none: they are `str`/`int` on the wire.

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -76,3 +76,55 @@ def hydrate(data: Any, *, what: str) -> Any:
             f"{what} uses the {prefix.decode()!r} format, which this SDK cannot read"
         )
     raise SerializationError(f"{what} has an unknown serialization format: {prefix!r}")
+
+
+def argument_array(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+    """The positional-argument array a call is recorded as.
+
+    `@workflow/core` records a call as the array of its positional arguments
+    and spreads it back into the callee (`workflowFn(...args)`). Workflows and
+    steps here take keyword arguments only, so that array is a single object —
+    which is exactly what `start(wf, {…})` writes on the TypeScript side, and
+    the object argument a JavaScript callee expects. A call with no arguments
+    records the empty array TS writes for one, rather than an empty object a
+    JavaScript callee would receive as a stray parameter.
+    """
+    return [kwargs] if kwargs else []
+
+
+def keyword_arguments(args: Any, *, what: str) -> dict[str, Any]:
+    """Read an argument array back, the inverse of :func:`argument_array`.
+
+    Anything else in the array is a real positional argument, which can only
+    have come from a JavaScript caller — so the error names the convention
+    rather than letting the mismatch surface as a ``TypeError`` inside the
+    user's function.
+    """
+    if not isinstance(args, list):
+        raise SerializationError(f"{what} is not an argument array: {type(args).__name__}")
+    if not args:
+        return {}
+    if len(args) == 1 and isinstance(args[0], dict) and all(isinstance(k, str) for k in args[0]):
+        return args[0]
+    raise SerializationError(
+        f"{what} carries {len(args)} positional argument(s); Python workflows and "
+        f"steps are called with keyword arguments only, so a caller has to pass "
+        f"a single object"
+    )
+
+
+def step_arguments(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """The object `@workflow/core` records a *step* call as.
+
+    A step's arguments are wrapped where a workflow's are not. TS puts
+    ``closureVars`` and ``thisVal`` in the same object, neither of which has a
+    Python analogue; its reader defaults both when they are absent.
+    """
+    return {"args": argument_array(kwargs)}
+
+
+def step_keyword_arguments(data: Any, *, what: str) -> dict[str, Any]:
+    """Read a step's recorded call back, the inverse of :func:`step_arguments`."""
+    if not isinstance(data, dict):
+        raise SerializationError(f"{what} is not a step argument object: {type(data).__name__}")
+    return keyword_arguments(data.get("args"), what=what)

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from vercel._internal import devalue
 
+from . import serde
+
 FORMAT_PREFIX_LENGTH = 4
 
 DEVALUE_V1 = b"devl"
@@ -42,10 +44,16 @@ class SerializationError(RuntimeError):
 def dehydrate(value: Any) -> bytes:
     """Encode *value* as a ``devl``-prefixed devalue payload."""
     try:
-        return DEVALUE_V1 + devalue.stringify(value).encode()
+        return DEVALUE_V1 + devalue.stringify(value, serde.REDUCERS).encode()
     except devalue.DevalueError as error:
         at = f" at {error.path}" if error.path else ""
-        raise SerializationError(f"Cannot serialize value{at}: {error}") from error
+        raise SerializationError(
+            f"Cannot serialize value{at}: {error}.{serde.registration_hint(error.value)}"
+        ) from error
+    except (ValueError, TypeError) as error:
+        # A registered serializer failed. `serde` has already named the class,
+        # so this only puts the codec-level frame behind a typed error.
+        raise SerializationError(f"Cannot serialize value: {error}") from error
 
 
 def hydrate(data: Any, *, what: str) -> Any:
@@ -68,7 +76,7 @@ def hydrate(data: Any, *, what: str) -> Any:
     prefix, payload = data[:FORMAT_PREFIX_LENGTH], data[FORMAT_PREFIX_LENGTH:]
     if prefix == DEVALUE_V1:
         try:
-            return devalue.parse(payload.decode())
+            return devalue.parse(payload.decode(), serde.REVIVERS)
         except (devalue.DevalueError, ValueError, TypeError) as error:
             raise SerializationError(f"Cannot deserialize {what}: {error}") from error
     if prefix in KNOWN_FORMATS:

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -1,0 +1,78 @@
+"""Payload encoding for workflow runs, steps and hooks.
+
+The wire format is the one `@workflow/core` defines in
+`src/serialization-format.ts`: a 4-byte ASCII format tag followed by the
+payload. The only format this SDK writes is ``devl`` — UTF-8
+`devalue.stringify` output — so a payload written here parses with
+`devalue.parse` in JavaScript and vice versa.
+
+The remaining tags are recognized so that an envelope written by the
+TypeScript SDK is reported as unsupported by name instead of as corrupt
+data. None of them are implemented: `encr`/`encp` need the run's key
+material, and `gzip`/`zstd` wrap another prefixed payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vercel._internal import devalue
+
+FORMAT_PREFIX_LENGTH = 4
+
+DEVALUE_V1 = b"devl"
+"""`devalue.stringify` output, UTF-8 encoded."""
+
+ENCRYPTED = b"encr"
+"""Symmetrically encrypted; the plaintext carries its own format prefix."""
+
+SEALED = b"encp"
+"""Sealed to a run's X25519 public key; likewise prefixed once opened."""
+
+GZIP = b"gzip"
+ZSTD = b"zstd"
+
+KNOWN_FORMATS = (DEVALUE_V1, ENCRYPTED, SEALED, GZIP, ZSTD)
+
+
+class SerializationError(RuntimeError):
+    """A payload could not be encoded, or arrived in a format we cannot read."""
+
+
+def dehydrate(value: Any) -> bytes:
+    """Encode *value* as a ``devl``-prefixed devalue payload."""
+    try:
+        return DEVALUE_V1 + devalue.stringify(value).encode()
+    except devalue.DevalueError as error:
+        at = f" at {error.path}" if error.path else ""
+        raise SerializationError(f"Cannot serialize value{at}: {error}") from error
+
+
+def hydrate(data: Any, *, what: str) -> Any:
+    """Decode a format-prefixed payload written by either SDK.
+
+    Takes ``Any`` because it is the boundary that checks: a payload field can
+    hold whatever the backend put there — an unresolved remote reference, or
+    the ``'[Circular]'`` marker a `run_created` response carries in place of
+    the input — and this is where that is turned into a readable error.
+
+    *what* names the payload in the error message — it is the only context
+    the caller has that would help someone reading the traceback.
+    """
+    if not isinstance(data, bytes | bytearray | memoryview):
+        raise SerializationError(f"{what} is not serialized data: {type(data).__name__}")
+    data = bytes(data)
+    if len(data) < FORMAT_PREFIX_LENGTH:
+        raise SerializationError(f"{what} is too short to carry a format prefix: {len(data)} bytes")
+
+    prefix, payload = data[:FORMAT_PREFIX_LENGTH], data[FORMAT_PREFIX_LENGTH:]
+    if prefix == DEVALUE_V1:
+        try:
+            return devalue.parse(payload.decode())
+        except (devalue.DevalueError, ValueError, TypeError) as error:
+            raise SerializationError(f"Cannot deserialize {what}: {error}") from error
+    if prefix in KNOWN_FORMATS:
+        raise SerializationError(
+            f"{what} uses the {prefix.decode()!r} format, which this SDK cannot read"
+        )
+    raise SerializationError(f"{what} has an unknown serialization format: {prefix!r}")

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -188,8 +188,8 @@ class BaseWorkflowRun(BaseModel):
     )
     # run_created returns input as str `'[Circular]'`,
     # while run_completed returns input_ref
-    input: list[bytes] | str | None = None
-    output: list[bytes] | None = None
+    input: bytes | str | None = None
+    output: bytes | None = None
     error: StructuredError | None = None
     expired_at: datetime | None = pydantic.Field(default=None, alias="expiredAt")
     started_at: datetime | None = pydantic.Field(default=None, alias="startedAt")
@@ -214,7 +214,7 @@ class CancelledWorkflowRun(BaseWorkflowRun):
 
 class CompletedWorkflowRun(BaseWorkflowRun):
     status: Literal["completed"]
-    output: list[bytes] | None = None  # create run_completed event returns run without output
+    output: bytes | None = None  # create run_completed event returns run without output
     error: None = None
     completed_at: datetime = pydantic.Field(alias="completedAt")
 
@@ -240,8 +240,8 @@ class BaseWorkflowStep(BaseModel):
     step_id: str = pydantic.Field(alias="stepId")
     step_name: str = pydantic.Field(alias="stepName")
     status: StepStatus
-    input: list[bytes] | None = None
-    output: list[bytes] | None = None
+    input: bytes | None = None
+    output: bytes | None = None
     """
     The error from a step_retrying or step_failed event.
     This tracks the most recent error the step encountered, which may
@@ -275,7 +275,7 @@ class CancelledWorkflowStep(BaseWorkflowStep):
 
 class CompletedWorkflowStep(BaseWorkflowStep):
     status: Literal["completed"]
-    output: list[bytes] | None = None
+    output: bytes | None = None
     completed_at: datetime = pydantic.Field(alias="completedAt")
 
 
@@ -326,7 +326,7 @@ class BaseEvent(BaseModel):
 class RunCreatedEventData(BaseModel):
     deployment_id: str = pydantic.Field(alias="deploymentId")
     workflow_name: str = pydantic.Field(alias="workflowName")
-    input: list[bytes]
+    input: bytes
     execution_context: dict[str, Any] | None = pydantic.Field(
         default=None, alias="executionContext", exclude_if=lambda e: e is None
     )
@@ -358,7 +358,7 @@ class RunStartedEvent(BaseEvent):
 
 
 class RunCompletedEventData(BaseModel):
-    output: list[bytes]
+    output: bytes
 
     def into_event(self) -> "RunCompletedEvent":
         return RunCompletedEvent(eventData=self)
@@ -400,7 +400,7 @@ class RunFailedEvent(BaseEvent):
 
 class StepCreatedEventData(BaseModel):
     step_name: str = pydantic.Field(alias="stepName")
-    input: list[bytes] | dict[str, Any]
+    input: bytes | dict[str, Any]
 
     def into_event(self, correlation_id: str) -> "StepCreatedEvent":
         return StepCreatedEvent(correlationId=correlation_id, eventData=self)
@@ -465,7 +465,7 @@ class StepRetryingEvent(BaseEvent):
 
 
 class StepCompletedEventData(BaseModel):
-    result: list[bytes] | Any = None
+    result: bytes | Any = None
 
     def into_event(self, correlation_id: str) -> "StepCompletedEvent":
         return StepCompletedEvent(correlationId=correlation_id, eventData=self)
@@ -504,7 +504,7 @@ class Hook(BaseModel):
     owner_id: str = pydantic.Field(alias="ownerId")
     project_id: str = pydantic.Field(alias="projectId")
     environment: str
-    metadata: list[bytes] | None = None
+    metadata: bytes | None = None
     created_at: datetime = pydantic.Field(alias="createdAt")
     spec_version: int | None = pydantic.Field(default=None, alias="specVersion")
     is_webhook: bool | None = pydantic.Field(default=None, alias="isWebhook")
@@ -513,7 +513,7 @@ class Hook(BaseModel):
 
 class HookCreatedEventData(BaseModel):
     token: str
-    metadata: list[bytes] | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
+    metadata: bytes | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
 
     def into_event(self, correlation_id: str) -> "HookCreatedEvent":
         return HookCreatedEvent(correlationId=correlation_id, eventData=self)
@@ -534,7 +534,7 @@ class HookCreatedEvent(BaseEvent):
 
 
 class HookReceivedEventData(BaseModel):
-    payload: list[bytes]
+    payload: bytes
 
     def into_event(self, correlation_id: str) -> "HookReceivedEvent":
         return HookReceivedEvent(correlationId=correlation_id, eventData=self)

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -555,7 +555,7 @@ class LocalWorld(w.World):
 
         elif data.event_type == "step_created" and hasattr(data, "event_data"):
             step_data = data.event_data
-            assert isinstance(step_data.input, list)
+            assert isinstance(step_data.input, bytes)
             step = w.NonFinalWorkflowStep(
                 runId=effective_run_id,
                 stepId=data.correlation_id,

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -71,6 +71,7 @@ dev-mode-dirs = [".."]
 only-include = [
     "/_internal/auth.py",
     "/_internal/blob",
+    "/_internal/devalue",
     "/_internal/fs.py",
     "/_internal/pagination.py",
     "/_internal/workflow",

--- a/src/vercel/tests/unit/test_workflow_determinism.py
+++ b/src/vercel/tests/unit/test_workflow_determinism.py
@@ -15,7 +15,7 @@ import pytest
 from vercel._internal.workflow import core, runtime, serialization as ser, world as w
 
 
-async def _greet(name: str) -> str:
+async def _greet(*, name: str) -> str:
     return name
 
 
@@ -33,9 +33,9 @@ def _context(
     return ctx
 
 
-def _args(*args: Any) -> bytes:
+def _args(**kwargs: Any) -> bytes:
     """A step input payload, encoded the way the runtime encodes one."""
-    return ser.dehydrate([list(args), {}])
+    return ser.dehydrate(ser.step_arguments(kwargs))
 
 
 def _suspension(correlation_id: str, args: bytes) -> runtime.Suspension:
@@ -48,10 +48,10 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event(cid)
+        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event(cid)
     ]
     ctx = _context(events)
-    sus = _suspension(cid, _args("b"))
+    sus = _suspension(cid, _args(name="b"))
     ctx.suspensions[cid] = sus
 
     ctx.resume()
@@ -65,10 +65,10 @@ async def test_matching_step_does_not_raise() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event(cid)
+        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event(cid)
     ]
     ctx = _context(events)
-    sus = _suspension(cid, _args("a"))
+    sus = _suspension(cid, _args(name="a"))
     ctx.suspensions[cid] = sus
 
     ctx.resume()
@@ -87,7 +87,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     """
     step = core.Step(_greet)
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event("step_1")
+        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event("step_1")
     ]
     ctx = _context(events)
     wait = runtime.Wait(
@@ -113,7 +113,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
 #     runs resume() when the loop's ready queue was otherwise empty (quiescent).
 #   * resume() applies at most one recorded event (single-step), or parks.
 
-_ARGS = _args("a")
+_ARGS = _args(name="a")
 
 
 def _created(step: "core.Step[Any, Any]", cid: str) -> w.Event:

--- a/src/vercel/tests/unit/test_workflow_determinism.py
+++ b/src/vercel/tests/unit/test_workflow_determinism.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from vercel._internal.workflow import core, runtime, world as w
+from vercel._internal.workflow import core, runtime, serialization as ser, world as w
 
 
 async def _greet(name: str) -> str:
@@ -33,10 +33,13 @@ def _context(
     return ctx
 
 
-def _suspension(correlation_id: str, args_json: bytes) -> runtime.Suspension:
-    return runtime.Suspension(
-        correlation_id=correlation_id, step=core.Step(_greet), input=args_json
-    )
+def _args(*args: Any) -> bytes:
+    """A step input payload, encoded the way the runtime encodes one."""
+    return ser.dehydrate([list(args), {}])
+
+
+def _suspension(correlation_id: str, args: bytes) -> runtime.Suspension:
+    return runtime.Suspension(correlation_id=correlation_id, step=core.Step(_greet), input=args)
 
 
 async def test_reordered_step_args_raise_nondeterminism() -> None:
@@ -45,10 +48,10 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event(cid)
+        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event(cid)
     ]
     ctx = _context(events)
-    sus = _suspension(cid, b'json[["b"], {}]')
+    sus = _suspension(cid, _args("b"))
     ctx.suspensions[cid] = sus
 
     ctx.resume()
@@ -62,10 +65,10 @@ async def test_matching_step_does_not_raise() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event(cid)
+        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event(cid)
     ]
     ctx = _context(events)
-    sus = _suspension(cid, b'json[["a"], {}]')
+    sus = _suspension(cid, _args("a"))
     ctx.suspensions[cid] = sus
 
     ctx.resume()
@@ -84,7 +87,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     """
     step = core.Step(_greet)
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=[b'json[["a"], {}]']).into_event("step_1")
+        w.StepCreatedEventData(stepName=step.name, input=_args("a")).into_event("step_1")
     ]
     ctx = _context(events)
     wait = runtime.Wait(
@@ -110,15 +113,15 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
 #     runs resume() when the loop's ready queue was otherwise empty (quiescent).
 #   * resume() applies at most one recorded event (single-step), or parks.
 
-_ARGS = b'json[["a"], {}]'
+_ARGS = _args("a")
 
 
 def _created(step: "core.Step[Any, Any]", cid: str) -> w.Event:
-    return w.StepCreatedEventData(stepName=step.name, input=[_ARGS]).into_event(cid)
+    return w.StepCreatedEventData(stepName=step.name, input=_ARGS).into_event(cid)
 
 
-def _completed(cid: str, result_json: bytes) -> w.Event:
-    return w.StepCompletedEventData(result=[b"json" + result_json]).into_event(cid)
+def _completed(cid: str, result: Any) -> w.Event:
+    return w.StepCompletedEventData(result=ser.dehydrate(result)).into_event(cid)
 
 
 async def test_single_step_delivers_one_completion_per_pass() -> None:
@@ -128,8 +131,8 @@ async def test_single_step_delivers_one_completion_per_pass() -> None:
     events: list[w.Event] = [
         _created(step, "step_1"),
         _created(step, "step_2"),
-        _completed("step_1", b'"one"'),
-        _completed("step_2", b'"two"'),
+        _completed("step_1", "one"),
+        _completed("step_2", "two"),
     ]
     ctx = _context(events)
     sus1 = _suspension("step_1", _ARGS)
@@ -156,7 +159,7 @@ async def test_resume_wrapper_defers_while_loop_has_pending_work() -> None:
     step = core.Step(_greet)
     events: list[w.Event] = [
         _created(step, "step_1"),
-        _completed("step_1", b'"one"'),
+        _completed("step_1", "one"),
     ]
     ctx = _context(events)
     sus1 = _suspension("step_1", _ARGS)
@@ -182,7 +185,7 @@ async def test_resume_wrapper_runs_resume_when_quiescent() -> None:
     step = core.Step(_greet)
     events: list[w.Event] = [
         _created(step, "step_1"),
-        _completed("step_1", b'"one"'),
+        _completed("step_1", "one"),
     ]
     ctx = _context(events)
     sus1 = _suspension("step_1", _ARGS)
@@ -254,7 +257,7 @@ async def test_now_advances_with_replay_index() -> None:
     step = core.Step(_greet)
     events: list[w.Event] = [
         _stamp(_created(step, "step_1"), t0, event_id="evt_1"),
-        _stamp(_completed("step_1", b'"one"'), t1, event_id="evt_2"),
+        _stamp(_completed("step_1", "one"), t1, event_id="evt_2"),
         _stamp(_created(step, "step_2"), t2, event_id="evt_3"),
     ]
     ctx = _context(events)

--- a/src/vercel/tests/unit/test_workflow_hook_disposal.py
+++ b/src/vercel/tests/unit/test_workflow_hook_disposal.py
@@ -9,7 +9,7 @@ EntityConflictError instead of double-deleting and writing a duplicate event.
 
 from __future__ import annotations
 
-from vercel._internal.workflow import world as w
+from vercel._internal.workflow import serialization as ser, world as w
 from vercel._internal.workflow.worlds import local as local_mod
 
 RUN_ID = "wrun_test"
@@ -39,7 +39,7 @@ async def test_redispose_raises_hook_not_found(tmp_path, monkeypatch) -> None:
 
 async def test_hook_received_for_missing_hook_raises_hook_not_found(tmp_path, monkeypatch) -> None:
     world = _world(tmp_path, monkeypatch)
-    data = w.HookReceivedEventData(payload=[b"json{}"])
+    data = w.HookReceivedEventData(payload=ser.dehydrate({}))
 
     try:
         await world.events_create(RUN_ID, data.into_event("hook_unknown"))

--- a/src/vercel/tests/unit/test_workflow_hook_resume.py
+++ b/src/vercel/tests/unit/test_workflow_hook_resume.py
@@ -10,9 +10,11 @@ way ``resume()`` in the runtime does it.
 from __future__ import annotations
 
 import dataclasses
+import decimal
 from datetime import datetime, timezone
 
 import pydantic
+import pytest
 
 from vercel._internal.workflow import runtime, serialization as ser, world as w
 from vercel._internal.workflow.worlds.local import LocalWorld
@@ -31,6 +33,20 @@ class Approval(BaseHook, pydantic.BaseModel):
 class Signoff(BaseHook):
     approved: bool
     reviewer: str
+
+
+class Refund(BaseHook, pydantic.BaseModel):
+    amount: decimal.Decimal
+
+
+class _Book:
+    """A class no one has registered for the wire."""
+
+
+class Ledger(BaseHook, pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+
+    book: _Book
 
 
 class _RecordingLocalWorld(LocalWorld):
@@ -113,6 +129,32 @@ async def test_json_mode_is_the_way_back_to_json_shaped_values(tmp_path, monkeyp
 
     payload = _received_payload((await world.events_list(run_id)).data)
     assert ser.hydrate(payload, what="the payload")["at"] == "2026-07-30T17:06:33Z"
+
+
+async def test_a_registered_stdlib_field_survives_python_mode(tmp_path, monkeypatch) -> None:
+    # `Decimal` survives `model_dump(mode="python")` as a `Decimal`, which
+    # devalue only carries because of the built-in `Instance` registration.
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world)
+
+    await Refund(amount=decimal.Decimal("1.50")).resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert ser.hydrate(payload, what="the payload") == {"amount": decimal.Decimal("1.50")}
+
+
+async def test_an_uncarryable_field_names_the_class_to_register(tmp_path, monkeypatch) -> None:
+    # A class nothing has registered. The field it sits in is named too, since
+    # a hook can have several and the codec-level message alone locates none.
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    await _run_with_hook(world)
+
+    with pytest.raises(
+        ser.SerializationError, match=r"at \.book.*Register _Book with @serializable"
+    ):
+        await Ledger(book=_Book()).resume(TOKEN)
 
 
 def _future():

--- a/src/vercel/tests/unit/test_workflow_hook_resume.py
+++ b/src/vercel/tests/unit/test_workflow_hook_resume.py
@@ -1,0 +1,121 @@
+"""Resuming a hook from outside the workflow.
+
+``BaseHook.resume()`` dehydrates the hook instance into the ``hook_received``
+event, and the orchestrator hydrates it back into the hook class when the run
+replays. The two halves are only correct together, so both are exercised here:
+a payload is written through the real ``LocalWorld`` and then reconstructed the
+way ``resume()`` in the runtime does it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+
+import pydantic
+
+from vercel._internal.workflow import runtime, serialization as ser, world as w
+from vercel._internal.workflow.worlds.local import LocalWorld
+from vercel.workflow import BaseHook
+
+TOKEN = "tok-abc"
+
+
+class Approval(BaseHook, pydantic.BaseModel):
+    approved: bool
+    reviewer: str
+    at: datetime
+
+
+@dataclasses.dataclass
+class Signoff(BaseHook):
+    approved: bool
+    reviewer: str
+
+
+class _RecordingLocalWorld(LocalWorld):
+    """Real LocalWorld for storage; only the outbound (networked) queue is stubbed."""
+
+    def __init__(self, data_dir) -> None:
+        super().__init__()
+        self.data_dir = data_dir
+        self.queued: list[tuple[str, w.QueuePayload]] = []
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_test"
+
+
+async def _run_with_hook(world: _RecordingLocalWorld) -> str:
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1", workflowName="test-wf", input=ser.dehydrate([])
+        ).into_event(),
+    )
+    assert result.run is not None
+    run_id = result.run.run_id
+    await world.events_create(run_id, w.RunStartedEvent())
+    await world.events_create(run_id, w.HookCreatedEventData(token=TOKEN).into_event("hook_0"))
+    return run_id
+
+
+def _received_payload(events: list[w.Event]) -> bytes:
+    (event,) = [e for e in events if isinstance(e, w.HookReceivedEvent)]
+    return event.event_data.payload
+
+
+async def test_pydantic_hook_round_trips_through_resume(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world)
+    at = datetime(2026, 7, 30, 17, 6, 33, tzinfo=timezone.utc)
+
+    await Approval(approved=True, reviewer="ada", at=at).resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    # `mode="python"`: the datetime crosses as a devalue `Date`, not a string.
+    assert ser.hydrate(payload, what="the payload") == {
+        "approved": True,
+        "reviewer": "ada",
+        "at": at,
+    }
+    # ...and the orchestrator rebuilds the model the workflow awaits.
+    hook = runtime.Hook(correlation_id="hook_0", token=TOKEN, hook_cls=Approval)
+    hook.futures.append(future := _future())
+    hook.set_result(ser.hydrate(payload, what="the payload"))
+    assert future.result() == Approval(approved=True, reviewer="ada", at=at)
+
+
+async def test_dataclass_hook_round_trips_through_resume(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world)
+
+    await Signoff(approved=False, reviewer="grace").resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    hook = runtime.Hook(correlation_id="hook_0", token=TOKEN, hook_cls=Signoff)
+    hook.futures.append(future := _future())
+    hook.set_result(ser.hydrate(payload, what="the payload"))
+    assert future.result() == Signoff(approved=False, reviewer="grace")
+
+
+async def test_json_mode_is_the_way_back_to_json_shaped_values(tmp_path, monkeypatch) -> None:
+    # The escape hatch for a field devalue has no wire type for: pydantic
+    # flattens it first, exactly as `model_dump_json` used to.
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world)
+    at = datetime(2026, 7, 30, 17, 6, 33, tzinfo=timezone.utc)
+
+    await Approval(approved=True, reviewer="ada", at=at).resume(TOKEN, mode="json")
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert ser.hydrate(payload, what="the payload")["at"] == "2026-07-30T17:06:33Z"
+
+
+def _future():
+    import asyncio
+
+    return asyncio.get_event_loop().create_future()

--- a/src/vercel/tests/unit/test_workflow_keyword_only.py
+++ b/src/vercel/tests/unit/test_workflow_keyword_only.py
@@ -1,0 +1,127 @@
+"""Workflows and steps are called with keyword arguments only.
+
+A call is recorded as the single object `@workflow/core` records for a
+one-argument call, so there is nowhere for a positional argument to go. That
+is enforced where it is cheapest to notice -- at registration, so a codebase
+reports every offending definition at import rather than one per run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vercel._internal.workflow import core, runtime, serialization as ser, world as w
+from vercel._internal.workflow.worlds.local import LocalWorld
+
+
+def _registry() -> core.Workflows:
+    return core.Workflows(as_vercel_job=False)
+
+
+def test_a_positional_step_parameter_is_rejected_at_registration() -> None:
+    registry = _registry()
+
+    with pytest.raises(TypeError, match=r"step .*charge takes positional parameter\(s\) amount"):
+
+        @registry.step
+        async def charge(amount: int) -> int:
+            return amount
+
+
+def test_a_positional_workflow_parameter_is_rejected_at_registration() -> None:
+    registry = _registry()
+
+    with pytest.raises(TypeError, match=r"workflow .*checkout takes positional"):
+
+        @registry.workflow
+        async def checkout(amount: int) -> int:
+            return amount
+
+
+def test_the_error_shows_how_to_fix_the_signature() -> None:
+    registry = _registry()
+
+    with pytest.raises(TypeError, match=r"async def charge\(\*, amount: \.\.\.\)"):
+
+        @registry.step
+        async def charge(amount: int, tier: str) -> int:
+            return amount
+
+
+def test_var_positional_is_rejected_too() -> None:
+    registry = _registry()
+
+    with pytest.raises(TypeError, match="args"):
+
+        @registry.step
+        async def charge(*args: int) -> int:
+            return len(args)
+
+
+def test_keyword_only_and_var_keyword_are_accepted() -> None:
+    registry = _registry()
+
+    @registry.step
+    async def charge(*, amount: int) -> int:
+        return amount
+
+    @registry.step
+    async def audit(**fields: str) -> int:
+        return len(fields)
+
+    @registry.workflow
+    async def nothing() -> None: ...
+
+    assert charge.name.endswith("charge")
+
+
+async def test_an_untyped_positional_call_is_refused_at_the_call_site() -> None:
+    # A type checker rejects this already -- `P.args` is empty for a
+    # keyword-only function -- so this is the backstop for untyped callers.
+    registry = _registry()
+
+    @registry.step
+    async def charge(*, amount: int) -> int:
+        return amount
+
+    with pytest.raises(TypeError, match="keyword arguments only"):
+        await charge(21)  # type: ignore[misc]
+
+
+async def test_start_refuses_an_untyped_positional_call(monkeypatch) -> None:
+    registry = _registry()
+
+    @registry.workflow
+    async def checkout(*, amount: int) -> int:
+        return amount
+
+    with pytest.raises(TypeError, match="keyword arguments only"):
+        await runtime.start(checkout, 21)  # type: ignore[misc]
+
+
+async def test_start_records_the_object_argument_ts_would_have(tmp_path, monkeypatch) -> None:
+    """The whole point: the bytes `start(wf, {amount: 21})` writes in TS."""
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    registry = _registry()
+
+    @registry.workflow
+    async def checkout(*, amount: int) -> int:
+        return amount
+
+    queued: list[str] = []
+
+    class _World(LocalWorld):
+        async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs) -> str:
+            queued.append(queue_name)
+            return "msg_1"
+
+    world = _World()
+    w.set_world(world)
+    try:
+        run = await runtime.start(checkout, amount=21)
+        stored = await world.runs_get(run.run_id)
+    finally:
+        w.set_world(None)
+
+    assert stored.input == ser.dehydrate([{"amount": 21}])
+    assert ser.hydrate(stored.input, what="the input") == [{"amount": 21}]

--- a/src/vercel/tests/unit/test_workflow_serde.py
+++ b/src/vercel/tests/unit/test_workflow_serde.py
@@ -114,11 +114,11 @@ class Point:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Point) and (self.x, self.y) == (other.x, other.y)
 
-    def __workflow_serialize__(self) -> dict[str, int]:
+    def _workflow_serialize(self) -> dict[str, int]:
         return {"x": self.x, "y": self.y}
 
     @classmethod
-    def __workflow_deserialize__(cls, data: dict[str, int]) -> Point:
+    def _workflow_deserialize(cls, data: dict[str, int]) -> Point:
         return cls(**data)
 
 
@@ -153,11 +153,11 @@ def test_a_user_class_round_trips_through_the_dunder_protocol() -> None:
 def test_the_decorator_registers_the_class_it_wraps() -> None:
     @serde.serializable
     class Tagged:
-        def __workflow_serialize__(self) -> int:
+        def _workflow_serialize(self) -> int:
             return 7
 
         @classmethod
-        def __workflow_deserialize__(cls, data: int) -> Tagged:
+        def _workflow_deserialize(cls, data: int) -> Tagged:
             return cls()
 
     assert isinstance(_round_trip(Tagged()), Tagged)
@@ -219,11 +219,11 @@ def _define_and_register() -> type:
 
     @serde.serializable(class_id="class//tests//Reloaded")
     class Reloaded:
-        def __workflow_serialize__(self) -> int:
+        def _workflow_serialize(self) -> int:
             return 7
 
         @classmethod
-        def __workflow_deserialize__(cls, data: int) -> Reloaded:
+        def _workflow_deserialize(cls, data: int) -> Reloaded:
             return cls()
 
     return Reloaded
@@ -243,10 +243,10 @@ def test_re_registering_replaces_rather_than_conflicts() -> None:
 def test_a_class_without_the_protocol_is_refused_at_registration() -> None:
     class Bare: ...
 
-    with pytest.raises(TypeError, match="__workflow_serialize__"):
+    with pytest.raises(TypeError, match="_workflow_serialize"):
         serde.register_serializable(Bare)
 
-    with pytest.raises(TypeError, match="__workflow_deserialize__"):
+    with pytest.raises(TypeError, match="_workflow_deserialize"):
         serde.register_serializable(Bare, serialize=str)
 
 
@@ -284,11 +284,11 @@ def test_corrupt_data_for_a_known_class_names_the_class() -> None:
 
 def test_a_failing_serializer_names_the_class() -> None:
     class Broken:
-        def __workflow_serialize__(self) -> dict:
+        def _workflow_serialize(self) -> dict:
             raise RuntimeError("boom")
 
         @classmethod
-        def __workflow_deserialize__(cls, data: dict) -> Broken:
+        def _workflow_deserialize(cls, data: dict) -> Broken:
             return cls()
 
     serde.register_serializable(Broken)

--- a/src/vercel/tests/unit/test_workflow_serde.py
+++ b/src/vercel/tests/unit/test_workflow_serde.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 import datetime
 import decimal
 import enum
+import gc
 import pathlib
 import uuid
 
 import pytest
 
 from vercel._internal import devalue
-from vercel._internal.workflow import serde, serialization as ser
+from vercel._internal.workflow import py_sandbox, serde, serialization as ser
 
 
 def _wire(value):
@@ -132,15 +133,15 @@ class _Ledger:
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Undo whatever a test registers, leaving the built-ins in place."""
-    class_ids = dict(serde._by_class_id)
-    classes = dict(serde._by_class)
+    """Undo whatever a test registers in the host registry."""
+    host = serde._HOST
+    class_ids, classes = dict(host.by_class_id), dict(host.by_class)
     yield
-    serde._by_class_id.clear()
-    serde._by_class_id.update(class_ids)
-    serde._by_class.clear()
-    serde._by_class.update(classes)
-    serde._resolved.clear()
+    host.by_class_id.clear()
+    host.by_class_id.update(class_ids)
+    host.by_class.clear()
+    host.by_class.update(classes)
+    host.resolved.clear()
 
 
 def test_a_user_class_round_trips_through_the_dunder_protocol() -> None:
@@ -238,6 +239,135 @@ def test_re_registering_replaces_rather_than_conflicts() -> None:
     # longer resolves -- there is one classId, and it names one class.
     assert type(_round_trip(second())) is second
     assert type(_round_trip(first())) is second
+
+
+def test_replays_do_not_accumulate_in_the_host_registry() -> None:
+    """A replay re-imports the workflow's module, registering its classes again.
+
+    Each import produces a new class object, so anything those registrations
+    reach would pin one dead class -- and its module globals -- per replay.
+    They go into the sandbox's own registry, which is dropped whole when the
+    sandbox exits, so the host's does not grow at all.
+    """
+    classes, class_ids = len(serde._HOST.by_class), len(serde._HOST.by_class_id)
+
+    for _ in range(50):
+        with serde.sandboxed_registrations():
+            _define_and_register()
+    gc.collect()
+
+    assert len(serde._HOST.by_class) == classes
+    assert len(serde._HOST.by_class_id) == class_ids
+
+
+def test_a_sandbox_registration_does_not_outlive_the_sandbox() -> None:
+    """A replay must not leave the host deserializing into the sandbox's class.
+
+    The sandbox re-imports the workflow's module, so the same classId is
+    registered again against a different class object. Without a registry of
+    its own the last one wins for the rest of the process, and an `Enum` is
+    where that shows: the host would hand its caller a member that is neither
+    `is` nor `==` the one the caller has.
+    """
+    host = _define_and_register()
+
+    with serde.sandboxed_registrations():
+        sandboxed = _define_and_register()
+        assert type(_round_trip(sandboxed())) is sandboxed, "its own class applies inside"
+        # The classId is the same on both sides, which is what lets a payload
+        # cross: a step input is dehydrated here and revived by the host.
+        crossing = ser.dehydrate(sandboxed())
+
+    assert type(_round_trip(host())) is host
+    assert type(ser.hydrate(crossing, what="a payload")) is host, "each side revives its own"
+
+
+def test_a_sandbox_registration_does_not_reach_the_host() -> None:
+    # Nothing carries a sandbox-registered class out: a run's payloads are all
+    # serialized inside the sandbox, its return value included.
+    with serde.sandboxed_registrations():
+        serde.register_serializable(Point, class_id="class//sandbox-only//Point")
+
+    with pytest.raises(ser.SerializationError, match="Register Point with @serializable"):
+        ser.dehydrate(Point(1, 2))
+
+
+def test_a_host_registration_is_not_visible_inside_a_sandbox() -> None:
+    """The isolation this buys.
+
+    A class the sandbox has not imported itself must not be reachable through
+    the registry, because reviving one hands workflow code a host class object
+    -- and through its `__globals__`, the host's module graph, which is what
+    the sandbox exists to keep out of reach.
+    """
+    serde.register_serializable(Point)
+    payload = ser.dehydrate(Point(1, 2))
+
+    with serde.sandboxed_registrations():
+        with pytest.raises(ser.SerializationError, match="unknown class"):
+            ser.hydrate(payload, what="a payload")
+
+
+def test_the_sandbox_registers_the_stdlib_classes_it_imported_itself() -> None:
+    """A sandbox re-imports most of the stdlib types this module registers.
+
+    Its `uuid.UUID` is a different class object, so a registry holding only the
+    host's would not cover a `UUID` built inside a workflow.
+    """
+    with py_sandbox.workflow_sandbox():
+        import uuid as sandboxed  # noqa: PLC0415
+
+        value = sandboxed.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        assert type(value) is not uuid.UUID, "premise: the sandbox re-imported uuid"
+        assert _round_trip(value) == value
+
+
+def test_a_restricted_stdlib_class_is_not_swapped_for_the_hosts() -> None:
+    """Reviving must build the sandbox's class, not the host's.
+
+    `datetime.date` inside a sandbox is a restricted subclass, there to keep
+    `date.today()` out of a workflow body. Handing back the host's class would
+    undo that.
+    """
+    payload = ser.dehydrate(datetime.date(2026, 8, 4))
+
+    with py_sandbox.workflow_sandbox():
+        import datetime as sandboxed  # noqa: PLC0415
+
+        revived = ser.hydrate(payload, what="a payload")
+        assert type(revived) is sandboxed.date
+        with pytest.raises(py_sandbox.SandboxRestrictionError):
+            type(revived).today()
+
+
+def test_the_wire_id_does_not_follow_the_sandbox_class_name() -> None:
+    # Derived from the class it would read `class//...//_RestrictedDate`, which
+    # the other side has never heard of.
+    with py_sandbox.workflow_sandbox():
+        import datetime as sandboxed  # noqa: PLC0415
+
+        wire = _wire(sandboxed.date(2026, 8, 4))
+        assert f'"{serde.CLASS_ID_PREFIX}datetime//date"' in wire
+        assert "_Restricted" not in wire
+
+
+def test_datetime_stays_native_inside_a_sandbox() -> None:
+    # `registry.native` has to hold the sandbox's `datetime`, not the host's,
+    # or the `date` registration would capture it through the MRO.
+    with py_sandbox.workflow_sandbox():
+        import datetime as sandboxed  # noqa: PLC0415
+
+        value = sandboxed.datetime(2026, 7, 30, tzinfo=datetime.timezone.utc)
+        assert "Instance" not in _wire(value)
+
+
+def test_built_ins_are_visible_inside_a_sandbox() -> None:
+    # They are registered when this module is imported, and `serde` is reached
+    # through to the host rather than re-imported, so a registry that started
+    # empty would not have them.
+    with serde.sandboxed_registrations():
+        assert _round_trip(decimal.Decimal("1.50")) == decimal.Decimal("1.50")
+        assert _round_trip(pathlib.Path("/tmp/x")) == pathlib.Path("/tmp/x")
 
 
 def test_a_class_without_the_protocol_is_refused_at_registration() -> None:

--- a/src/vercel/tests/unit/test_workflow_serde.py
+++ b/src/vercel/tests/unit/test_workflow_serde.py
@@ -1,0 +1,304 @@
+"""Custom value types on `@workflow/core`'s ``Instance`` rail.
+
+The tag and its payload shape are a contract with the TypeScript side, not an
+internal detail: `workflow inspect` renders ``["Instance", {classId, data}]``
+as ``Decimal@decimal '1.50'`` through `observabilityRevivers`, and a JavaScript
+peer can revive the real object by registering the same ``classId``. So the
+wire form is asserted here literally, not just round-tripped.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import enum
+import pathlib
+import uuid
+
+import pytest
+
+from vercel._internal import devalue
+from vercel._internal.workflow import serde, serialization as ser
+
+
+def _wire(value):
+    """The devalue text a payload carries, minus the format prefix."""
+    return ser.dehydrate(value)[len(ser.DEVALUE_V1) :].decode()
+
+
+def _round_trip(value):
+    return ser.hydrate(ser.dehydrate(value), what="a payload")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the wire form
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_the_tag_is_the_one_typescript_reads() -> None:
+    # `["Instance", {classId, data}]` -- flattened, so the parts are slots.
+    assert _wire(decimal.Decimal("1.50")) == (
+        '[["Instance",1],{"classId":2,"data":3},"class//decimal//Decimal","1.50"]'
+    )
+
+
+def test_an_unregistered_class_is_left_to_the_other_reducers() -> None:
+    # The reducer has to decline, not claim, or every value would become an
+    # Instance -- devalue treats any truthy return as a match.
+    assert _wire({"tier": "pro"}) == '[{"tier":1},"pro"]'
+    assert _wire([1, 2]) == "[[1,2],1,2]"
+
+
+def test_a_value_beside_a_custom_one_is_unaffected() -> None:
+    # The property that makes this rail worth using: one exotic value does not
+    # cost the payload around it, on either side.
+    restored = _round_trip({"total": decimal.Decimal("1.50"), "currency": "usd"})
+    assert restored == {"total": decimal.Decimal("1.50"), "currency": "usd"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# built-in registrations
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        decimal.Decimal("1.50"),
+        decimal.Decimal("-0.000001"),
+        uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+        datetime.date(2026, 7, 30),
+        datetime.time(17, 6, 33, 500000),
+        datetime.timedelta(days=2, seconds=3, microseconds=4),
+        pathlib.Path("/tmp/report.csv"),
+    ],
+)
+def test_stdlib_types_round_trip(value) -> None:
+    restored = _round_trip(value)
+    assert restored == value
+    assert type(restored) is type(value)
+
+
+def test_timedelta_keeps_microseconds() -> None:
+    # `total_seconds()` is a float and would round; the exact triple does not.
+    value = datetime.timedelta(days=999_999, microseconds=1)
+    assert _round_trip(value) == value
+
+
+def test_datetime_stays_a_native_date_not_an_instance() -> None:
+    """`datetime` is a `date` subclass, so the `date` registration must not
+    capture it -- devalue carries it as a JS `Date`, which JavaScript can read
+    without knowing anything about this SDK."""
+    value = datetime.datetime(2026, 7, 30, 17, 6, 33, tzinfo=datetime.timezone.utc)
+
+    assert _wire(value) == '[["Date","2026-07-30T17:06:33.000Z"]]'
+    assert _round_trip(value) == value
+
+
+@pytest.mark.parametrize("value", [(1, 2), frozenset({1}), {1, 2}, b"\\x00", "pro", 42])
+def test_types_devalue_already_carries_are_left_alone(value) -> None:
+    # Wrapping these would take a plain array/Set away from a JavaScript
+    # reader for the sake of a Python distinction.
+    assert "Instance" not in _wire(value)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# registering your own
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x, self.y = x, y
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Point) and (self.x, self.y) == (other.x, other.y)
+
+    def __workflow_serialize__(self) -> dict[str, int]:
+        return {"x": self.x, "y": self.y}
+
+    @classmethod
+    def __workflow_deserialize__(cls, data: dict[str, int]) -> Point:
+        return cls(**data)
+
+
+class Tier(enum.Enum):
+    PRO = "pro"
+
+
+class _Ledger:
+    """A class nothing registers, for the paths that must refuse one."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Undo whatever a test registers, leaving the built-ins in place."""
+    class_ids = dict(serde._by_class_id)
+    classes = dict(serde._by_class)
+    yield
+    serde._by_class_id.clear()
+    serde._by_class_id.update(class_ids)
+    serde._by_class.clear()
+    serde._by_class.update(classes)
+    serde._resolved.clear()
+
+
+def test_a_user_class_round_trips_through_the_dunder_protocol() -> None:
+    serde.register_serializable(Point)
+
+    assert _round_trip(Point(1, 2)) == Point(1, 2)
+    assert f'"{serde.default_class_id(Point)}"' in _wire(Point(1, 2))
+
+
+def test_the_decorator_registers_the_class_it_wraps() -> None:
+    @serde.serializable
+    class Tagged:
+        def __workflow_serialize__(self) -> int:
+            return 7
+
+        @classmethod
+        def __workflow_deserialize__(cls, data: int) -> Tagged:
+            return cls()
+
+    assert isinstance(_round_trip(Tagged()), Tagged)
+
+
+def test_an_enum_needs_no_methods() -> None:
+    serde.register_serializable(Tier)
+
+    assert _round_trip(Tier.PRO) is Tier.PRO
+    # The value, not the member name -- what a JavaScript reader wants to see.
+    assert '"pro"' in _wire(Tier.PRO)
+
+
+def test_an_unregistered_enum_says_how_to_send_it() -> None:
+    with pytest.raises(ser.SerializationError, match=r"Register Tier with @serializable"):
+        ser.dehydrate(Tier.PRO)
+    with pytest.raises(ser.SerializationError, match=r"enum.StrEnum"):
+        ser.dehydrate(Tier.PRO)
+
+
+def test_an_unregistered_class_says_how_to_send_it() -> None:
+    # The qualname is what you would pass to @serializable, so it is the name
+    # worth printing even when it is a mouthful.
+    with pytest.raises(ser.SerializationError, match=r"Register .*Ledger with @serializable"):
+        ser.dehydrate(_Ledger())
+
+
+def test_the_failing_field_is_named() -> None:
+    with pytest.raises(ser.SerializationError, match=r"at \.book"):
+        ser.dehydrate({"book": _Ledger()})
+
+
+def test_a_class_id_can_be_pinned_for_a_typescript_peer() -> None:
+    serde.register_serializable(Point, class_id="class//./src/geometry//Point")
+
+    assert '"class//./src/geometry//Point"' in _wire(Point(1, 2))
+    assert _round_trip(Point(1, 2)) == Point(1, 2)
+
+
+def test_a_registration_covers_subclasses_by_mro() -> None:
+    # How one `PurePath` registration serves `PosixPath` and `WindowsPath`.
+    class Origin(Point): ...
+
+    serde.register_serializable(Point)
+
+    assert '"class//' in _wire(Origin(0, 0))
+    # ...and reading gives the registered class back, since that is the only
+    # thing the classId names.
+    assert type(_round_trip(Origin(0, 0))) is Point
+
+
+def _define_and_register() -> type:
+    """A fresh class object under a classId that is already taken.
+
+    What the sandbox does: it re-imports the workflow's module, so every
+    decorated class in it is registered again, with a new class object each
+    time and the same classId.
+    """
+
+    @serde.serializable(class_id="class//tests//Reloaded")
+    class Reloaded:
+        def __workflow_serialize__(self) -> int:
+            return 7
+
+        @classmethod
+        def __workflow_deserialize__(cls, data: int) -> Reloaded:
+            return cls()
+
+    return Reloaded
+
+
+def test_re_registering_replaces_rather_than_conflicts() -> None:
+    first = _define_and_register()
+    second = _define_and_register()
+    assert first is not second
+
+    # The latest definition is the live one, and the previous class object no
+    # longer resolves -- there is one classId, and it names one class.
+    assert type(_round_trip(second())) is second
+    assert type(_round_trip(first())) is second
+
+
+def test_a_class_without_the_protocol_is_refused_at_registration() -> None:
+    class Bare: ...
+
+    with pytest.raises(TypeError, match="__workflow_serialize__"):
+        serde.register_serializable(Bare)
+
+    with pytest.raises(TypeError, match="__workflow_deserialize__"):
+        serde.register_serializable(Bare, serialize=str)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# reading what the other side wrote
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _foreign_instance(data) -> bytes:
+    """A payload carrying an ``Instance`` this side never registered."""
+    # Claim only the marker: a reducer that claims everything would also claim
+    # the payload dict it just returned.
+    reduce = {"Instance": lambda value: data if isinstance(value, _Ledger) else False}
+    return ser.DEVALUE_V1 + devalue.stringify(_Ledger(), reduce).encode()
+
+
+def test_an_unknown_class_id_is_refused_rather_than_guessed() -> None:
+    # A JavaScript class this side has never heard of. Handing the workflow a
+    # stand-in would be handing it something it was not sent.
+    payload = _foreign_instance({"classId": "class//./src/models//Money", "data": "1.50"})
+
+    with pytest.raises(ser.SerializationError, match=r"unknown class .*Money"):
+        ser.hydrate(payload, what="the input of run wrun_1")
+
+
+def test_corrupt_data_for_a_known_class_names_the_class() -> None:
+    # `Decimal("garbage")` raises `InvalidOperation`, which is an
+    # `ArithmeticError` -- not something the codec would recognize, so without
+    # attribution it escapes `hydrate` raw, from several frames inside `parse`.
+    payload = _foreign_instance({"classId": "class//decimal//Decimal", "data": "garbage"})
+
+    with pytest.raises(ser.SerializationError, match=r"class//decimal//Decimal could not be read"):
+        ser.hydrate(payload, what="the input of run wrun_1")
+
+
+def test_a_failing_serializer_names_the_class() -> None:
+    class Broken:
+        def __workflow_serialize__(self) -> dict:
+            raise RuntimeError("boom")
+
+        @classmethod
+        def __workflow_deserialize__(cls, data: dict) -> Broken:
+            return cls()
+
+    serde.register_serializable(Broken)
+
+    with pytest.raises(ser.SerializationError, match=r"Broken could not be written: boom"):
+        ser.dehydrate(Broken())
+
+
+def test_a_malformed_instance_payload_is_refused() -> None:
+    payload = _foreign_instance(["not an object"])
+
+    with pytest.raises(ser.SerializationError, match="malformed Instance payload"):
+        ser.hydrate(payload, what="a payload")

--- a/src/vercel/tests/unit/test_workflow_serialization.py
+++ b/src/vercel/tests/unit/test_workflow_serialization.py
@@ -12,6 +12,7 @@ be read is otherwise noticed several frames away from its cause.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_payload_is_devl_plus_devalue() -> None:
     # The exact bytes `@workflow/core`'s client codec produces:
     # `encodeWithFormatPrefix(DEVALUE_V1, encoder.encode(stringify(value)))`.
     assert ser.dehydrate("charged 42") == b'devl["charged 42"]'
-    value = [[21], {}]
+    value = [{"amount": 21}]
     assert ser.dehydrate(value) == b"devl" + devalue.stringify(value).encode()
 
 
@@ -33,7 +34,7 @@ def test_payload_is_devl_plus_devalue() -> None:
         None,
         42,
         "unicode 你好",
-        [[21], {"tier": "pro"}],
+        [{"amount": 21, "tier": "pro"}],
         {"nested": {"list": [1, 2.5, True, None]}},
         datetime(2026, 7, 30, 17, 6, 33, tzinfo=timezone.utc),
         b"\x00\xff\x80",
@@ -104,12 +105,12 @@ def test_a_stored_payload_loads_as_binary_not_text() -> None:
     pydantic's lax coercion would happily put a payload in the ``str`` arm --
     where it fails much later, at the point of use, rather than here.
     """
-    payload = ser.dehydrate([[21], {}])
+    payload = ser.dehydrate([{"amount": 21}])
 
     run = w.WorkflowRunAdaptor.validate_python(_run_row(input=payload))
 
     assert run.input == payload
-    assert ser.hydrate(run.input, what="the input of run wrun_1") == [[21], {}]
+    assert ser.hydrate(run.input, what="the input of run wrun_1") == [{"amount": 21}]
 
 
 def test_the_circular_marker_still_loads_as_text() -> None:
@@ -117,3 +118,62 @@ def test_the_circular_marker_still_loads_as_text() -> None:
     run = w.WorkflowRunAdaptor.validate_python(_run_row(input="[Circular]"))
 
     assert run.input == "[Circular]"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the argument array
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_a_call_is_recorded_as_ts_records_a_one_object_call() -> None:
+    # `start(wf, {amount: 21})` on the TypeScript side writes exactly this.
+    assert ser.argument_array({"amount": 21}) == [{"amount": 21}]
+    # ...and a call with no arguments writes the empty array TS writes, not an
+    # empty object a JavaScript callee would receive as a stray parameter.
+    assert ser.argument_array({}) == []
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"amount": 21}, {"amount": 21, "tier": "pro"}])
+def test_arguments_round_trip(kwargs) -> None:
+    assert ser.keyword_arguments(ser.argument_array(kwargs), what="a call") == kwargs
+
+
+def test_a_step_call_is_wrapped_the_way_ts_wraps_one() -> None:
+    # A step's arguments live under `args`, where a workflow's are the payload
+    # itself. TS's reader takes `.args` and defaults the siblings it also
+    # writes (`closureVars`, `thisVal`), so those are left out.
+    assert ser.step_arguments({"amount": 21}) == {"args": [{"amount": 21}]}
+    assert ser.step_arguments({}) == {"args": []}
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"amount": 21}])
+def test_step_arguments_round_trip(kwargs) -> None:
+    recorded = ser.step_arguments(kwargs)
+    assert ser.step_keyword_arguments(recorded, what="a step call") == kwargs
+
+
+def test_a_ts_written_step_input_is_read_through_its_args() -> None:
+    # The siblings TS writes are ignored rather than rejected.
+    data: dict[str, Any] = {"args": [{"amount": 21}], "closureVars": {}, "thisVal": None}
+
+    assert ser.step_keyword_arguments(data, what="a step call") == {"amount": 21}
+
+
+def test_a_step_input_that_is_not_an_object_is_reported() -> None:
+    with pytest.raises(ser.SerializationError, match="not a step argument object"):
+        ser.step_keyword_arguments([{"amount": 21}], what="the input of step step_1")
+
+
+def test_a_javascript_positional_call_is_reported_as_such() -> None:
+    # What a JS caller of a Python step writes if it passes its arguments
+    # positionally. Without this the mismatch surfaces as a TypeError inside
+    # the user's function, naming neither side.
+    with pytest.raises(ser.SerializationError, match="2 positional argument"):
+        ser.keyword_arguments([21, "usd"], what="the input of step step_1")
+    with pytest.raises(ser.SerializationError, match="1 positional argument"):
+        ser.keyword_arguments([21], what="the input of step step_1")
+
+
+def test_a_non_array_argument_payload_is_rejected() -> None:
+    with pytest.raises(ser.SerializationError, match="not an argument array"):
+        ser.keyword_arguments({"amount": 21}, what="the input of run wrun_1")

--- a/src/vercel/tests/unit/test_workflow_serialization.py
+++ b/src/vercel/tests/unit/test_workflow_serialization.py
@@ -1,0 +1,119 @@
+"""The payload wire format shared with `@workflow/core`.
+
+Every run input, step input, step result, workflow output and hook payload
+goes through :mod:`vercel._internal.workflow.serialization`, which writes a
+4-byte format tag followed by `devalue.stringify` output. The devalue codec
+itself is covered by ``test_devalue.py`` (and checked against the real JS
+library in ``tests/integration/test_devalue.py``); what is pinned here is the
+envelope around it and the errors it produces, because a payload that cannot
+be read is otherwise noticed several frames away from its cause.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from vercel._internal import devalue
+from vercel._internal.workflow import serialization as ser, world as w
+
+
+def test_payload_is_devl_plus_devalue() -> None:
+    # The exact bytes `@workflow/core`'s client codec produces:
+    # `encodeWithFormatPrefix(DEVALUE_V1, encoder.encode(stringify(value)))`.
+    assert ser.dehydrate("charged 42") == b'devl["charged 42"]'
+    value = [[21], {}]
+    assert ser.dehydrate(value) == b"devl" + devalue.stringify(value).encode()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        42,
+        "unicode 你好",
+        [[21], {"tier": "pro"}],
+        {"nested": {"list": [1, 2.5, True, None]}},
+        datetime(2026, 7, 30, 17, 6, 33, tzinfo=timezone.utc),
+        b"\x00\xff\x80",
+    ],
+)
+def test_round_trip(value) -> None:
+    assert ser.hydrate(ser.dehydrate(value), what="a payload") == value
+
+
+def test_shared_references_survive() -> None:
+    # devalue's flattened form is what makes a repeated value one slot; the
+    # JSON encoding this replaced silently duplicated it.
+    shared = {"id": 1}
+    restored = ser.hydrate(ser.dehydrate([shared, shared]), what="a payload")
+    assert restored[0] is restored[1]
+
+
+def test_envelope_formats_are_reported_by_name() -> None:
+    # Written by the TS SDK when a run has encryption or compression enabled.
+    # Unsupported here, but the payload is not corrupt and should not read as if
+    # it were.
+    for prefix in (ser.ENCRYPTED, ser.SEALED, ser.GZIP, ser.ZSTD):
+        with pytest.raises(ser.SerializationError, match=f"{prefix.decode()}.*cannot read"):
+            ser.hydrate(prefix + b"...", what="a payload")
+
+
+def test_unknown_format_is_rejected() -> None:
+    # `json` is what this SDK wrote before the devalue migration.
+    with pytest.raises(ser.SerializationError, match="unknown serialization format"):
+        ser.hydrate(b'json"charged 42"', what="a payload")
+
+
+def test_non_binary_payload_is_rejected_at_the_boundary() -> None:
+    # A `run_created` response carries the string '[Circular]' in place of the
+    # input it echoes back. Naming the payload is the point: the alternative is
+    # an AttributeError wherever the value is eventually used.
+    with pytest.raises(ser.SerializationError, match="the input of run wrun_1 is not"):
+        ser.hydrate("[Circular]", what="the input of run wrun_1")
+
+
+def test_truncated_payload_is_rejected() -> None:
+    with pytest.raises(ser.SerializationError, match="too short"):
+        ser.hydrate(b"dev", what="a payload")
+
+
+def test_undecodable_payload_names_the_field() -> None:
+    with pytest.raises(ser.SerializationError, match="Cannot deserialize the output of run"):
+        ser.hydrate(b"devlnot json", what="the output of run wrun_1")
+
+
+def _run_row(**overrides) -> dict:
+    return {
+        "runId": "wrun_1",
+        "status": "pending",
+        "deploymentId": "dpl_1",
+        "workflowName": "wf",
+        "specVersion": 2,
+        "createdAt": "2026-07-30T00:00:00.000Z",
+        "updatedAt": "2026-07-30T00:00:00.000Z",
+        **overrides,
+    }
+
+
+def test_a_stored_payload_loads_as_binary_not_text() -> None:
+    """A run's ``input`` must reach the model as ``bytes``.
+
+    It is typed ``bytes | str`` because of the ``'[Circular]'`` case below, and
+    pydantic's lax coercion would happily put a payload in the ``str`` arm --
+    where it fails much later, at the point of use, rather than here.
+    """
+    payload = ser.dehydrate([[21], {}])
+
+    run = w.WorkflowRunAdaptor.validate_python(_run_row(input=payload))
+
+    assert run.input == payload
+    assert ser.hydrate(run.input, what="the input of run wrun_1") == [[21], {}]
+
+
+def test_the_circular_marker_still_loads_as_text() -> None:
+    # What a `run_created` response echoes back in place of the input.
+    run = w.WorkflowRunAdaptor.validate_python(_run_row(input="[Circular]"))
+
+    assert run.input == "[Circular]"

--- a/src/vercel/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel/tests/unit/test_workflow_step_handler.py
@@ -35,7 +35,7 @@ def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
         createdAt=NOW,
         updatedAt=NOW,
         startedAt=NOW,
-        input=ser.dehydrate([[], {}]),
+        input=ser.dehydrate(ser.step_arguments({})),
     )
 
 
@@ -260,7 +260,7 @@ async def test_local_world_step_started_too_early_raises(tmp_path, monkeypatch) 
         createdAt=NOW,
         updatedAt=NOW,
         retryAfter=future,
-        input=ser.dehydrate([[], {}]),
+        input=ser.dehydrate(ser.step_arguments({})),
     )
     local_mod.write_json(world.data_dir / "steps" / f"{RUN_ID}-{STEP_ID}.json", step.model_dump())
 

--- a/src/vercel/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel/tests/unit/test_workflow_step_handler.py
@@ -17,7 +17,7 @@ import pytest
 import respx
 
 from vercel._internal.core.polyfills import UTC
-from vercel._internal.workflow import core, runtime, world as w
+from vercel._internal.workflow import core, runtime, serialization as ser, world as w
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
 RUN_ID = "wrun_test"
@@ -35,7 +35,7 @@ def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
         createdAt=NOW,
         updatedAt=NOW,
         startedAt=NOW,
-        input=[b"json[[], {}]"],
+        input=ser.dehydrate([[], {}]),
     )
 
 
@@ -260,7 +260,7 @@ async def test_local_world_step_started_too_early_raises(tmp_path, monkeypatch) 
         createdAt=NOW,
         updatedAt=NOW,
         retryAfter=future,
-        input=[b"json[[], {}]"],
+        input=ser.dehydrate([[], {}]),
     )
     local_mod.write_json(world.data_dir / "steps" / f"{RUN_ID}-{STEP_ID}.json", step.model_dump())
 

--- a/src/vercel/tests/unit/test_workflow_step_metadata.py
+++ b/src/vercel/tests/unit/test_workflow_step_metadata.py
@@ -14,8 +14,12 @@ from vercel._internal.workflow.worlds.local import LocalWorld
 from vercel.workflow import StepInfo, Workflows, get_step_metadata
 
 
-def _encode(args: list, kwargs: dict) -> bytes:
-    return ser.dehydrate([args, kwargs])
+def _run_input(**kwargs) -> bytes:
+    return ser.dehydrate(ser.argument_array(kwargs))
+
+
+def _step_input(**kwargs) -> bytes:
+    return ser.dehydrate(ser.step_arguments(kwargs))
 
 
 class _RecordingLocalWorld(LocalWorld):
@@ -44,7 +48,7 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
     captured: list[StepInfo] = []
 
     @registry.step
-    async def greet(name: str) -> str:
+    async def greet(*, name: str) -> str:
         captured.append(get_step_metadata())
         return f"hi {name}"
 
@@ -54,7 +58,7 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
         w.RunCreatedEventData(
             deploymentId="",
             workflowName="test-wf",
-            input=_encode(["world"], {}),
+            input=_run_input(name="world"),
         ).into_event(),
     )
     assert run_result.run is not None
@@ -64,7 +68,7 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
     step_id = "step_testid"
     await world.events_create(
         run_id,
-        w.StepCreatedEventData(stepName=greet.name, input=_encode(["world"], {})).into_event(
+        w.StepCreatedEventData(stepName=greet.name, input=_step_input(name="world")).into_event(
             step_id
         ),
     )

--- a/src/vercel/tests/unit/test_workflow_step_metadata.py
+++ b/src/vercel/tests/unit/test_workflow_step_metadata.py
@@ -7,17 +7,15 @@ as an idempotency key for non-idempotent side effects.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
-from vercel._internal.workflow import runtime, world as w
+from vercel._internal.workflow import runtime, serialization as ser, world as w
 from vercel._internal.workflow.worlds.local import LocalWorld
 from vercel.workflow import StepInfo, Workflows, get_step_metadata
 
 
-def _encode(args: list, kwargs: dict) -> list[bytes]:
-    return [b"json" + json.dumps([args, kwargs]).encode()]
+def _encode(args: list, kwargs: dict) -> bytes:
+    return ser.dehydrate([args, kwargs])
 
 
 class _RecordingLocalWorld(LocalWorld):

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -12,23 +12,27 @@ app = Workflows()
 
 
 @app.step
-async def charge_customer(customer_id: str) -> None:
+async def charge_customer(*, customer_id: str) -> None:
     ...
 
 
 @app.workflow
-async def renew_subscription(customer_id: str) -> None:
+async def renew_subscription(*, customer_id: str) -> None:
     await sleep("1h")
-    await charge_customer(customer_id)
+    await charge_customer(customer_id=customer_id)
 
 
 async def main() -> None:
-    run = await start(renew_subscription, "cus_123")
+    run = await start(renew_subscription, customer_id="cus_123")
 ```
 
 `app.workflow` registers async workflow functions. `app.step` registers async
 steps that can be called only from inside a workflow. `sleep()` creates a
 durable wait in a workflow run.
+
+Workflows and steps take **keyword arguments only**, so their parameters have
+to be declared keyword-only (after a bare `*`); a positional parameter is
+rejected when the function is registered.
 
 ## Queue namespaces
 

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -83,11 +83,11 @@ class Point:
     def __init__(self, x: int, y: int) -> None:
         self.x, self.y = x, y
 
-    def __workflow_serialize__(self) -> dict[str, int]:
+    def _workflow_serialize(self) -> dict[str, int]:
         return {"x": self.x, "y": self.y}
 
     @classmethod
-    def __workflow_deserialize__(cls, data: dict[str, int]) -> "Point":
+    def _workflow_deserialize(cls, data: dict[str, int]) -> "Point":
         return cls(**data)
 
 

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -64,3 +64,37 @@ async def wait_for_approval() -> bool:
 ```
 
 `BaseHook` supports dataclasses and Pydantic models for external resume events.
+
+## Serializing your own types
+
+Workflow inputs, step results and hook payloads travel in the devalue format
+`@workflow/core` uses, which carries `datetime`, `bytes`, `set` and repeated
+references natively. `Decimal`, `UUID`, `date`, `time`, `timedelta` and `Path`
+are registered on top of that; anything else needs a registration:
+
+```python
+import enum
+
+from vercel.workflow import serializable
+
+
+@serializable
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x, self.y = x, y
+
+    def __workflow_serialize__(self) -> dict[str, int]:
+        return {"x": self.x, "y": self.y}
+
+    @classmethod
+    def __workflow_deserialize__(cls, data: dict[str, int]) -> "Point":
+        return cls(**data)
+
+
+@serializable          # an Enum needs no methods
+class Tier(enum.Enum):
+    PRO = "pro"
+```
+
+`register_serializable()` is the function form, for classes you cannot
+decorate.

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -8,12 +8,14 @@ from vercel._internal.workflow.core import (
     time_ns,
 )
 from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
+from vercel._internal.workflow.serde import register_serializable, serializable
 
 from . import sandbox
 from .errors import (
     EntityConflictError,
     HookNotFoundError,
     RunExpiredError,
+    SerializationError,
     ThrottleError,
     TooEarlyError,
     WorkflowWorldError,
@@ -32,9 +34,12 @@ __all__ = [
     "HookEvent",
     "get_step_metadata",
     "StepInfo",
+    "serializable",
+    "register_serializable",
     "EntityConflictError",
     "HookNotFoundError",
     "RunExpiredError",
+    "SerializationError",
     "ThrottleError",
     "TooEarlyError",
     "WorkflowWorldError",

--- a/src/vercel/workflow/errors.py
+++ b/src/vercel/workflow/errors.py
@@ -1,3 +1,4 @@
+from vercel._internal.workflow.serialization import SerializationError
 from vercel._internal.workflow.world import (
     EntityConflictError,
     HookNotFoundError,
@@ -11,6 +12,7 @@ __all__ = [
     "EntityConflictError",
     "HookNotFoundError",
     "RunExpiredError",
+    "SerializationError",
     "ThrottleError",
     "TooEarlyError",
     "WorkflowWorldError",


### PR DESCRIPTION
Run inputs, step inputs and results, workflow outputs and hook payloads went out as `b"json"` plus `json.dumps`, wrapped in a one-element list — neither half is anything `@workflow/core` writes. They are now devalue payloads tagged `devl`,
stored as a single value, and a call is recorded as the single object TypeScript records for a one-argument call, so a Python run reads the same as one the TypeScript SDK started.

devalue only carries what JavaScript has a form for, so `Decimal`, `UUID`, `date`, `time`, `timedelta` and `Path` ride `@workflow/core`'s `Instance` tag, and `@serializable` puts your own classes there — a JavaScript reader that has never heard of the class still renders the value rather than losing the payload around it.

## Breaking

- **Workflows and steps take keyword arguments only**, and their parameters have to be declared keyword-only — `async def charge(*, amount: int)`. Every definition needs updating; a positional parameter is rejected when the function is registered, so a codebase reports all of them at import rather than one per run. Calls become `start(wf, amount=21)` / `charge(amount=21)`.
- **Runs recorded by an earlier version cannot be replayed.** Their payloads carry the old `json` prefix and are rejected with a `SerializationError`. In-flight runs in local dev projects should be drained before deploying this.
- **`BaseHook.resume()` forwards its keyword arguments to `model_dump()`** rather than `model_dump_json()`, in `"python"` mode. JSON-only options such as `indent` are no longer accepted; a `datetime` field now reaches the workflow as a `datetime` instead of a string; and a field whose class nothing has registered raises rather than being flattened to a string.

Verified end to end against the published `workflow` CLI, on the local world and on production: `input: [ { sku: 'ABC' } ]`, `output: { total: Decimal@decimal '1.50', … }`. Best read commit by commit — the first is a packaging fix (`_internal/devalue` was never in the wheel, which the second would have made fatal at import).