### PR TITLE
[integrations] APScheduler: Fence demoted writes; reconcile until converged

### DIFF
--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -345,7 +345,8 @@ over automatically on its first request that arrives through an environment
 alias. From that moment the demoted deployment is fenced out of the
 namespace entirely: its deliveries still arrive but every claim turns stale
 and acks, it repairs and rearms nothing, its cold starts write no
-declarations, and its mutation APIs refuse loudly. Its queue simply drains.
+declarations, its mutation APIs refuse loudly, and every job-store write is
+refused atomically by owning deployment. Its queue simply drains.
 A rollback is the same operation in the other direction; the mechanism has
 no notion of old and new, only of who owns the chain now. An opted-in
 preview activates the same way and remains active only while requests renew
@@ -368,6 +369,16 @@ the new code (typically because its function moved) is rewritten from the
 declaration and restarts its schedule. A `runtime` job whose definition no
 longer loads is quarantined: it leaves the due index, keeps its record for
 the operator, and logs an error.
+
+Reconciliation completes only once it converges. A revision race with a
+concurrent owner write reruns the pass against fresh state, and only the
+owner marks the sync as done, after a clean pass; a reconciliation that
+cannot converge stays unmarked and retries on the next activation. In-flight
+work is never interrupted: the demoted deployment's running job finishes or
+dies with its instance, its late writes are fenced, and the new generation's
+first claim waits for the active-owner lease to be released or to lapse.
+Jobs that run long should enqueue their work to another queue and return, so
+a promote is never delayed behind them.
 
 A takeover strands the previous owner's in-flight wake: it is consumed by
 the demoted deployment and acked as stale, and the new owner's chain starts
@@ -403,7 +414,9 @@ expiry would make reliable pause semantics impossible.
 | retried mutation fails on a conflicting id | the pending wake is still republished |
 | takeover while a wake is in flight | the demoted deployment consumes it and acks it as stale |
 | the owner's wake message dies | the overdue wake is presumed lost and republished by the owner |
-| takeover reconciliation races a demoted deployment's handler | ownership and revision CAS keep exactly one writer per job |
+| takeover reconciliation races a demoted deployment's handler | the demoted write is fenced atomically by owning deployment |
+| reconciliation loses a revision race to a concurrent owner write | the pass reruns with fresh state; completion is marked only once converged |
+| a deployment loses the namespace mid-reconciliation | its writes fence, it cannot stamp the marker, and the owner reconciles |
 | concurrent first requests | one automatic generation and one start identity |
 | request arrives after explicit pause | idle deadline renews but state remains paused |
 | preview idle deadline expires before claim | message is stale and no job runs |

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -210,9 +210,12 @@ class FakeDriver:
     def reconciled_deployment(self) -> str | None:
         return self.reconciled
 
-    def mark_reconciled(self, deployment: str, now: datetime) -> None:
+    def mark_reconciled(self, deployment: str, now: datetime) -> bool:
         del now
+        if self.owner_deployment_value != deployment:
+            return False
         self.reconciled = deployment
+        return True
 
     def repair_overdue_wake(self, now: datetime, *, grace_seconds: int = 600) -> bool:
         with self.lock:

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
@@ -21,7 +21,11 @@ from vercel.integrations.apscheduler import (
     install_vercel_apscheduler_integration,
 )
 from vercel.integrations.apscheduler._adapter import SchedulerAdapter, get_adapter
-from vercel.integrations.apscheduler._driver import RedisDriver, StartDecision
+from vercel.integrations.apscheduler._driver import (
+    NamespaceFencedError,
+    RedisDriver,
+    StartDecision,
+)
 
 UTC = timezone.utc
 REDIS_URL = environ.get("APSCHEDULER_TEST_REDIS_URL")
