### PR TITLE
Add package-owned example test tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,9 @@ jobs:
       - name: Test
         run: ./scripts/test.sh
 
+      - name: Test examples
+        if: matrix.python-version == '3.12'
+        run: uv run poe test-examples
+
       - name: Build package
         run: ./scripts/build.sh

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -40,5 +40,9 @@ jobs:
       - name: Run tests, including lint and typecheck
         run: ./scripts/test.sh
 
+      - name: Test examples
+        if: matrix.python-version == '3.12'
+        run: uv run poe test-examples
+
       - name: Build package
         run: ./scripts/build.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,13 @@
   scopes plus `-q`/`--quiet` and `-v`/`--verbose`; does not accept
   tool-specific options after `--`.
 - `uv run poe test` — Run tests (excludes example tests).
+- `uv run poe test-examples` — Run opted-in root and package example tests.
 - `uv run poe lint` — Run lint checks (ruff check + format).
 - `uv run poe typecheck` — Run type checks (mypy + ty).
 - `uv run poe fix` — Auto-fix lint issues and reformat code with ruff.
 - `./scripts/test-python-matrix.sh` — Run tests through tox across local Python
   versions. Accepts tox args before `--`, then normal `test.sh` scopes and
   pytest args after `--`.
-- `./scripts/test-examples.sh` — Run example tests in parallel. Accepts extra pytest args.
 
 The workspace `test`, `lint`, and `typecheck` Poe commands accept zero or more
 scopes before `--` and tool args after `--`. The aggregate `qa` command accepts
@@ -25,6 +25,23 @@ scopes but intentionally rejects tool-specific arguments after `--`.
 Example: `uv run poe test tests/unit/test_time.py -- -k coerce_duration`
 Or by package name: `uv run poe test vercel-oidc`.
 Matrix example: `./scripts/test-python-matrix.sh -e py310,py314 -- vercel-queue -- -k subscriptions`.
