### PR TITLE
workflow: accept event specVersion 3-5

### DIFF
--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -96,6 +96,19 @@ def get_physical_topic(queue_name: str) -> SanitizedName:
     )
 
 
+# Spec versions, mirroring `@workflow/world`'s `spec-version.ts`. The number a
+# row carries is a capability claim read by the *other* SDK, not a stamp of
+# which SDK wrote it:
+#
+#   1  legacy: direct entity mutation, unprefixed JSON payloads
+#   2  event sourcing, format-prefixed (`devl`) payloads
+#   3  CBOR queue transport
+#   4  native attributes (`attr_set`)
+#   5  payloads may be zstd- or gzip-compressed
+#
+SPEC_VERSION_CURRENT = 2
+
+
 class BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(serialize_by_alias=True)
 
@@ -307,9 +320,10 @@ class BaseEvent(BaseModel):
     correlation_id: str | None = pydantic.Field(
         default=None, alias="correlationId", exclude_if=lambda e: e is None
     )
-    spec_version: Literal[1, 2] = pydantic.Field(
-        default=2, alias="specVersion"
-    )  # 1: legacy JSON, 2: devalue
+    # Reading is deliberately unbounded: a run is a shared log, and whoever
+    # started it may be a newer TypeScript peer writing a version we have never
+    # heard of.
+    spec_version: int = pydantic.Field(default=SPEC_VERSION_CURRENT, alias="specVersion")
     server_props: ServerProps | None = pydantic.Field(default=None, exclude=True)
 
     @pydantic.model_validator(mode="before")

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -106,7 +106,7 @@ def get_physical_topic(queue_name: str) -> SanitizedName:
 #   4  native attributes (`attr_set`)
 #   5  payloads may be zstd- or gzip-compressed
 #
-SPEC_VERSION_CURRENT = 2
+SPEC_VERSION_CURRENT: Literal[2] = 2
 
 
 class BaseModel(pydantic.BaseModel):
@@ -320,10 +320,9 @@ class BaseEvent(BaseModel):
     correlation_id: str | None = pydantic.Field(
         default=None, alias="correlationId", exclude_if=lambda e: e is None
     )
-    # Reading is deliberately unbounded: a run is a shared log, and whoever
-    # started it may be a newer TypeScript peer writing a version we have never
-    # heard of.
-    spec_version: int = pydantic.Field(default=SPEC_VERSION_CURRENT, alias="specVersion")
+    spec_version: Literal[1, 2, 3, 4, 5] = pydantic.Field(
+        default=SPEC_VERSION_CURRENT, alias="specVersion"
+    )
     server_props: ServerProps | None = pydantic.Field(default=None, exclude=True)
 
     @pydantic.model_validator(mode="before")

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -531,7 +531,12 @@ class LocalWorld(w.World):
                 deploymentId=run_data.deployment_id,
                 status="pending",
                 workflowName=run_data.workflow_name,
-                specVersion=2,
+                # The event carries the version, and the row it opens inherits
+                # it — `@workflow/world-local` propagates it the same way
+                # (`storage/events-storage.ts` `effectiveSpecVersion`), so a run
+                # this world creates is labelled by whoever wrote the event
+                # rather than by which SDK happens to be storing it.
+                specVersion=data.spec_version,
                 executionContext=run_data.execution_context,
                 input=run_data.input,
                 createdAt=now,
@@ -656,7 +661,7 @@ class LocalWorld(w.World):
                 attempt=0,
                 createdAt=now,
                 updatedAt=now,
-                specVersion=2,
+                specVersion=data.spec_version,
             )
             step_composite_key = f"{effective_run_id}-{data.correlation_id}"
             step_path = self.data_dir / "steps" / f"{step_composite_key}.json"
@@ -794,7 +799,7 @@ class LocalWorld(w.World):
                 projectId="local-project",
                 environment="local",
                 createdAt=now,
-                specVersion=2,
+                specVersion=data.spec_version,
                 isWebhook=False,
                 isSystem=False,
             )

--- a/src/vercel/tests/unit/test_workflow_local_world_format.py
+++ b/src/vercel/tests/unit/test_workflow_local_world_format.py
@@ -216,3 +216,61 @@ async def test_hook_token_claim_matches_the_ts_sidecar(tmp_path, monkeypatch) ->
         "eventId": result.event.server_props.event_id,
     }
     assert " " not in text, "the claim sidecar is written compactly, as in TS"