@@ -958,6 +962,210 @@ def test_real_redis_takeover_restores_unloadable_declared_jobs(
         assert restored.next_run_time is not None
         second_store = second._jobstores["default"]
         assert client.zscore(second_store.run_times_key, "moved") is not None
+    finally:
+        client.delete(*keys)
+
+
+def _take_over_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    deployment: str,
+) -> tuple[BlockingScheduler, SchedulerAdapter]:
+    """Build a second scheduler over the shared scope, bound but not started."""
+    assert REDIS_URL is not None
+    _adapter_module._ACTIVE_IDENTITIES.clear()
+    monkeypatch.setenv("VERCEL_DEPLOYMENT_ID", deployment)
+    monkeypatch.delenv("VERCEL")
+    scheduler = BlockingScheduler(
+        timezone=UTC,
+        jobstores={"default": _redis_job_store(REDIS_URL)},
+    )
+    modules[TEST_SCHEDULER_MODULE].__dict__["scheduler"] = scheduler
+    monkeypatch.setenv("VERCEL", "1")
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+    adapter._bind_runtime()
+    return scheduler, adapter
+
+
+def _bump_revision(client: Redis, keys: tuple[str, ...], job_id: str) -> None:
+    """Mimic a concurrent owner write moving a job's revision."""
+    revision = client.hincrby(keys[3], "job_revision", 1)
+    client.hset(keys[2], job_id, str(revision))
+
+
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
+def test_real_redis_demoted_deployment_writes_are_fenced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A takeover atomically fences the demoted deployment's late writes.
+
+    An in-flight handler on the demoted deployment may finish after the
+    takeover; its job-store commit must be refused so reconciliation can
+    never lose to it, and it must not stamp reconciliation as its own.
+    """
+    assert REDIS_URL is not None
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_PROJECT_ID", "prj_fence")
+    first_scheduler, first_adapter, client, keys = _real_scheduler(
+        monkeypatch,
+        deployment="dpl_fence_one",
+    )
+    try:
+        first_scheduler.add_job(
+            durable_test_job,
+            "interval",
+            hours=1,
+            id="lingering",
+            replace_existing=True,
+        )
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            first_scheduler.start()
+        [(job, revision, _provenance)], _undecodable = (
+            first_adapter.coordinator.get_all_jobs_with_revisions()
+        )
+
+        second, second_adapter = _take_over_scheduler(monkeypatch, "dpl_fence_two")
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            second.start()
+        second_driver = second_adapter.driver
+        assert second_driver.owner_deployment() == "dpl_fence_two"
+
+        # The demoted deployment's in-flight handler writes with its own
+        # bound identity; only the environment is restored for the lookup.
+        monkeypatch.setenv("VERCEL_DEPLOYMENT_ID", "dpl_fence_one")
+        first_coordinator = first_adapter.coordinator
+        with pytest.raises(NamespaceFencedError):
+            first_coordinator.cas_update_job(job, revision)
+        with pytest.raises(NamespaceFencedError):
+            first_coordinator.remove_job("lingering")
+        assert not first_adapter.driver.mark_reconciled(
+            "dpl_fence_one",
+            datetime.now(UTC),
+        )
+        assert second_driver.reconciled_deployment() == "dpl_fence_two"
+    finally:
+        client.delete(*keys)
+
+
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
+def test_real_redis_reconciliation_retries_revision_races(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revision race reruns the pass instead of losing the removal."""
+    assert REDIS_URL is not None
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_PROJECT_ID", "prj_retry")
+    first_scheduler, _first_adapter, client, keys = _real_scheduler(
+        monkeypatch,
+        deployment="dpl_retry_one",
+    )
+    try:
+        first_scheduler.add_job(
+            durable_test_job,
+            "interval",
+            hours=1,
+            id="gone",
+            replace_existing=True,
+        )
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            first_scheduler.start()
+
+        second, second_adapter = _take_over_scheduler(monkeypatch, "dpl_retry_two")
+        coordinator = second_adapter.coordinator
+        original_remove = coordinator.cas_remove_job
+        calls: list[str] = []
+
+        def racing_remove(job_id: str, expected_revision: int) -> bool:
+            calls.append(job_id)
+            if len(calls) == 1:
+                _bump_revision(client, coordinator.keys, job_id)
+            return original_remove(job_id, expected_revision)
+
+        monkeypatch.setattr(coordinator, "cas_remove_job", racing_remove)
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            second.start()
+
+        assert calls == ["gone", "gone"]
+        assert not client.hexists(coordinator.keys[0], "gone")
+        assert second_adapter.driver.reconciled_deployment() == "dpl_retry_two"
+    finally:
+        client.delete(*keys)
+
+
+@pytest.mark.skipif(
+    REDIS_URL is None,
+    reason="requires a disposable Redis server",
+)
+def test_real_redis_unconverged_reconciliation_defers_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconciliation that cannot converge stays unmarked and retries later."""
+    assert REDIS_URL is not None
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.setenv("VERCEL_PROJECT_ID", "prj_defer")
+    first_scheduler, _first_adapter, client, keys = _real_scheduler(
+        monkeypatch,
+        deployment="dpl_defer_one",
+    )
+    try:
+        first_scheduler.add_job(
+            durable_test_job,
+            "interval",
+            hours=1,
+            id="gone",
+            replace_existing=True,
+        )
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            first_scheduler.start()
+
+        second, second_adapter = _take_over_scheduler(monkeypatch, "dpl_defer_two")
+        coordinator = second_adapter.coordinator
+        original_remove = coordinator.cas_remove_job
+
+        def always_racing_remove(job_id: str, expected_revision: int) -> bool:
+            _bump_revision(client, coordinator.keys, job_id)
+            return original_remove(job_id, expected_revision)
+
+        monkeypatch.setattr(coordinator, "cas_remove_job", always_racing_remove)
+        with patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg",
+        ):
+            second.start()
+
+        # Every pass lost its race: the job survives and the marker is not
+        # stamped, so the sync stays owed rather than silently skipped.
+        assert client.hexists(coordinator.keys[0], "gone")
+        assert second_adapter.driver.reconciled_deployment() == "dpl_defer_one"
+        assert second_adapter._reconciled is False
+
+        monkeypatch.setattr(coordinator, "cas_remove_job", original_remove)
+        second_adapter.ensure_local_started()
+
+        assert not client.hexists(coordinator.keys[0], "gone")
+        assert second_adapter.driver.reconciled_deployment() == "dpl_defer_two"
+        assert second_adapter._reconciled is True
     finally:
         client.delete(*keys)
 

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -18,6 +18,7 @@ import vercel.queue.sync as vqs_sync
 
 from ._driver import (
     APSchedulerConfigurationError,
+    NamespaceFencedError,
     RedisDriver,
     StartDecision,
     WakeToken,
@@ -57,6 +58,10 @@ RAW_STORE_KEY_ATTR = "_vercel_apscheduler_raw_jobs_key"
 # Queue delivery rounds wake delays up to whole seconds and adds dispatch
 # latency, so a grace below this cannot be met and skips occurrences.
 MIN_QUEUE_MISFIRE_GRACE_SECONDS = 5
+# A reconciliation pass can lose a revision race to a concurrent owner write;
+# rerunning with fresh state converges. Bounded so a mutation storm defers to
+# the next activation instead of spinning.
+RECONCILE_PASS_LIMIT = 3
 
 # One live adapter per durable identity. Two schedulers whose stores collapse
 # to the same identity would interleave one namespace, so the second claim
@@ -816,22 +821,52 @@ class SchedulerAdapter:
         if self.driver.reconciled_deployment() == self.deployment:
             self._reconciled = True
             return
+        try:
+            for _ in range(RECONCILE_PASS_LIMIT):
+                if not self._reconcile_pass(now):
+                    continue
+                if self.driver.mark_reconciled(self.deployment, now):
+                    self._reconciled = True
+                return
+        except NamespaceFencedError:
+            # Ownership moved mid-reconciliation; the marker stays unset and
+            # the current owner reconciles instead.
+            self._logger.info(
+                'Deployment "%s" lost the scheduler while reconciling; '
+                "leaving the sync to the current owner",
+                self.deployment,
+            )
+            return
+        self._logger.warning(
+            "Reconciliation kept losing revision races to concurrent writes; "
+            "it stays unfinished and retries on the next activation"
+        )
+
+    def _reconcile_pass(self, now: datetime) -> bool:
+        """Run one full declaration sync; False when a revision race dirtied it.
+
+        A lost compare-and-set means a concurrent owner write moved a job
+        after this pass read it; the caller reruns against fresh state so the
+        sync always reflects the store it actually saw.
+        """
+        clean = True
         missing = dict(self._declared_jobs)
         with self.scheduler._jobstores_lock:
             jobs, undecodable = self.coordinator.get_all_jobs_with_revisions()
-            self._reconcile_undecodable(undecodable, missing, now)
+            clean &= self._reconcile_undecodable(undecodable, missing, now)
             for job, revision, provenance in jobs:
                 missing.pop(str(job.id), None)
                 if provenance != PROVENANCE_DECLARED:
                     continue
                 declared = self._declared_jobs.get(str(job.id))
                 if declared is None:
-                    synced = self.coordinator.cas_remove_job(job.id, revision)
-                    if synced:
+                    if self.coordinator.cas_remove_job(job.id, revision):
                         self._logger.info(
                             'Removed job "%s": this deployment no longer declares it',
                             job.id,
                         )
+                    else:
+                        clean = False
                     continue
                 if _trigger_fingerprint(declared.trigger) == _trigger_fingerprint(job.trigger):
                     next_run_time = job.next_run_time
@@ -841,28 +876,22 @@ class SchedulerAdapter:
                         now.astimezone(self.scheduler.timezone),
                     )
                 declared._modify(next_run_time=next_run_time)
-                synced = self.coordinator.cas_update_job(declared, revision)
-                if not synced:
-                    # A concurrent handler moved the revision; the next sync
-                    # pass sees the current value.
-                    self._logger.debug(
-                        'Job "%s" changed while reconciling; leaving the newer revision',
-                        job.id,
-                    )
+                if not self.coordinator.cas_update_job(declared, revision):
+                    clean = False
             for declared in missing.values():
                 # Declared before this deployment owned the namespace, so the
                 # cold-start materialization deliberately did not write it.
                 self.coordinator.add_job(declared)
-        self.driver.mark_reconciled(self.deployment, now)
-        self._reconciled = True
+        return clean
 
     def _reconcile_undecodable(
         self,
         undecodable: list[tuple[str, int, str]],
         missing: dict[str, Any],
         now: datetime,
-    ) -> None:
+    ) -> bool:
         """Repair or sideline records this deployment's code cannot load."""
