### PR TITLE
workflow: Start using a custom event loop for workflows

### DIFF
--- a/src/vercel/_internal/workflow/loop.py
+++ b/src/vercel/_internal/workflow/loop.py
@@ -1,0 +1,43 @@
+import asyncio
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import collections
+
+
+class WorkflowLoop(asyncio.BaseEventLoop):
+    idle_hook = None
+
+    if TYPE_CHECKING:
+        _ready: collections.deque[Any]
+        _stopping: bool
+
+    def __init__(self, *, idle_hook: Callable[[], None] | None = None) -> None:
+        super().__init__()
+        self.idle_hook = idle_hook
+
+    def _run_once(self):
+        while self._ready and not self._stopping:
+            handle = self._ready.popleft()
+            if handle._cancelled:
+                continue
+            handle._run()
+        handle = None  # Needed to break cycles when an exception occurs.
+
+        if self.idle_hook:
+            self.idle_hook()
+
+    def _write_to_self(self):
+        # The loop has no way to suspend so we don't need to do
+        # anything to wake it up.
+        pass
+
+    def call_later(self, delay, callback, *args, context=None):
+        raise NotImplementedError
+
+    def call_at(self, when, callback, *args, context=None):
+        raise NotImplementedError
+
+    def time(self):
+        raise NotImplementedError

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -19,12 +19,11 @@ import pydantic
 
 from vercel._internal.core.polyfills import UTC, Self
 
-from . import core, nanoid, serialization as ser, ulid, world as w
+from . import core, loop, nanoid, serialization as ser, ulid, world as w
 from .py_sandbox import workflow_sandbox
 
 P = ParamSpec("P")
 T = TypeVar("T")
