### PR TITLE
[integrations] APScheduler: React to the first alias-routed request

### DIFF
--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -353,7 +353,11 @@ preview activates the same way and remains active only while requests renew
 its deadline.
 
 Automatic takeover is traffic-driven: it happens on the first request the
-promoted deployment serves through an environment alias. After promoting or
+promoted deployment serves through an environment alias, regardless of what
+arrived before it. Requests through the deployment's own URL neither take
+over nor delay it: while another deployment owns the chain, the activation
+hook stays eligible on every invocation and touches Redis only for an
+alias-routed request or a lapsed sweep interval. After promoting or
 rolling back a deployment that receives no organic traffic, send one request
 through the environment's domain (or schedule a cron heartbeat) so the chain
 hands over promptly. Alias routing is judged by the request host, so do not

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -203,6 +203,11 @@ def test_subscriber_request_does_not_register_automatic_activation(
     _automatic.register_automatic_activation()
 
 
+def _reset_hook_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_automatic, "_unsettled", False)
+    monkeypatch.setattr(_automatic, "_last_sweep", None)
+
+
 def test_automatic_activation_hook_uses_current_preview_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -210,10 +215,12 @@ def test_automatic_activation_hook_uses_current_preview_timeout(
     monkeypatch.setenv("VERCEL_ENV", "preview")
     monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.setenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, "120")
+    _reset_hook_state(monkeypatch)
 
-    def record_activation(timeout: int | None, *, takeover_allowed: bool) -> None:
+    def record_activation(timeout: int | None, *, takeover_allowed: bool) -> bool:
         del takeover_allowed
         calls.append(timeout)
+        return True
 
     monkeypatch.setattr(
         _automatic,
@@ -221,7 +228,7 @@ def test_automatic_activation_hook_uses_current_preview_timeout(
         record_activation,
     )
 
-    _automatic._automatic_activation_hook()
+    assert _automatic._automatic_activation_hook() is None
 
     assert calls == [120]
 
@@ -237,8 +244,9 @@ def test_automatic_activation_calls_every_adapter(
             *,
             idle_timeout_seconds: int | None = None,
             takeover_allowed: bool = False,
-        ) -> None:
+        ) -> bool:
             calls.append((idle_timeout_seconds, takeover_allowed))
