### PR TITLE
[integrations] APScheduler: Default unset misfire grace period

### DIFF
--- a/changes/vercel-apscheduler/queues-adapter.feature.md
+++ b/changes/vercel-apscheduler/queues-adapter.feature.md
@@ -3,4 +3,7 @@ patches `scheduler.start()`, `scheduler.pause()`, and `scheduler.resume()` with
 durable, deployment-scoped lifecycle transitions and atomic single-chain
 fencing. Paused occurrences are skipped on resume, and interrupted successor
 publication is repaired on retry. Production schedules activate on the first
-request, and opted-in previews stop after a durable idle timeout.
+request, and opted-in previews stop after a durable idle timeout. Jobs that
+do not choose a `misfire_grace_time` run their occurrences whenever the wake
+arrives: the stock one-second grace assumes in-process wakeup precision that
+queue delivery cannot meet.

--- a/integrations/vercel-apscheduler/README.md
+++ b/integrations/vercel-apscheduler/README.md
@@ -210,8 +210,9 @@ publication, and repeating an interrupted mutation republishes the pending
 wake even when the retry itself fails on a conflicting job id. With no idle
 heartbeat, an ambiguous failure while publishing the first wake for a dormant
 scheduler is repaired by a later `start()` or mutation call, not by a periodic
-timer. Set an appropriate `misfire_grace_time` (or `None`) for jobs whose
-occurrences must remain eligible after a delayed repair.
+timer. Unless a job chooses its own `misfire_grace_time`, occurrences run when
+their wake arrives, however late; set a finite `misfire_grace_time` on jobs
+that must not run late.
 
 These are chain guarantees, not exactly-once job execution. Vercel Queues is
 at-least-once, so a delivery interrupted after a job's side effect may run that

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -292,9 +292,8 @@ republishes the pending token. Repeating an interrupted mutation is also safe:
 a retried mutation republishes the pending wake even when the retry itself
 fails, for example on a conflicting job id. A completely dormant scheduler
 does not wake periodically to repair an otherwise unobserved ambiguous
-failure. A delayed repair can pass a job's default misfire window; jobs whose
-occurrence must remain eligible should set an appropriate
-`misfire_grace_time` or `None`.
+failure. A delayed repair can pass a finite misfire window; jobs that opt
+into one and must remain eligible after repairs should size it accordingly.
 
 ## Redis and execution requirements
 
@@ -315,6 +314,16 @@ Jobs use the integration's inline executor so that a wake remains active until
 the job has completed and the durable job-store update has happened. Custom
 executors are rejected in v1. A scheduled function can enqueue longer work to
 another queue.
+
+Queue delivery cannot honor APScheduler's stock one-second misfire grace:
+wake delays are rounded up to whole seconds and dispatch adds latency, so a
+routine delivery lands about a second late and would skip its occurrence as a
+misfire. On Vercel a job whose `misfire_grace_time` is not chosen explicitly
+(on the job or in `job_defaults`) therefore defaults to `None`: an occurrence
+runs when its wake arrives, however late, and the default `coalesce` collapses
+any backlog into one run. Jobs that must not run late opt in with a finite
+`misfire_grace_time`; explicit values below five seconds cannot be met by
+queue transport and log a warning.
 
 Code-declared jobs require explicit stable IDs. If a job with that ID is
 already persisted, the declaration must permit replacement, but materializing

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import logging
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from sys import modules
@@ -726,6 +727,76 @@ def test_options_reject_limits_the_queue_cannot_serve() -> None:
         # Raising the delay without also raising retention would publish
         # wakes that expire before they become visible.
         VercelAPSchedulerOptions(max_delay_seconds=3 * 24 * 60 * 60)
