### PR TITLE
Add sandbox auto-resume and session scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 - `uv` for package management, virtual environment construction, and running scripts
 - `ruff` for linting and formatting
 - `mypy` for type checking
+- Implementation code uses AnyIO primitives. Direct `asyncio` usage is allowed only in tests,
+  examples, and documentation.
 
 # Commands
 

--- a/scripts/poe/workspace_poe.py
+++ b/scripts/poe/workspace_poe.py
@@ -226,6 +226,7 @@ class WorkspaceRunner:
         uv_scope = ("--all-packages",) if scope.package == "root" else ("--package", scope.package)
         env = self.base_env()
         env["WORKSPACE_POE_PACKAGE"] = scope.package
+        env["WORKSPACE_POE_SCOPE_TASK"] = task
         if task in PYTEST_TASKS:
             env["WORKSPACE_POE_LOGRAIL_PROGRESS"] = "1"
         if scope.paths:

--- a/src/vercel-sandbox/README.md
+++ b/src/vercel-sandbox/README.md
@@ -30,3 +30,34 @@ Installing this package also provides the `vercel-sandbox` and `sandbox`
 console commands. Both are aliases that delegate all arguments to `npx sandbox`;
 they require Node.js with npm and `npx` installed. Node.js is not required when
 using the Python API directly.
+
+## Session lifecycles
+
+Sandbox-level process and filesystem operations resume a stopped sandbox
+lazily. The original sandbox handle adopts the replacement current session:
+
+```python
+box = await sandbox.get_sandbox(name="workspace")
+result = await box.run_process("python", ["script.py"])
+```
+
+Use `box.session()` when the session boundary should be explicit. Direct
+acquisition leaves the acquired session running, while managed acquisition
+stops exactly the session it yielded:
+
+```python
+active = await box.session()
+
+async with box.session() as exact_session:
+    await exact_session.run_process("python", ["script.py"])
+```
+
+The synchronous forms are `active = box.session()` and
+`with box.session() as exact_session:`. Operations through an explicit session
+remain pinned to its identity and never auto-resume. Operations through `box`
+may adopt a replacement; that replacement is not stopped by an older managed
+session scope.
+
+Managed sandbox and session exit does not wait for concurrent operations.
+Callers must join sandbox work before leaving a context when deterministic
+cleanup is required.

--- a/src/vercel-sandbox/examples/sandbox_05_sessions_and_resume.py
+++ b/src/vercel-sandbox/examples/sandbox_05_sessions_and_resume.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Demonstrate lazy sandbox resume and exact runtime-session scopes."""
+
+import asyncio
+from datetime import timedelta
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from vercel import sandbox
+from vercel.api import session
+from vercel.sandbox import SandboxStatus
+
+load_dotenv()
+
+
+async def main() -> None:
+    async with session():
+        await _main()
+
+
+async def _main() -> None:
+    name = f"vercel-py-sessions-{uuid4().hex[:12]}"
+
+    # Direct acquisition leaves the sandbox running. That is useful here
+    # because this example deliberately stops and resumes the same persistent
+    # sandbox several times before destroying it.
+    box = await sandbox.create_sandbox(
+        name=name,
+        runtime="python3.13",
+        persistent=True,
+        execution_time_limit=timedelta(minutes=2),
+    )
+
+    try:
+        await box.fs.write_text("workspace/message.txt", "hello from persistent storage\n")
+        stopped_session_id = box.current_session_id
+        await box.stop()
+
+        # Retrieval is passive: this lookup returns the stopped sandbox without
+        # starting a replacement runtime session.
+        box = await sandbox.get_sandbox(name=name)
+        assert box.current_session_id == stopped_session_id
+        assert box.current_session is not None
+        assert box.current_session.status is SandboxStatus.STOPPED
+        print(f"retrieved stopped session {stopped_session_id}")
+
+        # Sandbox-level process and filesystem operations resume lazily. The
+        # same box object adopts the replacement session before replaying this
+        # command. Use resume_sandbox(name=...) instead when startup should be
+        # explicit before the first operation.
+        result = await box.run_process(
+            "python",
+            [
+                "-c",
+                (
+                    "from pathlib import Path; "
+                    "print(Path('workspace/message.txt').read_text(), end='')"
+                ),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        resumed_session_id = box.current_session_id
+        assert resumed_session_id != stopped_session_id
+        print(f"auto-resumed as {resumed_session_id}: {result.stdout}", end="")
+
+        # box.session() makes the session boundary explicit. Managed use stops
+        # exactly the session yielded here, even if box later adopts a
+        # different session. active = await box.session() is the direct form
+        # when the acquired session should remain running.
+        async with box.session() as exact_session:
+            assert exact_session is box.current_session
+            exact_session_id = exact_session.id
+            exact_result = await exact_session.run_process(
+                "python",
+                ["-c", "print('running through an identity-bound session')"],
+                capture_output=True,
+                check=True,
+            )
+            print(f"{exact_session_id}: {exact_result.stdout}", end="")
+
+        assert exact_session.status is SandboxStatus.STOPPED
+        print(f"managed session {exact_session_id} stopped")
+
+        # The explicit session remains stopped and identity-bound. A later
+        # sandbox-level operation can resume box again and adopt a new current
+        # session.
+        await box.fs.write_text("workspace/after-session.txt", "replacement is active\n")
+        assert box.current_session_id != exact_session_id
+        print(f"sandbox resumed again as {box.current_session_id}")
+    finally:
+        await box.destroy()
+        print(f"destroyed sandbox {name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/vercel-sandbox/tests/live/test_examples.py
+++ b/src/vercel-sandbox/tests/live/test_examples.py
@@ -36,10 +36,17 @@ def _discover_examples(directory: Path) -> list[Path]:
     selected = []
     for scope_arg in scope_args:
         candidate = (Path.cwd() / scope_arg).resolve()
+        if candidate == Path(__file__).resolve():
+            return examples
         if candidate == directory:
             return examples
         if candidate.parent == directory and candidate in examples:
             selected.append(candidate)
+    if not selected and os.getenv("WORKSPACE_POE_SCOPE_TASK") == "test-examples":
+        raise pytest.UsageError(
+            f"no example scripts under {directory} matched the requested scope: "
+            f"{' '.join(scope_args)}"
+        )
     return selected or examples
 
 

--- a/src/vercel-sandbox/tests/sandbox_fixtures.py
+++ b/src/vercel-sandbox/tests/sandbox_fixtures.py
@@ -12,13 +12,20 @@ def sandbox_service_options(
     token: str = "token",
     team_id: str = "team_123",
     project_id: str = "prj_123",
+    sync: bool | None = None,
 ) -> list[ServiceOptions]:
     """Build Sandbox options for the test's current session mode."""
     credentials = SandboxCredentials(token=token, team_id=team_id, project_id=project_id)
 
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
+    if sync is None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            sync = True
+        else:
+            sync = False
+
+    if sync:
 
         def sync_credentials_factory() -> SandboxCredentials:
             return credentials

--- a/src/vercel-sandbox/tests/test_sandbox_api_client.py
+++ b/src/vercel-sandbox/tests/test_sandbox_api_client.py
@@ -43,6 +43,27 @@ class InvalidJsonTransport(BaseTransport):
         )
 
 
+class JsonTransport(BaseTransport):
+    def __init__(self, data: object) -> None:
+        self.data = data
+
+    async def send(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        params: QueryParamTypes | None = None,
+        body: RequestBody = None,
+        headers: HeaderTypes | None = None,
+        timeout: timedelta | None = None,
+        follow_redirects: bool | None = None,
+        stream: bool = False,
+        read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
+    ) -> httpx.Response:
+        return httpx.Response(200, json=self.data, request=httpx.Request(method, path))
+
+
 class _CompletedResponse(StreamingResponse):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
@@ -123,3 +144,49 @@ def test_format_url_path_quotes_placeholder_values() -> None:
         name="name/with spaces",
         command_id="cmd?x=1",
     ) == ("v2/sandboxes/name%2Fwith%20spaces/cmd%3Fx%3D1")
+
+
+async def test_stop_runtime_session_retains_sparse_sandbox_metadata() -> None:
+    client = _sandbox_client(
+        JsonTransport(
+            {
+                "session": {"id": "sbx_123", "status": "stopped"},
+                "sandbox": {
+                    "name": "preview",
+                    "currentSessionId": "sbx_123",
+                    "status": "stopped",
+                },
+            }
+        )
+    )
+
+    result = await client.stop_runtime_session(session_id="sbx_123")
+
+    assert result.session.status == "stopped"
+    assert result._sandbox_attached
+    assert result.sandbox is not None
+    assert result.sandbox.current_session_id == "sbx_123"
+    assert result.sandbox.project_id == "prj_123"
+    assert result.sandbox.raw == {
+        "name": "preview",
+        "currentSessionId": "sbx_123",
+        "status": "stopped",
+    }
+    assert not result.sandbox._routes_attached
+    assert not result.sandbox._current_session_attached
+
+
+async def test_stop_runtime_session_distinguishes_omitted_metadata() -> None:
+    client = _sandbox_client(JsonTransport({"session": {"id": "sbx_123", "status": "stopped"}}))
+
+    result = await client.stop_runtime_session(session_id="sbx_123")
+
+    assert result.sandbox is None
+    assert not result._sandbox_attached
+
+
+async def test_stop_runtime_session_rejects_replacement_identity() -> None:
+    client = _sandbox_client(JsonTransport({"session": {"id": "sbx_other", "status": "stopped"}}))
+
+    with pytest.raises(SandboxResponseError, match="different session identity"):
+        await client.stop_runtime_session(session_id="sbx_123")

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -3,7 +3,7 @@ import json
 import tarfile
 from collections.abc import AsyncIterator, Iterator
 from pathlib import PurePosixPath
-from typing import cast
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -111,6 +111,518 @@ def _tar_entries(content: bytes) -> dict[str, tuple[bytes, int]]:
     return entries
 
 