+
+
+async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch) -> None:
+    # `start()` is a world write, not an HTTP call, so the client that starts a
+    # run writes its first event -- and a current TypeScript client writes
+    # specVersion 5. Whoever *executes* the run then reads a log it did not
+    # open, so a version we have never heard of must not fail validation: we
+    # only read what the payload prefix tells us, never what the run claims.
+    world = _world(tmp_path, monkeypatch)
+    future = w.SPEC_VERSION_CURRENT + 3
+
+    result = await world.events_create(
+        None,
+        w.RunCreatedEvent(
+            eventData=w.RunCreatedEventData(
+                deploymentId="dpl_1",
+                workflowName="workflow//./src/wf//main",
+                input=ser.dehydrate([]),
+            ),
+            specVersion=future,
+        ),
+    )
+    assert result.run is not None
+    run_id = result.run.run_id
+
+    # The row a foreign event opens inherits that event's version rather than
+    # being relabelled with ours, which is what TS's world-local does too.
+    assert result.run.spec_version == future
+    assert json.loads((world.data_dir / "runs" / f"{run_id}.json").read_text())["specVersion"] == (
+        future
+    )
+
+    # And the log reads back, which is the part that used to raise before the
+    # runtime saw a single event.
+    events = await world.events_list(run_id)
+    assert [event.spec_version for event in events.data] == [future]
+
+    # Our own writes into that run keep the run's version intact.
+    await world.events_create(run_id, w.RunStartedEvent())
+    assert (await world.runs_get(run_id)).spec_version == future
+
+
+async def test_python_written_rows_claim_the_version_we_implement(tmp_path, monkeypatch) -> None:
+    # The number is a capability claim: a TS peer sharing the run reads it to
+    # decide whether it may compress payloads (>= 5) or write native attributes
+    # (>= 4). We implement neither, so every row we open says 2.
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _populate(world)
+
+    assert w.SPEC_VERSION_CURRENT == 2
+    rows = {
+        "run": world.data_dir / "runs" / f"{run_id}.json",
+        "step": world.data_dir / "steps" / f"{run_id}-step_0.json",
+        "hook": world.data_dir / "hooks" / "hook_0.json",
+    }
+    for kind, path in rows.items():
+        stored = json.loads(path.read_text(encoding="utf-8"))
+        assert stored["specVersion"] == w.SPEC_VERSION_CURRENT, f"{kind} row"

--- a/src/vercel/tests/unit/test_workflow_local_world_format.py
+++ b/src/vercel/tests/unit/test_workflow_local_world_format.py
@@ -219,14 +219,12 @@ async def test_hook_token_claim_matches_the_ts_sidecar(tmp_path, monkeypatch) ->
 
 
 async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch) -> None:
-    # `start()` is a world write, not an HTTP call, so the client that starts a
-    # run writes its first event -- and a current TypeScript client writes
-    # specVersion 5. Whoever *executes* the run then reads a log it did not
-    # open, so a version we have never heard of must not fail validation: we
-    # only read what the payload prefix tells us, never what the run claims.
+    # The shape of a `vercel/workflow` e2e run against a Python app: the log is
+    # opened by the TypeScript driver, whose `start()` writes `run_created` at
+    # its own SPEC_VERSION_CURRENT -- 5 today -- and the Python app under test
+    # replays it. Nothing here decodes by version (the payload prefix says the
+    # format), and the row inherits the version of the event.
     world = _world(tmp_path, monkeypatch)
-    future = w.SPEC_VERSION_CURRENT + 3
-
     result = await world.events_create(
         None,
         w.RunCreatedEvent(
@@ -235,42 +233,15 @@ async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch
                 workflowName="workflow//./src/wf//main",
                 input=ser.dehydrate([]),
             ),
-            specVersion=future,
+            specVersion=5,
         ),
     )
     assert result.run is not None
     run_id = result.run.run_id
+    assert result.run.spec_version == 5
+    assert json.loads((world.data_dir / "runs" / f"{run_id}.json").read_text())["specVersion"] == 5
+    assert [event.spec_version for event in (await world.events_list(run_id)).data] == [5]
 
-    # The row a foreign event opens inherits that event's version rather than
-    # being relabelled with ours, which is what TS's world-local does too.
-    assert result.run.spec_version == future
-    assert json.loads((world.data_dir / "runs" / f"{run_id}.json").read_text())["specVersion"] == (
-        future
-    )
-
-    # And the log reads back, which is the part that used to raise before the
-    # runtime saw a single event.
-    events = await world.events_list(run_id)
-    assert [event.spec_version for event in events.data] == [future]
-
-    # Our own writes into that run keep the run's version intact.
+    # Our own writes into the run leave its version alone.
     await world.events_create(run_id, w.RunStartedEvent())
-    assert (await world.runs_get(run_id)).spec_version == future
-
-
-async def test_python_written_rows_claim_the_version_we_implement(tmp_path, monkeypatch) -> None:
-    # The number is a capability claim: a TS peer sharing the run reads it to
-    # decide whether it may compress payloads (>= 5) or write native attributes
-    # (>= 4). We implement neither, so every row we open says 2.
-    world = _world(tmp_path, monkeypatch)
-    run_id = await _populate(world)
-
-    assert w.SPEC_VERSION_CURRENT == 2
-    rows = {
-        "run": world.data_dir / "runs" / f"{run_id}.json",
-        "step": world.data_dir / "steps" / f"{run_id}-step_0.json",
-        "hook": world.data_dir / "hooks" / "hook_0.json",
-    }
-    for kind, path in rows.items():
-        stored = json.loads(path.read_text(encoding="utf-8"))
-        assert stored["specVersion"] == w.SPEC_VERSION_CURRENT, f"{kind} row"
+    assert (await world.runs_get(run_id)).spec_version == 5


### PR DESCRIPTION
* New TS client writes 5 into a log we then read.
* Local world rows inherit the event's version instead of hard-coding 2.