### PR TITLE
workflow: Only run resume (idle_hook) when not stopping

### DIFF
--- a/src/vercel/_internal/workflow/loop.py
+++ b/src/vercel/_internal/workflow/loop.py
@@ -25,7 +25,7 @@ class WorkflowLoop(asyncio.BaseEventLoop):
             handle._run()
         handle = None  # Needed to break cycles when an exception occurs.
 
-        if self.idle_hook:
+        if self.idle_hook and not self._stopping:
             self.idle_hook()
 
     def _write_to_self(self):


### PR DESCRIPTION
Otherwise a _SuspendException raised there will actually suspend.
Previously, before the new loop, if it wanted to suspend after the
main coro had finished, it would cancel the future, which did nothing.
