### PR TITLE
workflow: make the local world's files interchangeable with the TypeScript SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,21 @@ jobs:
           git clone --depth 1 --branch v5.9.0
           https://github.com/sveltejs/devalue.git "$RUNNER_TEMP/devalue"
 
+      # The local-world interop test runs the real `workflow` CLI against the
+      # `.workflow-data` files the Python local world writes. Installed here
+      # rather than left to the test's own npm fallback, so npm runs once per
+      # job in a visible step instead of inside five test processes.
+      #
+      # A git checkout (as for devalue above) is not an option: the CLI is
+      # TypeScript and needs a pnpm workspace install plus a tsc build, so the
+      # published tarball is the practical artifact. `--ignore-scripts` skips
+      # the native postinstalls of @swc/core, esbuild and cbor-extract, which
+      # the read-only `inspect` path does not use.
+      - name: Install the workflow CLI
+        run: >-
+          npm install workflow@5.0.0-beta.38 --no-save --no-audit --no-fund
+          --ignore-scripts --prefix "$RUNNER_TEMP/workflow-cli"
+
       - name: Sync dependencies
         run: uv sync --all-packages --locked --python ${{ matrix.python-version }}
 
@@ -77,6 +92,7 @@ jobs:
         run: ./scripts/test.sh
         env:
           VERCEL_DEVALUE_JS: ${{ runner.temp }}/devalue
+          VERCEL_WORKFLOW_CLI: ${{ runner.temp }}/workflow-cli/node_modules/workflow
 
       - name: Build package
         run: ./scripts/build.sh

--- a/changes/vercel/20260730131700.breaking.md
+++ b/changes/vercel/20260730131700.breaking.md
@@ -1,0 +1,5 @@
+The local workflow world now stores its `.workflow-data` files as JSON in the
+same format the TypeScript `@workflow/world-local` package uses, instead of
+CBOR. Runs, steps, hooks and events written by either SDK are now readable by
+the other. Existing `.workflow-data` directories are not readable in the new
+format and should be deleted.

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -191,6 +191,9 @@ class BaseWorkflowRun(BaseModel):
     input: bytes | str | None = None
     output: bytes | None = None
     error: StructuredError | None = None
+    # Plaintext string-string metadata. Always materialized (as `{}` when
+    # unset) so a run row carries the same field set the TS SDK writes.
+    attributes: dict[str, str] = pydantic.Field(default_factory=dict)
     expired_at: datetime | None = pydantic.Field(default=None, alias="expiredAt")
     started_at: datetime | None = pydantic.Field(default=None, alias="startedAt")
     completed_at: datetime | None = pydantic.Field(default=None, alias="completedAt")

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import hashlib
 import json
@@ -13,7 +14,6 @@ from datetime import datetime
 from typing import Any, TypeVar, cast
 from uuid import uuid4
 
-import cbor2
 import pydantic
 
 import vercel.queue as vqs
@@ -37,10 +37,85 @@ def is_step_terminal(status: str) -> bool:
     return status in ["completed", "failed"]
 
 
