### PR TITLE
Backfill missing news fragments

### DIFF
--- a/changes/vercel-apscheduler/212.feature.md
+++ b/changes/vercel-apscheduler/212.feature.md
@@ -1,0 +1,2 @@
+Add the durable Redis driver for running APScheduler schedules through delayed
+Vercel Queue messages.

--- a/changes/vercel-internal-core/197.internal.md
+++ b/changes/vercel-internal-core/197.internal.md
@@ -1,0 +1,2 @@
+Key session service options by logical service so synchronous and asynchronous
+variants share configuration safely.

--- a/changes/vercel-oidc/232.bugfix.md
+++ b/changes/vercel-oidc/232.bugfix.md
@@ -1,0 +1,2 @@
+Record JWKS refetch outcomes before allowing another caller to fetch, avoiding
+duplicate requests under concurrency.

--- a/changes/vercel-sandbox/197.breaking.md
+++ b/changes/vercel-sandbox/197.breaking.md
@@ -1,0 +1,2 @@
+Require synchronous credential factories when configuring `vercel.sandbox.sync`;
+use asynchronous factories only with the async Sandbox API.

--- a/changes/vercel/228.internal.md
+++ b/changes/vercel/228.internal.md
@@ -1,0 +1,2 @@
+Use a consistent isolated event-loop lifecycle for workflow execution on
+Python 3.10.

--- a/changes/vercel/229.internal.md
+++ b/changes/vercel/229.internal.md
@@ -1,0 +1,2 @@
+Run workflows on a dedicated event loop that advances execution when the loop
+becomes idle.

--- a/changes/vercel/235.bugfix.md
+++ b/changes/vercel/235.bugfix.md
@@ -1,0 +1,2 @@
+Allow workflows on Python 3.12 and earlier to import `uuid` by safely exposing
+`platform.system()` while continuing to block host-specific platform inspection.

--- a/changes/vercel/237.internal.md
+++ b/changes/vercel/237.internal.md
@@ -1,0 +1,2 @@
+Avoid invoking the workflow event loop's idle hook after the loop begins
+stopping.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -13,6 +13,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
+
 try:
     from scripts import workspace
 except ImportError:  # pragma: no cover - script execution path
@@ -705,9 +706,14 @@ def check_fragments(base: str | None = None) -> int:
         print("Could not detect a base branch for news fragment enforcement.")
         return 1
 
-    changed = _changed_packages(packages_by_name, base=base, head=head, code_only=True)
-    changed -= _release_prepped_packages(packages_by_name, base=base, head=head)
-    packages_with_fragments = {fragment.package for fragment in fragments}
+    changed_paths = _changed_paths(base=base, head=head)
+    changed = packages_for_paths(packages_by_name, changed_paths, code_only=True)
+    changed -= {
+        name for name, package in packages_by_name.items() if package.version_file in changed_paths
+    }
+    packages_with_fragments = {
+        fragment.package for fragment in fragments if fragment.path in changed_paths
+    }
     missing = sorted(changed - packages_with_fragments)
     if missing:
         packages = ", ".join(missing)
@@ -744,15 +750,6 @@ def _changed_packages(
         _changed_paths(base=base, head=head),
         code_only=code_only,
     )
-
-
-def _release_prepped_packages(
-    packages_by_name: dict[str, workspace.Package], *, base: str, head: str | None
-) -> set[str]:
-    changed_paths = _changed_paths(base=base, head=head)
-    return {
-        name for name, package in packages_by_name.items() if package.version_file in changed_paths
-    }
 
 
 def _changed_paths(*, base: str, head: str | None) -> set[Path]:

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -780,13 +780,8 @@ def test_check_fragments_requires_changed_package_fragment(
     monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
     monkeypatch.setattr(
         release,
-        "_changed_packages",
-        lambda _packages, *, base, head, code_only: {"pkg"},
-    )
-    monkeypatch.setattr(
-        release,
-        "_release_prepped_packages",
-        lambda _packages, *, base, head: set(),
+        "_changed_paths",
+        lambda *, base, head: {tmp_path / "pkg/code.py"},
     )
 
     assert release.check_fragments(base="origin/main") == 1
@@ -805,13 +800,41 @@ def test_check_fragments_exempts_release_prep_version_bumps(
     monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
     monkeypatch.setattr(
         release,
-        "_changed_packages",
-        lambda _packages, *, base, head, code_only: {"pkg"},
+        "_changed_paths",
+        lambda *, base, head: {version_file},
     )
+
+    assert release.check_fragments(base="origin/main") == 0
+
+
+def test_check_fragments_ignores_unchanged_fragment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    version_file = tmp_path / "pkg/version.py"
+    fragment_path = tmp_path / "changes/pkg/old.bugfix.md"
+    package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
+    fragment = release.Fragment("pkg", fragment_path, "bugfix", "Fix an older bug.")
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(release, "parse_fragments", lambda _packages: [fragment])
+    monkeypatch.setattr(release, "_changed_paths", lambda *, base, head: {tmp_path / "pkg/code.py"})
+
+    assert release.check_fragments(base="origin/main") == 1
+    assert "Missing news fragments for changed packages: pkg" in capsys.readouterr().out
+
+
+def test_check_fragments_accepts_changed_fragment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    version_file = tmp_path / "pkg/version.py"
+    fragment_path = tmp_path / "changes/pkg/new.bugfix.md"
+    package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
+    fragment = release.Fragment("pkg", fragment_path, "bugfix", "Fix the current bug.")
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(release, "parse_fragments", lambda _packages: [fragment])
     monkeypatch.setattr(
         release,
-        "_release_prepped_packages",
-        lambda _packages, *, base, head: {"pkg"},
+        "_changed_paths",
+        lambda *, base, head: {tmp_path / "pkg/code.py", fragment_path},
     )
 
     assert release.check_fragments(base="origin/main") == 0


### PR DESCRIPTION
These are mostly Codex derived fragments based on the PRs, so please feel free to suggest better changelog lines as needed. Also adds some better detection around missing fragment _for this change_ rather than checking to see if there is any open fragment at all in a package.