+
+Example tests use the same scope and pytest passthrough conventions:
+
+```sh
+uv run poe test-examples
+uv run poe test-examples vercel-sandbox
+uv run poe test-examples vercel-sandbox -- -k sessions_and_resume
+VERCEL_OIDC_TOKEN="$(vc project token)" uv run poe test-examples vercel-sandbox
+```
+
+Example testing is opt-in: a package declares a local
+`[tool.poe.tasks.test-examples]` task, and owns its executable-example
+selection, runner, pytest configuration, credentials, setup, and cleanup. The
+root package declares the public aggregate plus the internal
+`test-examples-root` task for root examples. Packages without a declaration are
+excluded from an unscoped aggregate and produce a clear error when requested
+explicitly.
 
 The workspace task system is documented in `scripts/poe/README.md`. Workspace
 packages should include `scripts/poe/poe.toml` and inherit the shared `lint`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,33 @@ uv run poe test vercel-oidc
 uv run poe typecheck vercel-queue
 ```
 
+Example tests are an opt-in workspace aggregate. Run all declared example
+tasks, or scope to one package and pass pytest arguments after `--`:
+
+```sh
+uv run poe test-examples
+uv run poe test-examples vercel-sandbox
+uv run poe test-examples vercel-sandbox -- -k sessions_and_resume
+```
+
+Each participating package owns its executable-example discovery, pytest
+runner and configuration, credential checks, setup, and cleanup. Packages opt
+in with a local `[tool.poe.tasks.test-examples]` declaration; packages without
+one are skipped by the unscoped aggregate and are rejected if explicitly
+requested. Root examples are run by the root package's internal
+`test-examples-root` task.
+
+The canonical task does not acquire credentials automatically. For local
+Sandbox runs, supply an OIDC token explicitly when needed:
+
+```sh
+VERCEL_OIDC_TOKEN="$(vc project token)" uv run poe test-examples vercel-sandbox
+```
+
+CI supplies `BLOB_READ_WRITE_TOKEN`, `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and
+`VERCEL_TEAM_ID`; package-owned checks skip live examples safely when those
+secrets are unavailable.
+
 Auto-fix formatting and simple lint issues with:
 
 ```sh

--- a/changes/vercel-sandbox/20260804120000.internal.md
+++ b/changes/vercel-sandbox/20260804120000.internal.md
@@ -1,0 +1,1 @@
+Run Sandbox examples through the package-owned workspace Poe task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,16 @@ args = [
 [tool.poe.tasks.test-root]
 cmd = "scripts/poe/workspace_poe.py root-task test-root"
 
+[tool.poe.tasks.test-examples]
+cmd = "scripts/poe/workspace_poe.py workspace test-examples --poe-verbose ${verbose:-false} ${scopes}"
+args = [
+  { name = "verbose", options = ["-v", "--verbose"], type = "boolean" },
+  { name = "scopes", positional = true, multiple = true },
+]
+
+[tool.poe.tasks.test-examples-root]
+cmd = "scripts/poe/workspace_poe.py root-task test-examples-root"
+
 [tool.poe.tasks.qa]
 cmd = "scripts/poe/workspace_poe.py qa --poe-quiet ${quiet} --poe-verbose ${verbose} ${scopes}"
 args = [

--- a/scripts/poe/README.md
+++ b/scripts/poe/README.md
@@ -14,7 +14,8 @@ its local configuration differences.
   scripts and Poe tasks. It uses lograil for concurrent process dashboards and
   plain-mode output capture.
 - `workspace_poe_resolve.py` attributes package names and paths to workspace
-  packages for scoped runs.
+  packages for scoped runs and filters opt-in aggregate tasks to packages that
+  declare them locally.
 
 The top-level `scripts/fix.sh`, `scripts/lint.sh`, `scripts/test.sh`, and
 `scripts/typecheck.sh` are symlinks to `scripts/workspace-task.sh`. The symlink
@@ -57,6 +58,21 @@ The shared include defines these Poe tasks:
 
 Most packages should not redefine these tasks. Prefer tool configuration in
 `pyproject.toml` and inherit the shared tasks.
+
+Example testing is intentionally not a shared default task. A package that
+owns executable examples opts in by declaring a local task:
+
+```toml
+[tool.poe.tasks.test-examples]
+cmd = "$PYTEST -m live tests/live/test_examples.py"
+```
+
+The package task owns example discovery, pytest configuration, credentials,
+setup, and cleanup. The root package exposes the aggregate
+`uv run poe test-examples` and maps root examples to its internal
+`test-examples-root` task. An unscoped aggregate selects only packages and the
+root that declare the corresponding task; an explicitly requested package
+without support fails with a concise declaration error.
 
 Set `WORKSPACE_POE_PARALLEL=0` to run workspace and shared package checks
 sequentially. `false` and `no` are accepted as equivalent opt-outs. This also
@@ -138,6 +154,9 @@ The equivalent Poe commands are available at the workspace root:
 uv run poe lint vercel-oidc
 uv run poe typecheck vercel-oidc
 uv run poe test src/vercel/tests/unit/test_time.py -- -k coerce_duration
+uv run poe test-examples
+uv run poe test-examples vercel-sandbox
+uv run poe test-examples vercel-sandbox -- -k sessions_and_resume
 uv run poe qa src/vercel/tests/unit/test_time.py
 ```
 
@@ -192,14 +211,24 @@ The managed `pre-push.checks` hook invokes `uv run poe pre-push`, which runs
 news-fragment, lint, typecheck, and test checks concurrently through the
 Python/lograil runner.
 
+Example tasks use package scopes before `--` and pytest arguments after it.
+They run in parallel with the same workspace labels and pytest output parsing
+as the standard test task. Missing credentials are handled by each package's
+own checks, so forked pull requests can safely run the aggregate. For a local
+Sandbox run, callers can provide an OIDC token explicitly:
+
+```sh
+VERCEL_OIDC_TOKEN="$(vc project token)" uv run poe test-examples vercel-sandbox
+```
+
 ## Maintenance
 
 When changing this system, verify all shell code with system's default bash
 (helps catching new bash-isms on macOS).
 
 ```sh
-shellcheck -x scripts/build.sh scripts/test-examples.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
-/bin/bash -n scripts/build.sh scripts/test-examples.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
+shellcheck -x scripts/build.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
+/bin/bash -n scripts/build.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
 python3 -m py_compile scripts/poe/workspace_poe.py scripts/poe/workspace_poe_resolve.py scripts/workspace-task.sh scripts/qa.sh scripts/workspace-root-task.sh
 ```
 