+_RECOVERABLE_FILESYSTEM_OPERATIONS = (
+    "read_bytes",
+    "write_text",
+    "batch",
+    "listdir",
+    "rename",
+)
+
+
+async def _run_async_filesystem_operation(handle: sandbox.Sandbox, operation: str) -> object:
+    if operation == "read_bytes":
+        return await handle.fs.read_bytes("message.txt")
+    if operation == "write_text":
+        await handle.fs.write_text("message.txt", "replacement")
+        return None
+    if operation == "batch":
+        async with handle.fs.batch() as batch:
+            batch.write_text("message.txt", "replacement")
+        return None
+    if operation == "listdir":
+        return await handle.fs.listdir("directory")
+    if operation == "rename":
+        await handle.fs.rename("before.txt", "after.txt")
+        return None
+    raise AssertionError(f"Unexpected filesystem operation: {operation}")
+
+
+def _run_sync_filesystem_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:
+    if operation == "read_bytes":
+        return handle.fs.read_bytes("message.txt")
+    if operation == "write_text":
+        handle.fs.write_text("message.txt", "replacement")
+        return None
+    if operation == "batch":
+        with handle.fs.batch() as batch:
+            batch.write_text("message.txt", "replacement")
+        return None
+    if operation == "listdir":
+        return handle.fs.listdir("directory")
+    if operation == "rename":
+        handle.fs.rename("before.txt", "after.txt")
+        return None
+    raise AssertionError(f"Unexpected filesystem operation: {operation}")
+
+
+def _install_filesystem_recovery_routes(
+    operation: str,
+) -> tuple[list[str], Any, tuple[Any, Any]]:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response("sbx_old"))
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response("sbx_new"))
+
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+
+    def stopped_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    if operation == "read_bytes":
+        old_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read").mock(
+            side_effect=stopped_handler
+        )
+        replacement_route = respx.post(
+            "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/read"
+        ).mock(return_value=httpx.Response(200, content=b"replacement"))
+    elif operation in {"write_text", "batch"}:
+        old_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/write").mock(
+            side_effect=stopped_handler
+        )
+        replacement_route = respx.post(
+            "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/write"
+        ).mock(return_value=httpx.Response(204))
+    else:
+        old_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+            side_effect=stopped_handler
+        )
+        command_id = f"{operation}_new"
+        replacement_route = respx.post(
+            "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
+        ).mock(return_value=httpx.Response(200, json=_command_response(command_id, "sbx_new")))
+        respx.get(f"https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd/{command_id}").mock(
+            return_value=httpx.Response(
+                200, json=_command_response(command_id, "sbx_new", exit_code=0)
+            )
+        )
+        respx.get(f"https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd/{command_id}/logs").mock(
+            return_value=_logs_response("listed\0file\0" if operation == "listdir" else "")
+        )
+
+    return events, resume_route, (old_route, replacement_route)
+
+
+@pytest.mark.parametrize("operation", _RECOVERABLE_FILESYSTEM_OPERATIONS)
+@respx.mock
+async def test_async_sandbox_filesystem_replays_recoverable_operations(
+    mock_env_clear: None, operation: str
+) -> None:
+    events, resume_route, (old_route, replacement_route) = _install_filesystem_recovery_routes(
+        operation
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        result = await _run_async_filesystem_operation(box, operation)
+
+    assert box.current_session_id == "sbx_new"
+    assert old_route.call_count == 1
+    assert replacement_route.call_count == 1
+    assert resume_route.call_count == 2
+    assert events == ["lookup", "old", "resume"]
+    if operation == "read_bytes":
+        assert result == b"replacement"
+    elif operation == "listdir":
+        assert result == [DirectoryEntry(path="listed", kind="file")]
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize("operation", _RECOVERABLE_FILESYSTEM_OPERATIONS)
+@respx.mock
+def test_sync_sandbox_filesystem_replays_recoverable_operations(
+    mock_env_clear: None, operation: str
+) -> None:
+    events, resume_route, (old_route, replacement_route) = _install_filesystem_recovery_routes(
+        operation
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        result = _run_sync_filesystem_operation(box, operation)
+
+    assert box.current_session_id == "sbx_new"
+    assert old_route.call_count == 1
+    assert replacement_route.call_count == 1
+    assert resume_route.call_count == 2
+    assert events == ["lookup", "old", "resume"]
+    if operation == "read_bytes":
+        assert result == b"replacement"
+    elif operation == "listdir":
+        assert result == [DirectoryEntry(path="listed", kind="file")]
+    else:
+        assert result is None
+
+
+@respx.mock
+async def test_async_lazy_reader_entry_recovers_and_binds_replacement_session(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response("sbx_stopped"))
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response("sbx_replacement"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    old_read = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_stopped/fs/read").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    replacement_read = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_replacement/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        reader = box.fs.open("message.txt", "rb")
+        assert sandbox_route.call_count == 1
+        assert not old_read.called
+        assert not replacement_read.called
+
+        async with reader:
+            assert await reader.read() == b"replacement"
+
+    assert box.current_session_id == "sbx_replacement"
+    assert sandbox_route.call_count == 2
+    assert old_read.call_count == 1
+    assert replacement_read.call_count == 1
+    assert events == ["lookup", "resume"]
+
+
+@respx.mock
+def test_sync_lazy_reader_entry_recovers_and_binds_replacement_session(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response("sbx_stopped"))
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response("sbx_replacement"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    old_read = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_stopped/fs/read").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    replacement_read = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_replacement/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        reader = box.fs.open("message.txt", "rb")
+        assert sandbox_route.call_count == 1
+        assert not old_read.called
+        assert not replacement_read.called
+
+        with reader:
+            assert reader.read() == b"replacement"
+
+    assert box.current_session_id == "sbx_replacement"
+    assert sandbox_route.call_count == 2
+    assert old_read.call_count == 1
+    assert replacement_read.call_count == 1
+    assert events == ["lookup", "resume"]
+
+
+@respx.mock
+async def test_async_entered_reader_stays_pinned_after_other_filesystem_recovery(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response("sbx_old"))
+        events.append("sbx_replacement")
+        return httpx.Response(200, json=_sandbox_response("sbx_replacement"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    data = {"error": {"code": "sandbox_stopped", "message": "stream stopped"}}
+    failure = SandboxApiError(httpx.Response(409, json=data), "stream stopped", data=data)
+    stream = _TrackedAsyncStream([b"first", b"-second"], failure=failure)
+
+    def bound_read(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if payload["path"] == "stream.txt":
+            return httpx.Response(200, stream=stream)
+        assert payload["path"] == "recover.txt"
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    bound_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read"
+    ).mock(side_effect=bound_read)
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_replacement/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"recovered"))
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        async with box.fs.open("stream.txt", "rb") as reader:
+            assert await reader.read(1) == b"f"
+            assert await box.fs.read_bytes("recover.txt") == b"recovered"
+            assert box.current_session_id == "sbx_replacement"
+            assert await reader.read(6) == b"irst-s"
+            with pytest.raises(SandboxApiError) as exc_info:
+                await reader.read()
+
+    assert exc_info.value is failure
+    assert stream.aclose_called
+    assert sandbox_route.call_count == 2
+    assert bound_read_route.call_count == 2
+    assert replacement_read_route.call_count == 1
+    assert events == ["lookup", "sbx_replacement"]
+
+
+@respx.mock
+def test_sync_entered_reader_stays_pinned_after_other_filesystem_recovery(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response("sbx_old"))
+        events.append("sbx_replacement")
+        return httpx.Response(200, json=_sandbox_response("sbx_replacement"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    data = {"error": {"code": "sandbox_stopped", "message": "stream stopped"}}
+    failure = SandboxApiError(httpx.Response(409, json=data), "stream stopped", data=data)
+    stream = _TrackedSyncStream([b"first", b"-second"], failure=failure)
+
+    def bound_read(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if payload["path"] == "stream.txt":
+            return httpx.Response(200, stream=stream)
+        assert payload["path"] == "recover.txt"
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    bound_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read"
+    ).mock(side_effect=bound_read)
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_replacement/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"recovered"))
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with box.fs.open("stream.txt", "rb") as reader:
+            assert reader.read(1) == b"f"
+            assert box.fs.read_bytes("recover.txt") == b"recovered"
+            assert box.current_session_id == "sbx_replacement"
+            assert reader.read(6) == b"irst-s"
+            with pytest.raises(SandboxApiError) as exc_info:
+                reader.read()
+
+    assert exc_info.value is failure
+    assert stream.close_called
+    assert sandbox_route.call_count == 2
+    assert bound_read_route.call_count == 2
+    assert replacement_read_route.call_count == 1
+    assert events == ["lookup", "sbx_replacement"]
+
+
+@respx.mock
+async def test_async_active_writer_finish_lifecycle_failure_does_not_resume(
+    mock_env_clear: None,
+) -> None:
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=[
+            httpx.Response(200, json=_sandbox_response("sbx_old")),
+            httpx.Response(200, json=_sandbox_response("sbx_bound")),
+        ]
+    )
+    write_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_bound/fs/write").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "stream stopped"}},
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        with pytest.raises(SandboxFilesystemWriteError) as exc_info:
+            async with box.fs.open("stream.txt", "wb", size=7) as writer:
+                await writer.write(b"partial")
+
+    assert exc_info.value.cause.code == "sandbox_stopped"
+    assert write_route.call_count == 1
+    assert sandbox_route.call_count == 2
+
+
+@respx.mock
+def test_sync_active_writer_finish_lifecycle_failure_does_not_resume(
+    mock_env_clear: None,
+) -> None:
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=[
+            httpx.Response(200, json=_sandbox_response("sbx_old")),
+            httpx.Response(200, json=_sandbox_response("sbx_bound")),
+        ]
+    )
+    write_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_bound/fs/write").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "stream stopped"}},
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with pytest.raises(SandboxFilesystemWriteError) as exc_info:
+            with box.fs.open("stream.txt", "wb", size=7) as writer:
+                writer.write(b"partial")
+
+    assert exc_info.value.cause.code == "sandbox_stopped"
+    assert write_route.call_count == 1
+    assert sandbox_route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.parametrize("sync", [False, True])
+async def test_unsized_writer_recovers_at_publish(
+    mock_env_clear: None,
+    sync: bool,
+) -> None:
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=[
+            httpx.Response(200, json=_sandbox_response("sbx_old")),
+            httpx.Response(200, json=_sandbox_response("sbx_new")),
+        ]
+    )
+    old_write = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/write").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    new_write = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/write").mock(
+        return_value=httpx.Response(204)
+    )
+
+    if sync:
+        with session(service_options=_session_options()):
+            sync_box = sandbox_sync.get_sandbox(name="preview")
+            with sync_box.fs.open("replay.txt", "wb") as writer:
+                writer.write(b"replayable")
+    else:
+        async with session(service_options=_session_options()):
+            async_box = await sandbox.get_sandbox(name="preview")
+            async with async_box.fs.open("replay.txt", "wb") as writer:
+                await writer.write(b"replayable")
+
+    assert sandbox_route.call_count == 2
+    assert old_write.call_count == 1
+    assert new_write.call_count == 1
+    assert (
+        _tar_entries(new_write.calls[0].request.content)["vercel/sandbox/replay.txt"][0]
+        == b"replayable"
+    )
+
+
+@respx.mock
+async def test_async_runtime_session_filesystem_and_lazy_handle_do_not_resume(
+    mock_env_clear: None,
+) -> None:
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response("sbx_stopped"))
+    )
+    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_stopped/fs/read").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        runtime_session = box.current_session
+        assert runtime_session is not None
+        lazy_reader = runtime_session.fs.open("message.txt", "rb")
+        assert sandbox_route.call_count == 1
+        assert read_route.call_count == 0
+
+        with pytest.raises(SandboxApiError, match="session is stopped"):
+            await runtime_session.fs.read_bytes("message.txt")
+        with pytest.raises(SandboxApiError, match="session is stopped"):
+            async with lazy_reader:
+                pass
+
+    assert read_route.call_count == 2
+    assert sandbox_route.call_count == 1
+
+
+@respx.mock
+def test_sync_runtime_session_filesystem_and_lazy_handle_do_not_resume(
+    mock_env_clear: None,
+) -> None:
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response("sbx_stopped"))
+    )
+    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_stopped/fs/read").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        runtime_session = box.current_session
+        assert runtime_session is not None
+        lazy_reader = runtime_session.fs.open("message.txt", "rb")
+        assert sandbox_route.call_count == 1
+        assert read_route.call_count == 0
+
+        with pytest.raises(SandboxApiError, match="session is stopped"):
+            runtime_session.fs.read_bytes("message.txt")
+        with pytest.raises(SandboxApiError, match="session is stopped"):
+            with lazy_reader:
+                pass
+
+    assert read_route.call_count == 2
+    assert sandbox_route.call_count == 1
+
+
 @pytest.mark.parametrize(
     ("mode", "options", "error_type"),
     [
@@ -200,6 +712,9 @@ async def test_async_unknown_size_writer_publishes_temporary_spool(
     respx.post("https://sandbox.test/v2/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
     write = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
         return_value=httpx.Response(204)
     )
@@ -222,6 +737,9 @@ async def test_async_binary_writer_rejects_incomplete_declared_size(
     mock_env_clear: None, content: bytes
 ) -> None:
     respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
@@ -275,6 +793,9 @@ async def test_filesystem_target_binding_tracks_sandbox_but_not_runtime_session(
         return_value=httpx.Response(200, json=_sandbox_response("sbx_1"))
     )
     respx.patch("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response("sbx_2"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response("sbx_2"))
     )
     first = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/mkdir").mock(
@@ -481,6 +1002,9 @@ def test_sync_unknown_size_writer_publishes_temporary_spool(mock_env_clear: None
     respx.post("https://sandbox.test/v2/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
     write = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
         return_value=httpx.Response(204)
     )
@@ -503,6 +1027,9 @@ def test_sync_binary_writer_rejects_incomplete_declared_size(
     mock_env_clear: None, content: bytes
 ) -> None:
     respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
@@ -614,6 +1141,9 @@ async def test_text_reader_preserves_crlf_split_across_chunks(
 
     with respx.mock:
         respx.post("https://sandbox.test/v2/sandboxes").mock(
+            return_value=httpx.Response(200, json=_sandbox_response())
+        )
+        respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
             return_value=httpx.Response(200, json=_sandbox_response())
         )
         respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/read").mock(

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -540,7 +540,7 @@ async def test_unsized_writer_recovers_at_publish(
     )
 
     if sync:
-        with session(service_options=_session_options()):
+        with session(service_options=_session_options(sync=True)):
             sync_box = sandbox_sync.get_sandbox(name="preview")
             with sync_box.fs.open("replay.txt", "wb") as writer:
                 writer.write(b"replayable")

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -532,7 +532,7 @@ async def test_stream_binding_polls_transition_before_pinning_session(
     if sync:
         monkeypatch.setattr("vercel.sandbox._internal.sync_runtime.time.sleep", lambda _delay: None)
     else:
-        monkeypatch.setattr("vercel.sandbox._internal.async_runtime.asyncio.sleep", no_delay)
+        monkeypatch.setattr("vercel.sandbox._internal.async_runtime.anyio.sleep", no_delay)
 
     attempts = 0
 

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -519,6 +519,72 @@ def test_sync_active_writer_finish_lifecycle_failure_does_not_resume(
 
 @respx.mock
 @pytest.mark.parametrize("sync", [False, True])
+@pytest.mark.parametrize("error_code", ["sandbox_stopping", "sandbox_snapshotting"])
+async def test_stream_binding_polls_transition_before_pinning_session(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    sync: bool,
+    error_code: str,
+) -> None:
+    async def no_delay(_delay: float) -> None:
+        return None
+
+    if sync:
+        monkeypatch.setattr("vercel.sandbox._internal.sync_runtime.time.sleep", lambda _delay: None)
+    else:
+        monkeypatch.setattr("vercel.sandbox._internal.async_runtime.asyncio.sleep", no_delay)
+
+    attempts = 0
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.url.params["resume"] == "false":
+            return httpx.Response(200, json=_sandbox_response("sbx_old"))
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                409,
+                json={"error": {"code": error_code, "message": "transitioning"}},
+            )
+        return httpx.Response(200, json=_sandbox_response("sbx_new"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    old_session = cast(dict[str, object], _sandbox_response("sbx_old")["session"])
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session": {
+                    **old_session,
+                    "status": "stopped",
+                }
+            },
+        )
+    )
+    write_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/write").mock(
+        return_value=httpx.Response(204)
+    )
+
+    if sync:
+        with session(service_options=_session_options(sync=True)):
+            sync_box = sandbox_sync.get_sandbox(name="preview")
+            with sync_box.fs.open("stream.txt", "wb", size=4) as sync_writer:
+                sync_writer.write(b"data")
+    else:
+        async with session(service_options=_session_options()):
+            async_box = await sandbox.get_sandbox(name="preview")
+            async with async_box.fs.open("stream.txt", "wb", size=4) as async_writer:
+                await async_writer.write(b"data")
+
+    assert sandbox_route.call_count == 3
+    assert poll_route.call_count == 1
+    assert write_route.call_count == 1
+
+
+@respx.mock
+@pytest.mark.parametrize("sync", [False, True])
 async def test_unsized_writer_recovers_at_publish(
     mock_env_clear: None,
     sync: bool,

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -15,11 +15,11 @@ from vercel.api import session
 from vercel.sandbox import sync as sandbox_sync
 
 
-def _sandbox_response() -> dict[str, object]:
+def _sandbox_response(*, session_id: str = "sbx_1") -> dict[str, object]:
     return {
-        "sandbox": {"name": "preview", "currentSessionId": "sbx_1", "status": "running"},
+        "sandbox": {"name": "preview", "currentSessionId": session_id, "status": "running"},
         "session": {
-            "id": "sbx_1",
+            "id": session_id,
             "sourceSandboxName": "preview",
             "projectId": "prj_1",
             "status": "running",
@@ -33,6 +33,7 @@ def _process_response(
     *,
     args: list[str] | None = None,
     command_id: str = "cmd_1",
+    session_id: str = "sbx_1",
 ) -> dict[str, object]:
     return {
         "command": {
@@ -40,7 +41,7 @@ def _process_response(
             "name": "python",
             "args": args or [],
             "cwd": "/vercel/sandbox",
-            "sessionId": "sbx_1",
+            "sessionId": session_id,
             "exitCode": returncode,
             "startedAt": 1,
         }
@@ -55,12 +56,17 @@ def _logs_response() -> httpx.Response:
     return httpx.Response(200, text="".join(json.dumps(record) + "\n" for record in records))
 
 
-def _completed_response(returncode: int = 0, *, args: list[str] | None = None) -> httpx.Response:
+def _completed_response(
+    returncode: int = 0,
+    *,
+    args: list[str] | None = None,
+    session_id: str = "sbx_1",
+) -> httpx.Response:
     records = [
-        _process_response(args=args),
+        _process_response(args=args, session_id=session_id),
         {"stream": "stdout", "data": "out\n"},
         {"stream": "stderr", "data": "err\n"},
-        _process_response(returncode, args=args),
+        _process_response(returncode, args=args, session_id=session_id),
     ]
     return httpx.Response(200, text="".join(json.dumps(record) + "\n" for record in records))
 
@@ -612,6 +618,92 @@ def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
 
 
 @respx.mock
+async def test_async_run_process_replays_pre_stream_stopped_session_error(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-command")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_command_handler
+    )
+
+    def resume_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=resume_handler)
+
+    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-command")
+        return _completed_response(session_id="sbx_new")
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        side_effect=replacement_command_handler
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        result = await box.run_process("python", capture_output=True)
+
+    assert result.session_id == "sbx_new"
+    assert result.stdout == "out\n"
+    assert events == ["old-command", "resume", "replacement-command"]
+
+
+@respx.mock
+def test_sync_run_process_replays_pre_stream_stopped_session_error(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-command")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_command_handler
+    )
+
+    def resume_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=resume_handler)
+
+    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-command")
+        return _completed_response(session_id="sbx_new")
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        side_effect=replacement_command_handler
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        result = box.run_process("python", capture_output=True)
+
+    assert result.session_id == "sbx_new"
+    assert result.stdout == "out\n"
+    assert events == ["old-command", "resume", "replacement-command"]
+
+
+@respx.mock
 async def test_async_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
     respx.post("https://sandbox.test/v2/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
@@ -784,3 +876,73 @@ async def test_run_process_rejects_invalid_streams(
         box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
         with pytest.raises(error, match=match):
             await box.run_process("python")
+
+
+@respx.mock
+async def test_async_run_process_does_not_replay_lifecycle_stream_errors(
+    mock_env_clear: None,
+) -> None:
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
+        return_value=httpx.Response(
+            200,
+            text="".join(
+                json.dumps(record) + "\n"
+                for record in (
+                    _process_response(),
+                    {
+                        "stream": "error",
+                        "data": {"code": "sandbox_stopped", "message": "stream stopped"},
+                    },
+                )
+            ),
+        )
+    )
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        with pytest.raises(sandbox.SandboxStreamError, match="stream stopped") as exc_info:
+            await box.run_process("python")
+
+    assert exc_info.value.code == "sandbox_stopped"
+    assert not resume_route.called
+
+
+@respx.mock
+def test_sync_run_process_does_not_replay_lifecycle_stream_errors(
+    mock_env_clear: None,
+) -> None:
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
+        return_value=httpx.Response(
+            200,
+            text="".join(
+                json.dumps(record) + "\n"
+                for record in (
+                    _process_response(),
+                    {
+                        "stream": "error",
+                        "data": {"code": "sandbox_stopped", "message": "stream stopped"},
+                    },
+                )
+            ),
+        )
+    )
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        with pytest.raises(sandbox.SandboxStreamError, match="stream stopped") as exc_info:
+            box.run_process("python")
+
+    assert exc_info.value.code == "sandbox_stopped"
+    assert not resume_route.called

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -1,8 +1,11 @@
+import asyncio
 import io
 import json
 import signal
 import subprocess
 from collections.abc import AsyncIterator, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 
 import httpx
 import pytest
@@ -13,6 +16,10 @@ from vercel import sandbox
 from vercel._internal.core.options import ServiceOptions
 from vercel.api import session
 from vercel.sandbox import sync as sandbox_sync
+from vercel.sandbox._internal.state import (
+    SandboxRuntimeSessionState,
+    SandboxState,
+)
 
 
 def _sandbox_response(*, session_id: str = "sbx_1") -> dict[str, object]:
@@ -592,32 +599,6 @@ async def test_async_run_process_reads_chunked_ndjson(mock_env_clear: None) -> N
 
 
 @respx.mock
-def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
-    )
-    stream = _TrackingSyncStream(
-        _chunked_ndjson(
-            _process_response(),
-            {"stream": "stdout", "data": "café\n"},
-            {"stream": "stderr", "data": "雪\n"},
-            _process_response(0),
-        )
-    )
-    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
-        return_value=httpx.Response(200, stream=stream)
-    )
-
-    with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
-        result = box.run_process("python", capture_output=True)
-
-    assert result.stdout == "café\n"
-    assert result.stderr == "雪\n"
-    assert stream.closed
-
-
-@respx.mock
 async def test_async_run_process_replays_pre_stream_stopped_session_error(
     mock_env_clear: None,
 ) -> None:
@@ -629,7 +610,7 @@ async def test_async_run_process_replays_pre_stream_stopped_session_error(
     def old_command_handler(_request: httpx.Request) -> httpx.Response:
         events.append("old-command")
         return httpx.Response(
-            409,
+            410,
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
 
@@ -672,7 +653,7 @@ def test_sync_run_process_replays_pre_stream_stopped_session_error(
     def old_command_handler(_request: httpx.Request) -> httpx.Response:
         events.append("old-command")
         return httpx.Response(
-            409,
+            410,
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
 
@@ -701,6 +682,32 @@ def test_sync_run_process_replays_pre_stream_stopped_session_error(
     assert result.session_id == "sbx_new"
     assert result.stdout == "out\n"
     assert events == ["old-command", "resume", "replacement-command"]
+
+
+@respx.mock
+def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    stream = _TrackingSyncStream(
+        _chunked_ndjson(
+            _process_response(),
+            {"stream": "stdout", "data": "café\n"},
+            {"stream": "stderr", "data": "雪\n"},
+            _process_response(0),
+        )
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
+        return_value=httpx.Response(200, stream=stream)
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        result = box.run_process("python", capture_output=True)
+
+    assert result.stdout == "café\n"
+    assert result.stderr == "雪\n"
+    assert stream.closed
 
 
 @respx.mock
@@ -946,3 +953,472 @@ def test_sync_run_process_does_not_replay_lifecycle_stream_errors(
 
     assert exc_info.value.code == "sandbox_stopped"
     assert not resume_route.called
+
+
+def _stopped_error() -> sandbox.SandboxApiError:
+    data = {"error": {"code": "sandbox_stopped", "message": "session stopped"}}
+    return sandbox.SandboxApiError(httpx.Response(409), "session stopped", data=data)
+
+
+def _transition_error() -> sandbox.SandboxApiError:
+    data = {"error": {"code": "sandbox_stopping", "message": "sandbox stopping"}}
+    return sandbox.SandboxApiError(httpx.Response(409), "sandbox stopping", data=data)
+
+
+class _AsyncCoordinatedRecoveryService:
+    def __init__(self, *, resume_error: BaseException | None = None) -> None:
+        self.allow_resume = asyncio.Event()
+        self.resume_started = asyncio.Event()
+        self.resume_finished = asyncio.Event()
+        self.second_failure = asyncio.Event()
+        self.operation_count = 0
+        self.resume_count = 0
+        self.resume_error = resume_error
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        self.operation_count += 1
+        if session_id == "sbx_old":
+            if self.operation_count >= 2:
+                self.second_failure.set()
+            raise _stopped_error()
+        return []
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        self.resume_count += 1
+        self.resume_started.set()
+        await self.allow_resume.wait()
+        if self.resume_error is not None:
+            raise self.resume_error
+        result = SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+        self.resume_finished.set()
+        return result
+
+
+def _async_coordinated_box(
+    service: _AsyncCoordinatedRecoveryService,
+) -> sandbox.Sandbox:
+    return sandbox.Sandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPED
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+
+async def test_async_recovery_shares_resume_when_initiating_waiter_is_cancelled() -> None:
+    service = _AsyncCoordinatedRecoveryService()
+    box = _async_coordinated_box(service)
+
+    initiating = asyncio.create_task(box.query_processes())
+    await service.resume_started.wait()
+    waiting = asyncio.create_task(box.query_processes())
+    await service.second_failure.wait()
+    initiating.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await initiating
+    service.allow_resume.set()
+
+    assert await waiting == []
+    assert service.resume_count == 1
+    assert box.current_session_id == "sbx_new"
+
+
+async def test_async_recovery_finishes_and_applies_state_after_all_waiters_cancel() -> None:
+    service = _AsyncCoordinatedRecoveryService()
+    box = _async_coordinated_box(service)
+
+    first = asyncio.create_task(box.query_processes())
+    await service.resume_started.wait()
+    second = asyncio.create_task(box.query_processes())
+    await service.second_failure.wait()
+    first.cancel()
+    second.cancel()
+    results = await asyncio.gather(first, second, return_exceptions=True)
+    assert all(isinstance(result, asyncio.CancelledError) for result in results)
+
+    service.allow_resume.set()
+    await service.resume_finished.wait()
+    assert service.resume_count == 1
+    assert box.current_session_id == "sbx_new"
+
+
+async def test_async_recovery_shares_failure_and_clears_slot_for_retry() -> None:
+    resume_error = RuntimeError("resume failed")
+    service = _AsyncCoordinatedRecoveryService(resume_error=resume_error)
+    box = _async_coordinated_box(service)
+
+    first = asyncio.create_task(box.query_processes())
+    await service.resume_started.wait()
+    second = asyncio.create_task(box.query_processes())
+    await service.second_failure.wait()
+    service.allow_resume.set()
+    results = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert results == [resume_error, resume_error]
+    assert service.resume_count == 1
+    service.resume_error = None
+    assert await box.query_processes() == []
+    assert service.resume_count == 2
+
+
+class _DelayedLifecycleFailureService:
+    def __init__(self) -> None:
+        self.arrived = (asyncio.Event(), asyncio.Event())
+        self.release = (asyncio.Event(), asyncio.Event())
+        self.old_operation_count = 0
+        self.resume_count = 0
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        if session_id != "sbx_old":
+            return []
+        index = self.old_operation_count
+        self.old_operation_count += 1
+        self.arrived[index].set()
+        await self.release[index].wait()
+        raise _stopped_error()
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        self.resume_count += 1
+        return SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+
+
+async def test_delayed_async_lifecycle_failure_may_resume_again_after_slot_clears() -> None:
+    service = _DelayedLifecycleFailureService()
+    box = sandbox.Sandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPED
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+    first = asyncio.create_task(box.query_processes())
+    second = asyncio.create_task(box.query_processes())
+    await asyncio.gather(*(event.wait() for event in service.arrived))
+    service.release[0].set()
+    assert await first == []
+    service.release[1].set()
+    assert await second == []
+
+    assert service.resume_count == 2
+    assert box.current_session_id == "sbx_new"
+
+
+class _SyncCoordinatedRecoveryService:
+    def __init__(
+        self,
+        *,
+        interrupt_first_resume: bool = False,
+        first_resume_error: Exception | None = None,
+    ) -> None:
+        self.allow_resume = Event()
+        self.resume_returning = Event()
+        self.resume_started = Event()
+        self.second_failure = Event()
+        self._lock = Lock()
+        self._interrupt_first_resume = interrupt_first_resume
+        self.first_resume_error = first_resume_error
+        self.operation_count = 0
+        self.resume_count = 0
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        with self._lock:
+            self.operation_count += 1
+            operation_count = self.operation_count
+        if session_id == "sbx_old":
+            if operation_count >= 2:
+                self.second_failure.set()
+            raise _stopped_error()
+        return []
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        with self._lock:
+            self.resume_count += 1
+            resume_count = self.resume_count
+        if resume_count == 1:
+            self.resume_started.set()
+            assert self.allow_resume.wait(timeout=5)
+            if self._interrupt_first_resume:
+                raise KeyboardInterrupt
+            if self.first_resume_error is not None:
+                raise self.first_resume_error
+        self.resume_returning.set()
+        return SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+
+
+def _sync_coordinated_box(
+    service: _SyncCoordinatedRecoveryService,
+) -> sandbox_sync.SyncSandbox:
+    return sandbox_sync.SyncSandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPED
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("interrupt_initiator", [False, True])
+def test_sync_recovery_shares_or_re_elects_after_initiator_interruption(
+    interrupt_initiator: bool,
+) -> None:
+    service = _SyncCoordinatedRecoveryService(interrupt_first_resume=interrupt_initiator)
+    box = _sync_coordinated_box(service)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        initiating = executor.submit(box.query_processes)
+        assert service.resume_started.wait(timeout=5)
+        waiting = executor.submit(box.query_processes)
+        assert service.second_failure.wait(timeout=5)
+        service.allow_resume.set()
+        if interrupt_initiator:
+            with pytest.raises(KeyboardInterrupt):
+                initiating.result(timeout=5)
+        else:
+            assert initiating.result(timeout=5) == []
+        assert waiting.result(timeout=5) == []
+
+    assert service.resume_count == (2 if interrupt_initiator else 1)
+    assert box.current_session_id == "sbx_new"
+
+
+def test_sync_recovery_shares_failure_and_clears_slot_for_retry() -> None:
+    resume_error = RuntimeError("resume failed")
+    service = _SyncCoordinatedRecoveryService(first_resume_error=resume_error)
+    box = _sync_coordinated_box(service)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        initiating = executor.submit(box.query_processes)
+        assert service.resume_started.wait(timeout=5)
+        waiting = executor.submit(box.query_processes)
+        assert service.second_failure.wait(timeout=5)
+        service.allow_resume.set()
+        for participant in (initiating, waiting):
+            with pytest.raises(RuntimeError) as exc_info:
+                participant.result(timeout=5)
+            assert exc_info.value is resume_error
+
+    assert service.resume_count == 1
+    service.first_resume_error = None
+    assert box.query_processes() == []
+    assert service.resume_count == 2
+
+
+class _AsyncTransitionCoordinationService:
+    def __init__(self) -> None:
+        self.allow_resume = asyncio.Event()
+        self.resume_started = asyncio.Event()
+        self.second_poll_arrived = asyncio.Event()
+        self.second_poll_returning = asyncio.Event()
+        self.operation_count = 0
+        self.poll_count = 0
+        self.resume_count = 0
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        self.operation_count += 1
+        if session_id == "sbx_old":
+            raise _transition_error()
+        return []
+
+    async def get_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
+        assert session_id == "sbx_old"
+        self.poll_count += 1
+        poll_number = self.poll_count
+        if poll_number == 1:
+            await self.second_poll_arrived.wait()
+        else:
+            self.second_poll_arrived.set()
+            await self.resume_started.wait()
+            self.second_poll_returning.set()
+        return SandboxRuntimeSessionState(id="sbx_old", status=sandbox.SandboxStatus.STOPPED)
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        self.resume_count += 1
+        self.resume_started.set()
+        await self.allow_resume.wait()
+        return SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+
+
+async def test_async_transition_callers_poll_independently_and_share_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_delay(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_delay)
+    service = _AsyncTransitionCoordinationService()
+    box = sandbox.Sandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPING
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+    first = asyncio.create_task(box.query_processes())
+    second = asyncio.create_task(box.query_processes())
+    await service.second_poll_returning.wait()
+    service.allow_resume.set()
+
+    assert await asyncio.gather(first, second) == [[], []]
+    assert service.poll_count == 2
+    assert service.resume_count == 1
+    assert service.operation_count == 4
+
+
+class _SyncTransitionCoordinationService:
+    def __init__(self) -> None:
+        self.allow_resume = Event()
+        self.resume_started = Event()
+        self.second_poll_arrived = Event()
+        self.second_poll_returning = Event()
+        self._lock = Lock()
+        self.operation_count = 0
+        self.poll_count = 0
+        self.resume_count = 0
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        with self._lock:
+            self.operation_count += 1
+        if session_id == "sbx_old":
+            raise _transition_error()
+        return []
+
+    async def get_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
+        assert session_id == "sbx_old"
+        with self._lock:
+            self.poll_count += 1
+            poll_number = self.poll_count
+        if poll_number == 1:
+            assert self.second_poll_arrived.wait(timeout=5)
+        else:
+            self.second_poll_arrived.set()
+            assert self.resume_started.wait(timeout=5)
+            self.second_poll_returning.set()
+        return SandboxRuntimeSessionState(id="sbx_old", status=sandbox.SandboxStatus.STOPPED)
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        with self._lock:
+            self.resume_count += 1
+        self.resume_started.set()
+        assert self.allow_resume.wait(timeout=5)
+        return SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+
+
+def test_sync_transition_callers_poll_independently_and_share_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("vercel.sandbox._internal.sync_runtime.time.sleep", lambda _delay: None)
+    service = _SyncTransitionCoordinationService()
+    box = sandbox_sync.SyncSandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPING
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(box.query_processes)
+        second = executor.submit(box.query_processes)
+        assert service.second_poll_returning.wait(timeout=5)
+        service.allow_resume.set()
+        assert first.result(timeout=5) == []
+        assert second.result(timeout=5) == []
+
+    assert service.poll_count == 2
+    assert service.resume_count == 1
+    assert service.operation_count == 4
+
+
+class _SyncPollingExitService:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+        self.operation_count = 0
+        self.poll_count = 0
+        self.resume_count = 0
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        self.operation_count += 1
+        raise _transition_error()
+
+    async def get_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
+        self.poll_count += 1
+        raise self.error
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        self.resume_count += 1
+        raise AssertionError("poll exit must not resume")
+
+
+@pytest.mark.parametrize("poll_error", [RuntimeError("poll failed"), KeyboardInterrupt()])
+def test_sync_transition_poll_failure_or_interruption_exits_without_resume(
+    monkeypatch: pytest.MonkeyPatch,
+    poll_error: BaseException,
+) -> None:
+    monkeypatch.setattr("vercel.sandbox._internal.sync_runtime.time.sleep", lambda _delay: None)
+    service = _SyncPollingExitService(poll_error)
+    box = sandbox_sync.SyncSandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.STOPPING
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(type(poll_error)) as exc_info:
+        box.query_processes()
+
+    assert exc_info.value is poll_error
+    assert service.operation_count == 1
+    assert service.poll_count == 1
+    assert service.resume_count == 0

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -1,4 +1,3 @@
-import asyncio
 import io
 import json
 import signal
@@ -8,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from threading import Event, Lock
 
+import anyio
 import httpx
 import pytest
 import respx
@@ -968,10 +968,10 @@ def _transition_error() -> sandbox.SandboxApiError:
 
 class _AsyncCoordinatedRecoveryService:
     def __init__(self, *, resume_error: BaseException | None = None) -> None:
-        self.allow_resume = asyncio.Event()
-        self.resume_started = asyncio.Event()
-        self.resume_finished = asyncio.Event()
-        self.second_failure = asyncio.Event()
+        self.allow_resume = anyio.Event()
+        self.resume_started = anyio.Event()
+        self.resume_finished = anyio.Event()
+        self.second_failure = anyio.Event()
         self.operation_count = 0
         self.resume_count = 0
         self.resume_error = resume_error
@@ -1016,54 +1016,108 @@ def _async_coordinated_box(
     )
 
 
-async def test_async_recovery_shares_resume_when_initiating_waiter_is_cancelled() -> None:
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_recovery_shares_success(anyio_backend: str) -> None:
     service = _AsyncCoordinatedRecoveryService()
     box = _async_coordinated_box(service)
+    results: list[list[sandbox.Process]] = []
 
-    initiating = asyncio.create_task(box.query_processes())
-    await service.resume_started.wait()
-    waiting = asyncio.create_task(box.query_processes())
-    await service.second_failure.wait()
-    initiating.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await initiating
-    service.allow_resume.set()
+    async def query() -> None:
+        results.append(await box.query_processes())
 
-    assert await waiting == []
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(query)
+        await service.resume_started.wait()
+        task_group.start_soon(query)
+        await service.second_failure.wait()
+        service.allow_resume.set()
+
+    assert results == [[], []]
     assert service.resume_count == 1
     assert box.current_session_id == "sbx_new"
 
 
-async def test_async_recovery_finishes_and_applies_state_after_all_waiters_cancel() -> None:
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_recovery_waiter_re_elects_after_owner_cancellation(
+    anyio_backend: str,
+) -> None:
     service = _AsyncCoordinatedRecoveryService()
     box = _async_coordinated_box(service)
+    owner_scope = anyio.CancelScope()
+    owner_done = anyio.Event()
+    waiter_result: list[sandbox.Process] | None = None
 
-    first = asyncio.create_task(box.query_processes())
-    await service.resume_started.wait()
-    second = asyncio.create_task(box.query_processes())
-    await service.second_failure.wait()
-    first.cancel()
-    second.cancel()
-    results = await asyncio.gather(first, second, return_exceptions=True)
-    assert all(isinstance(result, asyncio.CancelledError) for result in results)
+    async def own_recovery() -> None:
+        with owner_scope:
+            try:
+                await box.query_processes()
+            finally:
+                owner_done.set()
 
-    service.allow_resume.set()
-    await service.resume_finished.wait()
-    assert service.resume_count == 1
+    async def wait_for_recovery() -> None:
+        nonlocal waiter_result
+        waiter_result = await box.query_processes()
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(own_recovery)
+        await service.resume_started.wait()
+        task_group.start_soon(wait_for_recovery)
+        await service.second_failure.wait()
+        owner_scope.cancel()
+        await owner_done.wait()
+        service.allow_resume.set()
+
+    assert waiter_result == []
+    assert service.resume_count == 2
     assert box.current_session_id == "sbx_new"
 
 
-async def test_async_recovery_shares_failure_and_clears_slot_for_retry() -> None:
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_recovery_is_abandoned_when_all_callers_cancel(
+    anyio_backend: str,
+) -> None:
+    service = _AsyncCoordinatedRecoveryService()
+    box = _async_coordinated_box(service)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(box.query_processes)
+        await service.resume_started.wait()
+        task_group.start_soon(box.query_processes)
+        await service.second_failure.wait()
+        task_group.cancel_scope.cancel()
+
+    service.allow_resume.set()
+    await anyio.sleep(0)
+    assert not service.resume_finished.is_set()
+    assert service.resume_count == 1
+    assert box.current_session_id == "sbx_old"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_recovery_shares_failure_and_clears_slot_for_retry(
+    anyio_backend: str,
+) -> None:
     resume_error = RuntimeError("resume failed")
     service = _AsyncCoordinatedRecoveryService(resume_error=resume_error)
     box = _async_coordinated_box(service)
+    results: list[BaseException] = []
 
-    first = asyncio.create_task(box.query_processes())
-    await service.resume_started.wait()
-    second = asyncio.create_task(box.query_processes())
-    await service.second_failure.wait()
-    service.allow_resume.set()
-    results = await asyncio.gather(first, second, return_exceptions=True)
+    async def query() -> None:
+        try:
+            await box.query_processes()
+        except BaseException as error:
+            results.append(error)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(query)
+        await service.resume_started.wait()
+        task_group.start_soon(query)
+        await service.second_failure.wait()
+        service.allow_resume.set()
 
     assert results == [resume_error, resume_error]
     assert service.resume_count == 1
@@ -1074,8 +1128,8 @@ async def test_async_recovery_shares_failure_and_clears_slot_for_retry() -> None
 
 class _DelayedLifecycleFailureService:
     def __init__(self) -> None:
-        self.arrived = (asyncio.Event(), asyncio.Event())
-        self.release = (asyncio.Event(), asyncio.Event())
+        self.arrived = (anyio.Event(), anyio.Event())
+        self.release = (anyio.Event(), anyio.Event())
         self.old_operation_count = 0
         self.resume_count = 0
 
@@ -1099,7 +1153,11 @@ class _DelayedLifecycleFailureService:
         )
 
 
-async def test_delayed_async_lifecycle_failure_may_resume_again_after_slot_clears() -> None:
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_delayed_async_lifecycle_failure_may_resume_again_after_slot_clears(
+    anyio_backend: str,
+) -> None:
     service = _DelayedLifecycleFailureService()
     box = sandbox.Sandbox(
         payload=SandboxState(
@@ -1112,14 +1170,22 @@ async def test_delayed_async_lifecycle_failure_may_resume_again_after_slot_clear
         service=service,  # type: ignore[arg-type]
     )
 
-    first = asyncio.create_task(box.query_processes())
-    second = asyncio.create_task(box.query_processes())
-    await asyncio.gather(*(event.wait() for event in service.arrived))
-    service.release[0].set()
-    assert await first == []
-    service.release[1].set()
-    assert await second == []
+    results: list[list[sandbox.Process]] = []
 
+    async def query() -> None:
+        results.append(await box.query_processes())
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(query)
+        task_group.start_soon(query)
+        await service.arrived[0].wait()
+        await service.arrived[1].wait()
+        service.release[0].set()
+        while len(results) < 1:
+            await anyio.sleep(0)
+        service.release[1].set()
+
+    assert results == [[], []]
     assert service.resume_count == 2
     assert box.current_session_id == "sbx_new"
 
@@ -1289,10 +1355,10 @@ def test_sync_mutation_reply_superseded_by_recovery_keeps_current_session() -> N
 
 class _AsyncTransitionCoordinationService:
     def __init__(self) -> None:
-        self.allow_resume = asyncio.Event()
-        self.resume_started = asyncio.Event()
-        self.second_poll_arrived = asyncio.Event()
-        self.second_poll_returning = asyncio.Event()
+        self.allow_resume = anyio.Event()
+        self.resume_started = anyio.Event()
+        self.second_poll_arrived = anyio.Event()
+        self.second_poll_returning = anyio.Event()
         self.operation_count = 0
         self.poll_count = 0
         self.resume_count = 0
@@ -1328,13 +1394,16 @@ class _AsyncTransitionCoordinationService:
         )
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_transition_callers_poll_independently_and_share_resume(
+    anyio_backend: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def no_delay(_delay: float) -> None:
         return None
 
-    monkeypatch.setattr(asyncio, "sleep", no_delay)
+    monkeypatch.setattr(anyio, "sleep", no_delay)
     service = _AsyncTransitionCoordinationService()
     box = sandbox.Sandbox(
         payload=SandboxState(
@@ -1347,12 +1416,18 @@ async def test_async_transition_callers_poll_independently_and_share_resume(
         service=service,  # type: ignore[arg-type]
     )
 
-    first = asyncio.create_task(box.query_processes())
-    second = asyncio.create_task(box.query_processes())
-    await service.second_poll_returning.wait()
-    service.allow_resume.set()
+    results: list[list[sandbox.Process]] = []
 
-    assert await asyncio.gather(first, second) == [[], []]
+    async def query() -> None:
+        results.append(await box.query_processes())
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(query)
+        task_group.start_soon(query)
+        await service.second_poll_returning.wait()
+        service.allow_resume.set()
+
+    assert results == [[], []]
     assert service.poll_count == 2
     assert service.resume_count == 1
     assert service.operation_count == 4

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -5,6 +5,7 @@ import signal
 import subprocess
 from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from threading import Event, Lock
 
 import httpx
@@ -1230,6 +1231,60 @@ def test_sync_recovery_shares_failure_and_clears_slot_for_retry() -> None:
     service.first_resume_error = None
     assert box.query_processes() == []
     assert service.resume_count == 2
+
+
+class _SyncSupersededMutationService:
+    def __init__(self) -> None:
+        self.allow_mutation = Event()
+        self.mutation_started = Event()
+
+    async def extend_runtime_session_timeout(
+        self, *, session_id: str, duration: timedelta
+    ) -> SandboxRuntimeSessionState:
+        assert session_id == "sbx_old"
+        assert duration == timedelta(seconds=2)
+        self.mutation_started.set()
+        assert self.allow_mutation.wait(timeout=5)
+        return SandboxRuntimeSessionState(id="sbx_old", status=sandbox.SandboxStatus.RUNNING)
+
+    async def query_processes(self, *, session_id: str) -> list[object]:
+        if session_id == "sbx_old":
+            raise _stopped_error()
+        assert session_id == "sbx_new"
+        return []
+
+    async def resume_sandbox(self, **_kwargs: object) -> SandboxState:
+        return SandboxState(
+            name="preview",
+            current_session_id="sbx_new",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_new", status=sandbox.SandboxStatus.RUNNING
+            ),
+        )
+
+
+def test_sync_mutation_reply_superseded_by_recovery_keeps_current_session() -> None:
+    service = _SyncSupersededMutationService()
+    box = sandbox_sync.SyncSandbox(
+        payload=SandboxState(
+            name="preview",
+            current_session_id="sbx_old",
+            current_session=SandboxRuntimeSessionState(
+                id="sbx_old", status=sandbox.SandboxStatus.RUNNING
+            ),
+        ),
+        service=service,  # type: ignore[arg-type]
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        mutation = executor.submit(box.extend_execution_time_limit, 2)
+        assert service.mutation_started.wait(timeout=5)
+        assert box.query_processes() == []
+        service.allow_mutation.set()
+        result = mutation.result(timeout=5)
+
+    assert result.id == "sbx_new"
+    assert box.current_session_id == "sbx_new"
 
 
 class _AsyncTransitionCoordinationService:

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -8,6 +8,7 @@ from itertools import islice
 from threading import Event
 from typing import Any
 
+import anyio
 import httpx
 import pytest
 import respx
@@ -2217,17 +2218,21 @@ async def _run_async_unrecovered_operation(handle: sandbox.Sandbox, operation: s
 
 
 @respx.mock
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_transition_polling_is_cancellable(
-    mock_env_clear: None, monkeypatch: pytest.MonkeyPatch
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    anyio_backend: str,
 ) -> None:
-    poll_waiting = asyncio.Event()
-    never_release = asyncio.Event()
+    poll_waiting = anyio.Event()
+    never_release = anyio.Event()
 
     async def blocked_delay(_delay: float) -> None:
         poll_waiting.set()
         await never_release.wait()
 
-    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", blocked_delay)
+    monkeypatch.setattr(sandbox_async_runtime.anyio, "sleep", blocked_delay)
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
@@ -2243,11 +2248,16 @@ async def test_async_transition_polling_is_cancellable(
 
     async with session(service_options=_session_options()):
         handle = await sandbox.get_sandbox(name="preview")
-        operation = asyncio.create_task(handle.query_processes())
-        await poll_waiting.wait()
-        operation.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await operation
+        cancel_scope = anyio.CancelScope()
+
+        async def query() -> None:
+            with cancel_scope:
+                await handle.query_processes()
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(query)
+            await poll_waiting.wait()
+            cancel_scope.cancel()
 
     assert poll_route.call_count == 0
 
@@ -2295,7 +2305,7 @@ async def test_async_transition_poll_failure_propagates_without_resuming(
     async def no_delay(_delay: float) -> None:
         return None
 
-    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
+    monkeypatch.setattr(sandbox_async_runtime.anyio, "sleep", no_delay)
     sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
@@ -2724,7 +2734,7 @@ async def test_async_session_acquisition_polls_transition_then_retries_once(
     async def no_delay(_delay: float) -> None:
         return None
 
-    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
+    monkeypatch.setattr(sandbox_async_runtime.anyio, "sleep", no_delay)
     attempts = 0
 
     def sandbox_handler(request: httpx.Request) -> httpx.Response:
@@ -2818,11 +2828,14 @@ def test_sync_session_acquisition_polls_transition_then_retries_once(
 
 
 @respx.mock
-async def test_async_session_entry_cancellation_owns_no_cleanup(
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_session_entry_cancellation_abandons_resume_and_owns_no_cleanup(
     mock_env_clear: None,
+    anyio_backend: str,
 ) -> None:
-    resume_started = asyncio.Event()
-    release_resume = asyncio.Event()
+    resume_started = anyio.Event()
+    release_resume = anyio.Event()
 
     respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
@@ -2842,34 +2855,39 @@ async def test_async_session_entry_cancellation_owns_no_cleanup(
 
     async with session(service_options=_session_options()):
         box = await sandbox.get_sandbox(name="preview")
+        cancel_scope = anyio.CancelScope()
+        entry_done = anyio.Event()
 
         async def enter() -> None:
-            async with box.session():
-                raise AssertionError("cancelled entry must not yield")
+            with cancel_scope:
+                try:
+                    async with box.session():
+                        raise AssertionError("cancelled entry must not yield")
+                finally:
+                    entry_done.set()
 
-        task = asyncio.create_task(enter())
-        await resume_started.wait()
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        release_resume.set()
-        for _ in range(10):
-            if box.current_session_id == "sbx_new":
-                break
-            await asyncio.sleep(0)
-        assert box.current_session_id == "sbx_new"
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(enter)
+            await resume_started.wait()
+            cancel_scope.cancel()
+            await entry_done.wait()
+            release_resume.set()
+        assert box.current_session_id == "sbx_old"
 
     assert stop_route.call_count == 0
 
 
 @respx.mock
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_session_cleanup_finishes_before_cancellation_propagates(
     mock_env_clear: None,
+    anyio_backend: str,
 ) -> None:
-    entered = asyncio.Event()
-    stop_started = asyncio.Event()
-    release_stop = asyncio.Event()
-    block_forever = asyncio.Event()
+    entered = anyio.Event()
+    stop_started = anyio.Event()
+    release_stop = anyio.Event()
+    block_forever = anyio.Event()
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
@@ -2885,20 +2903,25 @@ async def test_async_session_cleanup_finishes_before_cancellation_propagates(
 
     async with session(service_options=_session_options()):
         box = await sandbox.get_sandbox(name="preview")
+        cancel_scope = anyio.CancelScope()
+        managed_done = anyio.Event()
 
         async def managed() -> None:
-            async with box.session():
-                entered.set()
-                await block_forever.wait()
+            with cancel_scope:
+                try:
+                    async with box.session():
+                        entered.set()
+                        await block_forever.wait()
+                finally:
+                    managed_done.set()
 
-        task = asyncio.create_task(managed())
-        await entered.wait()
-        task.cancel()
-        await stop_started.wait()
-        assert not task.done()
-        release_stop.set()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(managed)
+            await entered.wait()
+            cancel_scope.cancel()
+            await stop_started.wait()
+            assert not managed_done.is_set()
+            release_stop.set()
 
     assert stop_route.call_count == 1
 
@@ -2936,11 +2959,14 @@ def test_listed_sync_session_cleanup_has_no_parent_linkage(mock_env_clear: None)
 
 
 @respx.mock
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_session_acquisition_shares_implicit_resume(
     mock_env_clear: None,
+    anyio_backend: str,
 ) -> None:
-    resume_started = asyncio.Event()
-    release_resume = asyncio.Event()
+    resume_started = anyio.Event()
+    release_resume = anyio.Event()
     respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
@@ -2965,14 +2991,26 @@ async def test_async_session_acquisition_shares_implicit_resume(
 
     async with session(service_options=_session_options()):
         box = await sandbox.get_sandbox(name="preview")
-        implicit = asyncio.create_task(box.query_processes())
-        await resume_started.wait()
-        explicit = asyncio.ensure_future(box.session())
-        await asyncio.sleep(0)
-        release_resume.set()
-        processes, acquired = await asyncio.gather(implicit, explicit)
+        processes: list[sandbox.Process] | None = None
+        acquired: sandbox.SandboxRuntimeSession | None = None
+
+        async def query() -> None:
+            nonlocal processes
+            processes = await box.query_processes()
+
+        async def acquire() -> None:
+            nonlocal acquired
+            acquired = await box.session()
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(query)
+            await resume_started.wait()
+            task_group.start_soon(acquire)
+            await anyio.sleep(0)
+            release_resume.set()
 
     assert processes == []
+    assert acquired is not None
     assert acquired is box.current_session
     assert acquired.id == "sbx_new"
     assert resume_route.call_count == 1
@@ -3122,11 +3160,14 @@ def test_sync_successful_block_wraps_unrelated_cleanup_failure(
 
 
 @respx.mock
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_cancellation_with_cleanup_failure_warns_structured_error(
     mock_env_clear: None,
+    anyio_backend: str,
 ) -> None:
-    entered = asyncio.Event()
-    block_forever = asyncio.Event()
+    entered = anyio.Event()
+    block_forever = anyio.Event()
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
@@ -3139,18 +3180,19 @@ async def test_async_cancellation_with_cleanup_failure_warns_structured_error(
 
     async with session(service_options=_session_options()):
         box = await sandbox.get_sandbox(name="preview")
+        cancel_scope = anyio.CancelScope()
 
         async def managed() -> None:
-            async with box.session():
-                entered.set()
-                await block_forever.wait()
+            with cancel_scope:
+                async with box.session():
+                    entered.set()
+                    await block_forever.wait()
 
-        task = asyncio.create_task(managed())
-        await entered.wait()
         with pytest.warns(RuntimeWarning) as warnings_info:
-            task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await task
+            async with anyio.create_task_group() as task_group:
+                task_group.start_soon(managed)
+                await entered.wait()
+                cancel_scope.cancel()
 
     cleanup_error = warnings_info[0].source
     assert isinstance(cleanup_error, SandboxCleanupError)

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -1904,11 +1904,16 @@ async def test_destroyed_async_handles_continue_issuing_requests(mock_env_clear:
 
 
 @respx.mock
-async def test_stopped_async_sandbox_is_inspectable_and_backend_authoritative(
+async def test_stopped_async_sandbox_recovers_a_covered_operation(
     mock_env_clear: None,
 ) -> None:
+    events: list[str] = []
+    stopped = _sandbox_response()
+    stopped_sandbox = stopped["sandbox"]
+    assert isinstance(stopped_sandbox, dict)
+    stopped_sandbox["persistent"] = False
     respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
+        return_value=httpx.Response(200, json=stopped)
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
         return_value=httpx.Response(
@@ -1918,16 +1923,56 @@ async def test_stopped_async_sandbox_is_inspectable_and_backend_authoritative(
             },
         )
     )
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-command")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
     command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
+        side_effect=old_command_handler
+    )
+    resumed = _sandbox_response(session_id="sbx_456")
+    resumed["routes"] = [
+        {
+            "url": "https://replacement.sandbox.test",
+            "subdomain": "replacement",
+            "port": 3000,
+            "system": False,
+        }
+    ]
+
+    def resume_handler(request: httpx.Request) -> httpx.Response:
+        events.append("resume")
+        assert request.url.params["resume"] == "true"
+        assert "__includeSystemRoutes" not in request.url.params
+        return httpx.Response(200, json=resumed)
+
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=resume_handler
+    )
+
+    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-command")
+        return httpx.Response(200, json=_command_response(session_id="sbx_456"))
+
+    replacement_command_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd"
+    ).mock(side_effect=replacement_command_handler)
+    process_refresh_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd/cmd_123"
+    ).mock(
         return_value=httpx.Response(
             409,
-            json={"error": {"code": "session_stopped", "message": "session is stopped"}},
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
     read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
         return_value=httpx.Response(
             409,
-            json={"error": {"code": "session_stopped", "message": "session is stopped"}},
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
 
@@ -1938,15 +1983,30 @@ async def test_stopped_async_sandbox_is_inspectable_and_backend_authoritative(
         assert await handle.stop() is handle
         assert handle.current_session is retained_session
         assert handle.current_session.status is SandboxStatus.STOPPED
-        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
-            await handle.create_process("python", ["--version"])
         with pytest.raises(SandboxApiError, match="session is stopped") as fs_exc:
             await handle.fs.read_bytes("message.txt")
+        process = await handle.create_process("python", ["--version"])
+        with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
+            await retained_session.create_process("python", ["--version"])
+        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
+            await process.refresh()
 
     assert command_route.called
+    assert resume_route.called
+    assert replacement_command_route.called
+    assert process_refresh_route.called
     assert read_route.called
-    assert process_exc.value.code == "session_stopped"
-    assert fs_exc.value.code == "session_stopped"
+    assert fs_exc.value.code == "sandbox_stopped"
+    assert retained_exc.value.code == "sandbox_stopped"
+    assert process_exc.value.code == "sandbox_stopped"
+    assert process.session_id == "sbx_456"
+    assert handle.current_session is not retained_session
+    assert handle.current_session is not None
+    assert handle.current_session.id == "sbx_456"
+    assert retained_session.id == "sbx_123"
+    assert retained_session.status is SandboxStatus.STOPPED
+    assert handle.routes[0].url == "https://replacement.sandbox.test"
+    assert events == ["old-command", "resume", "replacement-command", "old-command"]
 
 
 @respx.mock
@@ -1973,11 +2033,16 @@ def test_destroyed_sync_handles_continue_issuing_requests(mock_env_clear: None) 
 
 
 @respx.mock
-def test_stopped_sync_sandbox_is_inspectable_and_backend_authoritative(
+def test_stopped_sync_sandbox_recovers_a_covered_operation(
     mock_env_clear: None,
 ) -> None:
+    events: list[str] = []
+    stopped = _sandbox_response()
+    stopped_sandbox = stopped["sandbox"]
+    assert isinstance(stopped_sandbox, dict)
+    stopped_sandbox["persistent"] = False
     respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
+        return_value=httpx.Response(200, json=stopped)
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
         return_value=httpx.Response(
@@ -1987,16 +2052,56 @@ def test_stopped_sync_sandbox_is_inspectable_and_backend_authoritative(
             },
         )
     )
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-command")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
     command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
+        side_effect=old_command_handler
+    )
+    resumed = _sandbox_response(session_id="sbx_456")
+    resumed["routes"] = [
+        {
+            "url": "https://replacement.sandbox.test",
+            "subdomain": "replacement",
+            "port": 3000,
+            "system": False,
+        }
+    ]
+
+    def resume_handler(request: httpx.Request) -> httpx.Response:
+        events.append("resume")
+        assert request.url.params["resume"] == "true"
+        assert "__includeSystemRoutes" not in request.url.params
+        return httpx.Response(200, json=resumed)
+
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=resume_handler
+    )
+
+    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-command")
+        return httpx.Response(200, json=_command_response(session_id="sbx_456"))
+
+    replacement_command_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd"
+    ).mock(side_effect=replacement_command_handler)
+    process_refresh_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd/cmd_123"
+    ).mock(
         return_value=httpx.Response(
             409,
-            json={"error": {"code": "session_stopped", "message": "session is stopped"}},
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
     read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
         return_value=httpx.Response(
             409,
-            json={"error": {"code": "session_stopped", "message": "session is stopped"}},
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
 
@@ -2007,15 +2112,785 @@ def test_stopped_sync_sandbox_is_inspectable_and_backend_authoritative(
         assert handle.stop() is handle
         assert handle.current_session is retained_session
         assert handle.current_session.status is SandboxStatus.STOPPED
-        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
-            handle.create_process("python", ["--version"])
         with pytest.raises(SandboxApiError, match="session is stopped") as fs_exc:
             handle.fs.read_bytes("message.txt")
+        process = handle.create_process("python", ["--version"])
+        with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
+            retained_session.create_process("python", ["--version"])
+        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
+            process.refresh()
 
     assert command_route.called
+    assert resume_route.called
+    assert replacement_command_route.called
+    assert process_refresh_route.called
     assert read_route.called
-    assert process_exc.value.code == "session_stopped"
-    assert fs_exc.value.code == "session_stopped"
+    assert fs_exc.value.code == "sandbox_stopped"
+    assert retained_exc.value.code == "sandbox_stopped"
+    assert process_exc.value.code == "sandbox_stopped"
+    assert process.session_id == "sbx_456"
+    assert handle.current_session is not retained_session
+    assert handle.current_session is not None
+    assert handle.current_session.id == "sbx_456"
+    assert retained_session.id == "sbx_123"
+    assert retained_session.status is SandboxStatus.STOPPED
+    assert handle.routes[0].url == "https://replacement.sandbox.test"
+    assert events == ["old-command", "resume", "replacement-command", "old-command"]
+
+
+_RECOVERABLE_SANDBOX_OPERATIONS = (
+    (
+        "get_process",
+        "get",
+        "v2/sandboxes/sessions/sbx_old/cmd/cmd_123",
+        "v2/sandboxes/sessions/sbx_new/cmd/cmd_123",
+    ),
+    (
+        "query_processes",
+        "get",
+        "v2/sandboxes/sessions/sbx_old/cmd",
+        "v2/sandboxes/sessions/sbx_new/cmd",
+    ),
+    (
+        "extend_execution_time_limit",
+        "post",
+        "v2/sandboxes/sessions/sbx_old/extend-timeout",
+        "v2/sandboxes/sessions/sbx_new/extend-timeout",
+    ),
+    (
+        "update_network_policy",
+        "post",
+        "v2/sandboxes/sessions/sbx_old/network-policy",
+        "v2/sandboxes/sessions/sbx_new/network-policy",
+    ),
+    (
+        "snapshot",
+        "post",
+        "v2/sandboxes/sessions/sbx_old/snapshot",
+        "v2/sandboxes/sessions/sbx_new/snapshot",
+    ),
+)
+
+
+def _recovery_success_response(operation: str, *, session_id: str) -> httpx.Response:
+    session = _sandbox_response(session_id=session_id)["session"]
+    if operation in {"get_process", "query_processes"}:
+        command = _command_response(session_id=session_id)["command"]
+        if operation == "get_process":
+            return httpx.Response(200, json={"command": command})
+        return httpx.Response(200, json={"commands": [command]})
+    if operation == "snapshot":
+        return httpx.Response(
+            201,
+            json={
+                "snapshot": _snapshot_response(session_id=session_id)["snapshot"],
+                "session": session,
+            },
+        )
+    return httpx.Response(200, json={"session": session})
+
+
+async def _run_async_recoverable_operation(handle: sandbox.Sandbox, operation: str) -> object:
+    if operation == "get_process":
+        return await handle.get_process("cmd_123")
+    if operation == "query_processes":
+        return await handle.query_processes()
+    if operation == "extend_execution_time_limit":
+        return await handle.extend_execution_time_limit(2)
+    if operation == "update_network_policy":
+        return await handle.update_network_policy(NetworkPolicy.allow_all())
+    if operation == "snapshot":
+        return await handle.snapshot()
+    raise AssertionError(f"Unexpected operation: {operation}")
+
+
+def _run_sync_recoverable_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:
+    if operation == "get_process":
+        return handle.get_process("cmd_123")
+    if operation == "query_processes":
+        return handle.query_processes()
+    if operation == "extend_execution_time_limit":
+        return handle.extend_execution_time_limit(2)
+    if operation == "update_network_policy":
+        return handle.update_network_policy(NetworkPolicy.allow_all())
+    if operation == "snapshot":
+        return handle.snapshot()
+    raise AssertionError(f"Unexpected operation: {operation}")
+
+
+@pytest.mark.parametrize(
+    ("operation", "method", "old_path", "replacement_path"),
+    _RECOVERABLE_SANDBOX_OPERATIONS,
+)
+@respx.mock
+async def test_async_sandbox_replays_each_remaining_covered_operation(
+    mock_env_clear: None,
+    operation: str,
+    method: str,
+    old_path: str,
+    replacement_path: str,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+
+    def old_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    def replacement_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement")
+        return _recovery_success_response(operation, session_id="sbx_new")
+
+    getattr(respx, method)(f"https://sandbox.test/{old_path}").mock(side_effect=old_handler)
+    getattr(respx, method)(f"https://sandbox.test/{replacement_path}").mock(
+        side_effect=replacement_handler
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        result = await _run_async_recoverable_operation(handle, operation)
+
+    assert result is not None
+    assert handle.current_session_id == "sbx_new"
+    assert events == ["lookup", "old", "resume", "replacement"]
+
+
+@pytest.mark.parametrize(
+    ("operation", "method", "old_path", "replacement_path"),
+    _RECOVERABLE_SANDBOX_OPERATIONS,
+)
+@respx.mock
+def test_sync_sandbox_replays_each_remaining_covered_operation(
+    mock_env_clear: None,
+    operation: str,
+    method: str,
+    old_path: str,
+    replacement_path: str,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        events.append("resume")
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+
+    def old_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    def replacement_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement")
+        return _recovery_success_response(operation, session_id="sbx_new")
+
+    getattr(respx, method)(f"https://sandbox.test/{old_path}").mock(side_effect=old_handler)
+    getattr(respx, method)(f"https://sandbox.test/{replacement_path}").mock(
+        side_effect=replacement_handler
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        result = _run_sync_recoverable_operation(handle, operation)
+
+    assert result is not None
+    assert handle.current_session_id == "sbx_new"
+    assert events == ["lookup", "old", "resume", "replacement"]
+
+
+async def test_sandbox_payload_application_preserves_or_replaces_current_session(
+    mock_env_clear: None,
+) -> None:
+    async with session(service_options=_session_options()):
+        handle = sandbox.Sandbox(
+            payload=SandboxState(
+                name="preview",
+                current_session_id="sbx_old",
+                current_session=SandboxRuntimeSessionState(
+                    id="sbx_old",
+                    status=SandboxStatus.RUNNING,
+                ),
+            ),
+            service=get_sandbox_service(get_active_session()),
+        )
+        original_session = handle.current_session
+        assert original_session is not None
+
+        handle._apply_payload(
+            SandboxState(
+                name="preview",
+                current_session_id="sbx_old",
+                current_session=SandboxRuntimeSessionState(
+                    id="sbx_old",
+                    status=SandboxStatus.STOPPED,
+                ),
+            )
+        )
+        assert handle.current_session is original_session
+        assert original_session.status is SandboxStatus.STOPPED
+
+        handle._apply_payload(
+            SandboxState(
+                name="preview",
+                current_session_id="sbx_new",
+                current_session=None,
+                _current_session_attached=False,
+            )
+        )
+        assert handle.current_session_id == "sbx_new"
+        assert handle.current_session is None
+
+        handle._apply_payload(
+            SandboxState(
+                name="preview",
+                current_session_id="sbx_new",
+                current_session=SandboxRuntimeSessionState(
+                    id="sbx_new",
+                    status=SandboxStatus.RUNNING,
+                ),
+            )
+        )
+        assert handle.current_session is not None
+        assert handle.current_session is not original_session
+        assert handle.current_session.id == "sbx_new"
+
+
+@respx.mock
+async def test_async_sparse_sandbox_lookup_targets_current_session_without_resume(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+    sparse_response = _sandbox_response(session_id="sbx_sparse")
+    del sparse_response["session"]
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        events.append("lookup")
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=sparse_response)
+
+    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lookup_handler
+    )
+
+    def operation_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("operation")
+        return httpx.Response(200, json=_command_response(session_id="sbx_sparse"))
+
+    operation_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_sparse/cmd").mock(
+        side_effect=operation_handler
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        assert handle.current_session_id == "sbx_sparse"
+        assert handle.current_session is None
+        process = await handle.create_process("python")
+
+    assert process.session_id == "sbx_sparse"
+    assert lookup_route.call_count == operation_route.call_count == 1
+    assert events == ["lookup", "operation"]
+
+
+@respx.mock
+def test_sync_sparse_sandbox_lookup_targets_current_session_without_resume(
+    mock_env_clear: None,
+) -> None:
+    events: list[str] = []
+    sparse_response = _sandbox_response(session_id="sbx_sparse")
+    del sparse_response["session"]
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        events.append("lookup")
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=sparse_response)
+
+    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lookup_handler
+    )
+
+    def operation_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("operation")
+        return httpx.Response(200, json=_command_response(session_id="sbx_sparse"))
+
+    operation_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_sparse/cmd").mock(
+        side_effect=operation_handler
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        assert handle.current_session_id == "sbx_sparse"
+        assert handle.current_session is None
+        process = handle.create_process("python")
+
+    assert process.session_id == "sbx_sparse"
+    assert lookup_route.call_count == operation_route.call_count == 1
+    assert events == ["lookup", "operation"]
+
+
+@pytest.mark.parametrize(
+    ("include_system_routes", "expected_projection"),
+    [(True, "true"), (False, "false"), (None, None)],
+)
+@respx.mock
+async def test_async_sandbox_recovery_preserves_route_projection(
+    mock_env_clear: None,
+    include_system_routes: bool | None,
+    expected_projection: str | None,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        session_id = "sbx_old" if request.url.params["resume"] == "false" else "sbx_new"
+        return httpx.Response(
+            200,
+            json=_sandbox_response(session_id=session_id, project_id="prj_bound"),
+        )
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json=_command_response(session_id="sbx_new"))
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(
+            name="preview",
+            project_id="prj_bound",
+            include_system_routes=include_system_routes,
+        )
+        await handle.create_process("python")
+
+    assert [request.url.params["resume"] for request in requests] == ["false", "true"]
+    for request in requests:
+        assert request.url.params["projectId"] == "prj_bound"
+        assert request.url.params.get("__includeSystemRoutes") == expected_projection
+
+
+@pytest.mark.parametrize(
+    ("include_system_routes", "expected_projection"),
+    [(True, "true"), (False, "false"), (None, None)],
+)
+@respx.mock
+def test_sync_sandbox_recovery_preserves_route_projection(
+    mock_env_clear: None,
+    include_system_routes: bool | None,
+    expected_projection: str | None,
+) -> None:
+    events: list[str] = []
+    requests: list[httpx.Request] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            session_id = "sbx_old"
+        else:
+            events.append("resume")
+            session_id = "sbx_new"
+        return httpx.Response(
+            200,
+            json=_sandbox_response(session_id=session_id, project_id="prj_bound"),
+        )
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    old_command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_command_handler
+    )
+
+    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement")
+        return httpx.Response(200, json=_command_response(session_id="sbx_new"))
+
+    replacement_command_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
+    ).mock(side_effect=replacement_command_handler)
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(
+            name="preview",
+            project_id="prj_bound",
+            include_system_routes=include_system_routes,
+        )
+        handle.create_process("python")
+
+    assert [request.url.params["resume"] for request in requests] == ["false", "true"]
+    for request in requests:
+        assert request.url.params["projectId"] == "prj_bound"
+        assert request.url.params.get("__includeSystemRoutes") == expected_projection
+    assert old_command_route.call_count == replacement_command_route.call_count == 1
+    assert events == ["lookup", "old", "resume", "replacement"]
+
+
+@pytest.mark.parametrize("failure_phase", ["resume", "resume_410", "replay"])
+@respx.mock
+async def test_async_sandbox_recovery_propagates_failed_resume_or_replay(
+    mock_env_clear: None,
+    failure_phase: str,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        events.append("resume")
+        if failure_phase in {"resume", "resume_410"}:
+            return httpx.Response(
+                410 if failure_phase == "resume_410" else 409,
+                json={
+                    "error": {
+                        "code": (
+                            "snapshot_not_found"
+                            if failure_phase == "resume_410"
+                            else "resume_failed"
+                        ),
+                        "message": "resume failed",
+                    }
+                },
+            )
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_command_handler
+    )
+    if failure_phase == "replay":
+
+        def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+            events.append("replacement")
+            return httpx.Response(
+                409,
+                json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+            )
+
+        respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+            side_effect=replacement_command_handler
+        )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            await handle.create_process("python")
+
+    expected_code = {
+        "resume": "resume_failed",
+        "resume_410": "snapshot_not_found",
+        "replay": "sandbox_stopped",
+    }[failure_phase]
+    assert exc_info.value.code == expected_code
+    assert events == (
+        ["lookup", "old", "resume"]
+        if failure_phase in {"resume", "resume_410"}
+        else ["lookup", "old", "resume", "replacement"]
+    )
+
+
+@pytest.mark.parametrize("failure_phase", ["resume", "resume_410", "replay"])
+@respx.mock
+def test_sync_sandbox_recovery_propagates_failed_resume_or_replay(
+    mock_env_clear: None,
+    failure_phase: str,
+) -> None:
+    events: list[str] = []
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            events.append("lookup")
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        events.append("resume")
+        if failure_phase in {"resume", "resume_410"}:
+            return httpx.Response(
+                410 if failure_phase == "resume_410" else 409,
+                json={
+                    "error": {
+                        "code": (
+                            "snapshot_not_found"
+                            if failure_phase == "resume_410"
+                            else "resume_failed"
+                        ),
+                        "message": "resume failed",
+                    }
+                },
+            )
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+
+    def old_command_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old")
+        return httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+
+    old_command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_command_handler
+    )
+    if failure_phase == "replay":
+
+        def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
+            events.append("replacement")
+            return httpx.Response(
+                409,
+                json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+            )
+
+        respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+            side_effect=replacement_command_handler
+        )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            handle.create_process("python")
+
+    expected_code = {
+        "resume": "resume_failed",
+        "resume_410": "snapshot_not_found",
+        "replay": "sandbox_stopped",
+    }[failure_phase]
+    assert exc_info.value.code == expected_code
+    assert sandbox_route.call_count == 2
+    assert old_command_route.call_count == 1
+    assert events == (
+        ["lookup", "old", "resume"]
+        if failure_phase in {"resume", "resume_410"}
+        else ["lookup", "old", "resume", "replacement"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "data"),
+    [
+        (
+            400,
+            {"error": {"code": "invalid_request", "message": "invalid request"}},
+        ),
+    ],
+)
+@respx.mock
+async def test_async_sandbox_does_not_recover_unrelated_non_410_api_errors(
+    mock_env_clear: None,
+    status_code: int,
+    data: dict[str, object] | None,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+
+    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lookup_handler
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(status_code, json=data)
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            await handle.create_process("python")
+
+    assert exc_info.value.status_code == status_code
+    assert lookup_route.call_count == 1
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("status_code", "data", "expected_code"),
+    [
+        (
+            400,
+            {"error": {"code": "invalid_request", "message": "invalid request"}},
+            "invalid_request",
+        ),
+    ],
+)
+@respx.mock
+def test_sync_sandbox_does_not_recover_unrelated_non_410_api_errors(
+    mock_env_clear: None,
+    status_code: int,
+    data: dict[str, object] | None,
+    expected_code: str | None,
+) -> None:
+    events: list[str] = []
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        events.append("lookup")
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+
+    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lookup_handler
+    )
+
+    def operation_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("operation")
+        return httpx.Response(status_code, json=data)
+
+    operation_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=operation_handler
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            handle.create_process("python")
+
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.code == expected_code
+    assert exc_info.value.data == data
+    assert lookup_route.call_count == operation_route.call_count == 1
+    assert events == ["lookup", "operation"]
+
+
+_UNRECOVERED_SANDBOX_OPERATIONS = (
+    ("update", "patch", "v2/sandboxes/preview"),
+    ("stop", "post", "v2/sandboxes/sessions/sbx_old/stop"),
+    ("destroy", "delete", "v2/sandboxes/preview"),
+    ("list_sessions", "get", "v2/sandboxes/sessions"),
+    ("list_snapshots", "get", "v2/sandboxes/snapshots"),
+)
+
+
+async def _run_async_unrecovered_operation(handle: sandbox.Sandbox, operation: str) -> object:
+    if operation == "update":
+        return await handle.update(runtime="node22")
+    if operation == "stop":
+        return await handle.stop()
+    if operation == "destroy":
+        return await handle.destroy()
+    if operation == "list_sessions":
+        return await handle.list_sessions()
+    if operation == "list_snapshots":
+        return await handle.list_snapshots()
+    raise AssertionError(f"Unexpected operation: {operation}")
+
+
+@pytest.mark.parametrize(
+    ("operation", "method", "path"),
+    _UNRECOVERED_SANDBOX_OPERATIONS,
+)
+@respx.mock
+async def test_async_sandbox_does_not_recover_noncovered_operations(
+    mock_env_clear: None,
+    operation: str,
+    method: str,
+    path: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=lookup_handler)
+    getattr(respx, method)(f"https://sandbox.test/{path}").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            await _run_async_unrecovered_operation(handle, operation)
+
+    assert exc_info.value.code == "sandbox_stopped"
+    assert len(requests) == 1
+
+
+def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:
+    if operation == "update":
+        return handle.update(runtime="node22")
+    if operation == "stop":
+        return handle.stop()
+    if operation == "destroy":
+        return handle.destroy()
+    if operation == "list_sessions":
+        return handle.list_sessions()
+    if operation == "list_snapshots":
+        return handle.list_snapshots()
+    raise AssertionError(f"Unexpected operation: {operation}")
+
+
+@pytest.mark.parametrize(
+    ("operation", "method", "path"),
+    _UNRECOVERED_SANDBOX_OPERATIONS,
+)
+@respx.mock
+def test_sync_sandbox_does_not_recover_noncovered_operations(
+    mock_env_clear: None,
+    operation: str,
+    method: str,
+    path: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def lookup_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.url.params["resume"] == "false"
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=lookup_handler)
+    getattr(respx, method)(f"https://sandbox.test/{path}").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            _run_sync_unrecovered_operation(handle, operation)
+
+    assert exc_info.value.code == "sandbox_stopped"
+    assert len(requests) == 1
 
 
 @respx.mock

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from itertools import islice
-from threading import Event, Lock
+from threading import Event
 from typing import Any
 
 import httpx
@@ -39,6 +39,7 @@ from vercel.sandbox import (
     SandboxSource,
     SandboxStatus,
     SandboxTerminalStateError,
+    SandboxTimeoutError,
     SnapshotExpiration,
     SnapshotRetention,
     SnapshotRetentionState,
@@ -52,7 +53,10 @@ from vercel.sandbox._internal import (
     sync_runtime as sandbox_sync_runtime,
 )
 from vercel.sandbox._internal.service import get_sandbox_service
-from vercel.sandbox._internal.state import SandboxRuntimeSessionState, SandboxState
+from vercel.sandbox._internal.state import (
+    SandboxRuntimeSessionState,
+    SandboxState,
+)
 
 
 def _sandbox_response(
@@ -1886,445 +1890,59 @@ def test_sync_create_cleanup_attempts_destroy_after_stop_failure(
     assert exc_info.value.cause.code == "stop_failed"
 
 
-@respx.mock
-async def test_destroyed_async_handles_continue_issuing_requests(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
-    )
-    respx.delete("https://sandbox.test/v2/sandboxes/preview").mock(
-        return_value=httpx.Response(
-            200, json=_sandbox_response(status="stopped", session_status="stopped")
-        )
-    )
-    command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
-        return_value=httpx.Response(200, json=_command_response())
-    )
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.create_sandbox(name="preview", runtime="python3.13")
-        assert await handle.destroy() is handle
-        assert handle.status is SandboxStatus.STOPPED
-        assert (await handle.create_process("python", ["--version"])).id == "cmd_123"
-
-    assert command_route.called
-
-
-@respx.mock
-async def test_stopped_async_sandbox_recovers_a_covered_operation(
-    mock_env_clear: None,
-) -> None:
+def _install_public_recovery_smoke_routes() -> list[str]:
     events: list[str] = []
-    stopped = _sandbox_response()
-    stopped_sandbox = stopped["sandbox"]
-    assert isinstance(stopped_sandbox, dict)
-    stopped_sandbox["persistent"] = False
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=stopped)
-    )
-    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "session": _sandbox_response(status="stopped", session_status="stopped")["session"]
-            },
-        )
-    )
-
-    def old_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old-command")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
-        side_effect=old_command_handler
-    )
-    resumed = _sandbox_response(session_id="sbx_456")
-    resumed["routes"] = [
-        {
-            "url": "https://replacement.sandbox.test",
-            "subdomain": "replacement",
-            "port": 3000,
-            "system": False,
-        }
-    ]
-
-    def resume_handler(request: httpx.Request) -> httpx.Response:
-        events.append("resume")
-        assert request.url.params["resume"] == "true"
-        assert "__includeSystemRoutes" not in request.url.params
-        return httpx.Response(200, json=resumed)
-
-    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=resume_handler
-    )
-
-    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("replacement-command")
-        return httpx.Response(200, json=_command_response(session_id="sbx_456"))
-
-    replacement_command_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd"
-    ).mock(side_effect=replacement_command_handler)
-    process_refresh_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd/cmd_123"
-    ).mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-
-    def old_read_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old-read")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
-        side_effect=old_read_handler
-    )
-
-    def replacement_read_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("replacement-read")
-        return httpx.Response(200, content=b"recovered")
-
-    replacement_read_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/fs/read"
-    ).mock(side_effect=replacement_read_handler)
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.create_sandbox(name="preview", runtime="python3.13")
-        retained_session = handle.current_session
-        assert retained_session is not None
-        assert await handle.stop() is handle
-        assert handle.current_session is retained_session
-        assert handle.current_session.status is SandboxStatus.STOPPED
-        assert await handle.fs.read_bytes("message.txt") == b"recovered"
-        process = await handle.create_process("python", ["--version"])
-        with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
-            await retained_session.create_process("python", ["--version"])
-        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
-            await process.refresh()
-
-    assert command_route.called
-    assert resume_route.called
-    assert replacement_command_route.called
-    assert process_refresh_route.called
-    assert read_route.called
-    assert replacement_read_route.called
-    assert retained_exc.value.code == "sandbox_stopped"
-    assert process_exc.value.code == "sandbox_stopped"
-    assert process.session_id == "sbx_456"
-    assert handle.current_session is not retained_session
-    assert handle.current_session is not None
-    assert handle.current_session.id == "sbx_456"
-    assert retained_session.id == "sbx_123"
-    assert retained_session.status is SandboxStatus.STOPPED
-    assert handle.routes[0].url == "https://replacement.sandbox.test"
-    assert events == [
-        "old-read",
-        "resume",
-        "replacement-read",
-        "replacement-command",
-        "old-command",
-    ]
-
-
-@respx.mock
-def test_destroyed_sync_handles_continue_issuing_requests(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
-    )
-    respx.delete("https://sandbox.test/v2/sandboxes/preview").mock(
-        return_value=httpx.Response(
-            200, json=_sandbox_response(status="stopped", session_status="stopped")
-        )
-    )
-    command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
-        return_value=httpx.Response(200, json=_command_response())
-    )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
-        assert handle.destroy() is handle
-        assert handle.status is SandboxStatus.STOPPED
-        assert handle.create_process("python", ["--version"]).id == "cmd_123"
-
-    assert command_route.called
-
-
-@respx.mock
-def test_stopped_sync_sandbox_recovers_a_covered_operation(
-    mock_env_clear: None,
-) -> None:
-    events: list[str] = []
-    stopped = _sandbox_response()
-    stopped_sandbox = stopped["sandbox"]
-    assert isinstance(stopped_sandbox, dict)
-    stopped_sandbox["persistent"] = False
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=stopped)
-    )
-    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "session": _sandbox_response(status="stopped", session_status="stopped")["session"]
-            },
-        )
-    )
-
-    def old_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old-command")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/cmd").mock(
-        side_effect=old_command_handler
-    )
-    resumed = _sandbox_response(session_id="sbx_456")
-    resumed["routes"] = [
-        {
-            "url": "https://replacement.sandbox.test",
-            "subdomain": "replacement",
-            "port": 3000,
-            "system": False,
-        }
-    ]
-
-    def resume_handler(request: httpx.Request) -> httpx.Response:
-        events.append("resume")
-        assert request.url.params["resume"] == "true"
-        assert "__includeSystemRoutes" not in request.url.params
-        return httpx.Response(200, json=resumed)
-
-    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=resume_handler
-    )
-
-    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("replacement-command")
-        return httpx.Response(200, json=_command_response(session_id="sbx_456"))
-
-    replacement_command_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd"
-    ).mock(side_effect=replacement_command_handler)
-    process_refresh_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/cmd/cmd_123"
-    ).mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-
-    def old_read_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old-read")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
-        side_effect=old_read_handler
-    )
-
-    def replacement_read_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("replacement-read")
-        return httpx.Response(200, content=b"recovered")
-
-    replacement_read_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/fs/read"
-    ).mock(side_effect=replacement_read_handler)
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
-        retained_session = handle.current_session
-        assert retained_session is not None
-        assert handle.stop() is handle
-        assert handle.current_session is retained_session
-        assert handle.current_session.status is SandboxStatus.STOPPED
-        assert handle.fs.read_bytes("message.txt") == b"recovered"
-        process = handle.create_process("python", ["--version"])
-        with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
-            retained_session.create_process("python", ["--version"])
-        with pytest.raises(SandboxApiError, match="session is stopped") as process_exc:
-            process.refresh()
-
-    assert command_route.called
-    assert resume_route.called
-    assert replacement_command_route.called
-    assert process_refresh_route.called
-    assert read_route.called
-    assert replacement_read_route.called
-    assert retained_exc.value.code == "sandbox_stopped"
-    assert process_exc.value.code == "sandbox_stopped"
-    assert process.session_id == "sbx_456"
-    assert handle.current_session is not retained_session
-    assert handle.current_session is not None
-    assert handle.current_session.id == "sbx_456"
-    assert retained_session.id == "sbx_123"
-    assert retained_session.status is SandboxStatus.STOPPED
-    assert handle.routes[0].url == "https://replacement.sandbox.test"
-    assert events == [
-        "old-read",
-        "resume",
-        "replacement-read",
-        "replacement-command",
-        "old-command",
-    ]
-
-
-@respx.mock
-async def test_async_process_and_filesystem_recovery_share_one_resume_request(
-    mock_env_clear: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    resume_started = asyncio.Event()
-    second_recovery_waiter = asyncio.Event()
-    shared_resume_calls = 0
-    original_await_shared_resume = sandbox_async_runtime.Sandbox._await_shared_resume
-
-    async def track_shared_resume(handle: sandbox.Sandbox) -> None:
-        nonlocal shared_resume_calls
-        shared_resume_calls += 1
-        if shared_resume_calls == 2:
-            second_recovery_waiter.set()
-        await original_await_shared_resume(handle)
-
-    monkeypatch.setattr(sandbox_async_runtime.Sandbox, "_await_shared_resume", track_shared_resume)
 
     def sandbox_handler(request: httpx.Request) -> httpx.Response:
-        if request.url.params["resume"] == "false":
-            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-        raise AssertionError("The resume route must use its async handler")
+        resume = request.url.params["resume"] == "true"
+        events.append("resume" if resume else "lookup")
+        session_id = "sbx_new" if resume else "sbx_old"
+        return httpx.Response(200, json=_sandbox_response(session_id=session_id))
 
-    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
-        side_effect=sandbox_handler
-    )
-
-    async def resume_handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params["resume"] == "true"
-        resume_started.set()
-        await asyncio.wait_for(second_recovery_waiter.wait(), timeout=5)
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
-
-    resume_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
-    ).mock(side_effect=resume_handler)
-    old_process_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
         return_value=httpx.Response(
             409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
         )
     )
