### PR TITLE
Record JWKS refetch outcome before releasing the claim

### DIFF
--- a/src/vercel-oidc/tests/test_verify.py
+++ b/src/vercel-oidc/tests/test_verify.py
@@ -8,6 +8,7 @@ vector before the happy path is exercised at all.
 import base64
 import json
 import time
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import Any
 
@@ -625,6 +626,63 @@ def test_unknown_kid_refetch_is_rate_limited_under_concurrency(
 
     # Exactly one refetch for the whole burst: more would be amplification, none
     # would mean rotation could never be picked up.
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_refetch_throttle_engages_before_the_claim_is_released(
+    signing_key: rsa.RSAPrivateKey,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deterministic twin of the burst test above, pinned to the exact window.
+
+    The fetch claim used to be released in the fetch helper's `finally`, with the
+    throttle recorded only after key selection. A second unknown-kid caller
+    arriving in between claimed a fresh fetch, so a burst amplified anyway. Pause
+    the first caller's post-refetch selection and steer a second caller into that
+    window: it must wait on the claim, not fetch.
+    """
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    from vercel.oidc import verify as oidc_verify
+
+    route = jwks_route(signing_key)
+    clear_jwks_cache()
+    verify_vercel_oidc_token(sign(signing_key), **EXPECTATIONS)  # warm the cache
+    assert route.call_count == 1
+
+    original_select = oidc_verify._select_key
+    outcome_pending = threading.Event()
+    record_outcome = threading.Event()
+    first_kid_selections = 0
+
+    def paused_select(document: Mapping[str, Any], kid: str) -> Any:
+        nonlocal first_kid_selections
+        if kid == "forged-first":
+            first_kid_selections += 1
+            # Call 1 is the cache probe; call 2 inspects the refetched document,
+            # where the outcome (throttle) has not been recorded yet.
+            if first_kid_selections == 2:
+                outcome_pending.set()
+                assert record_outcome.wait(timeout=5)
+        return original_select(document, kid)
+
+    monkeypatch.setattr(oidc_verify, "_select_key", paused_select)
+
+    def attempt(kid: str) -> None:
+        with pytest.raises(VercelOidcVerificationError):
+            verify_vercel_oidc_token(sign(signing_key, kid=kid), **EXPECTATIONS)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(attempt, "forged-first")
+        assert outcome_pending.wait(timeout=5)
+        second = pool.submit(attempt, "forged-second")
+        time.sleep(0.25)  # let the second caller reach the fetch claim
+        record_outcome.set()
+        first.result(timeout=10)
+        second.result(timeout=10)
+
     assert route.call_count == 2
 
 

--- a/src/vercel-oidc/vercel/oidc/verify.py
+++ b/src/vercel-oidc/vercel/oidc/verify.py
@@ -118,20 +118,6 @@ def _store_jwks(url: str, document: JwksDocument) -> None:
         _jwks_cache[url] = (time.monotonic(), document)
 
 
-def _throttle_fetches(url: str) -> None:
-    """Suppress fetches for the rate-limit interval after an unproductive one."""
-    with _jwks_lock:
-        _jwks_throttled_until[url] = (
-            time.monotonic() + DEFAULT_JWKS_MIN_REFETCH_INTERVAL.total_seconds()
-        )
-
-
-def _allow_fetches(url: str) -> None:
-    """Clear the throttle after a fetch that produced the requested key."""
-    with _jwks_lock:
-        _jwks_throttled_until.pop(url, None)
-
-
 def _parse_jwks(payload: object) -> JwksDocument:
     if not isinstance(payload, dict) or not isinstance(payload.get("keys"), list):
         raise VercelOidcVerificationError("JWKS document is malformed")
@@ -155,9 +141,22 @@ def _claim_fetch(url: str) -> bool:
         return True
 
 
-def _end_fetch(url: str) -> None:
+def _end_fetch(url: str, *, productive: bool | None = None) -> None:
+    """Release the fetch claim, recording its outcome in the same critical section.
+
+    An unproductive fetch must set the throttle before the claim is released, or a
+    concurrent unknown-kid caller can claim a fresh fetch in the gap and a burst
+    fans out into repeated refetches. ``productive=None`` releases without touching
+    the throttle, for a fetch that did not run to completion.
+    """
     with _jwks_lock:
         _jwks_fetch_in_progress.discard(url)
+        if productive is True:
+            _jwks_throttled_until.pop(url, None)
+        elif productive is False:
+            _jwks_throttled_until[url] = (
+                time.monotonic() + DEFAULT_JWKS_MIN_REFETCH_INTERVAL.total_seconds()
+            )
 
 
 def _fetch_is_in_progress(url: str) -> bool:
@@ -166,12 +165,13 @@ def _fetch_is_in_progress(url: str) -> bool:
 
 
 def _select_and_record(url: str, kid: str, document: JwksDocument) -> RSAPublicKey | None:
-    """Select the key and record whether the fetch was productive."""
-    key = _select_key(document, kid)
-    if key is None:
-        _throttle_fetches(url)
-    else:
-        _allow_fetches(url)
+    """Select the key, then release the fetch claim with the outcome recorded."""
+    try:
+        key = _select_key(document, kid)
+    except BaseException:
+        _end_fetch(url, productive=False)
+        raise
+    _end_fetch(url, productive=key is not None)
     return key
 
 
@@ -182,7 +182,10 @@ def _record_fetch_outcome(
         document = fetch(url)
     except Exception:
         # A failing endpoint must not be retried by every caller.
-        _throttle_fetches(url)
+        _end_fetch(url, productive=False)
+        raise
+    except BaseException:
+        _end_fetch(url)
         raise
     return _select_and_record(url, kid, document)
 
@@ -191,7 +194,11 @@ async def _fetch_or_throttle_async(url: str) -> JwksDocument:
     try:
         return await _fetch_jwks_async(url)
     except Exception:
-        _throttle_fetches(url)
+        _end_fetch(url, productive=False)
+        raise
+    except BaseException:
+        # Cancelled mid-fetch: release the claim without recording an outcome.
+        _end_fetch(url)
         raise
 
 
@@ -227,16 +234,14 @@ def _fetch_jwks_sync_uncached(url: str) -> JwksDocument:
             response = client.get(url)
             response.raise_for_status()
             document = _parse_jwks(response.json())
-        # Stored before the marker is cleared, so a waiter that observes the fetch
-        # finishing always sees the document it produced.
+        # Stored before the caller releases the claim, so a waiter that observes
+        # the fetch finishing always sees the document it produced.
         _store_jwks(url, document)
         return document
     except VercelOidcVerificationError:
         raise
     except Exception as exc:
         raise VercelOidcVerificationError(f"could not fetch JWKS from {url}", exc) from exc
-    finally:
-        _end_fetch(url)
 
 
 async def _resolve_key_async(url: str, kid: str) -> RSAPublicKey | None:
@@ -271,15 +276,13 @@ async def _fetch_jwks_async(url: str) -> JwksDocument:
             response = await client.get(url)
             response.raise_for_status()
             document = _parse_jwks(response.json())
-        # Stored before the marker is cleared; see the sync twin.
+        # Stored before the caller releases the claim; see the sync twin.
         _store_jwks(url, document)
         return document
     except VercelOidcVerificationError:
         raise
     except Exception as exc:
         raise VercelOidcVerificationError(f"could not fetch JWKS from {url}", exc) from exc
-    finally:
-        _end_fetch(url)
 
 
 def _unverified_kid(token: str) -> str:


### PR DESCRIPTION
Fixes the intermittent `assert 3 == 2` failure in `test_unknown_kid_refetch_is_rate_limited_under_concurrency` that has been failing unrelated PRs.

The refetch path did three things in order: fetch the JWKS, release the single-flight claim, then record whether the fetch found the key. Between the last two steps, nothing holds the claim and no throttle is set yet. A concurrent unknown-kid caller landing in that moment starts its own fetch, so a burst of forged kids amplifies anyway.

Fast machines rarely hit the moment. CI's 2-core runners hit it most runs.

The fix is one rule: whoever holds the claim releases it in the same critical section that records the outcome.

```python
def _end_fetch(url, *, productive=None):
    with _jwks_lock:
        _jwks_fetch_in_progress.discard(url)
        if productive is True:    # key found: allow refetches
            _jwks_throttled_until.pop(url, None)
        elif productive is False: # not found or failed: throttle
            _jwks_throttled_until[url] = ...
```

Everything else is unchanged: same throttle interval, same waiter protocol, document still stored before release.

The new regression test makes the window deterministic instead of relying on thread timing: it pauses the first caller right where the gap used to be and sends a second caller through. Fails every run on the old code, passes on the fix.