--- a/scripts/poe/workspace_poe.py
+++ b/scripts/poe/workspace_poe.py
@@ -17,6 +17,14 @@ RESOLVER = SCRIPT_DIR / "workspace_poe_resolve.py"
 PARALLEL_FALSE = {"0", "false", "no"}
 FAILURE_TAIL_LINES = 20
 QUIET_FAILURE_DETAIL = "workspace_poe.failure.detail"
+ROOT_TASKS = {
+    "fix": "fix-root",
+    "lint": "lint-root",
+    "test": "test-root",
+    "typecheck": "typecheck-root",
+    "test-examples": "test-examples-root",
+}
+PYTEST_TASKS = {"test", "test-examples"}
 
 
 @dataclass(frozen=True)
@@ -156,7 +164,7 @@ class WorkspaceRunner:
         poe_flags: Sequence[str] = (),
         verbose_output: bool = False,
     ) -> list[CommandSpec]:
-        root_task = f"{task}-root" if task in {"fix", "lint", "test", "typecheck"} else None
+        root_task = ROOT_TASKS.get(task)
         return [
             self.scope_command(
                 task,
@@ -218,7 +226,7 @@ class WorkspaceRunner:
         uv_scope = ("--all-packages",) if scope.package == "root" else ("--package", scope.package)
         env = self.base_env()
         env["WORKSPACE_POE_PACKAGE"] = scope.package
-        if task == "test":
+        if task in PYTEST_TASKS:
             env["WORKSPACE_POE_LOGRAIL_PROGRESS"] = "1"
         if scope.paths:
             env["WORKSPACE_POE_SCOPE_ARGS"] = shlex.join(scope.paths)
@@ -234,19 +242,26 @@ class WorkspaceRunner:
             display_label=scope.package,
             category=task,
             subject=scope.package,
-            parser="pytest" if task == "test" else None,
+            parser="pytest" if task in PYTEST_TASKS else None,
             quiet=task in {"lint", "typecheck"} and not verbose_output,
         )
 
     def resolve_scopes(self, task: str, argv: Sequence[str]) -> tuple[Scope, ...]:
         env = self.base_env()
         env["WORKSPACE_POE_SCOPE_TASK"] = task
-        output = subprocess.check_output(
-            (sys.executable, str(RESOLVER), *argv),
-            cwd=self.root,
-            env=env,
-            text=True,
-        )
+        try:
+            output = subprocess.check_output(
+                (sys.executable, str(RESOLVER), *argv),
+                cwd=self.root,
+                env=env,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or "").strip()
+            raise SystemExit(
+                detail or f"could not resolve scopes for workspace task {task!r}"
+            ) from None
         scopes: list[Scope] = []
         for line in output.splitlines():
             if not line:
@@ -384,6 +399,17 @@ def run_root_task(task: str, argv: Sequence[str]) -> int:
                 "pytest",
                 shlex.join((os.environ["PYTEST"], *args)),
                 category="test",
+                parser="pytest",
+            )
+        )
+    if task == "test-examples-root":
+        extra_args = list(argv) or poe_extra_args()
+        args = ["tests/test_examples.py", *extra_args]
+        return run_command(
+            env_command(
+                "pytest",
+                shlex.join((os.environ["PYTEST"], *args)),
+                category="test-examples",
                 parser="pytest",
             )
         )

--- a/scripts/poe/workspace_poe_resolve.py
+++ b/scripts/poe/workspace_poe_resolve.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from collections import OrderedDict
+from collections.abc import Iterable
 
 try:
     import tomllib
@@ -30,15 +31,65 @@ def workspace_packages() -> list[tuple[str, str]]:
     )
 
 