-    old_read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read").mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
+
+    def replacement_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replay")
+        return httpx.Response(200, json=_command_response(session_id="sbx_new"))
+
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        side_effect=replacement_handler
     )
-    replacement_process_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
-    ).mock(return_value=httpx.Response(200, json={"commands": []}))
-    replacement_read_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/read"
-    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+    return events
+
+
+@respx.mock
+async def test_stopped_async_sandbox_recovers_one_public_operation(
+    mock_env_clear: None,
+) -> None:
+    events = _install_public_recovery_smoke_routes()
 
     async with session(service_options=_session_options()):
         handle = await sandbox.get_sandbox(name="preview")
-        process_task = asyncio.create_task(handle.query_processes())
-        await resume_started.wait()
-        filesystem_task = asyncio.create_task(handle.fs.read_bytes("message.txt"))
-        assert await process_task == []
-        assert await filesystem_task == b"replacement"
+        process = await handle.create_process("python", ["--version"])
 
-    assert handle.current_session_id == "sbx_new"
-    assert shared_resume_calls == 2
-    assert resume_route.call_count == 1
-    assert old_process_route.call_count == replacement_process_route.call_count == 1
-    assert old_read_route.call_count == replacement_read_route.call_count == 1
+    assert process.session_id == handle.current_session_id == "sbx_new"
+    assert events == ["lookup", "resume", "replay"]
 
 
 @respx.mock