+
+
+def test_unset_misfire_grace_defaults_to_none() -> None:
+    """Stock one-second grace is calibrated to in-process wakeup precision.
+
+    Queue delivery rounds wake delays up to whole seconds and adds dispatch
+    latency, so keeping the stock default would skip occurrences as misfires
+    on routine jitter.
+    """
+    scheduler = BlockingScheduler(
+        timezone=UTC,
+        jobstores={"default": InMemoryRedisJobStore()},
+    )
+
+    assert scheduler._job_defaults["misfire_grace_time"] is None
+
+
+def test_explicit_misfire_grace_default_is_preserved() -> None:
+    scheduler = BlockingScheduler(
+        timezone=UTC,
+        job_defaults={"misfire_grace_time": 15},
+        jobstores={"default": InMemoryRedisJobStore()},
+    )
+
+    assert scheduler._job_defaults["misfire_grace_time"] == 15
+
+
+def test_gconfig_misfire_grace_default_is_preserved() -> None:
+    scheduler = BlockingScheduler(
+        {"apscheduler.job_defaults.misfire_grace_time": "7"},
+        timezone=UTC,
+        jobstores={"default": InMemoryRedisJobStore()},
+    )
+
+    assert scheduler._job_defaults["misfire_grace_time"] == 7
+
+
+def test_misfire_grace_stays_stock_outside_vercel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERCEL", raising=False)
+    scheduler = BlockingScheduler(
+        timezone=UTC,
+        jobstores={"default": InMemoryRedisJobStore()},
+    )
+
+    assert scheduler._job_defaults["misfire_grace_time"] == 1
+
+
+def test_short_explicit_misfire_grace_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit sub-transport grace is honored but named for what it is."""
+    scheduler, adapter, _driver = scheduler_with_driver()
+    scheduler.add_job(
+        durable_noop_job,
+        "interval",
+        hours=1,
+        id="tight",
+        misfire_grace_time=1,
+        replace_existing=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        adapter.ensure_local_started()
+
+    assert any("misfire_grace_time=1" in record.getMessage() for record in caplog.records)
+    persisted = scheduler.get_job("tight")
+    assert persisted is not None
+    assert persisted.misfire_grace_time == 1
 
 
 def test_preview_state_stays_deployment_scoped(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -54,6 +54,9 @@ DEPLOYMENT_ENV = "VERCEL_DEPLOYMENT_ID"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 WAKEUP_KEY_PREFIX = "aps"
 RAW_STORE_KEY_ATTR = "_vercel_apscheduler_raw_jobs_key"
+# Queue delivery rounds wake delays up to whole seconds and adds dispatch
+# latency, so a grace below this cannot be met and skips occurrences.
+MIN_QUEUE_MISFIRE_GRACE_SECONDS = 5
 
 # One live adapter per durable identity. Two schedulers whose stores collapse
 # to the same identity would interleave one namespace, so the second claim
@@ -184,6 +187,7 @@ class SchedulerAdapter:
         self._runtime_mutation_depth = 0
         self._lifecycle_called = False
         self._queue_lifecycle_warning_emitted = False
+        self._short_grace_warned: set[str] = set()
         self._suppress_wakeup = False
         self._native_wakeup = scheduler.wakeup
         self._adopt_instance_methods()
@@ -630,6 +634,23 @@ class SchedulerAdapter:
             raise APSchedulerConfigurationError(
                 "jobs in a durable APScheduler store require an explicit stable id"
             )
+        # Before defaults fill, the attribute exists only when the job chose
+        # its own grace; the scheduler-level default is checked at configure.
+        grace = getattr(job, "misfire_grace_time", None)
+        if (
+            grace is not None
+            and grace < MIN_QUEUE_MISFIRE_GRACE_SECONDS
+            and str(job.id) not in self._short_grace_warned
+        ):
+            self._short_grace_warned.add(str(job.id))
+            self._logger.warning(
+                'Job "%s" sets misfire_grace_time=%s; queue delivery cannot '
+                "meet a grace below %s seconds, so occurrences may be "
+                "skipped as misfires",
+                job.id,
+                grace,
+                MIN_QUEUE_MISFIRE_GRACE_SECONDS,
+            )
         if not (self.is_runtime_mutation or self.is_wake_mutation):
             # Cold-start declarations are the reconciliation input on takeover.
             self._declared_jobs[str(job.id)] = job
@@ -1020,6 +1041,64 @@ def adopt_scheduler(
     return adapter
 
 
+def _grace_explicitly_configured(
+    gconfig: dict[str, Any],
+    prefix: str,
+    options: dict[str, Any],
+) -> bool:
+    """Whether this configure call chooses a misfire grace itself."""
+    job_defaults = options.get("job_defaults")
+    if isinstance(job_defaults, str):
+        # An opaque textual reference; assume it is a deliberate choice.
+        return True
+    if isinstance(job_defaults, dict) and "misfire_grace_time" in job_defaults:
+        return True
+    prefix_length = len(prefix) if prefix else 0
+    for key, value in gconfig.items():
+        name = str(key)
+        if prefix:
+            if not name.startswith(prefix):
+                continue
+            name = name[prefix_length:]
+        if name == "job_defaults.misfire_grace_time":
+            return True
+        if name == "job_defaults" and (
+            isinstance(value, str) or (isinstance(value, dict) and "misfire_grace_time" in value)
+        ):
+            return True
+    return False
+
+
+def _patched_configure(
+    self: BaseScheduler,
+    gconfig: dict[str, Any] | None = None,
+    prefix: str = "apscheduler.",
+    **options: Any,
+) -> Any:
+    resolved_gconfig: dict[str, Any] = {} if gconfig is None else gconfig
+    result = _original("configure")(self, resolved_gconfig, prefix, **options)
+    if not is_vercel_runtime():
+        return result
+    if _grace_explicitly_configured(resolved_gconfig, prefix, options):
+        value = self._job_defaults.get("misfire_grace_time")
+        if value is not None and value < MIN_QUEUE_MISFIRE_GRACE_SECONDS:
+            LOGGER.warning(
+                "job_defaults sets misfire_grace_time=%s; queue delivery "
+                "cannot meet a grace below %s seconds, so occurrences may "
+                "be skipped as misfires",
+                value,
+                MIN_QUEUE_MISFIRE_GRACE_SECONDS,
+            )
+    else:
+        # Stock APScheduler calibrates its one-second default grace to
+        # in-process wakeup precision, which queue delivery cannot meet:
+        # keeping it would skip occurrences on routine dispatch jitter.
+        # Unset grace on Vercel means occurrences run whenever their wake
+        # arrives; a finite grace is the explicit opt-in for skip-if-late.
+        self._job_defaults["misfire_grace_time"] = None
+    return result
+
+
 def _patched_init(self: BaseScheduler, *args: Any, **kwargs: Any) -> Any:
     result = _original("init")(self, *args, **kwargs)
     options = VercelAPSchedulerOptions.from_value(_PATCH_STATE.default_options)
@@ -1209,6 +1288,7 @@ def install_vercel_apscheduler_integration(
 
     _PATCH_STATE.originals = {
         "init": BaseScheduler.__init__,
+        "configure": BaseScheduler.configure,
         "add_job": BaseScheduler.add_job,
         "add_jobstore": BaseScheduler.add_jobstore,
         "real_add_job": BaseScheduler._real_add_job,
@@ -1221,6 +1301,7 @@ def install_vercel_apscheduler_integration(
         "resume": BaseScheduler.resume,
     }
     BaseScheduler.__init__ = _patched_init  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    BaseScheduler.configure = _patched_configure  # type: ignore[method-assign]
     BaseScheduler.add_jobstore = _patched_add_jobstore  # type: ignore[method-assign]
     BaseScheduler.add_job = _patched_add_job  # type: ignore[method-assign]
     BaseScheduler._real_add_job = _patched_real_add_job  # type: ignore[method-assign]


### PR DESCRIPTION
Sits on top of #216. Jobs that never chose a `misfire_grace_time` now run their occurrences whenever their wake arrives, instead of inheriting APScheduler's one-second default.

The stock default assumes an in-process wakeup loop with millisecond precision. Queue delivery rounds wake delays up to whole seconds and adds dispatch latency, so a routine wake lands about a second late and its occurrence is silently skipped as a misfire:

```text
Run time of job "heartbeat ..." was missed by 0:00:01.094551
```

Out of the box roughly half of all occurrences lose that lottery, and a cold deploy loses several in a row.

Behavior change, scoped to Vercel runtimes:

- unset grace (no per-job value, none in `job_defaults` or gconfig) materializes as `None`: occurrences run however late, and stock `coalesce` collapses any backlog into one run
- explicit values are honored wherever they can be expressed; an explicit grace below five seconds logs a warning, since queue transport cannot meet it
- outside Vercel nothing changes

Skip-if-late becomes the documented opt-in: jobs that must not run late set a finite `misfire_grace_time`.