-def first_task_cwd(package_path: str, task_name: str) -> str:
-    if not task_name:
-        return package_path
+ROOT_TASKS = {
+    "fix": "fix-root",
+    "lint": "lint-root",
+    "test": "test-root",
+    "typecheck": "typecheck-root",
+    "test-examples": "test-examples-root",
+}
+OPT_IN_TASKS = frozenset({"test-examples"})
+
+
+def local_tasks(package_path: str) -> dict[str, object]:
     pyproject = os.path.join(package_path, "pyproject.toml")
     try:
         with open(pyproject, "rb") as file:
             tasks = tomllib.load(file).get("tool", {}).get("poe", {}).get("tasks", {})
     except FileNotFoundError:
+        return {}
+    return tasks if isinstance(tasks, dict) else {}
+
+
+def local_task_declared(package_path: str, task_name: str) -> bool:
+    return task_name in local_tasks(package_path)
+
+
+def task_for_scope(package: str, task_name: str) -> str:
+    return ROOT_TASKS.get(task_name, task_name) if package == "root" else task_name
+
+
+def task_is_supported(package: str, package_path: str, task_name: str) -> bool:
+    if task_name not in OPT_IN_TASKS:
+        return True
+    return local_task_declared(package_path, task_for_scope(package, task_name))
+
+
+def opt_in_packages(task_name: str, packages: Iterable[tuple[str, str]], root: str) -> set[str]:
+    selected = {
+        package
+        for package, package_path in packages
+        if task_is_supported(package, package_path, task_name)
+    }
+    if task_is_supported("root", root, task_name):
+        selected.add("root")
+    return selected
+
+
+def require_task_support(package: str, package_path: str, task_name: str) -> None:
+    if task_is_supported(package, package_path, task_name):
+        return
+    declared_task = task_for_scope(package, task_name)
+    raise SystemExit(
+        f"workspace task {task_name!r} is not declared by {package!r}; "
+        f"add [tool.poe.tasks.{declared_task}] to {os.path.join(package_path, 'pyproject.toml')}"
+    )
+
+
+def first_task_cwd(package_path: str, task_name: str) -> str:
+    if not task_name:
         return package_path
+    tasks = local_tasks(package_path)
 
     def first_cwd(name: str) -> str | None:
         task = tasks.get(name, {})
@@ -64,14 +115,19 @@ def main(argv: list[str]) -> int:
     scoped_paths: dict[str, list[str]] = {}
 
     if not argv:
-        package_selected.update(package_paths)
-        package_selected.add("root")
+        if task_name in OPT_IN_TASKS:
+            package_selected.update(opt_in_packages(task_name, packages, root))
+        else:
+            package_selected.update(package_paths)
+            package_selected.add("root")
 
     for arg in argv:
         if arg in package_paths:
+            require_task_support(arg, package_paths[arg], task_name)
             package_selected.add(arg)
             continue
         if arg == "root":
+            require_task_support("root", root, task_name)
             package_selected.add("root")
             continue
 
@@ -86,6 +142,7 @@ def main(argv: list[str]) -> int:
                     owner_path = package_path
 
         task_cwd = root if owner == "root" else first_task_cwd(owner_path, task_name)
+        require_task_support(owner, owner_path, task_name)
         scoped_paths.setdefault(owner, []).append(os.path.relpath(abs_arg, task_cwd))
 
     for package, package_path in packages:

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-uv run --all-packages pytest -v --capture=tee-sys tests/test_examples.py -n auto "$@"

--- a/src/vercel-sandbox/pyproject.toml
+++ b/src/vercel-sandbox/pyproject.toml
@@ -69,3 +69,6 @@ packages = ["vercel.sandbox"]
 
 [tool.poe.tasks.typecheck]
 cmd = "$MYPY"
+
+[tool.poe.tasks.test-examples]
+cmd = "$PYTEST -m live tests/live/test_examples.py"

--- a/src/vercel-sandbox/tests/live/test_examples.py
+++ b/src/vercel-sandbox/tests/live/test_examples.py
@@ -1,3 +1,7 @@
+"""Executable Sandbox examples."""
+
+from __future__ import annotations
+
 import os
 import shlex
 import subprocess
