### PR TITLE
Read log records with getMessage in queue tests

### DIFF
--- a/src/vercel-queue/tests/unit/test_embedded_server.py
+++ b/src/vercel-queue/tests/unit/test_embedded_server.py
@@ -49,7 +49,9 @@ from .helpers import collect_messages, payloads
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 

--- a/src/vercel-queue/tests/unit/test_queue_accept_handle.py
+++ b/src/vercel-queue/tests/unit/test_queue_accept_handle.py
@@ -75,7 +75,9 @@ class _AsyncRequestLike:
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 

--- a/src/vercel-queue/tests/unit/test_queue_client_http.py
+++ b/src/vercel-queue/tests/unit/test_queue_client_http.py
@@ -38,7 +38,9 @@ from .helpers import make_leased_metadata
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 
@@ -639,7 +641,7 @@ def test_sync_retry_after_tolerates_missing_lease_with_warning(
         client.retry_after(make_leased_metadata("emails"), 5)
 
     assert any(
-        record.levelno == logging.WARNING and "no longer exists" in record.message
+        record.levelno == logging.WARNING and "no longer exists" in record.getMessage()
         for record in caplog.records
     )
 
@@ -696,7 +698,7 @@ async def test_async_retry_after_tolerates_missing_lease_with_warning(
         await client.retry_after(make_leased_metadata("emails"), 5)
 
     assert any(
-        record.levelno == logging.WARNING and "no longer exists" in record.message
+        record.levelno == logging.WARNING and "no longer exists" in record.getMessage()
         for record in caplog.records
     )
 

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -72,7 +72,9 @@ from .helpers import (
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 

--- a/src/vercel-queue/tests/unit/test_queue_polling.py
+++ b/src/vercel-queue/tests/unit/test_queue_polling.py
@@ -63,7 +63,9 @@ from .helpers import (
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 

--- a/src/vercel-queue/tests/unit/test_queue_push.py
+++ b/src/vercel-queue/tests/unit/test_queue_push.py
@@ -48,7 +48,9 @@ from .helpers import (
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 

--- a/src/vercel-queue/tests/unit/test_queue_subscriptions.py
+++ b/src/vercel-queue/tests/unit/test_queue_subscriptions.py
@@ -110,7 +110,9 @@ def _typecheck_str_container_examples() -> None:
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
     return [
-        json.loads(record.message) for record in caplog.records if record.name == "vercel.queue"
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name == "vercel.queue"
     ]
 
 


### PR DESCRIPTION
Fixes the intermittent `AttributeError: 'LogRecord' object has no attribute 'message'` in the lease debug-log test.

A `LogRecord` only gets its `.message` attribute when a handler formats it, and pytest's capture handler appends the record to `caplog.records` first and formats it second. A test that reads the log while a background thread (lease renewal, pollers) is mid-emit can catch a record in between: already in the list, not yet formatted.

`record.getMessage()` computes the same string on demand, so there is no gap to hit.

Only the lease test has failed so far, but the same helper is copy-pasted across seven queue test files, so all copies get the change, plus the two direct `.message` substring checks. No test behavior changes.