+            return True
 
     monkeypatch.setattr(
         _automatic,
@@ -247,9 +255,127 @@ def test_automatic_activation_calls_every_adapter(
     )
     monkeypatch.setattr(_adapter, "get_adapter", lambda scheduler: FakeAdapter())
 
-    _automatic._activate_configured_schedulers(1800, takeover_allowed=True)
+    assert _automatic._activate_configured_schedulers(1800, takeover_allowed=True)
 
     assert calls == [(1800, True), (1800, True)]
+
+
+def _fake_forwarded_host(
+    monkeypatch: pytest.MonkeyPatch,
+    host_holder: dict[str, str | None],
+) -> None:
+    invocation_hooks = ModuleType("vercel_runtime.invocation_hooks")
+    invocation_hooks.__dict__["current_forwarded_host"] = lambda: host_holder["host"]
+    runtime = ModuleType("vercel_runtime")
+    runtime.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vercel_runtime", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "vercel_runtime.invocation_hooks",
+        invocation_hooks,
+    )
+    monkeypatch.setenv("VERCEL_URL", "app-abc123-team.vercel.app")
+    monkeypatch.setenv("VERCEL_BRANCH_URL", "app-git-main-team.vercel.app")
+
+
+def test_own_host_run_does_not_blind_the_alias_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bug this fixes: takeover must not depend on request ordering.
+
+    A request through the deployment's own URL proves nothing; its hook run
+    must not consume the sweep window, so the alias-routed request seconds
+    later still takes the chain over.
+    """
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
+    monkeypatch.delenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, raising=False)
+    _reset_hook_state(monkeypatch)
+    host_holder: dict[str, str | None] = {"host": "app-abc123-team.vercel.app"}
+    _fake_forwarded_host(monkeypatch, host_holder)
+    sweeps: list[bool] = []
+
+    def record_activation(timeout: int | None, *, takeover_allowed: bool) -> bool:
+        del timeout
+        sweeps.append(takeover_allowed)
+        return takeover_allowed  # settles only once a takeover was allowed
+
+    monkeypatch.setattr(
+        _automatic,
+        "_activate_configured_schedulers",
+        record_activation,
+    )
+
+    # First request arrives through the deployment URL: sweep runs, proves
+    # nothing, and the hook asks to stay eligible.
+    assert _automatic._automatic_activation_hook() == pytest.approx(0.0)
+    # Second request, seconds later through the production alias: it must
+    # sweep again immediately and settle.
+    host_holder["host"] = "test-app.vercel.app"
+    assert _automatic._automatic_activation_hook() is None
+
+    assert sweeps == [False, True]
+
+
+def test_unsettled_own_host_requests_skip_the_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """While a takeover is owed, own-host traffic must cost no Redis calls."""
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
+    monkeypatch.delenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, raising=False)
+    _reset_hook_state(monkeypatch)
+    monkeypatch.setattr(_automatic, "_unsettled", True)
+    monkeypatch.setattr(_automatic, "_last_sweep", _automatic.monotonic())
+    host_holder: dict[str, str | None] = {"host": "app-abc123-team.vercel.app"}
+    _fake_forwarded_host(monkeypatch, host_holder)
+
+    def unexpected_sweep(timeout: int | None, *, takeover_allowed: bool) -> bool:
+        del timeout, takeover_allowed
+        pytest.fail("an own-host request while unsettled must not sweep")
+
+    monkeypatch.setattr(
+        _automatic,
+        "_activate_configured_schedulers",
+        unexpected_sweep,
+    )
+
+    assert _automatic._automatic_activation_hook() == pytest.approx(0.0)
+
+
+def test_unsettled_sweeps_resume_after_the_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interval fallback resyncs stale state, for example after a
+    manual start() through a user endpoint, even without alias traffic."""
+    monkeypatch.setenv("VERCEL_ENV", "production")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
+    monkeypatch.delenv(_automatic.PREVIEW_IDLE_TIMEOUT_ENV, raising=False)
+    _reset_hook_state(monkeypatch)
+    monkeypatch.setattr(_automatic, "_unsettled", True)
+    monkeypatch.setattr(
+        _automatic,
+        "_last_sweep",
+        _automatic.monotonic() - _automatic.HEAL_SWEEP_INTERVAL_SECONDS - 1,
+    )
+    host_holder: dict[str, str | None] = {"host": "app-abc123-team.vercel.app"}
+    _fake_forwarded_host(monkeypatch, host_holder)
+    sweeps: list[bool] = []
+
+    def record_activation(timeout: int | None, *, takeover_allowed: bool) -> bool:
+        del timeout
+        sweeps.append(takeover_allowed)
+        return True
+
+    monkeypatch.setattr(
+        _automatic,
+        "_activate_configured_schedulers",
+        record_activation,
+    )
+
+    assert _automatic._automatic_activation_hook() is None
+
+    assert sweeps == [False]
 
 
 def test_preview_timeout_must_be_positive(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -340,7 +340,7 @@ class SchedulerAdapter:
         *,
         idle_timeout_seconds: int | None = None,
         takeover_allowed: bool = False,
-    ) -> None:
+    ) -> bool:
         """Activate on request activity without overriding an explicit pause.
 
         ``takeover_allowed`` is true only when the triggering request arrived
@@ -348,6 +348,10 @@ class SchedulerAdapter:
         currently promoted deployment. Traffic to a deployment's own URL
         proves nothing about promotion, so it may drive an owned chain but
         never adopt someone else's.
+
+        Returns whether this deployment is settled: it drives the chain (an
+        explicit pause counts), so periodic sweeps suffice. False means a
+        takeover is still owed to a future alias-routed request.
         """
         self._lifecycle_called = True
         self.ensure_local_started()
@@ -358,15 +362,16 @@ class SchedulerAdapter:
             takeover_allowed=takeover_allowed,
         )
         if not decision.owned:
-            return
+            return False
         self._reconcile_takeover(now)
         if decision.state != "running":
             self._pause_local()
-            return
+            return True
         self._publish_start_if_needed(decision, now=now)
         if not decision.changed and decision.start_status == "active":
             self.repair_wakeup(now=now)
         self._resume_local_if_paused()
+        return True
 
     def pause(self) -> None:
         """Durably fence the current generation."""

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import logging
 from os import environ
+from time import monotonic
 
 from ._driver import APSchedulerConfigurationError
 from ._imports import BaseScheduler
@@ -28,6 +29,13 @@ MAX_PREVIEW_RENEW_INTERVAL_SECONDS = 5 * 60
 # heals a wake whose queue message died (for example stranded by a rollback).
 HEAL_SWEEP_INTERVAL_SECONDS = 5 * 60
 