@@ -6,21 +10,23 @@ from pathlib import Path
 
 import pytest
 
-# Optional when credentials are unavailable, including forked pull requests.
-_has_explicit_vercel_credentials = bool(
-    (os.getenv("VERCEL_TOKEN") or os.getenv("VERCEL_OIDC_TOKEN"))
-    and os.getenv("VERCEL_PROJECT_ID")
-    and os.getenv("VERCEL_TEAM_ID")
-)
-_has_credentials = bool(os.getenv("BLOB_READ_WRITE_TOKEN") and _has_explicit_vercel_credentials)
-_examples_dir = Path(__file__).resolve().parents[1] / "examples"
+from .conftest import requires_sandbox_credentials
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
+_EXAMPLE_ARGUMENTS = {
+    "sandbox_04_dev_server.py": ("--destroy",),
+}
 
 
 def _discover_examples(directory: Path) -> list[Path]:
+    """Return only top-level, standalone Sandbox example programs."""
     if not directory.is_dir():
         return []
+
     examples = sorted(
-        path for path in directory.iterdir() if path.is_file() and path.suffix == ".py"
+        path
+        for path in directory.iterdir()
+        if path.is_file() and path.suffix == ".py" and path.name.startswith("sandbox_")
     )
     scope_args = shlex.split(os.getenv("WORKSPACE_POE_SCOPE_ARGS", ""))
     if not scope_args:
@@ -37,24 +43,19 @@ def _discover_examples(directory: Path) -> list[Path]:
     return selected or examples
 
 
-_example_files = _discover_examples(_examples_dir)
+_EXAMPLE_FILES = _discover_examples(_EXAMPLES_DIR)
 
 
-@pytest.mark.skipif(
-    not _has_credentials,
-    reason=(
-        "Requires BLOB_READ_WRITE_TOKEN, VERCEL_TOKEN or VERCEL_OIDC_TOKEN, "
-        "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID"
-    ),
-)
-@pytest.mark.parametrize("script_path", _example_files, ids=lambda p: p.name)
+@requires_sandbox_credentials
+@pytest.mark.live
+@pytest.mark.parametrize("script_path", _EXAMPLE_FILES, ids=lambda path: path.name)
 def test_example(script_path: Path) -> None:
-    """Run a single example script and verify it succeeds."""
+    """Run one standalone Sandbox example and verify it succeeds."""
     _run_example(script_path)
 
 
 def _run_example(script_path: Path) -> None:
-    command = [sys.executable, str(script_path)]
+    command = [sys.executable, str(script_path), *_EXAMPLE_ARGUMENTS.get(script_path.name, ())]
 
     try:
         result = subprocess.run(
@@ -63,18 +64,18 @@ def _run_example(script_path: Path) -> None:
             text=True,
             timeout=300,
         )
-    except subprocess.TimeoutExpired as e:
-        stdout = e.stdout.decode() if e.stdout else ""
-        stderr = e.stderr.decode() if e.stderr else ""
-        # Tail stdout to avoid overwhelming output
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout.decode() if isinstance(error.stdout, bytes) else error.stdout or ""
+        stderr = error.stderr.decode() if isinstance(error.stderr, bytes) else error.stderr or ""
         max_chars = 10000
         if len(stdout) > max_chars:
             stdout = f"... [{len(stdout) - max_chars} chars truncated] ...\n" + stdout[-max_chars:]
         pytest.fail(
-            f"{script_path.name} timed out after {e.timeout}s\n"
+            f"{script_path.name} timed out after {error.timeout}s\n"
             f"STDOUT (tail):\n{stdout}\n"
             f"STDERR:\n{stderr}"
         )