-def test_sync_process_and_filesystem_recovery_share_one_resume_request(
+def test_stopped_sync_sandbox_recovers_one_public_operation(
     mock_env_clear: None,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resume_started = Event()
-    second_recovery_waiter = Event()
-    shared_resume_lock = Lock()
-    shared_resume_calls = 0
-    original_await_shared_resume = sandbox_sync_runtime.SyncSandbox._await_shared_resume
-
-    async def track_shared_resume(handle: sandbox_sync.SyncSandbox) -> None:
-        nonlocal shared_resume_calls
-        with shared_resume_lock:
-            shared_resume_calls += 1
-            if shared_resume_calls == 2:
-                second_recovery_waiter.set()
-        await original_await_shared_resume(handle)
-
-    monkeypatch.setattr(
-        sandbox_sync_runtime.SyncSandbox, "_await_shared_resume", track_shared_resume
-    )
-
-    def sandbox_handler(request: httpx.Request) -> httpx.Response:
-        if request.url.params["resume"] == "false":
-            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-        raise AssertionError("The resume route must use its blocking handler")
-
-    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
-        side_effect=sandbox_handler
-    )
-
-    def resume_handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params["resume"] == "true"
-        resume_started.set()
-        assert second_recovery_waiter.wait(timeout=5)
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
-
-    resume_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
-    ).mock(side_effect=resume_handler)
-    old_process_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-    old_read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read").mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-    replacement_process_route = respx.get(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
-    ).mock(return_value=httpx.Response(200, json={"commands": []}))
-    replacement_read_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/read"
-    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+    events = _install_public_recovery_smoke_routes()
 
     with session(service_options=_session_options()):
         handle = sandbox_sync.get_sandbox(name="preview")
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            process_future = executor.submit(handle.query_processes)
-            assert resume_started.wait(timeout=5)
-            filesystem_future = executor.submit(handle.fs.read_bytes, "message.txt")
-            assert process_future.result(timeout=5) == []
-            assert filesystem_future.result(timeout=5) == b"replacement"
+        process = handle.create_process("python", ["--version"])
 
-    assert handle.current_session_id == "sbx_new"
-    assert shared_resume_calls == 2
-    assert resume_route.call_count == 1
-    assert old_process_route.call_count == replacement_process_route.call_count == 1
-    assert old_read_route.call_count == replacement_read_route.call_count == 1
+    assert process.session_id == handle.current_session_id == "sbx_new"
+    assert events == ["lookup", "resume", "replay"]
 
 
 _RECOVERABLE_SANDBOX_OPERATIONS = (
@@ -2503,101 +2121,6 @@ def test_sync_sandbox_replays_each_remaining_covered_operation(
     assert events == ["lookup", "old", "resume", "replacement"]
 
 
-async def test_sandbox_payload_application_preserves_or_replaces_current_session(
-    mock_env_clear: None,
-) -> None:
-    async with session(service_options=_session_options()):
-        handle = sandbox.Sandbox(
-            payload=SandboxState(
-                name="preview",
-                current_session_id="sbx_old",
-                current_session=SandboxRuntimeSessionState(
-                    id="sbx_old",
-                    status=SandboxStatus.RUNNING,
-                ),
-            ),
-            service=get_sandbox_service(get_active_session()),
-        )
-        original_session = handle.current_session
-        assert original_session is not None
-
-        handle._apply_payload(
-            SandboxState(
-                name="preview",
-                current_session_id="sbx_old",
-                current_session=SandboxRuntimeSessionState(
-                    id="sbx_old",
-                    status=SandboxStatus.STOPPED,
-                ),
-            )
-        )
-        assert handle.current_session is original_session
-        assert original_session.status is SandboxStatus.STOPPED
-
-        handle._apply_payload(
-            SandboxState(
-                name="preview",
-                current_session_id="sbx_new",
-                current_session=None,
-                _current_session_attached=False,
-            )
-        )
-        assert handle.current_session_id == "sbx_new"
-        assert handle.current_session is None
-
-        handle._apply_payload(
-            SandboxState(
-                name="preview",
-                current_session_id="sbx_new",
-                current_session=SandboxRuntimeSessionState(
-                    id="sbx_new",
-                    status=SandboxStatus.RUNNING,
-                ),
-            )
-        )
-        assert handle.current_session is not None
-        assert handle.current_session is not original_session
-        assert handle.current_session.id == "sbx_new"
-
-
-async def test_recovery_poll_retains_a_concurrently_installed_replacement(
-    mock_env_clear: None,
-) -> None:
-    async with session(service_options=_session_options()):
-        handle = sandbox.Sandbox(
-            payload=SandboxState(
-                name="preview",
-                current_session_id="sbx_old",
-                current_session=SandboxRuntimeSessionState(
-                    id="sbx_old", status=SandboxStatus.STOPPING
-                ),
-            ),
-            service=get_sandbox_service(get_active_session()),
-        )
-        old_session = handle.current_session
-        assert old_session is not None
-        target = handle._capture_recovery_target()
-
-        handle._apply_payload(
-            SandboxState(
-                name="preview",
-                current_session_id="sbx_new",
-                current_session=SandboxRuntimeSessionState(
-                    id="sbx_new", status=SandboxStatus.RUNNING
-                ),
-            )
-        )
-        handle._apply_recovery_session_payload(
-            target,
-            SandboxRuntimeSessionState(id="sbx_old", status=SandboxStatus.STOPPED),
-        )
-
-    assert old_session.status is SandboxStatus.STOPPED
-    assert handle.current_session_id == "sbx_new"
-    assert handle.current_session is not None
-    assert handle.current_session.id == "sbx_new"
-
-
 @respx.mock
 async def test_async_sparse_sandbox_lookup_targets_current_session_without_resume(
     mock_env_clear: None,
@@ -2628,42 +2151,6 @@ async def test_async_sparse_sandbox_lookup_targets_current_session_without_resum
         assert handle.current_session_id == "sbx_sparse"
         assert handle.current_session is None
         process = await handle.create_process("python")
-
-    assert process.session_id == "sbx_sparse"
-    assert lookup_route.call_count == operation_route.call_count == 1
-    assert events == ["lookup", "operation"]
-
-
-@respx.mock
-def test_sync_sparse_sandbox_lookup_targets_current_session_without_resume(
-    mock_env_clear: None,
-) -> None:
-    events: list[str] = []
-    sparse_response = _sandbox_response(session_id="sbx_sparse")
-    del sparse_response["session"]
-
-    def lookup_handler(request: httpx.Request) -> httpx.Response:
-        events.append("lookup")
-        assert request.url.params["resume"] == "false"
-        return httpx.Response(200, json=sparse_response)
-
-    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=lookup_handler
-    )
-
-    def operation_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("operation")
-        return httpx.Response(200, json=_command_response(session_id="sbx_sparse"))
-
-    operation_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_sparse/cmd").mock(
-        side_effect=operation_handler
-    )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(name="preview")
-        assert handle.current_session_id == "sbx_sparse"
-        assert handle.current_session is None
-        process = handle.create_process("python")
 
     assert process.session_id == "sbx_sparse"
     assert lookup_route.call_count == operation_route.call_count == 1
@@ -2715,313 +2202,6 @@ async def test_async_sandbox_recovery_preserves_route_projection(
         assert request.url.params.get("__includeSystemRoutes") == expected_projection
 
 
-@pytest.mark.parametrize(
-    ("include_system_routes", "expected_projection"),
-    [(True, "true"), (False, "false"), (None, None)],
-)
-@respx.mock
-def test_sync_sandbox_recovery_preserves_route_projection(
-    mock_env_clear: None,
-    include_system_routes: bool | None,
-    expected_projection: str | None,
-) -> None:
-    events: list[str] = []
-    requests: list[httpx.Request] = []
-
-    def sandbox_handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        if request.url.params["resume"] == "false":
-            events.append("lookup")
-            session_id = "sbx_old"
-        else:
-            events.append("resume")
-            session_id = "sbx_new"
-        return httpx.Response(
-            200,
-            json=_sandbox_response(session_id=session_id, project_id="prj_bound"),
-        )
-
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
-
-    def old_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    old_command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=old_command_handler
-    )
-
-    def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("replacement")
-        return httpx.Response(200, json=_command_response(session_id="sbx_new"))
-
-    replacement_command_route = respx.post(
-        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
-    ).mock(side_effect=replacement_command_handler)
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(
-            name="preview",
-            project_id="prj_bound",
-            include_system_routes=include_system_routes,
-        )
-        handle.create_process("python")
-
-    assert [request.url.params["resume"] for request in requests] == ["false", "true"]
-    for request in requests:
-        assert request.url.params["projectId"] == "prj_bound"
-        assert request.url.params.get("__includeSystemRoutes") == expected_projection
-    assert old_command_route.call_count == replacement_command_route.call_count == 1
-    assert events == ["lookup", "old", "resume", "replacement"]
-
-
-@pytest.mark.parametrize("failure_phase", ["resume", "resume_410", "replay"])
-@respx.mock
-async def test_async_sandbox_recovery_propagates_failed_resume_or_replay(
-    mock_env_clear: None,
-    failure_phase: str,
-) -> None:
-    events: list[str] = []
-
-    def sandbox_handler(request: httpx.Request) -> httpx.Response:
-        if request.url.params["resume"] == "false":
-            events.append("lookup")
-            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-        events.append("resume")
-        if failure_phase in {"resume", "resume_410"}:
-            return httpx.Response(
-                410 if failure_phase == "resume_410" else 409,
-                json={
-                    "error": {
-                        "code": (
-                            "snapshot_not_found"
-                            if failure_phase == "resume_410"
-                            else "resume_failed"
-                        ),
-                        "message": "resume failed",
-                    }
-                },
-            )
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
-
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
-
-    def old_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=old_command_handler
-    )
-    if failure_phase == "replay":
-
-        def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
-            events.append("replacement")
-            return httpx.Response(
-                409,
-                json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-            )
-
-        respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
-            side_effect=replacement_command_handler
-        )
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            await handle.create_process("python")
-
-    expected_code = {
-        "resume": "resume_failed",
-        "resume_410": "snapshot_not_found",
-        "replay": "sandbox_stopped",
-    }[failure_phase]
-    assert exc_info.value.code == expected_code
-    assert events == (
-        ["lookup", "old", "resume"]
-        if failure_phase in {"resume", "resume_410"}
-        else ["lookup", "old", "resume", "replacement"]
-    )
-
-
-@pytest.mark.parametrize("failure_phase", ["resume", "resume_410", "replay"])
-@respx.mock
-def test_sync_sandbox_recovery_propagates_failed_resume_or_replay(
-    mock_env_clear: None,
-    failure_phase: str,
-) -> None:
-    events: list[str] = []
-
-    def sandbox_handler(request: httpx.Request) -> httpx.Response:
-        if request.url.params["resume"] == "false":
-            events.append("lookup")
-            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-        events.append("resume")
-        if failure_phase in {"resume", "resume_410"}:
-            return httpx.Response(
-                410 if failure_phase == "resume_410" else 409,
-                json={
-                    "error": {
-                        "code": (
-                            "snapshot_not_found"
-                            if failure_phase == "resume_410"
-                            else "resume_failed"
-                        ),
-                        "message": "resume failed",
-                    }
-                },
-            )
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
-
-    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=sandbox_handler
-    )
-
-    def old_command_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("old")
-        return httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-
-    old_command_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=old_command_handler
-    )
-    if failure_phase == "replay":
-
-        def replacement_command_handler(_request: httpx.Request) -> httpx.Response:
-            events.append("replacement")
-            return httpx.Response(
-                409,
-                json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-            )
-
-        respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
-            side_effect=replacement_command_handler
-        )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            handle.create_process("python")
-
-    expected_code = {
-        "resume": "resume_failed",
-        "resume_410": "snapshot_not_found",
-        "replay": "sandbox_stopped",
-    }[failure_phase]
-    assert exc_info.value.code == expected_code
-    assert sandbox_route.call_count == 2
-    assert old_command_route.call_count == 1
-    assert events == (
-        ["lookup", "old", "resume"]
-        if failure_phase in {"resume", "resume_410"}
-        else ["lookup", "old", "resume", "replacement"]
-    )
-
-
-@pytest.mark.parametrize(
-    ("status_code", "data"),
-    [
-        (
-            400,
-            {"error": {"code": "invalid_request", "message": "invalid request"}},
-        ),
-    ],
-)
-@respx.mock
-async def test_async_sandbox_does_not_recover_unrelated_non_410_api_errors(
-    mock_env_clear: None,
-    status_code: int,
-    data: dict[str, object] | None,
-) -> None:
-    requests: list[httpx.Request] = []
-
-    def lookup_handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        assert request.url.params["resume"] == "false"
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-
-    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=lookup_handler
-    )
-    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        return_value=httpx.Response(status_code, json=data)
-    )
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            await handle.create_process("python")
-
-    assert exc_info.value.status_code == status_code
-    assert lookup_route.call_count == 1
-    assert len(requests) == 1
-
-
-@pytest.mark.parametrize(
-    ("status_code", "data", "expected_code"),
-    [
-        (
-            400,
-            {"error": {"code": "invalid_request", "message": "invalid request"}},
-            "invalid_request",
-        ),
-    ],
-)
-@respx.mock
-def test_sync_sandbox_does_not_recover_unrelated_non_410_api_errors(
-    mock_env_clear: None,
-    status_code: int,
-    data: dict[str, object] | None,
-    expected_code: str | None,
-) -> None:
-    events: list[str] = []
-
-    def lookup_handler(request: httpx.Request) -> httpx.Response:
-        events.append("lookup")
-        assert request.url.params["resume"] == "false"
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-
-    lookup_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=lookup_handler
-    )
-
-    def operation_handler(_request: httpx.Request) -> httpx.Response:
-        events.append("operation")
-        return httpx.Response(status_code, json=data)
-
-    operation_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=operation_handler
-    )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            handle.create_process("python")
-
-    assert exc_info.value.status_code == status_code
-    assert exc_info.value.code == expected_code
-    assert exc_info.value.data == data
-    assert lookup_route.call_count == operation_route.call_count == 1
-    assert events == ["lookup", "operation"]
-
-
-_UNRECOVERED_SANDBOX_OPERATIONS = (
-    ("update", "patch", "v2/sandboxes/preview"),
-    ("stop", "post", "v2/sandboxes/sessions/sbx_old/stop"),
-    ("destroy", "delete", "v2/sandboxes/preview"),
-    ("list_sessions", "get", "v2/sandboxes/sessions"),
-    ("list_snapshots", "get", "v2/sandboxes/snapshots"),
-)
-
-
 async def _run_async_unrecovered_operation(handle: sandbox.Sandbox, operation: str) -> object:
     if operation == "update":
         return await handle.update(runtime="node22")
@@ -3034,119 +2214,6 @@ async def _run_async_unrecovered_operation(handle: sandbox.Sandbox, operation: s
     if operation == "list_snapshots":
         return await handle.list_snapshots()
     raise AssertionError(f"Unexpected operation: {operation}")
-
-
-@pytest.mark.parametrize(
-    ("operation", "method", "path"),
-    _UNRECOVERED_SANDBOX_OPERATIONS,
-)
-@respx.mock
-async def test_async_sandbox_does_not_recover_noncovered_operations(
-    mock_env_clear: None,
-    operation: str,
-    method: str,
-    path: str,
-) -> None:
-    requests: list[httpx.Request] = []
-
-    def lookup_handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        assert request.url.params["resume"] == "false"
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=lookup_handler)
-    getattr(respx, method)(f"https://sandbox.test/{path}").mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            await _run_async_unrecovered_operation(handle, operation)
-
-    assert exc_info.value.code == "sandbox_stopped"
-    assert len(requests) == 1
-
-
-@pytest.mark.parametrize(
-    ("error_code", "transition_status"),
-    [
-        ("sandbox_stopping", "stopping"),
-        ("sandbox_snapshotting", "snapshotting"),
-    ],
-)
-@respx.mock
-async def test_async_transition_recovery_polls_exact_session_then_replays(
-    mock_env_clear: None,
-    monkeypatch: pytest.MonkeyPatch,
-    error_code: str,
-    transition_status: str,
-) -> None:
-    events: list[str] = []
-    poll_statuses = iter([transition_status, transition_status, "stopped"])
-
-    async def no_delay(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=lambda request: httpx.Response(
-            200,
-            json=_sandbox_response(
-                session_id="sbx_old" if request.url.params["resume"] == "false" else "sbx_new"
-            ),
-        )
-    )
-
-    def old_operation(_request: httpx.Request) -> httpx.Response:
-        events.append("old-operation")
-        return httpx.Response(
-            409,
-            json={"error": {"code": error_code, "message": "transitioning"}},
-        )
-
-    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=old_operation
-    )
-
-    def poll(_request: httpx.Request) -> httpx.Response:
-        status = next(poll_statuses)
-        events.append(f"poll-{status}")
-        return httpx.Response(
-            200,
-            json={
-                "session": _sandbox_response(
-                    session_id="sbx_old", status=status, session_status=status
-                )["session"]
-            },
-        )
-
-    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
-        side_effect=poll
-    )
-    replacement_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
-        return_value=httpx.Response(200, json={"commands": []})
-    )
-
-    async with session(service_options=_session_options()):
-        handle = await sandbox.get_sandbox(name="preview")
-        old_session = handle.current_session
-        assert old_session is not None
-        assert await handle.query_processes() == []
-
-    assert poll_route.call_count == 3
-    assert replacement_route.call_count == 1
-    assert old_session.status is SandboxStatus.STOPPED
-    assert handle.current_session_id == "sbx_new"
-    assert events == [
-        "old-operation",
-        f"poll-{transition_status}",
-        f"poll-{transition_status}",
-        "poll-stopped",
-    ]
 
 
 @respx.mock
@@ -3186,6 +2253,42 @@ async def test_async_transition_polling_is_cancellable(
 
 
 @respx.mock
+@pytest.mark.parametrize("sync", [False, True])
+async def test_transition_polling_has_deadline(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    sync: bool,
+) -> None:
+    runtime = sandbox_sync_runtime if sync else sandbox_async_runtime
+    monkeypatch.setattr(runtime, "TRANSITION_TIMEOUT", -1.0)
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopping", "message": "transitioning"}},
+        )
+    )
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(500)
+    )
+
+    if sync:
+        with session(service_options=_session_options(sync=True)):
+            sync_handle = sandbox_sync.get_sandbox(name="preview")
+            with pytest.raises(SandboxTimeoutError, match="within -1.0s"):
+                sync_handle.query_processes()
+    else:
+        async with session(service_options=_session_options()):
+            async_handle = await sandbox.get_sandbox(name="preview")
+            with pytest.raises(SandboxTimeoutError, match="within -1.0s"):
+                await async_handle.query_processes()
+
+    assert poll_route.call_count == 0
+
+
+@respx.mock
 async def test_async_transition_poll_failure_propagates_without_resuming(
     mock_env_clear: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3219,80 +2322,6 @@ async def test_async_transition_poll_failure_propagates_without_resuming(
     assert sandbox_route.call_count == 1
 
 
-@pytest.mark.parametrize(
-    ("error_code", "transition_status"),
-    [
-        ("sandbox_stopping", "stopping"),
-        ("sandbox_snapshotting", "snapshotting"),
-    ],
-)
-@respx.mock
-def test_sync_transition_recovery_polls_exact_session_then_replays(
-    mock_env_clear: None,
-    monkeypatch: pytest.MonkeyPatch,
-    error_code: str,
-    transition_status: str,
-) -> None:
-    events: list[str] = []
-    poll_statuses = iter([transition_status, transition_status, "stopped"])
-    monkeypatch.setattr(sandbox_sync_runtime.time, "sleep", lambda _delay: None)
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
-        side_effect=lambda request: httpx.Response(
-            200,
-            json=_sandbox_response(
-                session_id="sbx_old" if request.url.params["resume"] == "false" else "sbx_new"
-            ),
-        )
-    )
-
-    def old_operation(_request: httpx.Request) -> httpx.Response:
-        events.append("old-operation")
-        return httpx.Response(
-            409,
-            json={"error": {"code": error_code, "message": "transitioning"}},
-        )
-
-    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
-        side_effect=old_operation
-    )
-
-    def poll(_request: httpx.Request) -> httpx.Response:
-        status = next(poll_statuses)
-        events.append(f"poll-{status}")
-        return httpx.Response(
-            200,
-            json={
-                "session": _sandbox_response(
-                    session_id="sbx_old", status=status, session_status=status
-                )["session"]
-            },
-        )
-
-    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
-        side_effect=poll
-    )
-    replacement_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
-        return_value=httpx.Response(200, json={"commands": []})
-    )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(name="preview")
-        old_session = handle.current_session
-        assert old_session is not None
-        assert handle.query_processes() == []
-
-    assert poll_route.call_count == 3
-    assert replacement_route.call_count == 1
-    assert old_session.status is SandboxStatus.STOPPED
-    assert handle.current_session_id == "sbx_new"
-    assert events == [
-        "old-operation",
-        f"poll-{transition_status}",
-        f"poll-{transition_status}",
-        "poll-stopped",
-    ]
-
-
 def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:
     if operation == "update":
         return handle.update(runtime="node22")
@@ -3305,41 +2334,6 @@ def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation:
     if operation == "list_snapshots":
         return handle.list_snapshots()
     raise AssertionError(f"Unexpected operation: {operation}")
-
-
-@pytest.mark.parametrize(
-    ("operation", "method", "path"),
-    _UNRECOVERED_SANDBOX_OPERATIONS,
-)
-@respx.mock
-def test_sync_sandbox_does_not_recover_noncovered_operations(
-    mock_env_clear: None,
-    operation: str,
-    method: str,
-    path: str,
-) -> None:
-    requests: list[httpx.Request] = []
-
-    def lookup_handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        assert request.url.params["resume"] == "false"
-        return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
-
-    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=lookup_handler)
-    getattr(respx, method)(f"https://sandbox.test/{path}").mock(
-        return_value=httpx.Response(
-            409,
-            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
-        )
-    )
-
-    with session(service_options=_session_options()):
-        handle = sandbox_sync.get_sandbox(name="preview")
-        with pytest.raises(SandboxApiError) as exc_info:
-            _run_sync_unrecovered_operation(handle, operation)
-
-    assert exc_info.value.code == "sandbox_stopped"
-    assert len(requests) == 1
 
 
 @respx.mock
@@ -3453,3 +2447,993 @@ def test_sync_query_sandboxes_paginates_and_supports_early_consumers(
             "tags": "env:prod",
         },
     ]
+
+
+def _stop_response(
+    session_id: str,
+    *,
+    sandbox_session_id: str | None = None,
+) -> dict[str, object]:
+    response: dict[str, object] = {
+        "session": _sandbox_response(
+            session_id=session_id,
+            status="stopped",
+            session_status="stopped",
+        )["session"]
+    }
+    if sandbox_session_id is not None:
+        response["sandbox"] = {
+            "name": "preview",
+            "currentSessionId": sandbox_session_id,
+            "status": "stopped",
+            "updatedAt": 99,
+        }
+    return response
+
+
+@respx.mock
+async def test_async_box_session_acquires_authoritatively_and_canonicalizes(
+    mock_env_clear: None,
+) -> None:
+    calls = iter(
+        [
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_new"),
+        ]
+    )
+    route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda _request: httpx.Response(200, json=next(calls))
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview", include_system_routes=True)
+        old = box.current_session
+        assert old is not None
+        acquired = await box.session()
+        assert acquired is old is box.current_session
+        replacement = await box.session()
+        assert replacement is box.current_session
+        assert replacement is not old
+
+    assert route.call_count == 3
+    assert [call.request.url.params["resume"] for call in route.calls] == [
+        "false",
+        "true",
+        "true",
+    ]
+    assert all(call.request.url.params["__includeSystemRoutes"] == "true" for call in route.calls)
+
+
+@respx.mock
+def test_sync_box_session_direct_and_managed_identity(mock_env_clear: None) -> None:
+    calls = iter(
+        [
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_new"),
+        ]
+    )
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda _request: httpx.Response(200, json=next(calls))
+    )
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_old"))
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        old = box.current_session
+        assert old is not None
+        acquired = box.session()
+        assert acquired is old is box.current_session
+        with acquired as entered:
+            assert entered is acquired
+            replacement = box.session()
+            assert replacement is box.current_session
+            assert replacement is not acquired
+
+    assert resume_route.call_count == 3
+    assert stop_route.call_count == 1
+    assert stop_route.calls[0].request.url.path.endswith("/sbx_old/stop")
+    assert replacement.status is SandboxStatus.RUNNING
+
+
+@respx.mock
+async def test_async_managed_session_applies_matching_stop_metadata(
+    mock_env_clear: None,
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json=_stop_response("sbx_123", sandbox_session_id="sbx_123"),
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        routes = box.routes
+        raw = box.raw
+        project_id = box.project_id
+        async with box.session() as acquired:
+            assert acquired is box.current_session
+        assert acquired.status is SandboxStatus.STOPPED
+        assert box.status is SandboxStatus.STOPPED
+        assert box.updated_at == 99
+        assert box.routes == routes
+        assert box.raw is not None
+        assert raw is not None
+        assert box.project_id == project_id == "prj_123"
+        assert box.current_session is acquired
+
+    assert stop_route.call_count == 1
+
+
+@respx.mock
+async def test_async_managed_session_cleanup_never_rolls_back_replacement(
+    mock_env_clear: None,
+) -> None:
+    responses = iter(
+        [
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_new"),
+        ]
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda _request: httpx.Response(200, json=next(responses))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json=_stop_response("sbx_old", sandbox_session_id="sbx_old"),
+        )
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        async with box.session() as acquired:
+            assert await box.query_processes() == []
+            replacement = box.current_session
+            assert replacement is not None and replacement.id == "sbx_new"
+        assert acquired.status is SandboxStatus.STOPPED
+        assert box.current_session is replacement
+        assert replacement.status is SandboxStatus.RUNNING
+
+    assert old_stop.call_count == 1
+    assert new_stop.call_count == 0
+
+
+@respx.mock
+@pytest.mark.parametrize("sync", [False, True])
+@pytest.mark.parametrize(
+    ("status_code", "data"),
+    [
+        (409, {"error": {"code": "sandbox_stopped", "message": "stopped"}}),
+        (410, {"error": {"message": "gone"}}),
+    ],
+)
+async def test_session_cleanup_suppresses_already_stopped(
+    mock_env_clear: None,
+    sync: bool,
+    status_code: int,
+    data: dict[str, object],
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            status_code,
+            json=data,
+        )
+    )
+
+    acquired_status: SandboxStatus | None
+    if sync:
+        with session(service_options=_session_options(sync=True)):
+            sync_box = sandbox_sync.get_sandbox(name="preview")
+            with sync_box.session() as sync_acquired:
+                pass
+            with sync_acquired:
+                pass
+            acquired_status = sync_acquired.status
+    else:
+        async with session(service_options=_session_options()):
+            async_box = await sandbox.get_sandbox(name="preview")
+            async with async_box.session() as async_acquired:
+                pass
+            acquired_status = async_acquired.status
+
+    assert acquired_status is SandboxStatus.STOPPED
+    assert stop_route.call_count == 1
+
+
+@respx.mock
+async def test_async_session_cleanup_preserves_block_error_and_warns(
+    mock_env_clear: None,
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            500,
+            json={"error": {"code": "stop_failed", "message": "failed"}},
+        )
+    )
+    original = ValueError("block failed")
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        with pytest.warns(RuntimeWarning) as warnings_info:
+            with pytest.raises(ValueError) as exc_info:
+                async with box.session():
+                    raise original
+
+    assert exc_info.value is original
+    cleanup_error = warnings_info[0].source
+    assert isinstance(cleanup_error, SandboxCleanupError)
+    assert cleanup_error.resource_type == "sandbox_runtime_session"
+    assert cleanup_error.resource_id == "sbx_123"
+    assert isinstance(cleanup_error.cause, SandboxApiError)
+
+
+@respx.mock
+async def test_async_session_operation_is_single_use_and_warns_unconsumed(
+    mock_env_clear: None,
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        operation = box.session()
+        await operation
+        with pytest.raises(RuntimeError, match="can only be used once"):
+            await operation
+        with pytest.warns(RuntimeWarning, match=r"await box\.session"):
+            unconsumed = box.session()
+            del unconsumed
+            gc.collect()
+
+
+@respx.mock
+@pytest.mark.parametrize("error_code", ["sandbox_stopping", "sandbox_snapshotting"])
+async def test_async_session_acquisition_polls_transition_then_retries_once(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+) -> None:
+    async def no_delay(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
+    attempts = 0
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.url.params["resume"] == "false":
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                409,
+                json={
+                    "error": {
+                        "code": error_code,
+                        "message": "transitioning",
+                    }
+                },
+            )
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session": _sandbox_response(
+                    session_id="sbx_old", status="stopped", session_status="stopped"
+                )["session"]
+            },
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        acquired = await box.session()
+
+    assert acquired.id == "sbx_new"
+    assert sandbox_route.call_count == 3
+    assert poll_route.call_count == 1
+
+
+@respx.mock
+@pytest.mark.parametrize("error_code", ["sandbox_stopping", "sandbox_snapshotting"])
+def test_sync_session_acquisition_polls_transition_then_retries_once(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+) -> None:
+    monkeypatch.setattr(sandbox_sync_runtime.time, "sleep", lambda _delay: None)
+    attempts = 0
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.url.params["resume"] == "false":
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                409,
+                json={
+                    "error": {
+                        "code": error_code,
+                        "message": "transitioning",
+                    }
+                },
+            )
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=sandbox_handler
+    )
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session": _sandbox_response(
+                    session_id="sbx_old", status="stopped", session_status="stopped"
+                )["session"]
+            },
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        acquired = box.session()
+
+    assert acquired.id == "sbx_new"
+    assert sandbox_route.call_count == 3
+    assert poll_route.call_count == 1
+
+
+@respx.mock
+async def test_async_session_entry_cancellation_owns_no_cleanup(
+    mock_env_clear: None,
+) -> None:
+    resume_started = asyncio.Event()
+    release_resume = asyncio.Event()
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+
+    async def resume_handler(_request: httpx.Request) -> httpx.Response:
+        resume_started.set()
+        await release_resume.wait()
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}).mock(
+        side_effect=resume_handler
+    )
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+
+        async def enter() -> None:
+            async with box.session():
+                raise AssertionError("cancelled entry must not yield")
+
+        task = asyncio.create_task(enter())
+        await resume_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release_resume.set()
+        for _ in range(10):
+            if box.current_session_id == "sbx_new":
+                break
+            await asyncio.sleep(0)
+        assert box.current_session_id == "sbx_new"
+
+    assert stop_route.call_count == 0
+
+
+@respx.mock
+async def test_async_session_cleanup_finishes_before_cancellation_propagates(
+    mock_env_clear: None,
+) -> None:
+    entered = asyncio.Event()
+    stop_started = asyncio.Event()
+    release_stop = asyncio.Event()
+    block_forever = asyncio.Event()
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    async def stop_handler(_request: httpx.Request) -> httpx.Response:
+        stop_started.set()
+        await release_stop.wait()
+        return httpx.Response(200, json=_stop_response("sbx_123"))
+
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        side_effect=stop_handler
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+
+        async def managed() -> None:
+            async with box.session():
+                entered.set()
+                await block_forever.wait()
+
+        task = asyncio.create_task(managed())
+        await entered.wait()
+        task.cancel()
+        await stop_started.wait()
+        assert not task.done()
+        release_stop.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert stop_route.call_count == 1
+
+
+@respx.mock
+def test_listed_sync_session_cleanup_has_no_parent_linkage(mock_env_clear: None) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "sessions": [_sandbox_response(session_id="sbx_old")["session"]],
+                "pagination": {"count": 1, "next": None, "prev": None},
+            },
+        )
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json=_stop_response("sbx_old", sandbox_session_id="sbx_old"),
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        historical = box.list_sessions()[0]
+        with historical:
+            pass
+
+    assert historical.status is SandboxStatus.STOPPED
+    assert box.status is SandboxStatus.RUNNING
+    assert box.current_session_id == "sbx_123"
+
+
+@respx.mock
+async def test_async_session_acquisition_shares_implicit_resume(
+    mock_env_clear: None,
+) -> None:
+    resume_started = asyncio.Event()
+    release_resume = asyncio.Event()
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+
+    async def resume_handler(_request: httpx.Request) -> httpx.Response:
+        resume_started.set()
+        await release_resume.wait()
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    resume_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
+    ).mock(side_effect=resume_handler)
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        implicit = asyncio.create_task(box.query_processes())
+        await resume_started.wait()
+        explicit = asyncio.ensure_future(box.session())
+        await asyncio.sleep(0)
+        release_resume.set()
+        processes, acquired = await asyncio.gather(implicit, explicit)
+
+    assert processes == []
+    assert acquired is box.current_session
+    assert acquired.id == "sbx_new"
+    assert resume_route.call_count == 1
+
+
+@respx.mock
+def test_sync_managed_session_cleanup_never_rolls_back_replacement(
+    mock_env_clear: None,
+) -> None:
+    responses = iter(
+        [
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_new"),
+        ]
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda _request: httpx.Response(200, json=next(responses))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json=_stop_response("sbx_old", sandbox_session_id="sbx_old"),
+        )
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with box.session() as acquired:
+            assert box.query_processes() == []
+            replacement = box.current_session
+            assert replacement is not None and replacement.id == "sbx_new"
+
+    assert acquired.status is SandboxStatus.STOPPED
+    assert box.current_session is replacement
+    assert replacement.status is SandboxStatus.RUNNING
+    assert old_stop.call_count == 1
+    assert new_stop.call_count == 0
+
+
+@pytest.mark.parametrize("sandbox_session_id", [None, "sbx_other"])
+@respx.mock
+def test_sync_session_cleanup_ignores_sparse_nonmatching_metadata(
+    mock_env_clear: None,
+    sandbox_session_id: str | None,
+) -> None:
+    get_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json=_stop_response("sbx_123", sandbox_session_id=sandbox_session_id),
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with box.session() as acquired:
+            pass
+
+    assert acquired.status is SandboxStatus.STOPPED
+    assert box.status is SandboxStatus.RUNNING
+    assert box.current_session_id == "sbx_123"
+    assert get_route.call_count == 2
+
+
+def _incoherent_stop_response() -> dict[str, object]:
+    response = _stop_response("sbx_123", sandbox_session_id="sbx_123")
+    sandbox_payload = response["sandbox"]
+    assert isinstance(sandbox_payload, dict)
+    sandbox_payload["name"] = "other"
+    return response
+
+
+@pytest.mark.parametrize("block_fails", [False, True])
+@respx.mock
+async def test_async_cleanup_wraps_stop_result_application_failure(
+    mock_env_clear: None,
+    block_fails: bool,
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(200, json=_incoherent_stop_response())
+    )
+    original = ValueError("block failed")
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        if block_fails:
+            with pytest.warns(RuntimeWarning) as warnings_info:
+                with pytest.raises(ValueError) as exc_info:
+                    async with box.session():
+                        raise original
+            assert exc_info.value is original
+            cleanup_error = warnings_info[0].source
+        else:
+            with pytest.raises(SandboxCleanupError) as cleanup_info:
+                async with box.session():
+                    pass
+            cleanup_error = cleanup_info.value
+
+    assert isinstance(cleanup_error, SandboxCleanupError)
+    assert cleanup_error.resource_type == "sandbox_runtime_session"
+    assert cleanup_error.resource_id == "sbx_123"
+    assert isinstance(cleanup_error.cause, SandboxResponseError)
+
+
+@respx.mock
+def test_sync_successful_block_wraps_unrelated_cleanup_failure(
+    mock_env_clear: None,
+) -> None:
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            503,
+            json={"error": {"code": "unavailable", "message": "unavailable"}},
+        )
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with pytest.raises(SandboxCleanupError) as exc_info:
+            with box.session():
+                pass
+
+    assert exc_info.value.resource_type == "sandbox_runtime_session"
+    assert exc_info.value.resource_id == "sbx_123"
+    assert isinstance(exc_info.value.cause, SandboxApiError)
+    assert exc_info.value.cause.code == "unavailable"
+
+
+@respx.mock
+async def test_async_cancellation_with_cleanup_failure_warns_structured_error(
+    mock_env_clear: None,
+) -> None:
+    entered = asyncio.Event()
+    block_forever = asyncio.Event()
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
+        return_value=httpx.Response(
+            503,
+            json={"error": {"code": "stop_failed", "message": "failed"}},
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+
+        async def managed() -> None:
+            async with box.session():
+                entered.set()
+                await block_forever.wait()
+
+        task = asyncio.create_task(managed())
+        await entered.wait()
+        with pytest.warns(RuntimeWarning) as warnings_info:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    cleanup_error = warnings_info[0].source
+    assert isinstance(cleanup_error, SandboxCleanupError)
+    assert cleanup_error.resource_id == "sbx_123"
+    assert isinstance(cleanup_error.cause, SandboxApiError)
+    assert cleanup_error.cause.code == "stop_failed"
+
+
+@respx.mock
+def test_sync_session_acquisition_shares_implicit_resume(mock_env_clear: None) -> None:
+    resume_started = Event()
+    release_resume = Event()
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+
+    def resume_handler(_request: httpx.Request) -> httpx.Response:
+        resume_started.set()
+        assert release_resume.wait(timeout=5)
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    resume_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
+    ).mock(side_effect=resume_handler)
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.get_sandbox(name="preview")
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            implicit = executor.submit(box.query_processes)
+            assert resume_started.wait(timeout=5)
+            explicit = executor.submit(box.session)
+            release_resume.set()
+            assert implicit.result(timeout=5) == []
+            acquired = explicit.result(timeout=5)
+
+    assert acquired is box.current_session
+    assert acquired.id == "sbx_new"
+    assert resume_route.call_count == 1
+
+
+@respx.mock
+def test_sync_managed_resume_sandbox_stops_adopted_replacement(
+    mock_env_clear: None,
+) -> None:
+    responses = iter(
+        [
+            _sandbox_response(session_id="sbx_old"),
+            _sandbox_response(session_id="sbx_new"),
+        ]
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda _request: httpx.Response(200, json=next(responses))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_old"))
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    with session(service_options=_session_options()):
+        with sandbox_sync.resume_sandbox(name="preview") as box:
+            assert box.query_processes() == []
+            assert box.current_session_id == "sbx_new"
+
+    assert old_stop.call_count == 0
+    assert new_stop.call_count == 1
+
+
+@respx.mock
+async def test_managed_create_sandbox_stops_replacement_before_destroy(
+    mock_env_clear: None,
+) -> None:
+    respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_old"))
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+    destroy_route = respx.delete("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(
+            200,
+            json=_sandbox_response(
+                session_id="sbx_new", status="stopped", session_status="stopped"
+            ),
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        async with sandbox.create_sandbox(name="preview", runtime="python3.13") as box:
+            assert await box.query_processes() == []
+
+    assert old_stop.call_count == 0
+    assert new_stop.call_count == 1
+    assert destroy_route.call_count == 1
+
+
+@respx.mock
+async def test_async_managed_exit_does_not_wait_for_racing_recovery(
+    mock_env_clear: None,
+) -> None:
+    resume_started = asyncio.Event()
+    release_resume = asyncio.Event()
+    resume_count = 0
+
+    async def sandbox_handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal resume_count
+        resume_count += 1
+        if resume_count == 1:
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        resume_started.set()
+        await release_resume.wait()
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_old"))
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    async with session(service_options=_session_options()):
+        async with sandbox.resume_sandbox(name="preview") as box:
+            operation = asyncio.create_task(box.query_processes())
+            await resume_started.wait()
+        assert old_stop.call_count == 1
+        release_resume.set()
+        assert await operation == []
+
+    assert box.current_session_id == "sbx_new"
+    assert box.current_session is not None
+    assert box.current_session.status is SandboxStatus.RUNNING
+    assert new_stop.call_count == 0
+
+
+@respx.mock
+async def test_async_sparse_stop_ignores_concurrent_recovery(
+    mock_env_clear: None,
+) -> None:
+    resume_started = asyncio.Event()
+    release_resume = asyncio.Event()
+    stop_started = asyncio.Event()
+    replacement_used = asyncio.Event()
+    resume_count = 0
+
+    async def sandbox_handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal resume_count
+        resume_count += 1
+        response = _sandbox_response(session_id="sbx_old")
+        if resume_count == 1:
+            del response["session"]
+            return httpx.Response(200, json=response)
+        resume_started.set()
+        await release_resume.wait()
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    async def stop_handler(_request: httpx.Request) -> httpx.Response:
+        stop_started.set()
+        await replacement_used.wait()
+        return httpx.Response(200, json=_stop_response("sbx_old"))
+
+    def replacement_handler(_request: httpx.Request) -> httpx.Response:
+        replacement_used.set()
+        return httpx.Response(200, json={"commands": []})
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        side_effect=replacement_handler
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        side_effect=stop_handler
+    )
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.get_sandbox(name="preview")
+        assert box.current_session is None
+        operation = asyncio.create_task(box.query_processes())
+        await resume_started.wait()
+        stopping = asyncio.create_task(box.stop())
+        await stop_started.wait()
+        release_resume.set()
+        assert await operation == []
+        assert await stopping is box
+
+    assert old_stop.call_count == 1
+    assert box.current_session_id == "sbx_new"
+    assert box.current_session is not None
+    assert box.current_session.status is SandboxStatus.RUNNING
+
+
+@respx.mock
+def test_sync_managed_exit_does_not_wait_for_racing_recovery(
+    mock_env_clear: None,
+) -> None:
+    resume_started = Event()
+    release_resume = Event()
+    resume_count = 0
+
+    def sandbox_handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal resume_count
+        resume_count += 1
+        if resume_count == 1:
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        resume_started.set()
+        assert release_resume.wait(timeout=5)
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=sandbox_handler)
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            410,
+            json={"error": {"code": "sandbox_stopped", "message": "stopped"}},
+        )
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+    old_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_old"))
+    )
+    new_stop = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_new/stop").mock(
+        return_value=httpx.Response(200, json=_stop_response("sbx_new"))
+    )
+
+    with session(service_options=_session_options()):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with sandbox_sync.resume_sandbox(name="preview") as box:
+                operation = executor.submit(box.query_processes)
+                assert resume_started.wait(timeout=5)
+            assert old_stop.call_count == 1
+            release_resume.set()
+            assert operation.result(timeout=5) == []
+
+    assert box.current_session_id == "sbx_new"
+    assert box.current_session is not None
+    assert box.current_session.status is SandboxStatus.RUNNING
+    assert new_stop.call_count == 0

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -2,8 +2,10 @@ import asyncio
 import gc
 import json
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from itertools import islice
+from threading import Event, Lock
 from typing import Any
 
 import httpx