+        clean = True
         for job_id, revision, provenance in undecodable:
             declared = missing.pop(job_id, None)
             if provenance != PROVENANCE_DECLARED:
@@ -875,6 +904,8 @@ class SchedulerAdapter:
                         'Removed job "%s": this deployment no longer declares it',
                         job_id,
                     )
+                else:
+                    clean = False
                 continue
             # The code still declares this job but its persisted record no
             # longer loads (typically its function moved). The declaration is
@@ -891,6 +922,9 @@ class SchedulerAdapter:
                     "definition no longer loads under this deployment",
                     job_id,
                 )
+            else:
+                clean = False
+        return clean
 
     def _rebase_before(self, activation_time: datetime) -> None:
         with self.scheduler._jobstores_lock:
@@ -990,17 +1024,28 @@ class SchedulerAdapter:
                             plan.run_times,
                         )
                     )
-                if plan.next_run_time is None:
-                    advanced = self.coordinator.cas_remove_job(
-                        plan.job.id,
-                        plan.expected_revision,
+                try:
+                    if plan.next_run_time is None:
+                        advanced = self.coordinator.cas_remove_job(
+                            plan.job.id,
+                            plan.expected_revision,
+                        )
+                    else:
+                        plan.job._modify(next_run_time=plan.next_run_time)
+                        advanced = self.coordinator.cas_update_job(
+                            plan.job,
+                            plan.expected_revision,
+                        )
+                except NamespaceFencedError:
+                    # Another deployment took the chain mid-run. Work already
+                    # executed stays executed (delivery is at least once);
+                    # remaining due jobs belong to the new owner.
+                    self._logger.info(
+                        'Deployment "%s" no longer drives this scheduler; '
+                        "leaving the remaining due jobs to the new owner",
+                        self.deployment,
                     )
-                else:
-                    plan.job._modify(next_run_time=plan.next_run_time)
-                    advanced = self.coordinator.cas_update_job(
-                        plan.job,
-                        plan.expected_revision,
-                    )
+                    break
                 if not advanced:
                     # A concurrent mutation moved the revision; its value wins
                     # and its dirty marker keeps the chain covered.

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_driver.py
@@ -32,6 +32,7 @@ __all__ = [
     "ClaimResult",
     "DriverSnapshot",
     "FinishResult",
+    "NamespaceFencedError",
     "RedisDriver",
     "StartDecision",
     "WakeToken",
@@ -40,6 +41,10 @@ __all__ = [
 
 class APSchedulerConfigurationError(RuntimeError):
     """Raised when a scheduler cannot satisfy the Vercel runtime contract."""
+
+
+class NamespaceFencedError(APSchedulerConfigurationError):
+    """Raised when a write is refused because another deployment owns the chain."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -598,6 +603,20 @@ redis.call(
 return 1
 """
 
+_MARK_RECONCILED_SCRIPT = """
+-- vercel-apscheduler-v1:mark-reconciled
+if redis.call("HGET", KEYS[1], "owner_deployment") ~= ARGV[1] then
+  return 0
+end
+redis.call(
+  "HSET",
+  KEYS[1],
+  "reconciled_deployment", ARGV[1],
+  "updated_at", ARGV[2]
+)
+return 1
+"""
+
 
 class RedisDriver:
     """Atomic driver state stored beside an APScheduler Redis job store."""
@@ -916,14 +935,20 @@ class RedisDriver:
         """Return the deployment that last synced declarations here."""
         return _optional_text(self.client.hget(self.key, "reconciled_deployment"))
 
-    def mark_reconciled(self, deployment: str, now: datetime) -> None:
-        self.client.hset(
-            self.key,
-            mapping={
-                "reconciled_deployment": deployment,
-                "updated_at": as_utc(now, name="now").isoformat(),
-            },
+    def mark_reconciled(self, deployment: str, now: datetime) -> bool:
+        """Record a completed declaration sync, only while owning the chain.
+
+        A deployment that lost the namespace mid-reconciliation must not
+        stamp it as reconciled: the marker would suppress the real owner's
+        own sync. The loser leaves the marker unset and the owner
+        reconciles on its next activation.
+        """
+        result = self._eval(
+            _MARK_RECONCILED_SCRIPT,
+            deployment,
+            as_utc(now, name="now").isoformat(),
         )
+        return bool(int(result))
 
     def renew(self, owner: str, now: datetime) -> bool:
         now_utc = as_utc(now, name="now")

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_jobstore.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_jobstore.py
@@ -17,6 +17,7 @@ from apscheduler.util import (  # type: ignore[import-untyped]
     datetime_to_utc_timestamp,
 )
 
+from ._driver import NamespaceFencedError
 from ._imports import RedisJobStore
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
@@ -32,6 +33,18 @@ PROVENANCE_DECLARED = "declared"
 PROVENANCE_RUNTIME = "runtime"
 
 __all__ = ["PROVENANCE_DECLARED", "PROVENANCE_RUNTIME", "RedisJobCoordinator"]
+
+
+# Shared head of the job write scripts: refuse the whole write when another
+# deployment owns the chain. A missing owner passes, so a fresh scope and a
+# preview's first materialization (which run before the driver records an
+# owner) still write. ARGV[8] is the writing deployment.
+_OWNER_FENCE_FRAGMENT = """
+local owner = redis.call("HGET", KEYS[4], "owner_deployment")
+if owner and owner ~= ARGV[8] then
+  return {"fenced", ""}
+end
+"""
 
 
 # Shared tail of the job write scripts: bump the store revision, persist the
@@ -80,6 +93,7 @@ return {"ok", tostring(revision)}
 
 _ADD_JOB_SCRIPT = f"""
 -- vercel-apscheduler-v1:add-job
+{_OWNER_FENCE_FRAGMENT}
 if redis.call("HEXISTS", KEYS[1], ARGV[1]) == 1 then
   return {{"conflict", ""}}
 end
@@ -90,6 +104,7 @@ redis.call("HSET", KEYS[5], ARGV[1], ARGV[7])
 
 _UPDATE_JOB_SCRIPT = f"""
 -- vercel-apscheduler-v1:update-job
+{_OWNER_FENCE_FRAGMENT}
 if redis.call("HEXISTS", KEYS[1], ARGV[1]) == 0 then
   return {{"missing", ""}}
 end
@@ -99,6 +114,10 @@ end
 
 _REMOVE_JOB_SCRIPT = """
 -- vercel-apscheduler-v1:remove-job
+local owner = redis.call("HGET", KEYS[4], "owner_deployment")
+if owner and owner ~= ARGV[2] then
+  return "fenced"
+end
 if redis.call("HEXISTS", KEYS[1], ARGV[1]) == 0 then
   return "missing"
 end
@@ -113,9 +132,13 @@ return "ok"
 
 _REMOVE_ALL_JOBS_SCRIPT = """
 -- vercel-apscheduler-v1:remove-all-jobs
+local owner = redis.call("HGET", KEYS[4], "owner_deployment")
+if owner and owner ~= ARGV[1] then
+  return "fenced"
+end
 redis.call("HINCRBY", KEYS[4], "job_revision", 1)
 redis.call("DEL", KEYS[1], KEYS[2], KEYS[3], KEYS[5])
-return 1
+return "ok"
 """
 
 
@@ -154,6 +177,10 @@ return result
 
 _CAS_UPDATE_JOB_SCRIPT = """
 -- vercel-apscheduler-v1:cas-update-job
+local owner = redis.call("HGET", KEYS[4], "owner_deployment")
+if owner and owner ~= ARGV[5] then
+  return -1
+end
 local current = tonumber(redis.call("HGET", KEYS[3], ARGV[1]) or "0")
 if redis.call("HEXISTS", KEYS[1], ARGV[1]) == 0 or current ~= tonumber(ARGV[2]) then
   return 0
@@ -172,6 +199,10 @@ return 1
 
 _CAS_REMOVE_JOB_SCRIPT = """
 -- vercel-apscheduler-v1:cas-remove-job
+local owner = redis.call("HGET", KEYS[4], "owner_deployment")
+if owner and owner ~= ARGV[3] then
+  return -1
+end
 local current = tonumber(redis.call("HGET", KEYS[3], ARGV[1]) or "0")
 if redis.call("HEXISTS", KEYS[1], ARGV[1]) == 0 or current ~= tonumber(ARGV[2]) then
   return 0
@@ -220,12 +251,15 @@ class RedisJobCoordinator:
 
     def add_job(self, job: Any) -> None:
         result = self._write(_ADD_JOB_SCRIPT, job, rearm=True)
+        state = _text(result[0])
+        if state == "fenced":
+            raise self._fenced(job.id)
         # Code declarations are materialized insert-if-absent. Concurrent cold
         # starts must retain the first durable value instead of replacing a
         # runtime mutation with a stale declaration. Runtime and in-wake adds
         # raise instead, so APScheduler's replace_existing fallback can update
         # the persisted job.
-        if _text(result[0]) == "conflict" and (
+        if state == "conflict" and (
             self.adapter.is_runtime_mutation or self.adapter.is_wake_mutation
         ):
             raise ConflictingIdError(job.id)
@@ -236,7 +270,10 @@ class RedisJobCoordinator:
             job,
             rearm=self.adapter.is_runtime_mutation,
         )
-        if _text(result[0]) == "missing":
+        state = _text(result[0])
+        if state == "fenced":
+            raise self._fenced(job.id)
+        if state == "missing":
             raise JobLookupError(job.id)
 
     def remove_job(self, job_id: str) -> None:
@@ -246,17 +283,25 @@ class RedisJobCoordinator:
                 len(self.keys),
                 *self.keys,
                 job_id,
+                self.driver.deployment,
             )
         )
+        if result == "fenced":
+            raise self._fenced(job_id)
         if result == "missing":
             raise JobLookupError(job_id)
 
     def remove_all_jobs(self) -> None:
-        self.redis.eval(
-            _REMOVE_ALL_JOBS_SCRIPT,
-            len(self.keys),
-            *self.keys,
+        result = _text(
+            self.redis.eval(
+                _REMOVE_ALL_JOBS_SCRIPT,
+                len(self.keys),
+                *self.keys,
+                self.driver.deployment,
+            )
         )
+        if result == "fenced":
+            raise self._fenced(None)
 
     def get_due_jobs_with_revisions(
         self,
@@ -311,31 +356,42 @@ class RedisJobCoordinator:
 
     def cas_update_job(self, job: Any, expected_revision: int) -> bool:
         state, score = self._serialized_job(job)
-        return bool(
-            int(
-                self.redis.eval(
-                    _CAS_UPDATE_JOB_SCRIPT,
-                    len(self.keys),
-                    *self.keys,
-                    job.id,
-                    str(expected_revision),
-                    state,
-                    score,
-                )
+        result = int(
+            self.redis.eval(
+                _CAS_UPDATE_JOB_SCRIPT,
+                len(self.keys),
+                *self.keys,
+                job.id,
+                str(expected_revision),
+                state,
+                score,
+                self.driver.deployment,
             )
         )
+        if result < 0:
+            raise self._fenced(job.id)
+        return bool(result)
 
     def cas_remove_job(self, job_id: str, expected_revision: int) -> bool:
-        return bool(
-            int(
-                self.redis.eval(
-                    _CAS_REMOVE_JOB_SCRIPT,
-                    len(self.keys),
-                    *self.keys,
-                    job_id,
-                    str(expected_revision),
-                )
+        result = int(
+            self.redis.eval(
+                _CAS_REMOVE_JOB_SCRIPT,
+                len(self.keys),
+                *self.keys,
+                job_id,
+                str(expected_revision),
+                self.driver.deployment,
             )
+        )
+        if result < 0:
+            raise self._fenced(job_id)
+        return bool(result)
+
+    def _fenced(self, job_id: str | None) -> NamespaceFencedError:
+        subject = f'job "{job_id}"' if job_id is not None else "the job store"
+        return NamespaceFencedError(
+            f'deployment "{self.driver.deployment}" no longer drives this '
+            f"scheduler; the write to {subject} was fenced"
         )
 
     def _write(self, script: str, job: Any, *, rearm: bool) -> Any:


### PR DESCRIPTION
Sits on top of #238. Fixes a takeover race that could permanently lose reconciliation work.

The race:

```text
dpl_1 is mid-run on my_job when dpl_2 is promoted
dpl_2 reconciliation reads my_job at revision R
dpl_1 finishes and commits, bumping the revision to R+1
dpl_2's compare-and-set remove fails, and it marks reconciliation
complete anyway
```

Reconciliation is single-shot per deployment, so the loss was permanent: a job the new code no longer declares kept firing forever (or kept its old trigger).

The core rule: ownership decides who may write, and reconciliation is done only when it converges.

- every job-store write script is now owner-fenced atomically, so a demoted deployment's late commit is refused instead of racing; a missing owner passes, keeping first materializations working
- `mark_reconciled` is owner-fenced, so a deployment that loses the namespace mid-sync cannot stamp the marker and suppress the real owner's reconciliation
- a reconciliation pass that loses a revision race to a concurrent owner write reruns against fresh state (bounded), and an unconverged sync stays unmarked and retries on the next activation

In-flight work is deliberately not interrupted: the demoted run finishes, its write fences, and the new generation's first claim still waits for the active-owner lease. Covered by real-Redis tests for the fence, the retry, and the defer-then-converge paths.