-SUSPENDED_MESSAGE = "<WORKFLOW SUSPENDED>"
 logger = logging.getLogger("vercel.workflow")
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
@@ -47,6 +46,10 @@ def _wait_continuation_dispatch(
     delay = min(timeout_seconds, WAIT_CONTINUATION_MAX_DELAY_SECONDS)
     key = wait_correlation_id if hop == 1 else f"{wait_correlation_id}:hop-{hop}"
     return delay, key
+
+
+class _SuspendException(BaseException):
+    """Raised to trigger suspending of the workflow."""
 
 
 class NondeterminismError(Exception):
@@ -202,26 +205,23 @@ else:
                 loop.close()
 
 
-def _run_in_default_loop(coro: Coroutine[Any, Any, T]) -> T:
-    return _run_in_loop(coro, loop_factory=asyncio.SelectorEventLoop)
-
-
-def _run_isolated(coro: Coroutine[Any, Any, T]) -> T:
+def _run_isolated(
+    coro: Coroutine[Any, Any, T],
+    *,
+    loop_factory: Callable[[], asyncio.AbstractEventLoop],
+) -> T:
     # The workflow is async, but it is not actually allowed to perform
     # any IO-full operations, and resume/resume_wrapper require that it
     # run in an isolated loop.
     #
-    # So hide our existing loop and run everything in a fresh loop. We
-    # explicitly specify a factory because we look at ._ready, which
-    # might not exist in uvloop etc.
-    # TODO: Use a custom loop implementation.
+    # So hide our existing loop and run everything in a fresh loop.
     old_loop = asyncio.get_running_loop()
     current_task = asyncio.current_task()
     if current_task:
         asyncio._leave_task(old_loop, current_task)
     asyncio._set_running_loop(None)
     try:
-        return _run_in_default_loop(coro)
+        return _run_in_loop(coro, loop_factory=loop_factory)
     finally:
         asyncio._set_running_loop(old_loop)
         if current_task:
@@ -243,11 +243,8 @@ class WorkflowOrchestratorContext:
         self.generate_ulid = functools.partial(ulid.monotonic_factory(prng.random), started_at)
         self.generate_nanoid = nanoid.custom_random(nanoid.URL_ALPHABET, 21, prng.random)
         self._user_random = random.Random(f"{seed}:random")
-        self._fut: asyncio.Future[Any] | None = None
         self.suspensions: dict[str, BaseSuspension] = {}
         self.hooks: dict[str, Hook] = {}
-        self.resume_handle: asyncio.Handle | None = None
-        self._suspended = False
         self.registry = registry
 
     @classmethod
@@ -272,18 +269,16 @@ class WorkflowOrchestratorContext:
             what = f"the input of run {workflow_run.run_id}"
             kwargs = ser.keyword_arguments(ser.hydrate(workflow_run.input, what=what), what=what)
 
-            async def inner():
-                self._fut = asyncio.ensure_future(obj.func(**kwargs))
-                self.resume_wrapper()  # arm the resume callback
-                await self._fut
-
             token = self._ctx.set(self)
             try:
-                _run_isolated(inner())
+                return ser.dehydrate(
+                    _run_isolated(
+                        obj.func(**kwargs),
+                        loop_factory=lambda: loop.WorkflowLoop(idle_hook=self.resume),
+                    )
+                )
             finally:
                 self._ctx.reset(token)
-            assert self._fut
-            return ser.dehydrate(self._fut.result())
 
     # `args` is always empty: `Step.__call__` refuses a positional call before
     # forwarding, and only spells one because a ParamSpec has to carry both
@@ -357,21 +352,6 @@ class WorkflowOrchestratorContext:
         elif isinstance(sus, (Suspension, Wait)) and not sus.future.done():
             sus.future.set_exception(exc)
 
-    def resume_wrapper(self) -> None:
-        """Make sure that resume() runs on an empty event loop ready queue."""
-
-        loop = asyncio.get_running_loop()
-        is_ready = bool(loop._ready)  # type: ignore[attr-defined]
-        self.resume_handle = loop.call_soon(self.resume_wrapper)
-        # We only want to resume() when all of the workflow tasks have
-        # suspended, so if anything else is running or ready to run,
-        # we defer. Our resume_handle callback will be at the back of
-        # the _ready queue, so everything else will go first.
-        if is_ready:
-            return
-
-        self.resume()
-
     def resume(self) -> None:
         """Run over the the event log and try to apply an event.
 
@@ -389,9 +369,6 @@ class WorkflowOrchestratorContext:
         If the event log is exhausted, cancel the future and suspend
         the workflow.
         """
-
-        if self._fut is None:
-            return
 
         # NOTE: resume() does single-step delivery, so we resolve at most
         # one suspension per invocation of resume().
@@ -490,13 +467,7 @@ class WorkflowOrchestratorContext:
                 case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
                     sus = self.suspensions.pop(event.correlation_id)
                     assert isinstance(sus, Suspension)
-                    try:
-                        result = ser.hydrate(
-                            data, what=f"the result of step {event.correlation_id}"
-                        )
-                    except ser.SerializationError as error:
-                        self._fut.cancel(str(error))
-                        return
+                    result = ser.hydrate(data, what=f"the result of step {event.correlation_id}")
                     sus.future.set_result(result)
 
                 case w.WaitCompletedEvent():
@@ -523,13 +494,7 @@ class WorkflowOrchestratorContext:
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]
                     assert isinstance(hook, Hook)
-                    try:
-                        result = ser.hydrate(
-                            data, what=f"the payload of hook {event.correlation_id}"
-                        )
-                    except ser.SerializationError as error:
-                        self._fut.cancel(str(error))
-                        return
+                    result = ser.hydrate(data, what=f"the payload of hook {event.correlation_id}")
                     hook.set_result(result)
                     if not hook.futures:
                         self.suspensions.pop(event.correlation_id)
@@ -546,10 +511,7 @@ class WorkflowOrchestratorContext:
         # event log exhausted without doing any work.
         # Suspend.
         else:
-            self._suspended = True
-            self._fut.cancel(SUSPENDED_MESSAGE)
-            if self.resume_handle:
-                self.resume_handle.cancel()
+            raise _SuspendException()
 
 
 async def workflow_handler(
@@ -656,26 +618,23 @@ async def workflow_handler(
     )
     try:
         output = context.run_workflow(workflow_run)
-    except BaseException as e:
-        if isinstance(e, asyncio.CancelledError) and e.args and e.args[0] == SUSPENDED_MESSAGE:
-            # Workflow suspended, continue outside the try..except block
-            pass
-        elif isinstance(e, Exception):
-            error_message = "".join(traceback.format_exception_only(type(e), e)).strip()
-            logger.exception("[Workflows] '%s' - workflow run failed: %s", run_id, error_message)
-            try:
-                await world.events_create(
-                    run_id,
-                    w.RunFailedEventData(
-                        error={"message": error_message, "stack": traceback.format_exc()},
-                        code=type(e).__name__,
-                    ).into_event(),
-                )
-            except w.EntityConflictError:
-                logger.warning(f"Workflow run {run_id} was already completed")
-            return None
-        else:
-            raise
+    except _SuspendException:
+        # Workflow suspended, continue outside the try..except block.
+        pass
+    except Exception as e:
+        error_message = "".join(traceback.format_exception_only(type(e), e)).strip()
+        logger.exception("[Workflows] '%s' - workflow run failed: %s", run_id, error_message)
+        try:
+            await world.events_create(
+                run_id,
+                w.RunFailedEventData(
+                    error={"message": error_message, "stack": traceback.format_exc()},
+                    code=type(e).__name__,
+                ).into_event(),
+            )
+        except w.EntityConflictError:
+            logger.warning(f"Workflow run {run_id} was already completed")
+        return None
     else:
         try:
             await world.events_create(
@@ -765,7 +724,7 @@ async def workflow_handler(
                 events_created = True
 
     if not context.suspensions and events_created:
-        # We captured a SUSPENDED_MESSAGE but there is no suspension - this is likely caused
+        # We captured a _SuspendException but there is no suspension - this is likely caused
         # by a disposed hook that cleared its suspensions. Just retry if event log changed.
         return await workflow_handler(
             message,

--- a/src/vercel/tests/unit/test_workflow_determinism.py
+++ b/src/vercel/tests/unit/test_workflow_determinism.py
@@ -6,13 +6,18 @@ results matched onto the wrong calls. ``resume()`` must detect this and fail
 loudly rather than silently returning the wrong value.
 """
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 
-from vercel._internal.workflow import core, runtime, serialization as ser, world as w
+from vercel._internal.workflow import (
+    core,
+    loop as workflow_loop,
+    runtime,
+    serialization as ser,
+    world as w,
+)
 
 
 async def _greet(*, name: str) -> str:
@@ -28,8 +33,6 @@ def _context(
         started_at=0,
         registry=core.Workflows(as_vercel_job=False),
     )
-    # resume() short-circuits unless a workflow future is in flight.
-    ctx._fut = asyncio.get_event_loop().create_future()
     return ctx
 
 
@@ -60,8 +63,8 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
     assert isinstance(sus.future.exception(), runtime.NondeterminismError)
 
 
-async def test_matching_step_does_not_raise() -> None:
-    """Same step + same input -> no error, suspension is marked replayed."""
+async def test_matching_step_parks_without_nondeterminism() -> None:
+    """Same step + same input -> suspension is replayed, then the run parks."""
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
@@ -71,7 +74,8 @@ async def test_matching_step_does_not_raise() -> None:
     sus = _suspension(cid, _args(name="a"))
     ctx.suspensions[cid] = sus
 
-    ctx.resume()
+    with pytest.raises(runtime._SuspendException):
+        ctx.resume()
 
     assert not sus.future.done()
     assert sus.has_created_event
@@ -101,7 +105,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     assert isinstance(wait.future.exception(), runtime.NondeterminismError)
 
 
-# --- concurrent delivery: the resume_wrapper gate + resume single-step -----------
+# --- concurrent delivery: the loop idle hook + resume single-step ----------------
 #
 # When a body issues several calls from concurrent coroutines, recorded
 # completions must be delivered ONE AT A TIME, each only once the body has fully
@@ -109,8 +113,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
 # still-running one and the two issue their next calls in a different order than
 # at record time -> the positional correlation IDs no longer line up ->
 # NondeterminismError. Two pieces cooperate:
-#   * resume_wrapper() is the heartbeat: it re-arms itself every tick and only
-#     runs resume() when the loop's ready queue was otherwise empty (quiescent).
+#   * WorkflowLoop calls resume() only when its ready queue is empty (quiescent).
 #   * resume() applies at most one recorded event (single-step), or parks.
 
 _ARGS = _args(name="a")
@@ -145,17 +148,14 @@ async def test_single_step_delivers_one_completion_per_pass() -> None:
     # exactly one completion delivered; its suspension consumed...
     assert sus1.future.done() and sus1.future.result() == "one"
     assert "step_1" not in ctx.suspensions
-    # ...the second still pending, and the run not parked (the heartbeat will
-    # deliver it on a later pass).
+    # ...the second still pending, and resume() returned normally so the loop
+    # can deliver it on a later idle pass.
     assert not sus2.future.done()
     assert "step_2" in ctx.suspensions
-    assert not ctx._suspended
 
 
-async def test_resume_wrapper_defers_while_loop_has_pending_work() -> None:
-    """A completion is available, but the loop still has a pending callback (the
-    body mid-reaction). The wrapper must NOT run resume() -- it re-arms and waits
-    for the next tick."""
+async def test_workflow_loop_runs_pending_work_before_resume() -> None:
+    """The idle hook runs only after the body's pending callbacks are drained."""
     step = core.Step(_greet)
     events: list[w.Event] = [
         _created(step, "step_1"),
@@ -165,23 +165,28 @@ async def test_resume_wrapper_defers_while_loop_has_pending_work() -> None:
     sus1 = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus1
 
-    loop = asyncio.get_running_loop()
-    pending = loop.call_soon(lambda: None)
+    pending_ran = False
+
+    def pending() -> None:
+        nonlocal pending_ran
+        pending_ran = True
+
+    def resume() -> None:
+        assert pending_ran
+        ctx.resume()
+
+    loop = workflow_loop.WorkflowLoop(idle_hook=resume)
     try:
-        ctx.resume_wrapper()
+        loop.call_soon(pending)
+        loop._run_once()
 
-        assert not sus1.future.done()  # resume() not run -> nothing delivered
-        assert ctx.replay_index == 0  # event log untouched
-        assert ctx.resume_handle is not None  # re-armed for the next tick
+        assert sus1.future.done() and sus1.future.result() == "one"
     finally:
-        pending.cancel()
-        if ctx.resume_handle is not None:
-            ctx.resume_handle.cancel()
+        loop.close()
 
 
-async def test_resume_wrapper_runs_resume_when_quiescent() -> None:
-    """With the ready queue empty, the wrapper runs resume() (delivering one
-    completion) and re-arms itself."""
+async def test_workflow_loop_runs_resume_when_quiescent() -> None:
+    """With the ready queue empty, the idle hook delivers one completion."""
     step = core.Step(_greet)
     events: list[w.Event] = [
         _created(step, "step_1"),
@@ -191,34 +196,32 @@ async def test_resume_wrapper_runs_resume_when_quiescent() -> None:
     sus1 = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus1
 
-    ctx.resume_wrapper()
+    loop = workflow_loop.WorkflowLoop(idle_hook=ctx.resume)
+    try:
+        loop._run_once()
+        assert sus1.future.done() and sus1.future.result() == "one"
+    finally:
+        loop.close()
 
-    assert sus1.future.done() and sus1.future.result() == "one"
-    assert ctx.resume_handle is not None  # heartbeat re-armed
 
-    ctx.resume_handle.cancel()
-
-
-async def test_resume_parks_and_cancels_heartbeat_when_nothing_to_deliver() -> None:
+async def test_idle_resume_parks_when_nothing_to_deliver() -> None:
     """Suspension registered and its create replayed, no completion yet -> the
-    run suspends (cancels its future) and stops the heartbeat rather than
-    spinning."""
+    run suspends by cancelling its future."""
     step = core.Step(_greet)
     events: list[w.Event] = [_created(step, "step_1")]
     ctx = _context(events)
     sus1 = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus1
-    # the heartbeat would have armed itself before calling resume().
-    loop = asyncio.get_running_loop()
-    ctx.resume_handle = loop.call_soon(ctx.resume_wrapper)
 
-    ctx.resume()
+    loop = workflow_loop.WorkflowLoop(idle_hook=ctx.resume)
+    try:
+        with pytest.raises(runtime._SuspendException):
+            loop._run_once()
 
-    assert sus1.has_created_event
-    assert not sus1.future.done()
-    assert ctx._suspended
-    assert ctx._fut is not None and ctx._fut.cancelled()
-    assert ctx.resume_handle.cancelled()  # heartbeat stopped
+        assert sus1.has_created_event
+        assert not sus1.future.done()
+    finally:
+        loop.close()
 
 
 # --- now(): deterministic clock anchored to replay progress, not list tail ------

--- a/src/vercel/tests/unit/test_workflow_run_isolated.py
+++ b/src/vercel/tests/unit/test_workflow_run_isolated.py
@@ -1,17 +1,21 @@
 """Isolated-loop execution for workflow bodies.
 
 ``run_workflow`` runs the (async but IO-free) workflow body in a fresh event
-loop so it can inspect the loop's ``_ready`` queue. ``_run_isolated`` hides the
-caller's running loop *and* its current task before doing so, then restores both
-afterward -- restoring the current task is what makes this work on Python 3.14,
-which errors if a new loop is entered while the outer task is still current.
+loop. ``_run_isolated`` hides the caller's running loop *and* its current task
+before doing so, then restores both afterward -- restoring the current task is
+what makes this work on Python 3.14, which errors if a new loop is entered while
+the outer task is still current.
 """
 
 import asyncio
 
 import pytest
 
-from vercel._internal.workflow import runtime
+from vercel._internal.workflow import loop, runtime
+
+
+def _loop_factory() -> asyncio.AbstractEventLoop:
+    return loop.WorkflowLoop()
 
 
 def test_run_in_loop_cleans_up_tasks() -> None:
@@ -28,7 +32,7 @@ def test_run_in_loop_cleans_up_tasks() -> None:
         asyncio.create_task(background())
         await asyncio.sleep(0)
 
-    runtime._run_in_loop(body(), loop_factory=asyncio.SelectorEventLoop)
+    runtime._run_in_loop(body(), loop_factory=_loop_factory)
 
     assert background_cancelled
 
@@ -37,7 +41,7 @@ async def test_run_isolated_returns_result() -> None:
     async def body() -> int:
         return 41 + 1
 
-    assert runtime._run_isolated(body()) == 42
+    assert runtime._run_isolated(body(), loop_factory=_loop_factory) == 42
 
 
 async def test_run_isolated_runs_in_fresh_loop_and_restores_caller() -> None:
@@ -48,7 +52,7 @@ async def test_run_isolated_runs_in_fresh_loop_and_restores_caller() -> None:
     async def body() -> None:
         inner_loop["loop"] = asyncio.get_running_loop()
 
-    runtime._run_isolated(body())
+    runtime._run_isolated(body(), loop_factory=_loop_factory)
 
     assert inner_loop["loop"] is not outer_loop
     assert asyncio.get_running_loop() is outer_loop
@@ -68,7 +72,7 @@ async def test_run_isolated_propagates_exceptions_and_restores_caller() -> None:
         raise Boom
 
     with pytest.raises(Boom):
-        runtime._run_isolated(body())
+        runtime._run_isolated(body(), loop_factory=_loop_factory)
 
     assert asyncio.get_running_loop() is outer_loop
     assert asyncio.current_task() is outer_task


### PR DESCRIPTION
The advantages here are:
1. We'll be able to ensure that no I/O can be done on the loop,
   even from libraries
2. We can get rid of other hacks

Currently this is done in a pretty minimal way by overloading BaseEventLoop.
Eventually we'll probably end up building our complete own version.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>