@@ -1973,12 +1975,25 @@ async def test_stopped_async_sandbox_recovers_a_covered_operation(
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
-    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
-        return_value=httpx.Response(
+
+    def old_read_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-read")
+        return httpx.Response(
             409,
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
+
+    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
+        side_effect=old_read_handler
     )
+
+    def replacement_read_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-read")
+        return httpx.Response(200, content=b"recovered")
+
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/fs/read"
+    ).mock(side_effect=replacement_read_handler)
 
     async with session(service_options=_session_options()):
         handle = await sandbox.create_sandbox(name="preview", runtime="python3.13")
@@ -1987,8 +2002,7 @@ async def test_stopped_async_sandbox_recovers_a_covered_operation(
         assert await handle.stop() is handle
         assert handle.current_session is retained_session
         assert handle.current_session.status is SandboxStatus.STOPPED
-        with pytest.raises(SandboxApiError, match="session is stopped") as fs_exc:
-            await handle.fs.read_bytes("message.txt")
+        assert await handle.fs.read_bytes("message.txt") == b"recovered"
         process = await handle.create_process("python", ["--version"])
         with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
             await retained_session.create_process("python", ["--version"])
@@ -2000,7 +2014,7 @@ async def test_stopped_async_sandbox_recovers_a_covered_operation(
     assert replacement_command_route.called
     assert process_refresh_route.called
     assert read_route.called
-    assert fs_exc.value.code == "sandbox_stopped"
+    assert replacement_read_route.called
     assert retained_exc.value.code == "sandbox_stopped"
     assert process_exc.value.code == "sandbox_stopped"
     assert process.session_id == "sbx_456"
@@ -2010,7 +2024,13 @@ async def test_stopped_async_sandbox_recovers_a_covered_operation(
     assert retained_session.id == "sbx_123"
     assert retained_session.status is SandboxStatus.STOPPED
     assert handle.routes[0].url == "https://replacement.sandbox.test"
-    assert events == ["old-command", "resume", "replacement-command", "old-command"]
+    assert events == [
+        "old-read",
+        "resume",
+        "replacement-read",
+        "replacement-command",
+        "old-command",
+    ]
 
 
 @respx.mock
@@ -2102,12 +2122,25 @@ def test_stopped_sync_sandbox_recovers_a_covered_operation(
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
     )
-    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
-        return_value=httpx.Response(
+
+    def old_read_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("old-read")
+        return httpx.Response(
             409,
             json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
         )
+
+    read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/fs/read").mock(
+        side_effect=old_read_handler
     )
+
+    def replacement_read_handler(_request: httpx.Request) -> httpx.Response:
+        events.append("replacement-read")
+        return httpx.Response(200, content=b"recovered")
+
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_456/fs/read"
+    ).mock(side_effect=replacement_read_handler)
 
     with session(service_options=_session_options()):
         handle = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
@@ -2116,8 +2149,7 @@ def test_stopped_sync_sandbox_recovers_a_covered_operation(
         assert handle.stop() is handle
         assert handle.current_session is retained_session
         assert handle.current_session.status is SandboxStatus.STOPPED
-        with pytest.raises(SandboxApiError, match="session is stopped") as fs_exc:
-            handle.fs.read_bytes("message.txt")
+        assert handle.fs.read_bytes("message.txt") == b"recovered"
         process = handle.create_process("python", ["--version"])
         with pytest.raises(SandboxApiError, match="session is stopped") as retained_exc:
             retained_session.create_process("python", ["--version"])
@@ -2129,7 +2161,7 @@ def test_stopped_sync_sandbox_recovers_a_covered_operation(
     assert replacement_command_route.called
     assert process_refresh_route.called
     assert read_route.called
-    assert fs_exc.value.code == "sandbox_stopped"
+    assert replacement_read_route.called
     assert retained_exc.value.code == "sandbox_stopped"
     assert process_exc.value.code == "sandbox_stopped"
     assert process.session_id == "sbx_456"
@@ -2139,7 +2171,160 @@ def test_stopped_sync_sandbox_recovers_a_covered_operation(
     assert retained_session.id == "sbx_123"
     assert retained_session.status is SandboxStatus.STOPPED
     assert handle.routes[0].url == "https://replacement.sandbox.test"
-    assert events == ["old-command", "resume", "replacement-command", "old-command"]
+    assert events == [
+        "old-read",
+        "resume",
+        "replacement-read",
+        "replacement-command",
+        "old-command",
+    ]
+
+
+@respx.mock
+async def test_async_process_and_filesystem_recovery_share_one_resume_request(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resume_started = asyncio.Event()
+    second_recovery_waiter = asyncio.Event()
+    shared_resume_calls = 0
+    original_await_shared_resume = sandbox_async_runtime.Sandbox._await_shared_resume
+
+    async def track_shared_resume(handle: sandbox.Sandbox) -> None:
+        nonlocal shared_resume_calls
+        shared_resume_calls += 1
+        if shared_resume_calls == 2:
+            second_recovery_waiter.set()
+        await original_await_shared_resume(handle)
+
+    monkeypatch.setattr(sandbox_async_runtime.Sandbox, "_await_shared_resume", track_shared_resume)
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        raise AssertionError("The resume route must use its async handler")
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
+        side_effect=sandbox_handler
+    )
+
+    async def resume_handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["resume"] == "true"
+        resume_started.set()
+        await asyncio.wait_for(second_recovery_waiter.wait(), timeout=5)
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    resume_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
+    ).mock(side_effect=resume_handler)
+    old_process_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+    old_read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+    replacement_process_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
+    ).mock(return_value=httpx.Response(200, json={"commands": []}))
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        process_task = asyncio.create_task(handle.query_processes())
+        await resume_started.wait()
+        filesystem_task = asyncio.create_task(handle.fs.read_bytes("message.txt"))
+        assert await process_task == []
+        assert await filesystem_task == b"replacement"
+
+    assert handle.current_session_id == "sbx_new"
+    assert shared_resume_calls == 2
+    assert resume_route.call_count == 1
+    assert old_process_route.call_count == replacement_process_route.call_count == 1
+    assert old_read_route.call_count == replacement_read_route.call_count == 1
+
+
+@respx.mock
+def test_sync_process_and_filesystem_recovery_share_one_resume_request(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resume_started = Event()
+    second_recovery_waiter = Event()
+    shared_resume_lock = Lock()
+    shared_resume_calls = 0
+    original_await_shared_resume = sandbox_sync_runtime.SyncSandbox._await_shared_resume
+
+    async def track_shared_resume(handle: sandbox_sync.SyncSandbox) -> None:
+        nonlocal shared_resume_calls
+        with shared_resume_lock:
+            shared_resume_calls += 1
+            if shared_resume_calls == 2:
+                second_recovery_waiter.set()
+        await original_await_shared_resume(handle)
+
+    monkeypatch.setattr(
+        sandbox_sync_runtime.SyncSandbox, "_await_shared_resume", track_shared_resume
+    )
+
+    def sandbox_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["resume"] == "false":
+            return httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+        raise AssertionError("The resume route must use its blocking handler")
+
+    respx.get("https://sandbox.test/v2/sandboxes/preview", params={"resume": "false"}).mock(
+        side_effect=sandbox_handler
+    )
+
+    def resume_handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["resume"] == "true"
+        resume_started.set()
+        assert second_recovery_waiter.wait(timeout=5)
+        return httpx.Response(200, json=_sandbox_response(session_id="sbx_new"))
+
+    resume_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/preview", params={"resume": "true"}
+    ).mock(side_effect=resume_handler)
+    old_process_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+    old_read_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_old/fs/read").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopped", "message": "session is stopped"}},
+        )
+    )
+    replacement_process_route = respx.get(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd"
+    ).mock(return_value=httpx.Response(200, json={"commands": []}))
+    replacement_read_route = respx.post(
+        "https://sandbox.test/v2/sandboxes/sessions/sbx_new/fs/read"
+    ).mock(return_value=httpx.Response(200, content=b"replacement"))
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            process_future = executor.submit(handle.query_processes)
+            assert resume_started.wait(timeout=5)
+            filesystem_future = executor.submit(handle.fs.read_bytes, "message.txt")
+            assert process_future.result(timeout=5) == []
+            assert filesystem_future.result(timeout=5) == b"replacement"
+
+    assert handle.current_session_id == "sbx_new"
+    assert shared_resume_calls == 2
+    assert resume_route.call_count == 1
+    assert old_process_route.call_count == replacement_process_route.call_count == 1
+    assert old_read_route.call_count == replacement_read_route.call_count == 1
 
 
 _RECOVERABLE_SANDBOX_OPERATIONS = (

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -45,6 +45,10 @@ from vercel.sandbox import (
     TarballSource,
     sync as sandbox_sync,
 )
+from vercel.sandbox._internal import (
+    async_runtime as sandbox_async_runtime,
+    sync_runtime as sandbox_sync_runtime,
+)
 from vercel.sandbox._internal.service import get_sandbox_service
 from vercel.sandbox._internal.state import SandboxRuntimeSessionState, SandboxState
 
@@ -2371,6 +2375,44 @@ async def test_sandbox_payload_application_preserves_or_replaces_current_session
         assert handle.current_session.id == "sbx_new"
 
 
+async def test_recovery_poll_retains_a_concurrently_installed_replacement(
+    mock_env_clear: None,
+) -> None:
+    async with session(service_options=_session_options()):
+        handle = sandbox.Sandbox(
+            payload=SandboxState(
+                name="preview",
+                current_session_id="sbx_old",
+                current_session=SandboxRuntimeSessionState(
+                    id="sbx_old", status=SandboxStatus.STOPPING
+                ),
+            ),
+            service=get_sandbox_service(get_active_session()),
+        )
+        old_session = handle.current_session
+        assert old_session is not None
+        target = handle._capture_recovery_target()
+
+        handle._apply_payload(
+            SandboxState(
+                name="preview",
+                current_session_id="sbx_new",
+                current_session=SandboxRuntimeSessionState(
+                    id="sbx_new", status=SandboxStatus.RUNNING
+                ),
+            )
+        )
+        handle._apply_recovery_session_payload(
+            target,
+            SandboxRuntimeSessionState(id="sbx_old", status=SandboxStatus.STOPPED),
+        )
+
+    assert old_session.status is SandboxStatus.STOPPED
+    assert handle.current_session_id == "sbx_new"
+    assert handle.current_session is not None
+    assert handle.current_session.id == "sbx_new"
+
+
 @respx.mock
 async def test_async_sparse_sandbox_lookup_targets_current_session_without_resume(
     mock_env_clear: None,
@@ -2842,6 +2884,228 @@ async def test_async_sandbox_does_not_recover_noncovered_operations(
 
     assert exc_info.value.code == "sandbox_stopped"
     assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("error_code", "transition_status"),
+    [
+        ("sandbox_stopping", "stopping"),
+        ("sandbox_snapshotting", "snapshotting"),
+    ],
+)
+@respx.mock
+async def test_async_transition_recovery_polls_exact_session_then_replays(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+    transition_status: str,
+) -> None:
+    events: list[str] = []
+    poll_statuses = iter([transition_status, transition_status, "stopped"])
+
+    async def no_delay(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda request: httpx.Response(
+            200,
+            json=_sandbox_response(
+                session_id="sbx_old" if request.url.params["resume"] == "false" else "sbx_new"
+            ),
+        )
+    )
+
+    def old_operation(_request: httpx.Request) -> httpx.Response:
+        events.append("old-operation")
+        return httpx.Response(
+            409,
+            json={"error": {"code": error_code, "message": "transitioning"}},
+        )
+
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_operation
+    )
+
+    def poll(_request: httpx.Request) -> httpx.Response:
+        status = next(poll_statuses)
+        events.append(f"poll-{status}")
+        return httpx.Response(
+            200,
+            json={
+                "session": _sandbox_response(
+                    session_id="sbx_old", status=status, session_status=status
+                )["session"]
+            },
+        )
+
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        side_effect=poll
+    )
+    replacement_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        old_session = handle.current_session
+        assert old_session is not None
+        assert await handle.query_processes() == []
+
+    assert poll_route.call_count == 3
+    assert replacement_route.call_count == 1
+    assert old_session.status is SandboxStatus.STOPPED
+    assert handle.current_session_id == "sbx_new"
+    assert events == [
+        "old-operation",
+        f"poll-{transition_status}",
+        f"poll-{transition_status}",
+        "poll-stopped",
+    ]
+
+
+@respx.mock
+async def test_async_transition_polling_is_cancellable(
+    mock_env_clear: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    poll_waiting = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def blocked_delay(_delay: float) -> None:
+        poll_waiting.set()
+        await never_release.wait()
+
+    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", blocked_delay)
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopping", "message": "transitioning"}},
+        )
+    )
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(500)
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        operation = asyncio.create_task(handle.query_processes())
+        await poll_waiting.wait()
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+
+    assert poll_route.call_count == 0
+
+
+@respx.mock
+async def test_async_transition_poll_failure_propagates_without_resuming(
+    mock_env_clear: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def no_delay(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(sandbox_async_runtime.asyncio, "sleep", no_delay)
+    sandbox_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        return_value=httpx.Response(
+            409,
+            json={"error": {"code": "sandbox_stopping", "message": "transitioning"}},
+        )
+    )
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        return_value=httpx.Response(
+            503,
+            json={"error": {"code": "poll_failed", "message": "poll failed"}},
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.get_sandbox(name="preview")
+        with pytest.raises(SandboxApiError) as exc_info:
+            await handle.query_processes()
+
+    assert exc_info.value.code == "poll_failed"
+    assert poll_route.call_count == 1
+    assert sandbox_route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("error_code", "transition_status"),
+    [
+        ("sandbox_stopping", "stopping"),
+        ("sandbox_snapshotting", "snapshotting"),
+    ],
+)
+@respx.mock
+def test_sync_transition_recovery_polls_exact_session_then_replays(
+    mock_env_clear: None,
+    monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+    transition_status: str,
+) -> None:
+    events: list[str] = []
+    poll_statuses = iter([transition_status, transition_status, "stopped"])
+    monkeypatch.setattr(sandbox_sync_runtime.time, "sleep", lambda _delay: None)
+    respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        side_effect=lambda request: httpx.Response(
+            200,
+            json=_sandbox_response(
+                session_id="sbx_old" if request.url.params["resume"] == "false" else "sbx_new"
+            ),
+        )
+    )
+
+    def old_operation(_request: httpx.Request) -> httpx.Response:
+        events.append("old-operation")
+        return httpx.Response(
+            409,
+            json={"error": {"code": error_code, "message": "transitioning"}},
+        )
+
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old/cmd").mock(
+        side_effect=old_operation
+    )
+
+    def poll(_request: httpx.Request) -> httpx.Response:
+        status = next(poll_statuses)
+        events.append(f"poll-{status}")
+        return httpx.Response(
+            200,
+            json={
+                "session": _sandbox_response(
+                    session_id="sbx_old", status=status, session_status=status
+                )["session"]
+            },
+        )
+
+    poll_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_old").mock(
+        side_effect=poll
+    )
+    replacement_route = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_new/cmd").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.get_sandbox(name="preview")
+        old_session = handle.current_session
+        assert old_session is not None
+        assert handle.query_processes() == []
+
+    assert poll_route.call_count == 3
+    assert replacement_route.call_count == 1
+    assert old_session.status is SandboxStatus.STOPPED
+    assert handle.current_session_id == "sbx_new"
+    assert events == [
+        "old-operation",
+        f"poll-{transition_status}",
+        f"poll-{transition_status}",
+        "poll-stopped",
+    ]
 
 
 def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:

--- a/src/vercel-sandbox/tests/test_sandbox_recovery.py
+++ b/src/vercel-sandbox/tests/test_sandbox_recovery.py
@@ -8,6 +8,7 @@ from vercel.sandbox._internal.errors import (
 )
 from vercel.sandbox._internal.recovery import (
     SandboxLifecycle,
+    SandboxRecoveryTarget,
     classify_sandbox_lifecycle_error,
     execute_with_sandbox_recovery,
 )
@@ -18,22 +19,36 @@ def _api_error(*, status_code: int = 409, code: str | None = None) -> SandboxApi
     return SandboxApiError(httpx.Response(status_code, json=data), "failed", data=data)
 
 
+_MISSING_CAUSE = object()
+
+
+def _malformed_write_error(cause: object = _MISSING_CAUSE) -> SandboxFilesystemWriteError:
+    error = SandboxFilesystemWriteError.__new__(SandboxFilesystemWriteError)
+    BaseException.__init__(error, "malformed write error")
+    if cause is not _MISSING_CAUSE:
+        error.cause = cause  # type: ignore[assignment]
+    return error
+
+
 @pytest.mark.parametrize(
     ("error", "expected"),
     [
-        (_api_error(code="sandbox_stopped"), SandboxLifecycle.STOPPED),
+        (_api_error(status_code=410, code="sandbox_stopped"), SandboxLifecycle.STOPPED),
+        (_api_error(status_code=410, code="sandbox_failed"), SandboxLifecycle.STOPPED),
+        (_api_error(status_code=410), SandboxLifecycle.STOPPED),
         (_api_error(code="sandbox_stopping"), SandboxLifecycle.STOPPING),
         (_api_error(code="sandbox_snapshotting"), SandboxLifecycle.SNAPSHOTTING),
         (
             SandboxFilesystemWriteError(
                 paths=("message.txt",),
                 cwd="/vercel/sandbox",
-                cause=_api_error(code="sandbox_stopped"),
+                cause=_api_error(status_code=410, code="sandbox_not_found"),
             ),
             SandboxLifecycle.STOPPED,
         ),
+        (_malformed_write_error(), None),
+        (_malformed_write_error(RuntimeError("non-api cause")), None),
         (_api_error(code="other"), None),
-        (_api_error(status_code=410), SandboxLifecycle.STOPPED),
         (SandboxStreamError("stopped", code="sandbox_stopped"), None),
     ],
 )
@@ -44,58 +59,108 @@ def test_classify_sandbox_lifecycle_error(
 
 
 class _Coordinator:
-    def __init__(self, *, recover: bool = True) -> None:
-        self.recover = recover
-        self.lifecycle: SandboxLifecycle | None = None
+    def __init__(
+        self,
+        *,
+        recover: bool = True,
+        recovery_error: BaseException | None = None,
+    ) -> None:
+        self.session_id = "session-1"
+        self.recover_result = recover
+        self.recovery_error = recovery_error
+        self.recoveries: list[tuple[SandboxLifecycle, SandboxRecoveryTarget]] = []
 
-    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
-        self.lifecycle = lifecycle
-        return self.recover
+    def _capture_recovery_target(self) -> SandboxRecoveryTarget:
+        return SandboxRecoveryTarget(session_id=self.session_id, session=None)
+
+    async def _recover(self, lifecycle: SandboxLifecycle, target: SandboxRecoveryTarget) -> bool:
+        self.recoveries.append((lifecycle, target))
+        if self.recovery_error is not None:
+            raise self.recovery_error
+        if self.recover_result:
+            self.session_id = "session-2"
+        return self.recover_result
 
 
-async def test_execute_with_sandbox_recovery_replays_once() -> None:
-    attempts = 0
+@pytest.mark.asyncio
+async def test_execute_recovers_once_and_replays_on_the_new_target() -> None:
     coordinator = _Coordinator()
+    targets: list[str] = []
 
-    async def operation() -> str:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise _api_error(code="sandbox_stopped")
-        return "replayed"
+    async def operation(session_id: str) -> str:
+        targets.append(session_id)
+        if len(targets) == 1:
+            raise _api_error(status_code=410)
+        return "result"
 
-    assert await execute_with_sandbox_recovery(operation, coordinator=coordinator) == "replayed"
-    assert attempts == 2
-    assert coordinator.lifecycle is SandboxLifecycle.STOPPED
+    assert await execute_with_sandbox_recovery(operation, coordinator=coordinator) == "result"
+    assert targets == ["session-1", "session-2"]
+    assert coordinator.recoveries == [
+        (
+            SandboxLifecycle.STOPPED,
+            SandboxRecoveryTarget(session_id="session-1", session=None),
+        )
+    ]
 
 
-async def test_execute_with_sandbox_recovery_propagates_a_replay_failure() -> None:
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "recover"),
+    [
+        (_api_error(status_code=409, code="other"), True),
+        (_api_error(status_code=410), False),
+    ],
+    ids=["unrelated-error", "recovery-declined"],
+)
+async def test_execute_preserves_the_original_error_without_replay(
+    error: SandboxApiError, recover: bool
+) -> None:
+    coordinator = _Coordinator(recover=recover)
     attempts = 0
-    replay_error = _api_error(code="sandbox_stopped")
 
-    async def operation() -> None:
+    async def operation(_session_id: str) -> None:
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            raise _api_error(code="sandbox_stopped")
-        raise replay_error
-
-    with pytest.raises(SandboxApiError) as exc_info:
-        await execute_with_sandbox_recovery(operation, coordinator=_Coordinator())
-
-    assert exc_info.value is replay_error
-    assert attempts == 2
-
-
-async def test_execute_with_sandbox_recovery_preserves_unhandled_failure() -> None:
-    error = _api_error(code="sandbox_stopping")
-    coordinator = _Coordinator(recover=False)
-
-    async def operation() -> None:
         raise error
 
-    with pytest.raises(SandboxApiError) as exc_info:
+    with pytest.raises(SandboxApiError) as caught:
         await execute_with_sandbox_recovery(operation, coordinator=coordinator)
 