+
     assert result.returncode == 0, (
         f"{script_path.name} failed with code {result.returncode}\n"
         f"STDOUT:\n{result.stdout}\n"

--- a/tests/unit/test_workspace_poe.py
+++ b/tests/unit/test_workspace_poe.py
@@ -104,6 +104,42 @@ def test_scope_command_lograil_name_includes_task_and_package() -> None:
     assert command.subject == "root"
 
 
+def test_example_scope_command_maps_root_to_internal_task() -> None:
+    runner = object.__new__(workspace_poe.WorkspaceRunner)
+    runner.root = Path.cwd()
+    runner.project_root = None
+    scope = workspace_poe.Scope("root", Path.cwd())
+
+    command = runner.scope_command(
+        "test-examples",
+        scope,
+        ("-k", "sessions_and_resume"),
+        workspace_poe.ROOT_TASKS["test-examples"],
+    )
+
+    assert "test-examples-root" in command.argv
+    assert command.argv[-2:] == ("-k", "sessions_and_resume")
+    assert command.parser == "pytest"
+    assert command.env["WORKSPACE_POE_LOGRAIL_PROGRESS"] == "1"
+
+
+def test_example_scope_command_preserves_package_passthrough() -> None:
+    runner = object.__new__(workspace_poe.WorkspaceRunner)
+    runner.root = Path.cwd()
+    runner.project_root = None
+    scope = workspace_poe.Scope("vercel-sandbox", Path.cwd())
+
+    command = runner.scope_command(
+        "test-examples",
+        scope,
+        ("-k", "sessions_and_resume"),
+        workspace_poe.ROOT_TASKS["test-examples"],
+    )
+
+    assert command.argv[-3:] == ("test-examples", "-k", "sessions_and_resume")
+    assert command.parser == "pytest"
+
+
 def test_tool_command_lograil_name_includes_tool_and_package(monkeypatch) -> None:
     monkeypatch.setenv("WORKSPACE_POE_PACKAGE", "vercel-celery")
 

--- a/tests/unit/test_workspace_poe_resolve.py
+++ b/tests/unit/test_workspace_poe_resolve.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "poe" / "workspace_poe_resolve.py"
+SPEC = importlib.util.spec_from_file_location("workspace_poe_resolve", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+workspace_poe_resolve = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = workspace_poe_resolve
+SPEC.loader.exec_module(workspace_poe_resolve)
+
+
+def _declare_task(package_path: Path, task_name: str) -> None:
+    package_path.mkdir()
+    (package_path / "pyproject.toml").write_text(
+        f"[tool.poe.tasks.{task_name}]\ncmd = \"python -c 'pass'\"\n",
+        encoding="utf-8",
+    )
+
+
+def test_unscoped_opt_in_selection_includes_only_declared_tasks(tmp_path: Path) -> None:
+    supported = tmp_path / "supported"
+    unsupported = tmp_path / "unsupported"
+    root = tmp_path / "root"
+    _declare_task(supported, "test-examples")
+    _declare_task(root, "test-examples-root")
+    unsupported.mkdir()
+
+    packages = [("supported", str(supported)), ("unsupported", str(unsupported))]
+
+    assert workspace_poe_resolve.opt_in_packages("test-examples", packages, str(root)) == {
+        "supported",
+        "root",
+    }
+
+
+def test_explicit_supported_package_scope_is_accepted(tmp_path: Path) -> None:
+    package = tmp_path / "sandbox"
+    _declare_task(package, "test-examples")
+
+    workspace_poe_resolve.require_task_support("vercel-sandbox", str(package), "test-examples")
+
+
+def test_explicit_unsupported_package_scope_is_clear(tmp_path: Path) -> None:
+    package = tmp_path / "headers"
+    package.mkdir()
+
+    with pytest.raises(SystemExit, match="test-examples.*vercel-headers"):
+        workspace_poe_resolve.require_task_support("vercel-headers", str(package), "test-examples")
+
+
+def test_root_example_task_uses_internal_declaration(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    _declare_task(root, "test-examples-root")
+
+    assert workspace_poe_resolve.task_for_scope("root", "test-examples") == "test-examples-root"
+    assert workspace_poe_resolve.task_is_supported("root", str(root), "test-examples")
+
+
+def test_standard_tasks_remain_supported_without_local_declarations(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    package.mkdir()
+
+    assert workspace_poe_resolve.task_is_supported("package", str(package), "test")


### PR DESCRIPTION
Move example execution into package-owned Poe tasks and add an opt-in workspace aggregate with scoped passthrough.