+# Whether the last sweep found a chain another deployment owns. While True,
+# the hook stays eligible on every invocation so the first alias-routed
+# request takes the chain over immediately, instead of waiting out a sweep
+# window consumed by a request that proved nothing.
+_unsettled = False
+_last_sweep: float | None = None
+
 
 def register_automatic_activation() -> None:
     """Buffer activation until the runtime has installed request credentials."""
@@ -36,15 +44,6 @@ def register_automatic_activation() -> None:
     if is_discovery_runtime() or is_queue_serving_runtime():
         return
 
-    timeout = _preview_idle_timeout()
-    interval = (
-        min(
-            float(MAX_PREVIEW_RENEW_INTERVAL_SECONDS),
-            timeout / 3,
-        )
-        if timeout is not None
-        else float(HEAL_SWEEP_INTERVAL_SECONDS)
-    )
     try:
         from vercel_runtime.invocation_hooks import (  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
             run_on_next_invocation,
@@ -58,15 +57,41 @@ def register_automatic_activation() -> None:
     run_on_next_invocation(
         ACTIVATION_HOOK_NAME,
         _automatic_activation_hook,
-        repeat_after_seconds=interval,
+        repeat_after_seconds=_sweep_interval(),
     )
 
 
-def _automatic_activation_hook() -> None:
-    _activate_configured_schedulers(
+def _sweep_interval() -> float:
+    """Return the settled cadence: heal sweeps plus preview deadline renewal."""
+    timeout = _preview_idle_timeout()
+    if timeout is not None:
+        return min(float(MAX_PREVIEW_RENEW_INTERVAL_SECONDS), timeout / 3)
+    return float(HEAL_SWEEP_INTERVAL_SECONDS)
+
+
+def _automatic_activation_hook() -> float | None:
+    """Sweep the configured schedulers; stay eager while a takeover is owed.
+
+    The return value sets the hook's next eligibility on runtimes that
+    support it. While another deployment owns the chain, only an
+    alias-routed request can change anything, so the hook stays eligible on
+    every invocation but touches Redis only when one arrives or when the
+    sweep interval lapses (the fallback that also resyncs after a manual
+    ``start()``). Once settled it returns to the registered cadence.
+    """
+    global _last_sweep, _unsettled  # noqa: PLW0603 - process-lifetime sweep state
+    now = monotonic()
+    alias_routed = _request_is_alias_routed()
+    recently_swept = _last_sweep is not None and now - _last_sweep < _sweep_interval()
+    if _unsettled and recently_swept and not alias_routed:
+        return 0.0
+    settled = _activate_configured_schedulers(
         _preview_idle_timeout(),
-        takeover_allowed=_request_is_alias_routed(),
+        takeover_allowed=alias_routed,
     )
+    _last_sweep = now
+    _unsettled = not settled
+    return 0.0 if not settled else None
 
 
 def _request_is_alias_routed() -> bool:
@@ -157,19 +182,23 @@ def _activate_configured_schedulers(
     idle_timeout_seconds: int | None,
     *,
     takeover_allowed: bool,
-) -> None:
+) -> bool:
+    """Sweep every configured scheduler; True when all are settled."""
     from ._adapter import get_adapter
 
+    settled = True
     for scheduler in _configured_schedulers():
         adapter = get_adapter(scheduler)
         if adapter is None:
             raise APSchedulerConfigurationError(
                 "configured APScheduler subscriber was not adopted by the integration"
             )
-        adapter.auto_activate(
+        if not adapter.auto_activate(
             idle_timeout_seconds=idle_timeout_seconds,
             takeover_allowed=takeover_allowed,
-        )
+        ):
+            settled = False
+    return settled
 
 
 def _configured_schedulers() -> list[BaseScheduler]:


### PR DESCRIPTION
Sits on top of #239. Fixes takeover being ordering-dependent: visiting a promoted deployment through its own URL first consumed the activation hook's five minute window, so the alias-routed request seconds later, the one that proves promotion, was never evaluated.

The core rule: throttle by outcome, not by "ran without raising". The hook now returns its own next eligibility (vercel-internal#97):

- settled (this deployment drives the chain, or paused): sweep once per registered interval, unchanged steady state
- unsettled + alias-routed request: sweep immediately with takeover allowed, the fix
- unsettled + own-host request: stay eligible but skip Redis entirely, a request that proves nothing now costs nothing
- unsettled + sweep interval lapsed: sweep anyway, resyncing state after a manual `start()` and preserving today's baseline on runtimes without rescheduling support

Takeover now happens on the first request through an environment alias regardless of what arrived before it. Old runtimes ignore the return value and keep current behavior.