-    assert exc_info.value is error
-    assert coordinator.lifecycle is SandboxLifecycle.STOPPING
+    assert caught.value is error
+    assert attempts == 1
+    assert len(coordinator.recoveries) == (0 if recover else 1)
+
+
+@pytest.mark.asyncio
+async def test_execute_propagates_recovery_failure() -> None:
+    recovery_error = RuntimeError("resume failed")
+    coordinator = _Coordinator(recovery_error=recovery_error)
+
+    async def operation(_session_id: str) -> None:
+        raise _api_error(status_code=410)
+
+    with pytest.raises(RuntimeError) as caught:
+        await execute_with_sandbox_recovery(operation, coordinator=coordinator)
+
+    assert caught.value is recovery_error
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_recover_a_failed_replay() -> None:
+    coordinator = _Coordinator()
+    attempts = 0
+    replay_error = _api_error(status_code=410, code="sandbox_stopped")
+
+    async def operation(_session_id: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _api_error(status_code=410)
+        raise replay_error
+
+    with pytest.raises(SandboxApiError) as caught:
+        await execute_with_sandbox_recovery(operation, coordinator=coordinator)
+
+    assert caught.value is replay_error
+    assert attempts == 2
+    assert len(coordinator.recoveries) == 1

--- a/src/vercel-sandbox/tests/test_sandbox_recovery.py
+++ b/src/vercel-sandbox/tests/test_sandbox_recovery.py
@@ -1,0 +1,101 @@
+import httpx
+import pytest
+
+from vercel.sandbox._internal.errors import (
+    SandboxApiError,
+    SandboxFilesystemWriteError,
+    SandboxStreamError,
+)
+from vercel.sandbox._internal.recovery import (
+    SandboxLifecycle,
+    classify_sandbox_lifecycle_error,
+    execute_with_sandbox_recovery,
+)
+
+
+def _api_error(*, status_code: int = 409, code: str | None = None) -> SandboxApiError:
+    data = None if code is None else {"error": {"code": code, "message": "failed"}}
+    return SandboxApiError(httpx.Response(status_code, json=data), "failed", data=data)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (_api_error(code="sandbox_stopped"), SandboxLifecycle.STOPPED),
+        (_api_error(code="sandbox_stopping"), SandboxLifecycle.STOPPING),
+        (_api_error(code="sandbox_snapshotting"), SandboxLifecycle.SNAPSHOTTING),
+        (
+            SandboxFilesystemWriteError(
+                paths=("message.txt",),
+                cwd="/vercel/sandbox",
+                cause=_api_error(code="sandbox_stopped"),
+            ),
+            SandboxLifecycle.STOPPED,
+        ),
+        (_api_error(code="other"), None),
+        (_api_error(status_code=410), SandboxLifecycle.STOPPED),
+        (SandboxStreamError("stopped", code="sandbox_stopped"), None),
+    ],
+)
+def test_classify_sandbox_lifecycle_error(
+    error: BaseException, expected: SandboxLifecycle | None
+) -> None:
+    assert classify_sandbox_lifecycle_error(error) is expected
+
+
+class _Coordinator:
+    def __init__(self, *, recover: bool = True) -> None:
+        self.recover = recover
+        self.lifecycle: SandboxLifecycle | None = None
+
+    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
+        self.lifecycle = lifecycle
+        return self.recover
+
+
+async def test_execute_with_sandbox_recovery_replays_once() -> None:
+    attempts = 0
+    coordinator = _Coordinator()
+
+    async def operation() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _api_error(code="sandbox_stopped")
+        return "replayed"
+
+    assert await execute_with_sandbox_recovery(operation, coordinator=coordinator) == "replayed"
+    assert attempts == 2
+    assert coordinator.lifecycle is SandboxLifecycle.STOPPED
+
+
+async def test_execute_with_sandbox_recovery_propagates_a_replay_failure() -> None:
+    attempts = 0
+    replay_error = _api_error(code="sandbox_stopped")
+
+    async def operation() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _api_error(code="sandbox_stopped")
+        raise replay_error
+
+    with pytest.raises(SandboxApiError) as exc_info:
+        await execute_with_sandbox_recovery(operation, coordinator=_Coordinator())
+
+    assert exc_info.value is replay_error
+    assert attempts == 2
+
+
+async def test_execute_with_sandbox_recovery_preserves_unhandled_failure() -> None:
+    error = _api_error(code="sandbox_stopping")
+    coordinator = _Coordinator(recover=False)
+
+    async def operation() -> None:
+        raise error
+
+    with pytest.raises(SandboxApiError) as exc_info:
+        await execute_with_sandbox_recovery(operation, coordinator=coordinator)
+
+    assert exc_info.value is error
+    assert coordinator.lifecycle is SandboxLifecycle.STOPPING

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -17,6 +17,7 @@ from vercel.sandbox._internal.async_runtime import (
     SandboxFilesystem,
     SandboxFilesystemBatch,
     SandboxRuntimeSession,
+    SandboxSessionOperation,
     Snapshot,
     create_sandbox_operation as _create_sandbox_operation,
     get_or_create_sandbox as _get_or_create_sandbox,
@@ -212,6 +213,10 @@ async def get_sandbox(
     include_system_routes: bool | None = None,
 ) -> Sandbox:
     """Fetch a sandbox by name without resuming it.
+
+    Session-bound operations on the returned handle resume lazily when needed.
+    Use ``current_session`` for passive inspection or ``session()`` for an
+    authoritative exact-session acquisition and optional managed scope.
 
     Args:
         name: Sandbox name.
@@ -409,6 +414,7 @@ __all__ = [
     "ResumeSandboxOperation",
     "SandboxStreamError",
     "SandboxRuntimeSession",
+    "SandboxSessionOperation",
     "SandboxServiceOptions",
     "SandboxSource",
     "SandboxStatus",

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -41,6 +41,7 @@ from vercel.sandbox._internal.errors import (
     SandboxResponseError,
     SandboxStreamError,
     SandboxTerminalStateError,
+    SandboxTimeoutError as SandboxTimeoutError,
     SandboxUploadSizeMismatchError,
 )
 from vercel.sandbox._internal.models import (

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -64,6 +64,7 @@ from vercel.sandbox._internal.state import (
     CompletedProcessState,
     ProcessState,
     RuntimeSessionsPageState,
+    RuntimeSessionStopState,
     SandboxesPageState,
     SandboxRouteState,
     SandboxRuntimeSessionState,
@@ -493,6 +494,7 @@ class _CommandsResponse(_ApiModel):
 
 class _RuntimeSessionResponse(_ApiModel):
     session: _RuntimeSessionPayload | None = None
+    sandbox: _SandboxPayload | None = None
     routes: list[_SandboxRoutePayload] = Field(default_factory=list)
 
     def to_runtime_session(self) -> SandboxRuntimeSessionState:
@@ -502,6 +504,32 @@ class _RuntimeSessionResponse(_ApiModel):
                 data=self.model_dump(by_alias=True),
             )
         return _runtime_session_state(self.session)
+
+    def to_runtime_session_stop(self, *, project_id: str | None = None) -> RuntimeSessionStopState:
+        session = self.to_runtime_session()
+        sandbox = self.sandbox
+        return RuntimeSessionStopState(
+            session=session,
+            sandbox=(
+                None
+                if sandbox is None
+                else _sandbox_state(
+                    sandbox,
+                    raw=cast(
+                        JSONObject,
+                        sandbox.model_dump(
+                            by_alias=True,
+                            exclude_none=True,
+                            exclude={"routes", "current_session", "raw"},
+                        ),
+                    ),
+                    project_id=session.project_id or project_id,
+                    routes_attached=False,
+                    current_session_attached=False,
+                )
+            ),
+            _sandbox_attached="sandbox" in self.model_fields_set,
+        )
 
 
 class _RuntimeSessionsResponse(_ApiModel):
@@ -1049,7 +1077,7 @@ class SandboxApiClient:
             include_system_routes=include_system_routes,
         )
 
-    async def stop_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
+    async def stop_runtime_session(self, *, session_id: str) -> RuntimeSessionStopState:
         credentials = await self._credentials_factory()
         data = await self._request_json(
             "POST",
@@ -1057,10 +1085,18 @@ class SandboxApiClient:
             credentials=credentials,
             body={},
         )
-        return _validate_response(_RuntimeSessionResponse, data).to_runtime_session()
+        result = _validate_response(_RuntimeSessionResponse, data).to_runtime_session_stop(
+            project_id=credentials.project_id
+        )
+        if result.session.id != session_id:
+            raise SandboxResponseError(
+                "Sandbox current-session operation returned a different session identity",
+                data=result.session,
+            )
+        return result
 
     async def destroy_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
-        return await self.stop_runtime_session(session_id=session_id)
+        return (await self.stop_runtime_session(session_id=session_id)).session
 
     async def get_runtime_session(
         self,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -21,6 +21,7 @@ from vercel.sandbox._internal.async_filesystem_handle import (
     SandboxTextWriter,
 )
 from vercel.sandbox._internal.errors import (
+    SandboxApiError,
     SandboxCleanupError,
     SandboxResponseError,
     SandboxTerminalStateError,
@@ -70,6 +71,7 @@ from vercel.sandbox._internal.recovery import (
     TRANSITION_TIMEOUT,
     SandboxLifecycle,
     SandboxRecoveryTarget,
+    classify_sandbox_lifecycle_error,
     execute_with_sandbox_recovery,
 )
 from vercel.sandbox._internal.runtime_common import (
@@ -846,7 +848,7 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
         payload = await self._service.get_runtime_session(
             session_id=self.id, include_system_routes=include_system_routes
         )
-        self._apply_payload(payload)
+        self._apply_payload_with_parent(payload)
         return self
 
     async def extend_execution_time_limit(self, duration: DurationInput) -> Self:
@@ -885,8 +887,8 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
 
     async def stop(self) -> Self:
         """Stop this runtime session and refresh the handle."""
-        payload = await self._service.stop_runtime_session(session_id=self.id)
-        self._apply_payload(payload)
+        result = await self._service.stop_runtime_session(session_id=self.id)
+        self._apply_stop_result(result)
         return self
 
 
@@ -894,9 +896,10 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     """Control an asynchronous Vercel Sandbox.
 
     A sandbox has at most one active current session. Process and filesystem
-    operations target the session recorded by this handle. Use
-    ``sandbox.resume_sandbox`` to ensure the sandbox has an active session,
-    ``stop`` to stop it, and ``destroy`` to permanently remove the sandbox.
+    session-bound operations lazily resume when needed and update this handle's
+    canonical current session. Use ``session`` for an explicit exact-session
+    lifecycle, ``stop`` to stop the current session, and ``destroy`` to
+    permanently remove the sandbox.
     """
 
     __slots__ = ("_recovery_task", "_service", "fs")
@@ -952,6 +955,35 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         """Ensure an active current session before binding a lazy stream."""
         await self._await_shared_resume()
         return self.current_session_id
+
+    async def _acquire_session(self) -> SandboxRuntimeSession:
+        target = self._capture_recovery_target()
+        try:
+            await self._await_shared_resume()
+        except Exception as error:
+            lifecycle = classify_sandbox_lifecycle_error(error)
+            if lifecycle not in {
+                SandboxLifecycle.STOPPING,
+                SandboxLifecycle.SNAPSHOTTING,
+            }:
+                raise
+            await self._wait_for_transition(target)
+            await self._await_shared_resume()
+        session = self.current_session
+        if session is None:
+            raise SandboxResponseError(
+                "Sandbox resume response is missing the current-session attachment",
+                data=self.raw,
+            )
+        return session
+
+    def session(self) -> "SandboxSessionOperation":
+        """Prepare an authoritative active-session acquisition operation.
+
+        Await the operation to leave the acquired session running, or enter it
+        to stop that exact session identity on exit.
+        """
+        return SandboxSessionOperation(self)
 
     async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
         deadline = time.monotonic() + TRANSITION_TIMEOUT
@@ -1185,8 +1217,22 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
 
     async def stop(self) -> Self:
         """Stop the current session and return this sandbox handle."""
-        payload = await self._service.stop_runtime_session(session_id=self.current_session_id)
-        self._apply_current_session_payload(payload)
+        session = self.current_session
+        target_id = self.current_session_id
+        if session is None:
+            result = await self._service.stop_runtime_session(session_id=target_id)
+            if self.current_session_id != target_id:
+                return self
+            self._apply_current_session_payload(result.session)
+            if (
+                result._sandbox_attached
+                and result.sandbox is not None
+                and result.sandbox.current_session_id == result.session.id
+            ):
+                self._apply_payload(result.sandbox)
+        else:
+            result = await self._service.stop_runtime_session(session_id=session.id)
+            session._apply_stop_result(result)
         return self
 
     async def destroy(self) -> Self:
@@ -1239,6 +1285,99 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         )
         self._apply_payload(payload)
         return self
+
+
+async def _cleanup_exact_session(handle: SandboxRuntimeSession) -> None:
+    if handle.status == SandboxStatus.STOPPED:
+        return
+    try:
+        result = await handle._service.stop_runtime_session(session_id=handle.id)
+        handle._apply_stop_result(result)
+    except SandboxApiError as error:
+        if classify_sandbox_lifecycle_error(error) is SandboxLifecycle.STOPPED:
+            handle._mark_stopped()
+            return
+        raise SandboxCleanupError(
+            f"Failed to clean up sandbox runtime session {handle.id!r}",
+            resource_type="sandbox_runtime_session",
+            resource_id=handle.id,
+            cause=error,
+        ) from error
+    except Exception as error:
+        raise SandboxCleanupError(
+            f"Failed to clean up sandbox runtime session {handle.id!r}",
+            resource_type="sandbox_runtime_session",
+            resource_id=handle.id,
+            cause=error,
+        ) from error
+
+
+def _warn_cleanup_after_block(error: SandboxCleanupError) -> None:
+    warnings.warn(str(error), RuntimeWarning, source=error, stacklevel=3)
+
+
+class SandboxSessionOperation:
+    """Acquire one sandbox session directly or as an exact-session scope.
+
+    Awaiting leaves the acquired session running. Async context management
+    stops only the session identity yielded by successful entry.
+    """
+
+    def __init__(self, handle: Sandbox) -> None:
+        self._sandbox = handle
+        self._consumed = False
+        self._handle: SandboxRuntimeSession | None = None
+
+    def _mark_consumed(self) -> None:
+        if self._consumed:
+            raise RuntimeError("Sandbox.session() operations can only be used once")
+        self._consumed = True
+
+    async def _run_once(self) -> SandboxRuntimeSession:
+        self._mark_consumed()
+        return await self._sandbox._acquire_session()
+
+    def __await__(self) -> Generator[Any, None, SandboxRuntimeSession]:
+        return self._run_once().__await__()
+
+    async def __aenter__(self) -> SandboxRuntimeSession:
+        handle = await self._run_once()
+        self._handle = handle
+        return handle
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        handle = self._handle
+        if handle is None:
+            return None
+        cleanup_task = asyncio.create_task(_cleanup_exact_session(handle))
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            try:
+                await cleanup_task
+            except SandboxCleanupError as cleanup_error:
+                _warn_cleanup_after_block(cleanup_error)
+            raise
+        except SandboxCleanupError as cleanup_error:
+            if exc is None:
+                raise
+            _warn_cleanup_after_block(cleanup_error)
+        return None
+
+    def __del__(self) -> None:
+        if self._consumed:
+            return
+        warnings.warn(
+            "Sandbox.session() operation was never awaited or entered; use "
+            "`await box.session()` or `async with box.session()` to acquire a session",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -1,7 +1,9 @@
 """Async runtime handles and entry points for Sandbox operations."""
 
+import asyncio
 import signal as signal_module
 import subprocess
+import time
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass
@@ -22,6 +24,7 @@ from vercel.sandbox._internal.errors import (
     SandboxCleanupError,
     SandboxResponseError,
     SandboxTerminalStateError,
+    SandboxTimeoutError,
 )
 from vercel.sandbox._internal.filesystem_handle_common import _validate_open_options
 from vercel.sandbox._internal.filesystem_handle_core import (
@@ -41,6 +44,7 @@ from vercel.sandbox._internal.models import (
     SandboxQuery,
     SandboxResources,
     SandboxSource,
+    SandboxStatus,
     SnapshotExpiration,
     SnapshotExpirationInput,
     SnapshotRetention,
@@ -61,7 +65,10 @@ from vercel.sandbox._internal.process_output import (
     _validate_reader_destination,
 )
 from vercel.sandbox._internal.recovery import (
+    TRANSITION_POLL_INTERVAL,
+    TRANSITION_TIMEOUT,
     SandboxLifecycle,
+    SandboxRecoveryTarget,
     execute_with_sandbox_recovery,
 )
 from vercel.sandbox._internal.runtime_common import (
@@ -82,6 +89,7 @@ from vercel.sandbox._internal.state import (
     ProcessState,
     SandboxRuntimeSessionState,
     SandboxState,
+    SnapshotSessionState,
     SnapshotState,
 )
 from vercel.sandbox._internal.text_reader import TextReader, _text_readers
@@ -847,7 +855,7 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     ``stop`` to stop it, and ``destroy`` to permanently remove the sandbox.
     """
 
-    __slots__ = ("_service", "fs")
+    __slots__ = ("_recovery_task", "_service", "fs")
 
     def __init__(
         self,
@@ -862,21 +870,56 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
             include_system_routes=include_system_routes,
         )
         self._service = service
+        self._recovery_task: asyncio.Task[None] | None = None
         self.fs = SandboxFilesystem(
             service=service,
             session_id=lambda: self.current_session_id,
             write_files_cwd=self._write_files_cwd,
         )
 
-    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
-        if lifecycle is not SandboxLifecycle.STOPPED:
-            return False
+    async def _resume_for_recovery(self) -> None:
         payload = await self._service.resume_sandbox(
             name=self.name,
             project_id=self.project_id,
             include_system_routes=self._include_system_routes,
         )
         self._apply_payload(payload)
+
+    def _clear_recovery_task(self, task: asyncio.Task[None]) -> None:
+        if self._recovery_task is task:
+            self._recovery_task = None
+        if not task.cancelled():
+            task.exception()
+
+    async def _await_shared_resume(self) -> None:
+        task = self._recovery_task
+        if task is None:
+            task = asyncio.create_task(self._resume_for_recovery())
+            self._recovery_task = task
+            task.add_done_callback(self._clear_recovery_task)
+        await asyncio.shield(task)
+
+    async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
+        deadline = time.monotonic() + TRANSITION_TIMEOUT
+        while True:
+            if time.monotonic() >= deadline:
+                raise SandboxTimeoutError(
+                    f"Sandbox session {target.session_id!r} did not leave a "
+                    f"transitional state within {TRANSITION_TIMEOUT}s"
+                )
+            await asyncio.sleep(TRANSITION_POLL_INTERVAL)
+            payload = await self._service.get_runtime_session(session_id=target.session_id)
+            self._apply_recovery_session_payload(target, payload)
+            if payload.status not in {
+                SandboxStatus.STOPPING,
+                SandboxStatus.SNAPSHOTTING,
+            }:
+                return
+
+    async def _recover(self, lifecycle: SandboxLifecycle, target: SandboxRecoveryTarget) -> bool:
+        if lifecycle in {SandboxLifecycle.STOPPING, SandboxLifecycle.SNAPSHOTTING}:
+            await self._wait_for_transition(target)
+        await self._await_shared_resume()
         return True
 
     async def run_process(
@@ -902,8 +945,8 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         )
         parsed_kill_after = parse_duration_seconds(kill_after)
         state = await execute_with_sandbox_recovery(
-            lambda: self._service.run_process(
-                session_id=self.current_session_id,
+            lambda session_id: self._service.run_process(
+                session_id=session_id,
                 command=command,
                 args=args,
                 cwd=cwd,
@@ -954,8 +997,8 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         parsed_args = list(args) if args is not None else None
         parsed_kill_after = parse_duration_seconds(kill_after)
         state = await execute_with_sandbox_recovery(
-            lambda: self._service.create_process(
-                session_id=self.current_session_id,
+            lambda session_id: self._service.create_process(
+                session_id=session_id,
                 command=command,
                 args=parsed_args,
                 cwd=cwd,
@@ -970,8 +1013,8 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     async def get_process(self, process_id: str, *, wait: bool = False) -> Process:
         """Get a process from the current session."""
         state = await execute_with_sandbox_recovery(
-            lambda: self._service.get_process(
-                session_id=self.current_session_id,
+            lambda session_id: self._service.get_process(
+                session_id=session_id,
                 process_id=process_id,
                 wait=wait,
             ),
@@ -982,7 +1025,7 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     async def query_processes(self) -> list[Process]:
         """Return handles for processes in the current session."""
         states = await execute_with_sandbox_recovery(
-            lambda: self._service.query_processes(session_id=self.current_session_id),
+            lambda session_id: self._service.query_processes(session_id=session_id),
             coordinator=self,
         )
         return [Process(payload=state, service=self._service) for state in states]
@@ -1029,38 +1072,62 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         The service rejects durations shorter than one second.
         """
         parsed_duration = parse_required_duration_seconds(duration)
-        payload = await execute_with_sandbox_recovery(
-            lambda: self._service.extend_runtime_session_timeout(
-                session_id=self.current_session_id,
+
+        async def extend(
+            session_id: str,
+        ) -> tuple[str, SandboxRuntimeSessionState]:
+            payload = await self._service.extend_runtime_session_timeout(
+                session_id=session_id,
                 duration=parsed_duration,
-            ),
-            coordinator=self,
-        )
-        return self._apply_current_session_payload(payload)
+            )
+            return session_id, payload
+
+        target_id, payload = await execute_with_sandbox_recovery(extend, coordinator=self)
+        return self._apply_current_session_payload_if_current(payload, target_id)
 
     async def update_network_policy(self, network_policy: NetworkPolicy) -> SandboxRuntimeSession:
         """Replace the current session's network policy."""
-        payload = await execute_with_sandbox_recovery(
-            lambda: self._service.update_runtime_session_network_policy(
-                session_id=self.current_session_id,
+
+        async def update(
+            session_id: str,
+        ) -> tuple[str, SandboxRuntimeSessionState]:
+            payload = await self._service.update_runtime_session_network_policy(
+                session_id=session_id,
                 network_policy=network_policy,
-            ),
-            coordinator=self,
-        )
-        return self._apply_current_session_payload(payload)
+            )
+            return session_id, payload
+
+        target_id, payload = await execute_with_sandbox_recovery(update, coordinator=self)
+        return self._apply_current_session_payload_if_current(payload, target_id)
 
     async def snapshot(self, *, expiration: SnapshotExpirationInput = None) -> Snapshot:
         """Create a filesystem snapshot from the current session."""
         parsed_expiration = _parse_snapshot_expiration(expiration)
-        result = await execute_with_sandbox_recovery(
-            lambda: self._service.create_snapshot(
-                session_id=self.current_session_id,
+
+        async def create(session_id: str) -> tuple[str, SnapshotSessionState]:
+            result = await self._service.create_snapshot(
+                session_id=session_id,
                 expiration=parsed_expiration,
-            ),
-            coordinator=self,
-        )
-        self._apply_current_session_payload(result.session)
+            )
+            return session_id, result
+
+        target_id, result = await execute_with_sandbox_recovery(create, coordinator=self)
+        self._apply_current_session_payload_if_current(result.session, target_id)
         return Snapshot(payload=result.snapshot, service=self._service)
+
+    def _apply_current_session_payload_if_current(
+        self, payload: SandboxRuntimeSessionState, target_id: str
+    ) -> SandboxRuntimeSession:
+        """Ignore an operation reply superseded by a concurrent recovery."""
+        if target_id == self.current_session_id:
+            return self._apply_current_session_payload(payload)
+        session = self.current_session
+        if session is None:
+            raise SandboxResponseError(
+                "Sandbox current-session operation returned a different session identity",
+                data=payload,
+            )
+        return session
 
     async def stop(self) -> Self:
         """Stop the current session and return this sandbox handle."""

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -31,6 +31,7 @@ from vercel.sandbox._internal.filesystem_handle_core import (
     BinaryReaderCore,
     BinaryWriterCore,
     FilesystemHandleBinding,
+    FilesystemOperationBinding,
     TextReaderCore,
     TextWriterCore,
 )
@@ -218,17 +219,17 @@ class Snapshot(SnapshotHandleBase):
 class SandboxFilesystem:
     """Perform filesystem operations in a sandbox runtime session."""
 
-    __slots__ = ("_service", "_session_id", "_write_files_cwd")
+    __slots__ = ("_execution", "_service", "_write_files_cwd")
 
     def __init__(
         self,
         *,
         service: SandboxService,
-        session_id: Callable[[], str],
+        execution: FilesystemOperationBinding,
         write_files_cwd: Callable[[RemotePath | None], str],
     ) -> None:
         self._service = service
-        self._session_id = session_id
+        self._execution = execution
         self._write_files_cwd = write_files_cwd
 
     @overload
@@ -313,7 +314,7 @@ class SandboxFilesystem:
         binding = FilesystemHandleBinding(
             service=self._service,
             runtime=self._service.staging_file_runtime,
-            session_id=self._session_id,
+            execution=self._execution,
             write_files_cwd=self._write_files_cwd,
             path=path,
             cwd=normalized_cwd,
@@ -354,11 +355,15 @@ class SandboxFilesystem:
             SandboxPathNotFoundError: If a parent directory is missing and
                 ``recursive`` is false.
         """
-        await self._service.mkdir(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            recursive=recursive,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        await self._execution.execute(
+            lambda session_id: self._service.mkdir(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                recursive=recursive,
+            )
         )
 
     async def read_bytes(self, path: RemotePath, *, cwd: RemotePath | None = None) -> bytes:
@@ -374,11 +379,15 @@ class SandboxFilesystem:
         Raises:
             SandboxPathNotFoundError: If the file does not exist.
         """
-        return await self._service.read_bytes(
-            operation="read_bytes",
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        return await self._execution.execute(
+            lambda session_id: self._service.read_bytes(
+                operation="read_bytes",
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+            )
         )
 
     async def read_text(
@@ -465,25 +474,35 @@ class SandboxFilesystem:
     async def _write_files(
         self, files: Sequence[_WriteFile], *, cwd: RemotePath | None = None
     ) -> None:
+        """Upload an in-memory write set with deliberate at-least-once replay.
+
+        Sandbox-level lifecycle recovery may replay the full archive once. The
+        first non-atomic upload may already have written some paths when it
+        reports a recognized lifecycle failure.
+        """
         for file in files:
             _validate_file_mode(file.mode)
-        resolved_cwd = self._write_files_cwd(cwd)
-        entries = [
-            _UploadFileEntry(
-                path=f.path,
-                size=len(f.content),
-                source=AsyncByteStreamRuntime.reader(f.content),
-                mode=f.mode,
-                archive_path=_normalize_tar_path(f.path, cwd=resolved_cwd),
+
+        async def write(session_id: str) -> None:
+            resolved_cwd = self._write_files_cwd(cwd)
+            entries = [
+                _UploadFileEntry(
+                    path=file.path,
+                    size=len(file.content),
+                    source=AsyncByteStreamRuntime.reader(file.content),
+                    mode=file.mode,
+                    archive_path=_normalize_tar_path(file.path, cwd=resolved_cwd),
+                )
+                for file in files
+            ]
+            await self._service.write_stream_archive(
+                session_id=session_id,
+                entries=entries,
+                paths=tuple(entry.path for entry in entries),
+                cwd=resolved_cwd,
             )
-            for f in files
-        ]
-        await self._service.write_stream_archive(
-            session_id=self._session_id(),
-            entries=entries,
-            paths=tuple(entry.path for entry in entries),
-            cwd=resolved_cwd,
-        )
+
+        await self._execution.execute(write)
 
     def batch(self, *, cwd: RemotePath | None = None) -> "SandboxFilesystemBatch":
         """Create an async context manager that stages files for one write request.
@@ -505,11 +524,15 @@ class SandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
-        return await self._service.exists(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            collect_output=self._collect_output,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        return await self._execution.execute(
+            lambda session_id: self._service.exists(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                collect_output=self._collect_output,
+            )
         )
 
     async def is_file(self, path: RemotePath, *, cwd: RemotePath | None = None) -> bool:
@@ -518,11 +541,15 @@ class SandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
-        return await self._service.is_file(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            collect_output=self._collect_output,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        return await self._execution.execute(
+            lambda session_id: self._service.is_file(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                collect_output=self._collect_output,
+            )
         )
 
     async def is_dir(self, path: RemotePath, *, cwd: RemotePath | None = None) -> bool:
@@ -531,11 +558,15 @@ class SandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
-        return await self._service.is_dir(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            collect_output=self._collect_output,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        return await self._execution.execute(
+            lambda session_id: self._service.is_dir(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                collect_output=self._collect_output,
+            )
         )
 
     async def listdir(
@@ -554,11 +585,15 @@ class SandboxFilesystem:
             SandboxFilesystemCommandError: If the listing fails, including
                 when the directory does not exist.
         """
-        return await self._service.listdir(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            collect_output=self._collect_output,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        return await self._execution.execute(
+            lambda session_id: self._service.listdir(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                collect_output=self._collect_output,
+            )
         )
 
     async def remove(
@@ -581,13 +616,17 @@ class SandboxFilesystem:
             SandboxFilesystemCommandError: If removal fails, including when
                 the path is missing and ``missing_ok`` is false.
         """
-        await self._service.remove(
-            session_id=self._session_id(),
-            path=_coerce_remote_path(path),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            recursive=recursive,
-            missing_ok=missing_ok,
-            collect_output=self._collect_output,
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        await self._execution.execute(
+            lambda session_id: self._service.remove(
+                session_id=session_id,
+                path=remote_path,
+                cwd=remote_cwd,
+                recursive=recursive,
+                missing_ok=missing_ok,
+                collect_output=self._collect_output,
+            )
         )
 
     async def rename(
@@ -607,12 +646,17 @@ class SandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the rename fails.
         """
-        await self._service.rename(
-            session_id=self._session_id(),
-            source=_coerce_remote_path(source),
-            destination=_coerce_remote_path(destination),
-            cwd=None if cwd is None else _coerce_remote_path(cwd),
-            collect_output=self._collect_output,
+        remote_source = _coerce_remote_path(source)
+        remote_destination = _coerce_remote_path(destination)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
+        await self._execution.execute(
+            lambda session_id: self._service.rename(
+                session_id=session_id,
+                source=remote_source,
+                destination=remote_destination,
+                cwd=remote_cwd,
+                collect_output=self._collect_output,
+            )
         )
 
 
@@ -661,7 +705,7 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
         self._service = service
         self.fs = SandboxFilesystem(
             service=service,
-            session_id=lambda: self.id,
+            execution=FilesystemOperationBinding.direct(self.id),
             write_files_cwd=self._write_files_cwd,
         )
 
@@ -873,7 +917,12 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         self._recovery_task: asyncio.Task[None] | None = None
         self.fs = SandboxFilesystem(
             service=service,
-            session_id=lambda: self.current_session_id,
+            execution=FilesystemOperationBinding(
+                execute=lambda operation: execute_with_sandbox_recovery(
+                    operation, coordinator=self
+                ),
+                bind=self._ensure_active,
+            ),
             write_files_cwd=self._write_files_cwd,
         )
 
@@ -898,6 +947,11 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
             self._recovery_task = task
             task.add_done_callback(self._clear_recovery_task)
         await asyncio.shield(task)
+
+    async def _ensure_active(self) -> str:
+        """Ensure an active current session before binding a lazy stream."""
+        await self._await_shared_resume()
+        return self.current_session_id
 
     async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
         deadline = time.monotonic() + TRANSITION_TIMEOUT

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -953,8 +953,7 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
 
     async def _ensure_active(self) -> str:
         """Ensure an active current session before binding a lazy stream."""
-        await self._await_shared_resume()
-        return self.current_session_id
+        return (await self._acquire_session()).id
 
     async def _acquire_session(self) -> SandboxRuntimeSession:
         target = self._capture_recovery_target()

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -60,6 +60,10 @@ from vercel.sandbox._internal.process_output import (
     ProcessOutputRouter,
     _validate_reader_destination,
 )
+from vercel.sandbox._internal.recovery import (
+    SandboxLifecycle,
+    execute_with_sandbox_recovery,
+)
 from vercel.sandbox._internal.runtime_common import (
     RemotePath,
     RuntimeSessionHandleBase,
@@ -845,10 +849,17 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
 
     __slots__ = ("_service", "fs")
 
-    def __init__(self, *, payload: SandboxState, service: SandboxService) -> None:
+    def __init__(
+        self,
+        *,
+        payload: SandboxState,
+        service: SandboxService,
+        include_system_routes: bool | None = None,
+    ) -> None:
         super().__init__(
             payload,
             session_factory=lambda session: SandboxRuntimeSession(payload=session, service=service),
+            include_system_routes=include_system_routes,
         )
         self._service = service
         self.fs = SandboxFilesystem(
@@ -856,6 +867,17 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
             session_id=lambda: self.current_session_id,
             write_files_cwd=self._write_files_cwd,
         )
+
+    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
+        if lifecycle is not SandboxLifecycle.STOPPED:
+            return False
+        payload = await self._service.resume_sandbox(
+            name=self.name,
+            project_id=self.project_id,
+            include_system_routes=self._include_system_routes,
+        )
+        self._apply_payload(payload)
+        return True
 
     async def run_process(
         self,
@@ -878,15 +900,19 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         output_router = ProcessOutputRouter(
             stdout=stdout, stderr=stderr, capture_output=capture_output
         )
-        state = await self._service.run_process(
-            session_id=self.current_session_id,
-            command=command,
-            args=args,
-            cwd=cwd,
-            env=env,
-            sudo=sudo,
-            kill_after=parse_duration_seconds(kill_after),
-            output_router=output_router,
+        parsed_kill_after = parse_duration_seconds(kill_after)
+        state = await execute_with_sandbox_recovery(
+            lambda: self._service.run_process(
+                session_id=self.current_session_id,
+                command=command,
+                args=args,
+                cwd=cwd,
+                env=env,
+                sudo=sudo,
+                kill_after=parsed_kill_after,
+                output_router=output_router,
+            ),
+            coordinator=self,
         )
         assert state.process.returncode is not None
         result = CompletedProcess(
@@ -925,27 +951,40 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         """
         stdout = _validate_reader_destination(stdout, name="stdout")
         stderr = _validate_reader_destination(stderr, name="stderr", allow_stdout_merge=True)
-        state = await self._service.create_process(
-            session_id=self.current_session_id,
-            command=command,
-            args=list(args) if args is not None else None,
-            cwd=cwd,
-            env=env,
-            sudo=sudo,
-            kill_after=parse_duration_seconds(kill_after),
+        parsed_args = list(args) if args is not None else None
+        parsed_kill_after = parse_duration_seconds(kill_after)
+        state = await execute_with_sandbox_recovery(
+            lambda: self._service.create_process(
+                session_id=self.current_session_id,
+                command=command,
+                args=parsed_args,
+                cwd=cwd,
+                env=env,
+                sudo=sudo,
+                kill_after=parsed_kill_after,
+            ),
+            coordinator=self,
         )
         return Process(payload=state, service=self._service, stdout=stdout, stderr=stderr)
 
     async def get_process(self, process_id: str, *, wait: bool = False) -> Process:
         """Get a process from the current session."""
-        state = await self._service.get_process(
-            session_id=self.current_session_id, process_id=process_id, wait=wait
+        state = await execute_with_sandbox_recovery(
+            lambda: self._service.get_process(
+                session_id=self.current_session_id,
+                process_id=process_id,
+                wait=wait,
+            ),
+            coordinator=self,
         )
         return Process(payload=state, service=self._service)
 
     async def query_processes(self) -> list[Process]:
         """Return handles for processes in the current session."""
-        states = await self._service.query_processes(session_id=self.current_session_id)
+        states = await execute_with_sandbox_recovery(
+            lambda: self._service.query_processes(session_id=self.current_session_id),
+            coordinator=self,
+        )
         return [Process(payload=state, service=self._service) for state in states]
 
     async def list_sessions(
@@ -989,24 +1028,36 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
 
         The service rejects durations shorter than one second.
         """
-        payload = await self._service.extend_runtime_session_timeout(
-            session_id=self.current_session_id,
-            duration=parse_required_duration_seconds(duration),
+        parsed_duration = parse_required_duration_seconds(duration)
+        payload = await execute_with_sandbox_recovery(
+            lambda: self._service.extend_runtime_session_timeout(
+                session_id=self.current_session_id,
+                duration=parsed_duration,
+            ),
+            coordinator=self,
         )
         return self._apply_current_session_payload(payload)
 
     async def update_network_policy(self, network_policy: NetworkPolicy) -> SandboxRuntimeSession:
         """Replace the current session's network policy."""
-        payload = await self._service.update_runtime_session_network_policy(
-            session_id=self.current_session_id, network_policy=network_policy
+        payload = await execute_with_sandbox_recovery(
+            lambda: self._service.update_runtime_session_network_policy(
+                session_id=self.current_session_id,
+                network_policy=network_policy,
+            ),
+            coordinator=self,
         )
         return self._apply_current_session_payload(payload)
 
     async def snapshot(self, *, expiration: SnapshotExpirationInput = None) -> Snapshot:
         """Create a filesystem snapshot from the current session."""
-        result = await self._service.create_snapshot(
-            session_id=self.current_session_id,
-            expiration=_parse_snapshot_expiration(expiration),
+        parsed_expiration = _parse_snapshot_expiration(expiration)
+        result = await execute_with_sandbox_recovery(
+            lambda: self._service.create_snapshot(
+                session_id=self.current_session_id,
+                expiration=parsed_expiration,
+            ),
+            coordinator=self,
         )
         self._apply_current_session_payload(result.session)
         return Snapshot(payload=result.snapshot, service=self._service)
@@ -1295,8 +1346,24 @@ def create_sandbox_operation(
     )
 
 
-async def get_sandbox(service: SandboxService, **kwargs: Any) -> Sandbox:
-    return Sandbox(payload=await service.get_sandbox(**kwargs), service=service)
+async def get_sandbox(
+    service: SandboxService,
+    *,
+    name: str,
+    project_id: str | None = None,
+    resume: bool = False,
+    include_system_routes: bool | None = None,
+) -> Sandbox:
+    return Sandbox(
+        payload=await service.get_sandbox(
+            name=name,
+            project_id=project_id,
+            resume=resume,
+            include_system_routes=include_system_routes,
+        ),
+        service=service,
+        include_system_routes=include_system_routes,
+    )
 
 
 async def get_or_create_sandbox(
@@ -1336,13 +1403,41 @@ async def get_or_create_sandbox(
             snapshot_expiration=_parse_snapshot_expiration(snapshot_expiration),
             snapshot_retention=snapshot_retention,
         )
-        return Sandbox(payload=state, service=service), created
+        return (
+            Sandbox(
+                payload=state,
+                service=service,
+                include_system_routes=include_system_routes,
+            ),
+            created,
+        )
     except _SandboxTerminalState as error:
-        raise _terminal_error(error, Sandbox(payload=error.sandbox, service=service)) from error
+        raise _terminal_error(
+            error,
+            Sandbox(
+                payload=error.sandbox,
+                service=service,
+                include_system_routes=include_system_routes,
+            ),
+        ) from error
 
 
-async def resume_sandbox(service: SandboxService, **kwargs: Any) -> Sandbox:
-    return Sandbox(payload=await service.resume_sandbox(**kwargs), service=service)
+async def resume_sandbox(
+    service: SandboxService,
+    *,
+    name: str,
+    project_id: str | None = None,
+    include_system_routes: bool | None = None,
+) -> Sandbox:
+    return Sandbox(
+        payload=await service.resume_sandbox(
+            name=name,
+            project_id=project_id,
+            include_system_routes=include_system_routes,
+        ),
+        service=service,
+        include_system_routes=include_system_routes,
+    )
 
 
 def resume_sandbox_operation(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -1,6 +1,5 @@
 """Async runtime handles and entry points for Sandbox operations."""
 
-import asyncio
 import signal as signal_module
 import subprocess
 import time
@@ -10,6 +9,8 @@ from dataclasses import dataclass
 from datetime import timedelta
 from types import TracebackType
 from typing import Any, Literal, TextIO, overload
+
+import anyio
 
 from vercel._internal.core.byte_stream import AsyncByteStreamRuntime
 from vercel._internal.core.polyfills import Self
@@ -892,6 +893,13 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
         return self
 
 
+@dataclass(slots=True)
+class _AsyncRecoveryAttempt:
+    completed: anyio.Event
+    status: Literal["in_flight", "succeeded", "failed", "abandoned"] = "in_flight"
+    error: BaseException | None = None
+
+
 class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     """Control an asynchronous Vercel Sandbox.
 
@@ -902,7 +910,7 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     permanently remove the sandbox.
     """
 
-    __slots__ = ("_recovery_task", "_service", "fs")
+    __slots__ = ("_recovery_attempt", "_recovery_lock", "_service", "fs")
 
     def __init__(
         self,
@@ -917,7 +925,8 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
             include_system_routes=include_system_routes,
         )
         self._service = service
-        self._recovery_task: asyncio.Task[None] | None = None
+        self._recovery_lock = anyio.Lock()
+        self._recovery_attempt: _AsyncRecoveryAttempt | None = None
         self.fs = SandboxFilesystem(
             service=service,
             execution=FilesystemOperationBinding(
@@ -929,27 +938,51 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
             write_files_cwd=self._write_files_cwd,
         )
 
-    async def _resume_for_recovery(self) -> None:
-        payload = await self._service.resume_sandbox(
-            name=self.name,
-            project_id=self.project_id,
-            include_system_routes=self._include_system_routes,
-        )
-        self._apply_payload(payload)
-
-    def _clear_recovery_task(self, task: asyncio.Task[None]) -> None:
-        if self._recovery_task is task:
-            self._recovery_task = None
-        if not task.cancelled():
-            task.exception()
-
     async def _await_shared_resume(self) -> None:
-        task = self._recovery_task
-        if task is None:
-            task = asyncio.create_task(self._resume_for_recovery())
-            self._recovery_task = task
-            task.add_done_callback(self._clear_recovery_task)
-        await asyncio.shield(task)
+        while True:
+            async with self._recovery_lock:
+                attempt = self._recovery_attempt
+                if attempt is None:
+                    attempt = _AsyncRecoveryAttempt(completed=anyio.Event())
+                    self._recovery_attempt = attempt
+                    owns_attempt = True
+                else:
+                    owns_attempt = False
+
+            if not owns_attempt:
+                await attempt.completed.wait()
+                if attempt.status == "succeeded":
+                    return
+                if attempt.status == "failed":
+                    assert attempt.error is not None
+                    raise attempt.error
+                continue
+
+            outcome: Literal["succeeded", "failed", "abandoned"] = "abandoned"
+            attempt_error: BaseException | None = None
+            try:
+                payload = await self._service.resume_sandbox(
+                    name=self.name,
+                    project_id=self.project_id,
+                    include_system_routes=self._include_system_routes,
+                )
+                self._apply_payload(payload)
+            except Exception as error:
+                if not isinstance(error, InterruptedError):
+                    outcome = "failed"
+                    attempt_error = error
+                raise
+            else:
+                outcome = "succeeded"
+            finally:
+                with anyio.CancelScope(shield=True):
+                    async with self._recovery_lock:
+                        attempt.status = outcome
+                        attempt.error = attempt_error
+                        if self._recovery_attempt is attempt:
+                            self._recovery_attempt = None
+                        attempt.completed.set()
+            return
 
     async def _ensure_active(self) -> str:
         """Ensure an active current session before binding a lazy stream."""
@@ -992,7 +1025,7 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
                     f"Sandbox session {target.session_id!r} did not leave a "
                     f"transitional state within {TRANSITION_TIMEOUT}s"
                 )
-            await asyncio.sleep(TRANSITION_POLL_INTERVAL)
+            await anyio.sleep(TRANSITION_POLL_INTERVAL)
             payload = await self._service.get_runtime_session(session_id=target.session_id)
             self._apply_recovery_session_payload(target, payload)
             if payload.status not in {
@@ -1353,19 +1386,13 @@ class SandboxSessionOperation:
         handle = self._handle
         if handle is None:
             return None
-        cleanup_task = asyncio.create_task(_cleanup_exact_session(handle))
-        try:
-            await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError:
+        with anyio.CancelScope(shield=True):
             try:
-                await cleanup_task
+                await _cleanup_exact_session(handle)
             except SandboxCleanupError as cleanup_error:
+                if exc is None:
+                    raise
                 _warn_cleanup_after_block(cleanup_error)
-            raise
-        except SandboxCleanupError as cleanup_error:
-            if exc is None:
-                raise
-            _warn_cleanup_after_block(cleanup_error)
         return None
 
     def __del__(self) -> None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/errors.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/errors.py
@@ -71,6 +71,10 @@ class SandboxResponseError(SandboxError):
         self.data = data
 
 
+class SandboxTimeoutError(SandboxError):
+    """Raised when a Sandbox lifecycle transition exceeds its deadline."""
+
+
 class SandboxCredentialsError(SandboxError):
     """Raised when Sandbox credentials cannot be resolved."""
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/filesystem_handle_core.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/filesystem_handle_core.py
@@ -1,7 +1,8 @@
 """Shared state machines for sync and async Sandbox file handles."""
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from typing import Any, TypeVar, cast
 
 from vercel._internal.core.byte_stream import (
     StagingFileRuntime,
@@ -16,6 +17,7 @@ from vercel.sandbox._internal.filesystem_handle_common import (
 from vercel.sandbox._internal.filesystem_write import (
     _BoundWrite,
     _FilesystemWriteTargetSource,
+    _SpooledWriteTargetSource,
     _WriteTarget,
     _WriteTargetSource,
 )
@@ -26,6 +28,41 @@ from vercel.sandbox._internal.runtime_common import (
 from vercel.sandbox._internal.service import SandboxService
 
 _CHUNK_SIZE = 64 * 1024
+_ResultT = TypeVar("_ResultT")
+
+
+class FilesystemOperationBinding:
+    """Execute whole filesystem operations and bind one stream session."""
+
+    __slots__ = ("_bind", "_execute")
+
+    def __init__(
+        self,
+        *,
+        execute: Callable[..., Awaitable[Any]],
+        bind: Callable[[], Awaitable[str]],
+    ) -> None:
+        self._execute = execute
+        self._bind = bind
+
+    @classmethod
+    def direct(cls, session_id: str) -> "FilesystemOperationBinding":
+        """Return a non-recovering binding fixed to one runtime session."""
+
+        async def execute(operation: Callable[[str], Awaitable[Any]]) -> Any:
+            return await operation(session_id)
+
+        async def bind() -> str:
+            return session_id
+
+        return cls(execute=execute, bind=bind)
+
+    async def execute(self, operation: Callable[[str], Awaitable[_ResultT]]) -> _ResultT:
+        return cast(_ResultT, await self._execute(operation))
+
+    async def bind(self) -> str:
+        """Best-effort ensure activity, then pin an unreplayable stream session."""
+        return await self._bind()
 
 
 class FilesystemHandleBinding:
@@ -34,31 +71,33 @@ class FilesystemHandleBinding:
         *,
         service: SandboxService,
         runtime: StagingFileRuntime,
-        session_id: Callable[[], str],
+        execution: FilesystemOperationBinding,
         write_files_cwd: Callable[[RemotePath | None], str],
         path: str,
         cwd: RemotePath | None,
     ) -> None:
         self.service = service
         self.runtime = runtime
-        self._session_id = session_id
+        self._execution = execution
         self._write_files_cwd = write_files_cwd
         self.path = path
         self.cwd = None if cwd is None else str(cwd)
 
     async def open_response(self) -> StreamingResponse:
-        return await self.service.open_read_response(
-            operation="open",
-            session_id=self._session_id(),
-            path=self.path,
-            cwd=self.cwd,
+        return await self._execution.execute(
+            lambda session_id: self.service.open_read_response(
+                operation="open",
+                session_id=session_id,
+                path=self.path,
+                cwd=self.cwd,
+            )
         )
 
-    def bind_write(self) -> _BoundWrite:
+    def bound_write(self, session_id: str) -> _BoundWrite:
         cwd = self._write_files_cwd(self.cwd)
         return _BoundWrite(
             service=self.service,
-            session_id=self._session_id(),
+            session_id=session_id,
             path=self.path,
             cwd=cwd,
             archive_path=_normalize_tar_path(self.path, cwd=cwd),
@@ -67,10 +106,21 @@ class FilesystemHandleBinding:
     def write_target_source(
         self, *, size: int | None, permissions: int | None
     ) -> _WriteTargetSource:
+        if size is None:
+            return _SpooledWriteTargetSource(
+                name=self.path,
+                runtime=self.runtime,
+                execution=self._execution.execute,
+                bound_write=self.bound_write,
+                permissions=permissions,
+            )
+
+        async def bind_write() -> _BoundWrite:
+            return self.bound_write(await self._execution.bind())
+
         return _FilesystemWriteTargetSource(
             name=self.path,
-            runtime=self.runtime,
-            bind=self.bind_write,
+            bind=bind_write,
             size=size,
             permissions=permissions,
         )

--- a/src/vercel-sandbox/vercel/sandbox/_internal/filesystem_write.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/filesystem_write.py
@@ -1,6 +1,6 @@
 """Write targets for streaming Sandbox filesystem handles."""
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Protocol
 
@@ -96,36 +96,63 @@ class _FilesystemWriteTargetSource:
         self,
         *,
         name: str,
-        runtime: _TemporaryFileRuntime,
-        bind: Callable[[], _WriteBinding],
-        size: int | None,
+        bind: Callable[[], Awaitable[_WriteBinding]],
+        size: int,
         permissions: int | None,
     ) -> None:
         self.name = name
-        self._runtime = runtime
         self._bind = bind
         self._size = size
         self._permissions = permissions
 
     def acquire(self) -> AbstractAsyncContextManager[_WriteTarget]:
         return _acquire_write_target(
-            runtime=self._runtime,
-            bound=self._bind(),
+            bind=self._bind,
             name=self.name,
             size=self._size,
             permissions=self._permissions,
         )
 
 
+class _SpooledWriteTargetSource:
+    def __init__(
+        self,
+        *,
+        name: str,
+        runtime: _TemporaryFileRuntime,
+        execution: Callable[[Callable[[str], Awaitable[None]]], Awaitable[None]],
+        bound_write: Callable[[str], _WriteBinding],
+        permissions: int | None,
+    ) -> None:
+        self.name = name
+        self._runtime = runtime
+        self._execution = execution
+        self._bound_write = bound_write
+        self._permissions = permissions
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[_WriteTarget]:
+        async with self._runtime.temporary_file() as spool:
+            yield _SpooledWriteTarget(
+                spool,
+                execution=self._execution,
+                bound_write=self._bound_write,
+                permissions=self._permissions,
+            )
+
+
 class _SpooledWriteTarget:
     def __init__(
         self,
         spool: StagingByteFile,
-        bound: _WriteBinding,
+        *,
+        execution: Callable[[Callable[[str], Awaitable[None]]], Awaitable[None]],
+        bound_write: Callable[[str], _WriteBinding],
         permissions: int | None,
     ) -> None:
         self._spool = spool
-        self._bound = bound
+        self._execution = execution
+        self._bound_write = bound_write
         self._permissions = permissions
 
     async def write(self, data: bytes) -> None:
@@ -137,8 +164,12 @@ class _SpooledWriteTarget:
     async def finish(self) -> None:
         await self._spool.flush()
         size = await self._spool.tell()
-        await self._spool.seek(0)
-        await self._bound.publish(self._spool, size, self._permissions)
+
+        async def publish(session_id: str) -> None:
+            await self._spool.seek(0)
+            await self._bound_write(session_id).publish(self._spool, size, self._permissions)
+
+        await self._execution(publish)
 
     async def abort(self) -> None:
         pass
@@ -168,15 +199,11 @@ class _ExactSizeWriteTarget:
 @asynccontextmanager
 async def _acquire_write_target(
     *,
-    runtime: _TemporaryFileRuntime,
-    bound: _WriteBinding,
+    bind: Callable[[], Awaitable[_WriteBinding]],
     name: str,
-    size: int | None,
+    size: int,
     permissions: int | None,
 ) -> AsyncIterator[_WriteTarget]:
-    if size is None:
-        async with runtime.temporary_file() as spool:
-            yield _SpooledWriteTarget(spool, bound, permissions)
-    else:
-        async with bound.open_upload(size, permissions) as upload:
-            yield _ExactSizeWriteTarget(upload, name=name, size=size)
+    bound = await bind()
+    async with bound.open_upload(size, permissions) as upload:
+        yield _ExactSizeWriteTarget(upload, name=name, size=size)

--- a/src/vercel-sandbox/vercel/sandbox/_internal/recovery.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/recovery.py
@@ -1,0 +1,85 @@
+"""Shared recovery policy for sandbox-level session operations."""
+
+from collections.abc import Awaitable, Callable
+from enum import Enum
+from typing import Protocol, TypeVar
+
+from vercel.sandbox._internal.errors import (
+    SandboxApiError,
+    SandboxFilesystemWriteError,
+)
+
+
+class SandboxLifecycle(Enum):
+    """A lifecycle condition reported by a sandbox operation."""
+
+    STOPPED = "stopped"
+    STOPPING = "stopping"
+    SNAPSHOTTING = "snapshotting"
+
+
+_LIFECYCLE_ERROR_CODES = {
+    "sandbox_stopped": SandboxLifecycle.STOPPED,
+    "sandbox_stopping": SandboxLifecycle.STOPPING,
+    "sandbox_snapshotting": SandboxLifecycle.SNAPSHOTTING,
+}
+
+TRANSITION_POLL_INTERVAL = 0.5
+TRANSITION_TIMEOUT = 300.0
+
+
+def classify_sandbox_lifecycle_error(error: BaseException) -> SandboxLifecycle | None:
+    """Return the supported lifecycle condition carried by ``error``.
+
+    Only direct Sandbox API failures and the direct cause wrapped by a native
+    filesystem write failure participate in lifecycle recovery. In particular,
+    stream failures and arbitrary exception chains are intentionally excluded.
+    """
+    api_error: SandboxApiError | None
+    if isinstance(error, SandboxApiError):
+        api_error = error
+    elif isinstance(error, SandboxFilesystemWriteError) and isinstance(
+        error.cause, SandboxApiError
+    ):
+        api_error = error.cause
+    else:
+        return None
+    if api_error.status_code == 410:
+        return SandboxLifecycle.STOPPED
+    return None if api_error.code is None else _LIFECYCLE_ERROR_CODES.get(api_error.code)
+
+
+class SandboxRecoveryCoordinator(Protocol):
+    """Coordinate one lifecycle recovery before an operation is replayed.
+
+    Returning ``False`` leaves the original operation failure in place. This
+    lets runtime-specific coordinators add transition waiting and shared
+    recovery without changing the one-attempt/one-replay policy.
+    """
+
+    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
+        """Recover the current sandbox session when this runtime supports it."""
+        ...
+
+
+_ResultT = TypeVar("_ResultT")
+
+
+async def execute_with_sandbox_recovery(
+    operation: Callable[[], Awaitable[_ResultT]],
+    *,
+    coordinator: SandboxRecoveryCoordinator,
+) -> _ResultT:
+    """Run an operation once, optionally recover, and replay it once.
+
+    ``operation`` is called separately for the first attempt and the replay,
+    so callers can resolve their current session ID immediately before each
+    request. A replay failure is never eligible for another recovery cycle.
+    """
+    try:
+        return await operation()
+    except Exception as error:
+        lifecycle = classify_sandbox_lifecycle_error(error)
+        if lifecycle is None or not await coordinator._recover(lifecycle):
+            raise
+    return await operation()

--- a/src/vercel-sandbox/vercel/sandbox/_internal/recovery.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/recovery.py
@@ -1,6 +1,7 @@
 """Shared recovery policy for sandbox-level session operations."""
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol, TypeVar
 
@@ -39,7 +40,7 @@ def classify_sandbox_lifecycle_error(error: BaseException) -> SandboxLifecycle |
     if isinstance(error, SandboxApiError):
         api_error = error
     elif isinstance(error, SandboxFilesystemWriteError) and isinstance(
-        error.cause, SandboxApiError
+        getattr(error, "cause", None), SandboxApiError
     ):
         api_error = error.cause
     else:
@@ -57,16 +58,28 @@ class SandboxRecoveryCoordinator(Protocol):
     recovery without changing the one-attempt/one-replay policy.
     """
 
-    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
+    def _capture_recovery_target(self) -> "SandboxRecoveryTarget":
+        """Capture the session identity and optional bound handle for an attempt."""
+        ...
+
+    async def _recover(self, lifecycle: SandboxLifecycle, target: "SandboxRecoveryTarget") -> bool:
         """Recover the current sandbox session when this runtime supports it."""
         ...
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxRecoveryTarget:
+    """The exact session used by an operation's first attempt."""
+
+    session_id: str
+    session: object | None
 
 
 _ResultT = TypeVar("_ResultT")
 
 
 async def execute_with_sandbox_recovery(
-    operation: Callable[[], Awaitable[_ResultT]],
+    operation: Callable[[str], Awaitable[_ResultT]],
     *,
     coordinator: SandboxRecoveryCoordinator,
 ) -> _ResultT:
@@ -76,10 +89,12 @@ async def execute_with_sandbox_recovery(
     so callers can resolve their current session ID immediately before each
     request. A replay failure is never eligible for another recovery cycle.
     """
+    target = coordinator._capture_recovery_target()
     try:
-        return await operation()
+        return await operation(target.session_id)
     except Exception as error:
         lifecycle = classify_sandbox_lifecycle_error(error)
-        if lifecycle is None or not await coordinator._recover(lifecycle):
+        if lifecycle is None or not await coordinator._recover(lifecycle, target):
             raise
-    return await operation()
+    replay_target = coordinator._capture_recovery_target()
+    return await operation(replay_target.session_id)

--- a/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
@@ -3,12 +3,13 @@
 import copy
 import posixpath
 import signal as signal_module
+import weakref
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from enum import Enum, auto
 from pathlib import PurePosixPath
-from typing import Generic, Literal, TypeAlias, TypeVar
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from vercel._internal.core.byte_stream import ReadableByteStream
 from vercel.sandbox._internal.errors import SandboxResponseError
@@ -22,6 +23,7 @@ from vercel.sandbox._internal.models import (
 from vercel.sandbox._internal.recovery import SandboxRecoveryTarget
 from vercel.sandbox._internal.state import (
     ProcessState,
+    RuntimeSessionStopState,
     SandboxRouteState,
     SandboxRuntimeSessionState,
     SandboxState,
@@ -302,10 +304,11 @@ class SnapshotHandleBase:
 
 
 class RuntimeSessionHandleBase:
-    __slots__ = ("_payload",)
+    __slots__ = ("_parent_ref", "_payload")
 
     def __init__(self, payload: SandboxRuntimeSessionState) -> None:
         self._payload = payload
+        self._parent_ref: weakref.ReferenceType[SandboxHandleBase[Any]] | None = None
 
     @property
     def id(self) -> str:
@@ -371,6 +374,24 @@ class RuntimeSessionHandleBase:
             )
         self._payload = payload
 
+    def _set_parent(self, parent: "SandboxHandleBase[Any]") -> None:
+        self._parent_ref = weakref.ref(parent)
+
+    def _apply_payload_with_parent(self, payload: SandboxRuntimeSessionState) -> None:
+        self._apply_payload(payload)
+        parent = None if self._parent_ref is None else self._parent_ref()
+        if parent is not None:
+            parent._apply_session_payload_from_child(self, payload)
+
+    def _apply_stop_result(self, result: RuntimeSessionStopState) -> None:
+        self._apply_payload(result.session)
+        parent = None if self._parent_ref is None else self._parent_ref()
+        if parent is not None:
+            parent._apply_session_stop_from_child(self, result)
+
+    def _mark_stopped(self) -> None:
+        self._apply_payload_with_parent(replace(self._payload, status=SandboxStatus.STOPPED))
+
     def _write_files_cwd(self, cwd: RemotePath | None) -> str:
         return _resolve_write_files_cwd(cwd, default=self.cwd or "/vercel/sandbox")
 
@@ -381,6 +402,7 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
         "_current_session",
         "_session_factory",
         "_handle_include_system_routes",
+        "__weakref__",
     )
 
     def __init__(
@@ -396,6 +418,8 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
         self._current_session = (
             None if payload.current_session is None else session_factory(payload.current_session)
         )
+        if self._current_session is not None:
+            self._current_session._set_parent(self)
 
     @property
     def current_session(self) -> RuntimeSessionHandleT | None:
@@ -510,6 +534,7 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
                 self._current_session._apply_payload(returned_session)
             else:
                 self._current_session = self._session_factory(returned_session)
+                self._current_session._set_parent(self)
         elif (
             payload._current_session_attached
             or payload.current_session_id != self._payload.current_session_id
@@ -535,9 +560,36 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
             )
         if self._current_session is None:
             self._current_session = self._session_factory(payload)
+            self._current_session._set_parent(self)
         else:
             self._current_session._apply_payload(payload)
+        self._payload = replace(self._payload, current_session=payload)
         return self._current_session
+
+    def _apply_session_payload_from_child(
+        self,
+        child: RuntimeSessionHandleBase,
+        payload: SandboxRuntimeSessionState,
+    ) -> None:
+        if self.current_session_id != child.id or self._current_session is not child:
+            return
+        self._payload = replace(self._payload, current_session=payload)
+
+    def _apply_session_stop_from_child(
+        self,
+        child: RuntimeSessionHandleBase,
+        result: RuntimeSessionStopState,
+    ) -> None:
+        if self.current_session_id != child.id or self._current_session is not child:
+            return
+        self._payload = replace(self._payload, current_session=result.session)
+        sandbox = result.sandbox
+        if (
+            result._sandbox_attached
+            and sandbox is not None
+            and sandbox.current_session_id == child.id
+        ):
+            self._apply_payload(sandbox)
 
     def _capture_recovery_target(self) -> SandboxRecoveryTarget:
         session = self._current_session

--- a/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
@@ -19,6 +19,7 @@ from vercel.sandbox._internal.models import (
     SandboxStatus,
     _WriteFile,
 )
+from vercel.sandbox._internal.recovery import SandboxRecoveryTarget
 from vercel.sandbox._internal.state import (
     ProcessState,
     SandboxRouteState,
@@ -537,6 +538,31 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
         else:
             self._current_session._apply_payload(payload)
         return self._current_session
+
+    def _capture_recovery_target(self) -> SandboxRecoveryTarget:
+        session = self._current_session
+        if session is not None and session.id != self.current_session_id:
+            session = None
+        return SandboxRecoveryTarget(session_id=self.current_session_id, session=session)
+
+    def _apply_recovery_session_payload(
+        self,
+        target: SandboxRecoveryTarget,
+        payload: SandboxRuntimeSessionState,
+    ) -> None:
+        """Refresh an old bound session without replacing a newer current session."""
+        if payload.id != target.session_id:
+            raise SandboxResponseError(
+                "Sandbox recovery poll returned a different session identity",
+                data=payload,
+            )
+        target_session = target.session
+        if target_session is not None:
+            assert isinstance(target_session, RuntimeSessionHandleBase)
+            target_session._apply_payload(payload)
+        if self.current_session_id == target.session_id:
+            if self._current_session is not target_session:
+                self._apply_current_session_payload(payload)
 
     def _write_files_cwd(self, cwd: RemotePath | None) -> str:
         if self.current_session is not None and self.current_session.cwd is not None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
@@ -375,15 +375,23 @@ class RuntimeSessionHandleBase:
 
 
 class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
-    __slots__ = ("_payload", "_current_session", "_session_factory")
+    __slots__ = (
+        "_payload",
+        "_current_session",
+        "_session_factory",
+        "_handle_include_system_routes",
+    )
 
     def __init__(
         self,
         payload: SandboxState,
         session_factory: Callable[[SandboxRuntimeSessionState], RuntimeSessionHandleT],
+        *,
+        include_system_routes: bool | None = None,
     ) -> None:
         self._payload = payload
         self._session_factory = session_factory
+        self._handle_include_system_routes = include_system_routes
         self._current_session = (
             None if payload.current_session is None else session_factory(payload.current_session)
         )
@@ -391,6 +399,11 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
     @property
     def current_session(self) -> RuntimeSessionHandleT | None:
         return self._current_session
+
+    @property
+    def _include_system_routes(self) -> bool | None:
+        """Return the route projection selected when this handle was created."""
+        return self._handle_include_system_routes
 
     @property
     def name(self) -> str:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -53,6 +53,7 @@ from vercel.sandbox._internal.state import (
     CompletedProcessState,
     ProcessState,
     RuntimeSessionsPageState,
+    RuntimeSessionStopState,
     SandboxesPageState,
     SandboxRuntimeSessionState,
     SandboxState,
@@ -433,15 +434,15 @@ class SandboxService:
             )
         return sandbox
 
-    async def stop_runtime_session(self, *, session_id: str) -> SandboxRuntimeSessionState:
+    async def stop_runtime_session(self, *, session_id: str) -> RuntimeSessionStopState:
         self._ensure_open()
-        session = await self._api_client.stop_runtime_session(session_id=session_id)
-        if session.id != session_id:
+        result = await self._api_client.stop_runtime_session(session_id=session_id)
+        if result.session.id != session_id:
             raise SandboxResponseError(
                 "Sandbox current-session operation returned a different session identity",
-                data=session,
+                data=result.session,
             )
-        return session
+        return result
 
     async def get_runtime_session(
         self, *, session_id: str, include_system_routes: bool | None = None

--- a/src/vercel-sandbox/vercel/sandbox/_internal/state.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/state.py
@@ -89,6 +89,15 @@ class SandboxState:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeSessionStopState:
+    """State returned after stopping one exact runtime session."""
+
+    session: SandboxRuntimeSessionState
+    sandbox: SandboxState | None = None
+    _sandbox_attached: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class SnapshotState:
     id: str
     source_session_id: str

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -2,8 +2,11 @@
 
 import signal as signal_module
 import subprocess
+import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import timedelta
+from threading import Condition
 from types import TracebackType
 from typing import Any, Literal, TextIO, overload
 
@@ -15,6 +18,7 @@ from vercel.sandbox._internal.errors import (
     SandboxCleanupError,
     SandboxResponseError,
     SandboxTerminalStateError,
+    SandboxTimeoutError,
 )
 from vercel.sandbox._internal.filesystem_handle_common import _validate_open_options
 from vercel.sandbox._internal.filesystem_handle_core import (
@@ -34,6 +38,7 @@ from vercel.sandbox._internal.models import (
     SandboxQuery,
     SandboxResources,
     SandboxSource,
+    SandboxStatus,
     SnapshotExpirationInput,
     SnapshotRetention,
     SnapshotRetentionUpdate,
@@ -53,7 +58,10 @@ from vercel.sandbox._internal.process_output import (
     _validate_reader_destination,
 )
 from vercel.sandbox._internal.recovery import (
+    TRANSITION_POLL_INTERVAL,
+    TRANSITION_TIMEOUT,
     SandboxLifecycle,
+    SandboxRecoveryTarget,
     execute_with_sandbox_recovery,
 )
 from vercel.sandbox._internal.runtime_common import (
@@ -881,6 +889,12 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
         return self
 
 
+@dataclass(slots=True)
+class _SyncRecoveryAttempt:
+    status: Literal["in_flight", "succeeded", "failed", "abandoned"] = "in_flight"
+    error: BaseException | None = None
+
+
 class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     """Control a synchronous Vercel Sandbox.
 
@@ -890,7 +904,7 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     ``stop`` to stop it, and ``destroy`` to permanently remove the sandbox.
     """
 
-    __slots__ = ("_service", "fs")
+    __slots__ = ("_recovery_attempt", "_recovery_condition", "_service", "fs")
 
     def __init__(
         self,
@@ -907,21 +921,94 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
             include_system_routes=include_system_routes,
         )
         self._service = service
+        self._recovery_condition = Condition()
+        self._recovery_attempt: _SyncRecoveryAttempt | None = None
         self.fs = SyncSandboxFilesystem(
             service=service,
             session_id=lambda: self.current_session_id,
             write_files_cwd=self._write_files_cwd,
         )
 
-    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
-        if lifecycle is not SandboxLifecycle.STOPPED:
-            return False
-        payload = await self._service.resume_sandbox(
-            name=self.name,
-            project_id=self.project_id,
-            include_system_routes=self._include_system_routes,
-        )
-        self._apply_payload(payload)
+    def _capture_recovery_target(self) -> SandboxRecoveryTarget:
+        with self._recovery_condition:
+            return super()._capture_recovery_target()
+
+    def _apply_recovery_session_payload(
+        self,
+        target: SandboxRecoveryTarget,
+        payload: SandboxRuntimeSessionState,
+    ) -> None:
+        with self._recovery_condition:
+            super()._apply_recovery_session_payload(target, payload)
+
+    async def _await_shared_resume(self) -> None:
+        while True:
+            with self._recovery_condition:
+                attempt = self._recovery_attempt
+                if attempt is None:
+                    attempt = _SyncRecoveryAttempt()
+                    self._recovery_attempt = attempt
+                    owns_attempt = True
+                else:
+                    owns_attempt = False
+
+                if not owns_attempt:
+                    while attempt.status == "in_flight":
+                        self._recovery_condition.wait()
+                    if attempt.status == "succeeded":
+                        return
+                    if attempt.status == "failed":
+                        assert attempt.error is not None
+                        raise attempt.error
+                    continue
+
+            outcome: Literal["succeeded", "failed", "abandoned"] = "abandoned"
+            attempt_error: BaseException | None = None
+            try:
+                payload = await self._service.resume_sandbox(
+                    name=self.name,
+                    project_id=self.project_id,
+                    include_system_routes=self._include_system_routes,
+                )
+                with self._recovery_condition:
+                    self._apply_payload(payload)
+            except Exception as error:
+                if not isinstance(error, InterruptedError):
+                    outcome = "failed"
+                    attempt_error = error
+                raise
+            else:
+                outcome = "succeeded"
+            finally:
+                with self._recovery_condition:
+                    attempt.status = outcome
+                    attempt.error = attempt_error
+                    if self._recovery_attempt is attempt:
+                        self._recovery_attempt = None
+                    self._recovery_condition.notify_all()
+            return
+
+    async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
+        deadline = time.monotonic() + TRANSITION_TIMEOUT
+        while True:
+            if time.monotonic() >= deadline:
+                raise SandboxTimeoutError(
+                    f"Sandbox session {target.session_id!r} did not leave a "
+                    f"transitional state within {TRANSITION_TIMEOUT}s"
+                )
+            time.sleep(TRANSITION_POLL_INTERVAL)
+            payload = await self._service.get_runtime_session(session_id=target.session_id)
+            self._apply_recovery_session_payload(target, payload)
+            if payload.status not in {
+                SandboxStatus.STOPPING,
+                SandboxStatus.SNAPSHOTTING,
+            }:
+                return
+
+    async def _recover(self, lifecycle: SandboxLifecycle, target: SandboxRecoveryTarget) -> bool:
+        if lifecycle in {SandboxLifecycle.STOPPING, SandboxLifecycle.SNAPSHOTTING}:
+            await self._wait_for_transition(target)
+        await self._await_shared_resume()
         return True
 
     def run_process(
@@ -948,8 +1035,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         parsed_kill_after = parse_duration_seconds(kill_after)
         state = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.run_process(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.run_process(
+                    session_id=session_id,
                     command=command,
                     args=args,
                     cwd=cwd,
@@ -1002,8 +1089,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         parsed_kill_after = parse_duration_seconds(kill_after)
         state = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.create_process(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.create_process(
+                    session_id=session_id,
                     command=command,
                     args=parsed_args,
                     cwd=cwd,
@@ -1020,8 +1107,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         """Get a process from the current session."""
         state = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.get_process(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.get_process(
+                    session_id=session_id,
                     process_id=process_id,
                     wait=wait,
                 ),
@@ -1034,7 +1121,7 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         """Return handles for processes in the current session."""
         states = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.query_processes(session_id=self.current_session_id),
+                lambda session_id: self._service.query_processes(session_id=session_id),
                 coordinator=self,
             )
         )
@@ -1082,8 +1169,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         parsed_duration = parse_required_duration_seconds(duration)
         payload = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.extend_runtime_session_timeout(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.extend_runtime_session_timeout(
+                    session_id=session_id,
                     duration=parsed_duration,
                 ),
                 coordinator=self,
@@ -1095,8 +1182,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         """Replace the current session's network policy."""
         payload = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.update_runtime_session_network_policy(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.update_runtime_session_network_policy(
+                    session_id=session_id,
                     network_policy=network_policy,
                 ),
                 coordinator=self,
@@ -1109,8 +1196,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         parsed_expiration = _parse_snapshot_expiration(expiration)
         result = iter_coroutine(
             execute_with_sandbox_recovery(
-                lambda: self._service.create_snapshot(
-                    session_id=self.current_session_id,
+                lambda session_id: self._service.create_snapshot(
+                    session_id=session_id,
                     expiration=parsed_expiration,
                 ),
                 coordinator=self,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -52,6 +52,10 @@ from vercel.sandbox._internal.process_output import (
     ProcessOutputRouter,
     _validate_reader_destination,
 )
+from vercel.sandbox._internal.recovery import (
+    SandboxLifecycle,
+    execute_with_sandbox_recovery,
+)
 from vercel.sandbox._internal.runtime_common import (
     RemotePath,
     RuntimeSessionHandleBase,
@@ -888,12 +892,19 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
 
     __slots__ = ("_service", "fs")
 
-    def __init__(self, *, payload: SandboxState, service: SandboxService) -> None:
+    def __init__(
+        self,
+        *,
+        payload: SandboxState,
+        service: SandboxService,
+        include_system_routes: bool | None = None,
+    ) -> None:
         super().__init__(
             payload,
             session_factory=lambda session: SyncSandboxRuntimeSession(
                 payload=session, service=service
             ),
+            include_system_routes=include_system_routes,
         )
         self._service = service
         self.fs = SyncSandboxFilesystem(
@@ -901,6 +912,17 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
             session_id=lambda: self.current_session_id,
             write_files_cwd=self._write_files_cwd,
         )
+
+    async def _recover(self, lifecycle: SandboxLifecycle) -> bool:
+        if lifecycle is not SandboxLifecycle.STOPPED:
+            return False
+        payload = await self._service.resume_sandbox(
+            name=self.name,
+            project_id=self.project_id,
+            include_system_routes=self._include_system_routes,
+        )
+        self._apply_payload(payload)
+        return True
 
     def run_process(
         self,
@@ -923,16 +945,20 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         output_router = ProcessOutputRouter(
             stdout=stdout, stderr=stderr, capture_output=capture_output
         )
+        parsed_kill_after = parse_duration_seconds(kill_after)
         state = iter_coroutine(
-            self._service.run_process(
-                session_id=self.current_session_id,
-                command=command,
-                args=args,
-                cwd=cwd,
-                env=env,
-                sudo=sudo,
-                kill_after=parse_duration_seconds(kill_after),
-                output_router=output_router,
+            execute_with_sandbox_recovery(
+                lambda: self._service.run_process(
+                    session_id=self.current_session_id,
+                    command=command,
+                    args=args,
+                    cwd=cwd,
+                    env=env,
+                    sudo=sudo,
+                    kill_after=parsed_kill_after,
+                    output_router=output_router,
+                ),
+                coordinator=self,
             )
         )
         assert state.process.returncode is not None
@@ -972,15 +998,20 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         """
         stdout = _validate_reader_destination(stdout, name="stdout")
         stderr = _validate_reader_destination(stderr, name="stderr", allow_stdout_merge=True)
+        parsed_args = list(args) if args is not None else None
+        parsed_kill_after = parse_duration_seconds(kill_after)
         state = iter_coroutine(
-            self._service.create_process(
-                session_id=self.current_session_id,
-                command=command,
-                args=list(args) if args is not None else None,
-                cwd=cwd,
-                env=env,
-                sudo=sudo,
-                kill_after=parse_duration_seconds(kill_after),
+            execute_with_sandbox_recovery(
+                lambda: self._service.create_process(
+                    session_id=self.current_session_id,
+                    command=command,
+                    args=parsed_args,
+                    cwd=cwd,
+                    env=env,
+                    sudo=sudo,
+                    kill_after=parsed_kill_after,
+                ),
+                coordinator=self,
             )
         )
         return SyncProcess(payload=state, service=self._service, stdout=stdout, stderr=stderr)
@@ -988,15 +1019,25 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     def get_process(self, process_id: str, *, wait: bool = False) -> SyncProcess:
         """Get a process from the current session."""
         state = iter_coroutine(
-            self._service.get_process(
-                session_id=self.current_session_id, process_id=process_id, wait=wait
+            execute_with_sandbox_recovery(
+                lambda: self._service.get_process(
+                    session_id=self.current_session_id,
+                    process_id=process_id,
+                    wait=wait,
+                ),
+                coordinator=self,
             )
         )
         return SyncProcess(payload=state, service=self._service)
 
     def query_processes(self) -> list[SyncProcess]:
         """Return handles for processes in the current session."""
-        states = iter_coroutine(self._service.query_processes(session_id=self.current_session_id))
+        states = iter_coroutine(
+            execute_with_sandbox_recovery(
+                lambda: self._service.query_processes(session_id=self.current_session_id),
+                coordinator=self,
+            )
+        )
         return [SyncProcess(payload=state, service=self._service) for state in states]
 
     def list_sessions(
@@ -1038,10 +1079,14 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
 
         The service rejects durations shorter than one second.
         """
+        parsed_duration = parse_required_duration_seconds(duration)
         payload = iter_coroutine(
-            self._service.extend_runtime_session_timeout(
-                session_id=self.current_session_id,
-                duration=parse_required_duration_seconds(duration),
+            execute_with_sandbox_recovery(
+                lambda: self._service.extend_runtime_session_timeout(
+                    session_id=self.current_session_id,
+                    duration=parsed_duration,
+                ),
+                coordinator=self,
             )
         )
         return self._apply_current_session_payload(payload)
@@ -1049,18 +1094,26 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     def update_network_policy(self, network_policy: NetworkPolicy) -> SyncSandboxRuntimeSession:
         """Replace the current session's network policy."""
         payload = iter_coroutine(
-            self._service.update_runtime_session_network_policy(
-                session_id=self.current_session_id, network_policy=network_policy
+            execute_with_sandbox_recovery(
+                lambda: self._service.update_runtime_session_network_policy(
+                    session_id=self.current_session_id,
+                    network_policy=network_policy,
+                ),
+                coordinator=self,
             )
         )
         return self._apply_current_session_payload(payload)
 
     def snapshot(self, *, expiration: SnapshotExpirationInput = None) -> SyncSnapshot:
         """Create a filesystem snapshot from the current session."""
+        parsed_expiration = _parse_snapshot_expiration(expiration)
         result = iter_coroutine(
-            self._service.create_snapshot(
-                session_id=self.current_session_id,
-                expiration=_parse_snapshot_expiration(expiration),
+            execute_with_sandbox_recovery(
+                lambda: self._service.create_snapshot(
+                    session_id=self.current_session_id,
+                    expiration=parsed_expiration,
+                ),
+                coordinator=self,
             )
         )
         self._apply_current_session_payload(result.session)
@@ -1162,8 +1215,13 @@ class _ManagedSyncSandbox(SyncSandbox):
         payload: SandboxState,
         service: SandboxService,
         destroy_on_exit: bool,
+        include_system_routes: bool | None = None,
     ) -> None:
-        super().__init__(payload=payload, service=service)
+        super().__init__(
+            payload=payload,
+            service=service,
+            include_system_routes=include_system_routes,
+        )
         self._destroy_on_exit = destroy_on_exit
 
     def __enter__(self) -> Self:
@@ -1223,8 +1281,26 @@ def create_sandbox(
         raise _terminal_error(error, SyncSandbox(payload=error.sandbox, service=service)) from error
 
 
-def get_sandbox(service: SandboxService, **kwargs: Any) -> SyncSandbox:
-    return SyncSandbox(payload=iter_coroutine(service.get_sandbox(**kwargs)), service=service)
+def get_sandbox(
+    service: SandboxService,
+    *,
+    name: str,
+    project_id: str | None = None,
+    resume: bool = False,
+    include_system_routes: bool | None = None,
+) -> SyncSandbox:
+    return SyncSandbox(
+        payload=iter_coroutine(
+            service.get_sandbox(
+                name=name,
+                project_id=project_id,
+                resume=resume,
+                include_system_routes=include_system_routes,
+            )
+        ),
+        service=service,
+        include_system_routes=include_system_routes,
+    )
 
 
 def get_or_create_sandbox(
@@ -1266,16 +1342,43 @@ def get_or_create_sandbox(
                 snapshot_retention=snapshot_retention,
             )
         )
-        return SyncSandbox(payload=state, service=service), created
+        return (
+            SyncSandbox(
+                payload=state,
+                service=service,
+                include_system_routes=include_system_routes,
+            ),
+            created,
+        )
     except _SandboxTerminalState as error:
-        raise _terminal_error(error, SyncSandbox(payload=error.sandbox, service=service)) from error
+        raise _terminal_error(
+            error,
+            SyncSandbox(
+                payload=error.sandbox,
+                service=service,
+                include_system_routes=include_system_routes,
+            ),
+        ) from error
 
 
-def resume_sandbox(service: SandboxService, **kwargs: Any) -> _ManagedSyncSandbox:
+def resume_sandbox(
+    service: SandboxService,
+    *,
+    name: str,
+    project_id: str | None = None,
+    include_system_routes: bool | None = None,
+) -> _ManagedSyncSandbox:
     return _ManagedSyncSandbox(
-        payload=iter_coroutine(service.resume_sandbox(**kwargs)),
+        payload=iter_coroutine(
+            service.resume_sandbox(
+                name=name,
+                project_id=project_id,
+                include_system_routes=include_system_routes,
+            )
+        ),
         service=service,
         destroy_on_exit=False,
+        include_system_routes=include_system_routes,
     )
 
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -25,6 +25,7 @@ from vercel.sandbox._internal.filesystem_handle_core import (
     BinaryReaderCore,
     BinaryWriterCore,
     FilesystemHandleBinding,
+    FilesystemOperationBinding,
     TextReaderCore,
     TextWriterCore,
 )
@@ -220,17 +221,17 @@ class SyncSnapshot(SnapshotHandleBase):
 class SyncSandboxFilesystem:
     """Perform synchronous filesystem operations in a sandbox session."""
 
-    __slots__ = ("_service", "_session_id", "_write_files_cwd")
+    __slots__ = ("_execution", "_service", "_write_files_cwd")
 
     def __init__(
         self,
         *,
         service: SandboxService,
-        session_id: Callable[[], str],
+        execution: FilesystemOperationBinding,
         write_files_cwd: Callable[[RemotePath | None], str],
     ) -> None:
         self._service = service
-        self._session_id = session_id
+        self._execution = execution
         self._write_files_cwd = write_files_cwd
 
     @overload
@@ -320,7 +321,7 @@ class SyncSandboxFilesystem:
         binding = FilesystemHandleBinding(
             service=self._service,
             runtime=self._service.staging_file_runtime,
-            session_id=self._session_id,
+            execution=self._execution,
             write_files_cwd=self._write_files_cwd,
             path=path,
             cwd=normalized_cwd,
@@ -363,12 +364,16 @@ class SyncSandboxFilesystem:
             SandboxPathNotFoundError: If a parent directory is missing and
                 ``recursive`` is false.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         iter_coroutine(
-            self._service.mkdir(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                recursive=recursive,
+            self._execution.execute(
+                lambda session_id: self._service.mkdir(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    recursive=recursive,
+                )
             )
         )
 
@@ -385,12 +390,16 @@ class SyncSandboxFilesystem:
         Raises:
             SandboxPathNotFoundError: If the file does not exist.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         return iter_coroutine(
-            self._service.read_bytes(
-                operation="read_bytes",
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
+            self._execution.execute(
+                lambda session_id: self._service.read_bytes(
+                    operation="read_bytes",
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                )
             )
         )
 
@@ -476,27 +485,35 @@ class SyncSandboxFilesystem:
         )
 
     def _write_files(self, files: Sequence[_WriteFile], *, cwd: RemotePath | None = None) -> None:
+        """Upload an in-memory write set with deliberate at-least-once replay.
+
+        Sandbox-level lifecycle recovery may replay the full archive once. The
+        first non-atomic upload may already have written some paths when it
+        reports a recognized lifecycle failure.
+        """
         for file in files:
             _validate_file_mode(file.mode)
-        resolved_cwd = self._write_files_cwd(cwd)
-        entries = [
-            _UploadFileEntry(
-                path=f.path,
-                size=len(f.content),
-                source=SyncByteStreamRuntime.reader(f.content),
-                mode=f.mode,
-                archive_path=_normalize_tar_path(f.path, cwd=resolved_cwd),
-            )
-            for f in files
-        ]
-        iter_coroutine(
-            self._service.write_stream_archive(
-                session_id=self._session_id(),
+
+        async def write(session_id: str) -> None:
+            resolved_cwd = self._write_files_cwd(cwd)
+            entries = [
+                _UploadFileEntry(
+                    path=file.path,
+                    size=len(file.content),
+                    source=SyncByteStreamRuntime.reader(file.content),
+                    mode=file.mode,
+                    archive_path=_normalize_tar_path(file.path, cwd=resolved_cwd),
+                )
+                for file in files
+            ]
+            await self._service.write_stream_archive(
+                session_id=session_id,
                 entries=entries,
                 paths=tuple(entry.path for entry in entries),
                 cwd=resolved_cwd,
             )
-        )
+
+        iter_coroutine(self._execution.execute(write))
 
     def batch(self, *, cwd: RemotePath | None = None) -> "SyncSandboxFilesystemBatch":
         """Create a context manager that stages files for one write request.
@@ -520,12 +537,16 @@ class SyncSandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         return iter_coroutine(
-            self._service.exists(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.exists(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -535,12 +556,16 @@ class SyncSandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         return iter_coroutine(
-            self._service.is_file(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.is_file(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -550,12 +575,16 @@ class SyncSandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the remote check fails.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         return iter_coroutine(
-            self._service.is_dir(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.is_dir(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -575,12 +604,16 @@ class SyncSandboxFilesystem:
             SandboxFilesystemCommandError: If the listing fails, including
                 when the directory does not exist.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         return iter_coroutine(
-            self._service.listdir(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.listdir(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -604,14 +637,18 @@ class SyncSandboxFilesystem:
             SandboxFilesystemCommandError: If removal fails, including when
                 the path is missing and ``missing_ok`` is false.
         """
+        remote_path = _coerce_remote_path(path)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         iter_coroutine(
-            self._service.remove(
-                session_id=self._session_id(),
-                path=_coerce_remote_path(path),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                recursive=recursive,
-                missing_ok=missing_ok,
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.remove(
+                    session_id=session_id,
+                    path=remote_path,
+                    cwd=remote_cwd,
+                    recursive=recursive,
+                    missing_ok=missing_ok,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -632,13 +669,18 @@ class SyncSandboxFilesystem:
         Raises:
             SandboxFilesystemCommandError: If the rename fails.
         """
+        remote_source = _coerce_remote_path(source)
+        remote_destination = _coerce_remote_path(destination)
+        remote_cwd = None if cwd is None else _coerce_remote_path(cwd)
         iter_coroutine(
-            self._service.rename(
-                session_id=self._session_id(),
-                source=_coerce_remote_path(source),
-                destination=_coerce_remote_path(destination),
-                cwd=None if cwd is None else _coerce_remote_path(cwd),
-                collect_output=self._collect_output,
+            self._execution.execute(
+                lambda session_id: self._service.rename(
+                    session_id=session_id,
+                    source=remote_source,
+                    destination=remote_destination,
+                    cwd=remote_cwd,
+                    collect_output=self._collect_output,
+                )
             )
         )
 
@@ -687,7 +729,7 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
         self._service = service
         self.fs = SyncSandboxFilesystem(
             service=service,
-            session_id=lambda: self.id,
+            execution=FilesystemOperationBinding.direct(self.id),
             write_files_cwd=self._write_files_cwd,
         )
 
@@ -925,7 +967,12 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         self._recovery_attempt: _SyncRecoveryAttempt | None = None
         self.fs = SyncSandboxFilesystem(
             service=service,
-            session_id=lambda: self.current_session_id,
+            execution=FilesystemOperationBinding(
+                execute=lambda operation: execute_with_sandbox_recovery(
+                    operation, coordinator=self
+                ),
+                bind=self._ensure_active,
+            ),
             write_files_cwd=self._write_files_cwd,
         )
 
@@ -987,6 +1034,11 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
                         self._recovery_attempt = None
                     self._recovery_condition.notify_all()
             return
+
+    async def _ensure_active(self) -> str:
+        """Ensure an active current session before binding a lazy stream."""
+        await self._await_shared_resume()
+        return self.current_session_id
 
     async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
         deadline = time.monotonic() + TRANSITION_TIMEOUT

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -87,6 +87,7 @@ from vercel.sandbox._internal.state import (
     RuntimeSessionStopState,
     SandboxRuntimeSessionState,
     SandboxState,
+    SnapshotSessionState,
     SnapshotState,
 )
 from vercel.sandbox._internal.sync_filesystem_handle import (
@@ -1094,8 +1095,7 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
 
     async def _ensure_active(self) -> str:
         """Ensure an active current session before binding a lazy stream."""
-        await self._await_shared_resume()
-        return self.current_session_id
+        return (await self._acquire_session()).id
 
     async def _acquire_session(self) -> SyncSandboxRuntimeSession:
         target = self._capture_recovery_target()
@@ -1305,44 +1305,63 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         The service rejects durations shorter than one second.
         """
         parsed_duration = parse_required_duration_seconds(duration)
-        payload = iter_coroutine(
-            execute_with_sandbox_recovery(
-                lambda session_id: self._service.extend_runtime_session_timeout(
-                    session_id=session_id,
-                    duration=parsed_duration,
-                ),
-                coordinator=self,
+
+        async def extend(
+            session_id: str,
+        ) -> tuple[str, SandboxRuntimeSessionState]:
+            payload = await self._service.extend_runtime_session_timeout(
+                session_id=session_id,
+                duration=parsed_duration,
             )
-        )
-        return self._apply_current_session_payload(payload)
+            return session_id, payload
+
+        target_id, payload = iter_coroutine(execute_with_sandbox_recovery(extend, coordinator=self))
+        return self._apply_current_session_payload_if_current(payload, target_id)
 
     def update_network_policy(self, network_policy: NetworkPolicy) -> SyncSandboxRuntimeSession:
         """Replace the current session's network policy."""
-        payload = iter_coroutine(
-            execute_with_sandbox_recovery(
-                lambda session_id: self._service.update_runtime_session_network_policy(
-                    session_id=session_id,
-                    network_policy=network_policy,
-                ),
-                coordinator=self,
+
+        async def update(
+            session_id: str,
+        ) -> tuple[str, SandboxRuntimeSessionState]:
+            payload = await self._service.update_runtime_session_network_policy(
+                session_id=session_id,
+                network_policy=network_policy,
             )
-        )
-        return self._apply_current_session_payload(payload)
+            return session_id, payload
+
+        target_id, payload = iter_coroutine(execute_with_sandbox_recovery(update, coordinator=self))
+        return self._apply_current_session_payload_if_current(payload, target_id)
 
     def snapshot(self, *, expiration: SnapshotExpirationInput = None) -> SyncSnapshot:
         """Create a filesystem snapshot from the current session."""
         parsed_expiration = _parse_snapshot_expiration(expiration)
-        result = iter_coroutine(
-            execute_with_sandbox_recovery(
-                lambda session_id: self._service.create_snapshot(
-                    session_id=session_id,
-                    expiration=parsed_expiration,
-                ),
-                coordinator=self,
+
+        async def create(session_id: str) -> tuple[str, SnapshotSessionState]:
+            result = await self._service.create_snapshot(
+                session_id=session_id,
+                expiration=parsed_expiration,
             )
-        )
-        self._apply_current_session_payload(result.session)
+            return session_id, result
+
+        target_id, result = iter_coroutine(execute_with_sandbox_recovery(create, coordinator=self))
+        self._apply_current_session_payload_if_current(result.session, target_id)
         return SyncSnapshot(payload=result.snapshot, service=self._service)
+
+    def _apply_current_session_payload_if_current(
+        self, payload: SandboxRuntimeSessionState, target_id: str
+    ) -> SyncSandboxRuntimeSession:
+        """Ignore an operation reply superseded by a concurrent recovery."""
+        with self._recovery_condition:
+            if target_id == self.current_session_id:
+                return self._apply_current_session_payload(payload)
+            session = self.current_session
+            if session is None:
+                raise SandboxResponseError(
+                    "Sandbox current-session operation returned a different session identity",
+                    data=payload,
+                )
+            return session
 
     def stop(self) -> Self:
         """Stop the current session and return this sandbox handle."""

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -3,6 +3,7 @@
 import signal as signal_module
 import subprocess
 import time
+import warnings
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
@@ -15,6 +16,7 @@ from vercel._internal.core.iter_coroutine import iter_coroutine
 from vercel._internal.core.polyfills import Self
 from vercel._internal.core.time import parse_duration_seconds, parse_required_duration_seconds
 from vercel.sandbox._internal.errors import (
+    SandboxApiError,
     SandboxCleanupError,
     SandboxResponseError,
     SandboxTerminalStateError,
@@ -63,6 +65,7 @@ from vercel.sandbox._internal.recovery import (
     TRANSITION_TIMEOUT,
     SandboxLifecycle,
     SandboxRecoveryTarget,
+    classify_sandbox_lifecycle_error,
     execute_with_sandbox_recovery,
 )
 from vercel.sandbox._internal.runtime_common import (
@@ -81,6 +84,7 @@ from vercel.sandbox._internal.runtime_common import (
 from vercel.sandbox._internal.service import SandboxService, _SandboxTerminalState
 from vercel.sandbox._internal.state import (
     ProcessState,
+    RuntimeSessionStopState,
     SandboxRuntimeSessionState,
     SandboxState,
     SnapshotState,
@@ -743,15 +747,16 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
         traceback: TracebackType | None,
     ) -> None:
         try:
-            payload = iter_coroutine(self._service.stop_runtime_session(session_id=self.id))
-            self._apply_payload(payload)
-        except Exception as cleanup_exc:
-            raise SandboxCleanupError(
-                f"Failed to clean up sandbox runtime session {self.id!r}",
-                resource_type="sandbox_runtime_session",
-                resource_id=self.id,
-                cause=cleanup_exc,
-            ) from cleanup_exc
+            _cleanup_exact_sync_session(self)
+        except SandboxCleanupError as cleanup_error:
+            if exc is None:
+                raise
+            warnings.warn(
+                str(cleanup_error),
+                RuntimeWarning,
+                source=cleanup_error,
+                stacklevel=2,
+            )
 
     def run_process(
         self,
@@ -888,7 +893,7 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
                 session_id=self.id, include_system_routes=include_system_routes
             )
         )
-        self._apply_payload(payload)
+        self._apply_payload_with_parent(payload)
         return self
 
     def extend_execution_time_limit(self, duration: DurationInput) -> Self:
@@ -926,9 +931,34 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
 
     def stop(self) -> Self:
         """Stop this runtime session and refresh the handle."""
-        payload = iter_coroutine(self._service.stop_runtime_session(session_id=self.id))
-        self._apply_payload(payload)
+        result = iter_coroutine(self._service.stop_runtime_session(session_id=self.id))
+        self._apply_stop_result(result)
         return self
+
+
+def _cleanup_exact_sync_session(handle: SyncSandboxRuntimeSession) -> None:
+    if handle.status == SandboxStatus.STOPPED:
+        return
+    try:
+        result = iter_coroutine(handle._service.stop_runtime_session(session_id=handle.id))
+        handle._apply_stop_result(result)
+    except SandboxApiError as error:
+        if classify_sandbox_lifecycle_error(error) is SandboxLifecycle.STOPPED:
+            handle._mark_stopped()
+            return
+        raise SandboxCleanupError(
+            f"Failed to clean up sandbox runtime session {handle.id!r}",
+            resource_type="sandbox_runtime_session",
+            resource_id=handle.id,
+            cause=error,
+        ) from error
+    except Exception as error:
+        raise SandboxCleanupError(
+            f"Failed to clean up sandbox runtime session {handle.id!r}",
+            resource_type="sandbox_runtime_session",
+            resource_id=handle.id,
+            cause=error,
+        ) from error
 
 
 @dataclass(slots=True)
@@ -941,9 +971,10 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     """Control a synchronous Vercel Sandbox.
 
     A sandbox has at most one active current session. Process and filesystem
-    operations target the session recorded by this handle. Use
-    ``sandbox.resume_sandbox`` to ensure the sandbox has an active session,
-    ``stop`` to stop it, and ``destroy`` to permanently remove the sandbox.
+    session-bound operations lazily resume when needed and update this handle's
+    canonical current session. Use ``session`` for an explicit exact-session
+    lifecycle, ``stop`` to stop the current session, and ``destroy`` to
+    permanently remove the sandbox.
     """
 
     __slots__ = ("_recovery_attempt", "_recovery_condition", "_service", "fs")
@@ -955,6 +986,7 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         service: SandboxService,
         include_system_routes: bool | None = None,
     ) -> None:
+        self._recovery_condition = Condition()
         super().__init__(
             payload,
             session_factory=lambda session: SyncSandboxRuntimeSession(
@@ -963,7 +995,6 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
             include_system_routes=include_system_routes,
         )
         self._service = service
-        self._recovery_condition = Condition()
         self._recovery_attempt: _SyncRecoveryAttempt | None = None
         self.fs = SyncSandboxFilesystem(
             service=service,
@@ -975,6 +1006,32 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
             ),
             write_files_cwd=self._write_files_cwd,
         )
+
+    def _apply_payload(self, payload: SandboxState) -> None:
+        with self._recovery_condition:
+            super()._apply_payload(payload)
+
+    def _apply_current_session_payload(
+        self, payload: SandboxRuntimeSessionState
+    ) -> SyncSandboxRuntimeSession:
+        with self._recovery_condition:
+            return super()._apply_current_session_payload(payload)
+
+    def _apply_session_payload_from_child(
+        self,
+        child: RuntimeSessionHandleBase,
+        payload: SandboxRuntimeSessionState,
+    ) -> None:
+        with self._recovery_condition:
+            super()._apply_session_payload_from_child(child, payload)
+
+    def _apply_session_stop_from_child(
+        self,
+        child: RuntimeSessionHandleBase,
+        result: RuntimeSessionStopState,
+    ) -> None:
+        with self._recovery_condition:
+            super()._apply_session_stop_from_child(child, result)
 
     def _capture_recovery_target(self) -> SandboxRecoveryTarget:
         with self._recovery_condition:
@@ -1039,6 +1096,35 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         """Ensure an active current session before binding a lazy stream."""
         await self._await_shared_resume()
         return self.current_session_id
+
+    async def _acquire_session(self) -> SyncSandboxRuntimeSession:
+        target = self._capture_recovery_target()
+        try:
+            await self._await_shared_resume()
+        except Exception as error:
+            lifecycle = classify_sandbox_lifecycle_error(error)
+            if lifecycle not in {
+                SandboxLifecycle.STOPPING,
+                SandboxLifecycle.SNAPSHOTTING,
+            }:
+                raise
+            await self._wait_for_transition(target)
+            await self._await_shared_resume()
+        session = self.current_session
+        if session is None:
+            raise SandboxResponseError(
+                "Sandbox resume response is missing the current-session attachment",
+                data=self.raw,
+            )
+        return session
+
+    def session(self) -> SyncSandboxRuntimeSession:
+        """Acquire and return the canonical active runtime session eagerly.
+
+        Entering the returned handle does not reacquire it and stops only that
+        exact session identity on exit.
+        """
+        return iter_coroutine(self._acquire_session())
 
     async def _wait_for_transition(self, target: SandboxRecoveryTarget) -> None:
         deadline = time.monotonic() + TRANSITION_TIMEOUT
@@ -1260,10 +1346,23 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
 
     def stop(self) -> Self:
         """Stop the current session and return this sandbox handle."""
-        payload = iter_coroutine(
-            self._service.stop_runtime_session(session_id=self.current_session_id)
-        )
-        self._apply_current_session_payload(payload)
+        with self._recovery_condition:
+            session = self.current_session
+            target_id = self.current_session_id
+        result = iter_coroutine(self._service.stop_runtime_session(session_id=target_id))
+        if session is None:
+            with self._recovery_condition:
+                if self.current_session_id != target_id:
+                    return self
+                self._apply_current_session_payload(result.session)
+                if (
+                    result._sandbox_attached
+                    and result.sandbox is not None
+                    and result.sandbox.current_session_id == result.session.id
+                ):
+                    self._apply_payload(result.sandbox)
+        else:
+            session._apply_stop_result(result)
         return self
 
     def destroy(self) -> Self:

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -17,6 +17,7 @@ from vercel.sandbox._internal.errors import (
     SandboxResponseError,
     SandboxStreamError,
     SandboxTerminalStateError,
+    SandboxTimeoutError as SandboxTimeoutError,
     SandboxUploadSizeMismatchError,
 )
 from vercel.sandbox._internal.models import (

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -209,6 +209,10 @@ def get_sandbox(
 ) -> SyncSandbox:
     """Fetch a sandbox by name without resuming it.
 
+    Session-bound operations on the returned handle resume lazily when needed.
+    Use ``current_session`` for passive inspection or ``session()`` for an
+    authoritative exact-session acquisition and optional managed scope.
+
     Args:
         name: Sandbox name.
         project_id: Project that owns the sandbox.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,10 +30,17 @@ def _discover_examples(directory: Path) -> list[Path]:
     selected = []
     for scope_arg in scope_args:
         candidate = (Path.cwd() / scope_arg).resolve()
+        if candidate == Path(__file__).resolve():
+            return examples
         if candidate == directory:
             return examples
         if candidate.parent == directory and candidate in examples:
             selected.append(candidate)
+    if not selected and os.getenv("WORKSPACE_POE_SCOPE_TASK") == "test-examples":
+        raise pytest.UsageError(
+            f"no example scripts under {directory} matched the requested scope: "
+            f"{' '.join(scope_args)}"
+        )
     return selected or examples
 
 

--- a/tests/unit/test_workspace_poe.py
+++ b/tests/unit/test_workspace_poe.py
@@ -121,6 +121,7 @@ def test_example_scope_command_maps_root_to_internal_task() -> None:
     assert command.argv[-2:] == ("-k", "sessions_and_resume")
     assert command.parser == "pytest"
     assert command.env["WORKSPACE_POE_LOGRAIL_PROGRESS"] == "1"
+    assert command.env["WORKSPACE_POE_SCOPE_TASK"] == "test-examples"
 
 
 def test_example_scope_command_preserves_package_passthrough() -> None:


### PR DESCRIPTION
Adds automatic Sandbox session recovery for sync and async operations. When a covered process, snapshot, network-policy, execution-limit, or filesystem operation encounters a stopped session, the existing handle resumes the sandbox and replays the operation once against the replacement session.

Recovery coordinates concurrent callers so they share one resume attempt, polls bounded stopping or snapshotting transitions, and preserves cancellation and interruption behavior. Lazy handles follow the active session, while runtime-session handles, process handles, and already-open streams remain pinned to their original session.

Adds `box.session()` scopes for acquiring an active session and stopping that exact session on exit. Cleanup preserves replacement sessions and sparse sandbox metadata during recovery races.

Filesystem recovery covers reads, writes, batch writes, and unsized writers while retaining at-least-once write semantics. Failures after streaming begins are never replayed. Recovery also preserves route projection, session identity, HTTP 410 handling, and the one-recovery/one-replay limit.