+# Marker the TypeScript `world-local` package uses to smuggle binary payloads
+# through JSON. See its `jsonReplacer` / `jsonReviver`.
+UINT8ARRAY_TYPE_TAG = "Uint8Array"
+
+
+def to_js_iso(value: datetime) -> str:
+    """Format a datetime exactly like JS ``Date.prototype.toISOString``.
+
+    Always UTC with a ``Z`` suffix and exactly three fractional digits;
+    naive datetimes are read as UTC. Sub-millisecond precision is dropped,
+    which a JS ``Date`` never had in the first place.
+    """
+    value = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+    return f"{value:%Y-%m-%dT%H:%M:%S}.{value.microsecond // 1000:03d}Z"
+
+
+def js_now() -> datetime:
+    """The current time at JS ``Date`` resolution (whole milliseconds).
+
+    Timestamps are stored via :func:`to_js_iso`, which truncates to
+    milliseconds. Truncating up front keeps the value we hand back to the
+    caller equal to the one a reader will parse back out of the file.
+    """
+    now = datetime.now(UTC)
+    return now.replace(microsecond=now.microsecond // 1000 * 1000)
+
+
+def _encode_js(value: Any) -> Any:
+    """Rewrite a dumped model into what TS feeds to ``JSON.stringify``."""
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {
+            "__type": UINT8ARRAY_TYPE_TAG,
+            "data": base64.b64encode(bytes(value)).decode("ascii"),
+        }
+    if isinstance(value, datetime):
+        return to_js_iso(value)
+    if isinstance(value, dict):
+        return {k: _encode_js(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_encode_js(v) for v in value]
+    if isinstance(value, float) and not isinstance(value, bool):
+        # JS has a single number type: 1.0 stringifies as `1`, and
+        # `JSON.stringify` writes non-finite numbers as null.
+        if not math.isfinite(value):
+            return None
+        return int(value) if value.is_integer() else value
+    return value
+
+
+def _decode_js(value: Any) -> Any:
+    """Inverse of :func:`_encode_js` for the parts TS revives on read."""
+    if isinstance(value, dict):
+        if value.get("__type") == UINT8ARRAY_TYPE_TAG and isinstance(value.get("data"), str):
+            return base64.b64decode(value["data"])
+        return {k: _decode_js(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_decode_js(v) for v in value]
+    return value
+
+
+def dumps_js(data: Any) -> bytes:
+    """Serialize like ``JSON.stringify(data, jsonReplacer, 2)`` in TS.
+
+    Two-space indent, no space before the comma, and no ``\\uXXXX`` escapes
+    for non-ASCII — the byte-for-byte shape `world-local` writes.
+    """
+    text = json.dumps(
+        _encode_js(data),
+        indent=2,
+        separators=(",", ": "),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return text.encode()
+
+
 def read_json(path: pathlib.Path, schema: type[T] | pydantic.TypeAdapter[T]) -> T | None:
     if path.exists():
-        with path.open("rb") as f:
-            data = cbor2.load(f)
+        data = _decode_js(json.loads(path.read_text(encoding="utf-8")))
         if isinstance(schema, pydantic.TypeAdapter):
             return schema.validate_python(data)
         else:
@@ -82,9 +157,13 @@ def write_json(path: pathlib.Path, data: w.BaseModel | dict, *, overwrite: bool 
         raise w.EntityConflictError(f"File already exists: {path}")
 
     if isinstance(data, w.BaseModel):
-        data = data.model_dump()
+        # `exclude_none` mirrors JS: an unset field is `undefined`, which
+        # `JSON.stringify` drops. Writing an explicit null instead would be
+        # rejected by the TS reader, whose schemas type these as `undefined`
+        # (and would silently coerce a null date to the epoch).
+        data = data.model_dump(exclude_none=True)
     try:
-        atomic_write(path, cbor2.dumps(data), overwrite=overwrite)
+        atomic_write(path, dumps_js(data), overwrite=overwrite)
     except FileExistsError:
         raise w.EntityConflictError(f"File already exists: {path}") from None
 
@@ -147,6 +226,14 @@ def _local_queue_delivery(
         "ce-vqscreatedat": datetime.now(UTC).isoformat(),
         "content-type": request.headers.get("content-type") or "application/json",
     }
+
+
+def event_record(event: w.Event) -> dict[str, Any]:
+    """The on-disk event row: the event plus the world-assigned server props."""
+    record = event.model_dump(exclude_none=True)
+    if event.server_props is not None:
+        record |= event.server_props.model_dump()
+    return record
 
 
 class LocalWorld(w.World):
@@ -355,7 +442,7 @@ class LocalWorld(w.World):
 
     def _events_create_impl(self, run_id: str | None, data: w.Event) -> w.EventResult:
         event_id = f"evnt_{self.monotonic_ulid(None)}"
-        now = datetime.now(UTC)
+        now = js_now()
 
         if data.event_type == "run_created" and not run_id:
             effective_run_id = f"wrun_{self.monotonic_ulid(None)}"
@@ -384,7 +471,7 @@ class LocalWorld(w.World):
                 )
                 composite_key = f"{effective_run_id}-{event_id}"
                 event_path = self.data_dir / "events" / f"{composite_key}.json"
-                write_json(event_path, event.model_dump() | event.server_props.model_dump())
+                write_json(event_path, event_record(event))
                 return w.EventResult(event=event, run=current_run)
 
             if data.event_type in run_terminal_events or data.event_type == "run_cancelled":
@@ -462,6 +549,7 @@ class LocalWorld(w.World):
                     specVersion=current_run.spec_version,
                     executionContext=current_run.execution_context,
                     input=current_run.input,
+                    attributes=current_run.attributes,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     status="running",
@@ -481,6 +569,7 @@ class LocalWorld(w.World):
                     specVersion=current_run.spec_version,
                     executionContext=current_run.execution_context,
                     input=current_run.input,
+                    attributes=current_run.attributes,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,
@@ -517,6 +606,7 @@ class LocalWorld(w.World):
                     specVersion=current_run.spec_version,
                     executionContext=current_run.execution_context,
                     input=current_run.input,
+                    attributes=current_run.attributes,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,
@@ -542,6 +632,7 @@ class LocalWorld(w.World):
                     specVersion=current_run.spec_version,
                     executionContext=current_run.execution_context,
                     input=current_run.input,
+                    attributes=current_run.attributes,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,
@@ -651,12 +742,17 @@ class LocalWorld(w.World):
             constraint_path = self.data_dir / "hooks" / "tokens" / f"{hashed_token}.json"
             token_claimed = write_exclusive(
                 constraint_path,
+                # Compact, key-for-key what TS writes here — including the
+                # `eventId` its cross-process claim recovery reads back.
                 json.dumps(
                     {
                         "token": hook_data.token,
                         "hookId": data.correlation_id,
                         "runId": effective_run_id,
-                    }
+                        "eventId": event_id,
+                    },
+                    separators=(",", ":"),
+                    ensure_ascii=False,
                 ),
             )
             if not token_claimed:
@@ -682,10 +778,7 @@ class LocalWorld(w.World):
                 assert conflict_event.server_props is not None
                 composite_key = f"{effective_run_id}-{event_id}"
                 event_path = self.data_dir / "events" / f"{composite_key}.json"
-                write_json(
-                    event_path,
-                    conflict_event.model_dump() | conflict_event.server_props.model_dump(),
-                )
+                write_json(event_path, event_record(conflict_event))
                 return w.EventResult(
                     event=conflict_event,
                     run=run,
@@ -703,6 +796,7 @@ class LocalWorld(w.World):
                 createdAt=now,
                 specVersion=2,
                 isWebhook=False,
+                isSystem=False,
             )
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             write_json(hook_path, hook)
@@ -739,10 +833,7 @@ class LocalWorld(w.World):
 
         composite_key = f"{effective_run_id}-{event_id}"
         event_path = self.data_dir / "events" / f"{composite_key}.json"
-        if event.server_props:
-            write_json(event_path, event.model_dump() | event.server_props.model_dump())
-        else:
-            write_json(event_path, event.model_dump())
+        write_json(event_path, event_record(event))
 
         return w.EventResult(
             event=event,

--- a/src/vercel/tests/integration/test_workflow_cli_interop.py
+++ b/src/vercel/tests/integration/test_workflow_cli_interop.py
@@ -1,0 +1,382 @@
+"""Interop: the JavaScript ``workflow`` CLI reading Python-written local files.
+
+``LocalWorld`` shares its ``.workflow-data`` directory with the TypeScript
+``@workflow/world-local`` package, and the unit tests in
+``tests/unit/test_workflow_local_world_format.py`` pin the file format against
+hand-written expectations. Those expectations can only encode what their author
+believed the TS side does. This test runs the real consumer instead: a genuine
+Python workflow executes end to end against a real ``LocalWorld``, and then the
+published ``workflow`` CLI is asked to read what it wrote.
+
+Nothing is faked. ``LocalWorld`` runs its embedded queue service in-process,
+so the run goes through the real queue and the real handlers -- the same path
+``vercel dev`` takes -- and every file the CLI reads was written by the
+implementation under test.
+
+Metadata *and* payloads are asserted: Python writes a single ``devl``-prefixed
+devalue payload, so the CLI's hydration pipeline reads the values Python
+recorded rather than failing soft to ``{}``.
+
+The suite needs Node. Following the precedent in ``tests/integration/
+test_devalue.py`` it is optional locally and mandatory on CI, so a developer
+without Node is not blocked but a real divergence cannot merge green. Locally
+the first run pays an ``npm install`` (~450 packages), cached in a
+version-keyed temp directory and reused; CI installs the CLI in its own step
+and points ``VERCEL_WORKFLOW_CLI`` at it, so npm never runs inside a test
+there. Set that variable to a ``workflow`` checkout's ``bin/run.js`` to test
+against something other than the pinned release -- useful when a format change
+is being made on both sides at once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vercel._internal.workflow import core, runtime, serialization as ser, world as w
+from vercel._internal.workflow.worlds import local as local_mod
+from vercel.queue.testing import clear_subscriptions
+
+# The version fetched from npm when VERCEL_WORKFLOW_CLI is not set. Keep this in
+# step with the `@workflow/world-local` release the on-disk format is written
+# against -- an older CLI predates fields the format now carries -- and with the
+# pin in the "Install the workflow CLI" step of .github/workflows/ci.yml.
+WORKFLOW_CLI_VERSION = "5.0.0-beta.38"
+
+_IS_CI = bool(os.getenv("CI"))
+
+# How long the Python side gets to finish the run. It takes well under a second;
+# this is only here so that a run which never finishes fails the test instead of
+# hanging until the CI job's own timeout.
+RUN_DEADLINE_SECONDS = 30
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# locating the JavaScript CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _entry_in(prefix: Path) -> Path:
+    return prefix / "node_modules" / "workflow" / "bin" / "run.js"
+
+
+def _npm_install_into(prefix: Path) -> bool:
+    prefix.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [
+            "npm",
+            "install",
+            f"workflow@{WORKFLOW_CLI_VERSION}",
+            "--no-save",
+            "--no-audit",
+            "--no-fund",
+            # The tree pulls in @swc/core, esbuild and cbor-extract, whose
+            # postinstalls fetch native binaries. `inspect` is a pure-JS read
+            # path that needs none of them, so skipping the scripts is both
+            # faster and one less thing executing from the registry.
+            "--ignore-scripts",
+            "--prefix",
+            str(prefix),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    return result.returncode == 0 and _entry_in(prefix).is_file()
+
+
+def _npm_install_cli() -> Path | None:
+    """Install the pinned CLI into a version-keyed temp dir, and reuse it.
+
+    Mirrors ``test_devalue.py``: pytest-xdist gives every worker its own session
+    fixture, so several processes reach this at once. npm rebuilds
+    ``node_modules`` in place and non-atomically, so installing straight into
+    the shared directory lets one worker observe ``run.js`` and then have it
+    vanish underneath a running node. Each worker therefore installs into a
+    private staging directory and publishes it with a single atomic rename;
+    losers of that race reuse the winner's copy.
+    """
+    shared = Path(tempfile.gettempdir()) / f"vercel-py-workflow-cli-{WORKFLOW_CLI_VERSION}"
+    if _entry_in(shared).is_file():
+        return _entry_in(shared)
+
+    staging = Path(tempfile.mkdtemp(prefix=f"vercel-py-workflow-cli-{WORKFLOW_CLI_VERSION}-"))
+    if not _npm_install_into(staging):
+        shutil.rmtree(staging, ignore_errors=True)
+        return None
+
+    try:
+        # Atomic when `shared` does not exist; raises if another worker won.
+        staging.rename(shared)
+    except OSError:
+        if _entry_in(shared).is_file():
+            shutil.rmtree(staging, ignore_errors=True)
+            return _entry_in(shared)
+        # `shared` exists but holds no usable install (e.g. a partial tree from
+        # an interrupted run). Keep our own copy rather than deleting a path
+        # another process may be reading.
+        return _entry_in(staging)
+
+    return _entry_in(shared)
+
+
+def _resolve_cli_entry() -> tuple[Path | None, str]:
+    """Return the CLI entry point, or ``None`` plus the reason it is missing."""
+    override = os.getenv("VERCEL_WORKFLOW_CLI")
+    if override:
+        candidate = Path(override).expanduser()
+        if candidate.is_dir():
+            candidate = candidate / "bin" / "run.js"
+        if not candidate.is_file():
+            return None, f"VERCEL_WORKFLOW_CLI does not point at a workflow CLI: {override}"
+        return candidate, ""
+
+    if shutil.which("node") is None:
+        return None, "node is not installed"
+    if shutil.which("npm") is None:
+        return None, "npm is not installed"
+
+    entry = _npm_install_cli()
+    if entry is None:
+        return None, f"could not npm install workflow@{WORKFLOW_CLI_VERSION}"
+    return entry, ""
+
+
+@pytest.fixture(scope="session")
+def workflow_cli() -> Path:
+    entry, reason = _resolve_cli_entry()
+    if entry is None:
+        message = (
+            f"JS workflow CLI unavailable ({reason}). Install node, or point "
+            f"VERCEL_WORKFLOW_CLI at a workflow checkout's bin/run.js."
+        )
+        if _IS_CI:
+            pytest.fail(message)
+        pytest.skip(message)
+    return entry
+
+
+def _inspect(cli: Path, data_dir: Path, *args: str) -> Any:
+    """Run ``workflow inspect … --json`` against ``data_dir`` and parse stdout.
+
+    In JSON mode the CLI sends every log line to stderr, so stdout is pure
+    JSON. The environment is scrubbed of the other ``WORKFLOW_*`` variables so
+    an ambient one cannot silently redirect the command at another backend or
+    data directory, and the working directory is the throwaway data dir so no
+    ``workflow`` config or ``.workflow-data`` from this repo is discovered.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("WORKFLOW_")}
+    env.pop("DEBUG", None)
+    env["WORKFLOW_LOCAL_DATA_DIR"] = str(data_dir)
+    env["WORKFLOW_NO_UPDATE_CHECK"] = "1"
+
+    result = subprocess.run(
+        ["node", str(cli), "inspect", *args, "--backend", "local", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=data_dir,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"`workflow inspect {' '.join(args)}` exited {result.returncode}\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise AssertionError(
+            f"`workflow inspect {' '.join(args)}` did not print JSON: {error}\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        ) from None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the Python workflow under test
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Module level, not function level: replay re-imports the workflow's defining
+# module by name inside the sandbox, so the workflow has to live somewhere
+# importable. `as_vercel_job=False` only defers subscribing the handlers to the
+# queue -- `py_run` does that itself, once a world pointing at its `tmp_path`
+# is installed.
+registry = core.Workflows(as_vercel_job=False)
+
+
+@registry.step
+async def charge(*, amount: int) -> int:
+    return amount * 2
+
+
+@registry.step
+async def notify(*, total: int) -> str:
+    return f"charged {total}"
+
+
+@registry.workflow
+async def checkout(*, amount: int) -> str:
+    total = await charge(amount=amount)
+    return await notify(total=total)
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+    # Queue subscriptions are process-global and refuse to be registered
+    # twice for the same topic pattern, so each test has to hand its own back.
+    clear_subscriptions()
+
+
+@pytest.fixture
+async def py_run(tmp_path, monkeypatch) -> tuple[Path, str]:
+    """Execute the workflow for real and return its data dir and run id.
+
+    Nothing is faked. `LocalWorld` runs an embedded queue service in-process,
+    and `workflow_entrypoint` / `step_entrypoint` subscribe the real handlers
+    to it -- which is what `Workflows()` does for itself outside a test, and
+    what a developer gets from `vercel dev`. Doing it here rather than at
+    import is what lets the run land in this test's `tmp_path`: those
+    entrypoints bind whichever world is installed when they are called.
+    """
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = local_mod.LocalWorld()
+    w.set_world(world)
+    runtime.workflow_entrypoint(registry)
+    runtime.step_entrypoint(registry)
+
+    try:
+        run = await runtime.start(checkout, amount=21)
+        result = await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS)
+
+        # Guard the premise: if Python itself did not finish the run, a later
+        # assertion about the CLI's view would be misleading.
+        assert result == "charged 42", f"python run returned {result!r}"
+        final = await world.runs_get(run.run_id)
+        assert final.status == "completed", f"python run did not complete: {final.status}"
+        assert final.output == ser.dehydrate("charged 42")
+    finally:
+        # Closed here, before the tests run, rather than in a teardown: the
+        # embedded service's cancel scope has to be exited from the task that
+        # entered it, and a fixture's teardown is not that task. Nothing below
+        # needs the world -- what the CLI reads is on disk.
+        await world.aclose()
+
+    return tmp_path, run.run_id
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def test_cli_lists_the_run_python_wrote(workflow_cli, py_run) -> None:
+    data_dir, run_id = py_run
+
+    page = _inspect(workflow_cli, data_dir, "runs")
+
+    assert page["hasMore"] is False
+    assert [run["runId"] for run in page["data"]] == [run_id]
+    (run,) = page["data"]
+    assert run["status"] == "completed"
+    assert run["workflowName"] == checkout.workflow_id
+    assert run["specVersion"] == 2
+    # Written by py because TS materializes it on every run row.
+    assert run["attributes"] == {}
+    # Dates survive as `Date`s: the CLI re-serializes them to the same
+    # millisecond-precision ISO strings, not to epoch (which is what a null
+    # would coerce to through `z.coerce.date()`).
+    assert run["createdAt"].endswith("Z")
+    assert run["startedAt"] <= run["completedAt"]
+
+
+async def test_cli_lists_the_steps_python_wrote(workflow_cli, py_run) -> None:
+    data_dir, run_id = py_run
+
+    steps = _inspect(workflow_cli, data_dir, "steps", f"--runId={run_id}")
+
+    assert {step["stepName"] for step in steps} == {charge.name, notify.name}
+    for step in steps:
+        assert step["runId"] == run_id
+        assert step["status"] == "completed"
+        assert step["attempt"] == 1
+        assert step["specVersion"] == 2
+
+
+async def test_cli_lists_the_event_log_python_wrote(workflow_cli, py_run) -> None:
+    data_dir, run_id = py_run
+
+    events = _inspect(workflow_cli, data_dir, "events", f"--runId={run_id}")
+
+    assert all(event["runId"] == run_id for event in events)
+    # `inspect events` sorts newest first. Reversed, this is the exact lifecycle
+    # the Python runtime recorded -- so the CLI agrees on both the set of events
+    # and their (createdAt, eventId) ordering.
+    assert [event["eventType"] for event in reversed(events)] == [
+        "run_created",
+        "run_started",
+        "step_created",
+        "step_started",
+        "step_completed",
+        "step_created",
+        "step_started",
+        "step_completed",
+        "run_completed",
+    ]
+    created = [event for event in events if event["eventType"] == "step_created"]
+    assert {event["eventData"]["stepName"] for event in created} == {charge.name, notify.name}
+
+
+async def test_cli_shows_the_single_run_python_wrote(workflow_cli, py_run) -> None:
+    # The detail view takes a different code path from the list view: it
+    # resolves data and runs the hydration pipeline over the payloads.
+    data_dir, run_id = py_run
+
+    run = _inspect(workflow_cli, data_dir, "run", run_id)
+
+    assert run["runId"] == run_id
+    assert run["status"] == "completed"
+    assert run["workflowName"] == checkout.workflow_id
+
+
+async def test_cli_hydrates_the_payloads_python_wrote(workflow_cli, py_run) -> None:
+    """The end of the round trip: TS devalue reads what Python devalue wrote.
+
+    Hydration on the TS side fails *soft* -- an unreadable payload renders as
+    ``{}`` rather than erroring -- so this is the assertion that would notice a
+    payload-format regression. The other tests here would not.
+
+    The values are also the ones TypeScript would have written: a call is
+    recorded as the single object it records for a one-argument call, so
+    ``input`` here is what ``start(wf, {amount: 21})`` writes.
+    """
+    data_dir, run_id = py_run
+
+    run = _inspect(workflow_cli, data_dir, "run", run_id)
+
+    assert run["input"] == [{"amount": 21}]
+    assert run["output"] == "charged 42"
+
+
+async def test_cli_hydrates_the_step_payloads_python_wrote(workflow_cli, py_run) -> None:
+    data_dir, run_id = py_run
+
+    # `--withData` is what makes the list view resolve and hydrate payloads.
+    steps = _inspect(workflow_cli, data_dir, "steps", f"--runId={run_id}", "--withData")
+    by_name = {step["stepName"]: step for step in steps}
+
+    assert by_name[charge.name]["input"] == {"args": [{"amount": 21}]}
+    assert by_name[charge.name]["output"] == 42
+    assert by_name[notify.name]["input"] == {"args": [{"total": 42}]}
+    assert by_name[notify.name]["output"] == "charged 42"

--- a/src/vercel/tests/unit/test_workflow_local_world_format.py
+++ b/src/vercel/tests/unit/test_workflow_local_world_format.py
@@ -1,0 +1,218 @@
+"""On-disk format of the LocalWorld data directory.
+
+The TypeScript `@workflow/world-local` package reads and writes the same
+`.workflow-data` tree, so the files have to be interchangeable. Its writer is
+``JSON.stringify(value, jsonReplacer, 2)``: two-space indent, ``Uint8Array``
+smuggled through a ``{__type, data}`` wrapper, ``Date`` as
+``toISOString()``, and unset fields simply absent -- ``undefined`` is not a
+JSON value. Its reader is correspondingly strict: the run schema types
+``output`` / ``error`` / ``completedAt`` as ``z.undefined()``, which rejects an
+explicit null outright, and ``z.coerce.date()`` would quietly turn a null
+``startedAt`` into the epoch. So the omissions below are load-bearing, not
+cosmetic.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+from vercel._internal.workflow import serialization as ser, world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_test"
+
+
+def _world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    return local_mod.LocalWorld()
+
+
+def _iter_json_files(data_dir):
+    return sorted(p for p in data_dir.rglob("*.json") if p.is_file())
+
+
+async def _populate(world) -> str:
+    """Drive a run through every entity the local world persists."""
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1",
+            workflowName="workflow//./src/wf//main",
+            input=ser.dehydrate([]),
+            executionContext={"workflowCoreVersion": "5.0.0"},
+        ).into_event(),
+    )
+    assert result.run is not None
+    run_id = result.run.run_id
+    await world.events_create(run_id, w.RunStartedEvent())
+    await world.events_create(
+        run_id,
+        w.StepCreatedEventData(
+            stepName="step//./src/wf//pay", input=ser.dehydrate(ser.step_arguments({}))
+        ).into_event("step_0"),
+    )
+    await world.events_create(run_id, w.StepStartedEventData().into_event("step_0"))
+    await world.events_create(
+        run_id, w.StepCompletedEventData(result=ser.dehydrate(42)).into_event("step_0")
+    )
+    await world.events_create(run_id, w.HookCreatedEventData(token="tok-abc").into_event("hook_0"))
+    return run_id
+
+
+def test_dumps_js_matches_json_stringify_conventions() -> None:
+    # Mirrors `JSON.stringify(value, jsonReplacer, 2)`: two-space indent, no
+    # space before the comma, no \uXXXX escaping of non-ASCII, and no trailing
+    # newline. JS has one number type, so an integral float loses its ".0".
+    payload = {
+        "note": "你好",
+        "blob": b"\x00\xff\x80",
+        "at": datetime(2026, 7, 30, 17, 6, 33, 759000, tzinfo=timezone.utc),
+        "count": 1.0,
+        "ratio": 0.25,
+        "empty": {},
+        "items": [],
+    }
+    assert local_mod.dumps_js(payload).decode() == (
+        "{\n"
+        '  "note": "你好",\n'
+        '  "blob": {\n'
+        '    "__type": "Uint8Array",\n'
+        f'    "data": "{base64.b64encode(bytes([0, 255, 128])).decode()}"\n'
+        "  },\n"
+        '  "at": "2026-07-30T17:06:33.759Z",\n'
+        '  "count": 1,\n'
+        '  "ratio": 0.25,\n'
+        '  "empty": {},\n'
+        '  "items": []\n'
+        "}"
+    )
+
+
+def test_to_js_iso_matches_date_to_iso_string() -> None:
+    # `Date.prototype.toISOString` is always UTC with exactly three fractional
+    # digits. Sub-millisecond precision is truncated (a JS Date never had it),
+    # a naive datetime is read as UTC, and an offset-aware one is converted.
+    assert (
+        local_mod.to_js_iso(datetime(2026, 7, 30, 17, 6, 33, 759876, tzinfo=timezone.utc))
+        == "2026-07-30T17:06:33.759Z"
+    )
+    assert local_mod.to_js_iso(datetime(2026, 1, 2, 3, 4, 5)) == "2026-01-02T03:04:05.000Z"
+    assert (
+        local_mod.to_js_iso(datetime(2026, 7, 30, 13, 6, 33, tzinfo=timezone(timedelta(hours=-4))))
+        == "2026-07-30T17:06:33.000Z"
+    )
+
+
+def test_binary_payloads_round_trip_through_the_uint8array_wrapper() -> None:
+    blob = bytes(range(256))
+    encoded = local_mod.dumps_js({"blob": blob})
+    # On disk it is the wrapper TS's `jsonReplacer` produces, not a bare string.
+    assert json.loads(encoded)["blob"] == {
+        "__type": "Uint8Array",
+        "data": base64.b64encode(blob).decode(),
+    }
+    assert local_mod._decode_js(json.loads(encoded)) == {"blob": blob}
+
+
+async def test_written_files_are_json_stringify_output(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    await _populate(world)
+
+    files = _iter_json_files(world.data_dir)
+    assert files, "expected the run to persist some entities"
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        # Parses as JSON (not CBOR or any other container)...
+        data = json.loads(text)
+        # ...and is formatted the way JSON.stringify(value, replacer, 2) is.
+        # The token-claim sidecar is the one file TS writes compactly.
+        indent = None if path.parent.name == "tokens" else 2
+        assert text == json.dumps(
+            data, indent=indent, separators=(",", ":") if indent is None else (",", ": ")
+        ), f"{path.relative_to(world.data_dir)} is not JSON.stringify output"
+
+
+async def test_unset_fields_are_omitted_not_null(tmp_path, monkeypatch) -> None:
+    # The TS run schema types output/error/completedAt as `z.undefined()`, which
+    # rejects null, and its date fields would coerce a null to the epoch. A null
+    # anywhere a field is merely unset therefore breaks the TS reader.
+    world = _world(tmp_path, monkeypatch)
+    await _populate(world)
+
+    def assert_no_null(value, path: str) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                assert item is not None, f"{path}.{key} is null; TS omits unset fields"
+                assert_no_null(item, f"{path}.{key}")
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                assert_no_null(item, f"{path}[{index}]")
+
+    for path in _iter_json_files(world.data_dir):
+        assert_no_null(
+            json.loads(path.read_text(encoding="utf-8")), str(path.relative_to(world.data_dir))
+        )
+
+
+async def test_run_row_always_carries_attributes(tmp_path, monkeypatch) -> None:
+    # TS writes `attributes: runData.attributes ?? {}` on creation and copies it
+    # forward on every lifecycle transition, so the field is never absent.
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _populate(world)
+    run_path = world.data_dir / "runs" / f"{run_id}.json"
+
+    assert json.loads(run_path.read_text(encoding="utf-8"))["attributes"] == {}
+
+    # A transition must preserve attributes another writer put there rather than
+    # clobbering them with its own stale snapshot.
+    stored = json.loads(run_path.read_text(encoding="utf-8"))
+    stored["attributes"] = {"tier": "pro"}
+    run_path.write_text(json.dumps(stored), encoding="utf-8")
+    await world.events_create(
+        run_id, w.RunCompletedEventData(output=ser.dehydrate(42)).into_event()
+    )
+    assert json.loads(run_path.read_text(encoding="utf-8"))["attributes"] == {"tier": "pro"}
+
+
+async def test_timestamps_survive_the_round_trip(tmp_path, monkeypatch) -> None:
+    # Timestamps land on disk at millisecond resolution, so the world stamps
+    # them at that resolution too -- otherwise the value handed to the caller
+    # would differ from the one a later read parses back out.
+    world = _world(tmp_path, monkeypatch)
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1",
+            workflowName="workflow//./src/wf//main",
+            input=ser.dehydrate([]),
+        ).into_event(),
+    )
+    assert result.run is not None
+    reread = await world.runs_get(result.run.run_id)
+    assert reread.created_at == result.run.created_at
+    assert reread.updated_at == result.run.updated_at
+
+
+async def test_hook_token_claim_matches_the_ts_sidecar(tmp_path, monkeypatch) -> None:
+    # TS writes `JSON.stringify({token, hookId, runId, eventId})` -- compact,
+    # and carrying the eventId its claim-recovery path reads back.
+    world = _world(tmp_path, monkeypatch)
+    result = await world.events_create(
+        RUN_ID, w.HookCreatedEventData(token="tok-abc").into_event("hook_0")
+    )
+
+    assert result.event is not None
+    assert result.event.server_props is not None
+
+    claims = list((world.data_dir / "hooks" / "tokens").glob("*.json"))
+    assert len(claims) == 1
+    text = claims[0].read_text(encoding="utf-8")
+    assert json.loads(text) == {
+        "token": "tok-abc",
+        "hookId": "hook_0",
+        "runId": RUN_ID,
+        "eventId": result.event.server_props.event_id,
+    }
+    assert " " not in text, "the claim sidecar is written compactly, as in TS"


### PR DESCRIPTION
The local world used to write CBOR into files named `.json`. TypeScript's `@workflow/world-local` writes real JSON, so neither side could read the other's `.workflow-data` tree.

Now Python writes what TS `JSON.stringify(value, jsonReplacer, 2)` writes:

​```json
{
  "runId": "wrun_01KZ7ARFVCB83N043NCT1SG49R",
  "status": "running",
  "input": {
    "__type": "Uint8Array",
    "data": "ZGV2bFtbXV0="
  },
  "attributes": {},
  "startedAt": "2026-08-04T21:27:02.766Z"
}
​```

- two-space indent, non-ASCII unescaped
- `bytes` in the `{__type, data}` base64 wrapper
- `datetime` as `toISOString()`, three fractional digits
- integral floats as plain integers
- unset fields omitted, never `null`

`null` is the one that bites: TS types `output`, `error` and `completedAt` as `z.undefined()`, which rejects it, and its date fields use `z.coerce.date()`, so a null `startedAt` would read back as the epoch.

Three field sets differed and are now aligned: runs always carry `attributes` (copied forward on lifecycle transitions), hooks carry `isSystem`, tokens carry the `eventId` TS claim recovery reads back.

## End-to-end Test PoC

Second commit: a real Python workflow runs end to end against a real `LocalWorld`, then the TS `workflow` CLI reads back what it wrote.

```python
# workflow inspect run <id> --backend local --json
assert run["input"] == [{"amount": 21}]
assert run["output"] == "charged 42"
```

CI installs the CLI in its own step and points `VERCEL_WORKFLOW_CLI` at it. Locally it installs on demand and skips without node.

## Breaking

Existing `.workflow-data` directories are unreadable in the new format and should be deleted.