### PR TITLE
Add Runtime Cache backend for APScheduler integration

### DIFF
--- a/changes/vercel-apscheduler/runtime-cache-backend.feature.md
+++ b/changes/vercel-apscheduler/runtime-cache-backend.feature.md
@@ -1,0 +1,12 @@
+Add a Vercel Runtime Cache backend and use it by default when Redis is not
+configured, so schedulers run with zero infrastructure. Jobs stay defined in
+code; the cache document only coordinates the chain (generation, start and
+wake bookkeeping, lifecycle flags). Because cache entries are evictable and
+per-region, the queue messages remain the authority: an evicted document is
+rebuilt from the arriving wake, idempotency keys still fence duplicate
+starts, and pause/resume flags additionally ride the start topic. Scheduler
+identity comes from the builder-assigned subscriber id, with a
+declared-subscriber lookup for web processes. Under `vercel dev` the backend
+falls back to a per-process in-memory cache and activates on the first
+request like production, using a stable deployment id derived from the
+project directory.

--- a/integrations/vercel-apscheduler/README.md
+++ b/integrations/vercel-apscheduler/README.md
@@ -224,6 +224,26 @@ pause semantics, so use a durable Redis service rather than an ephemeral
 cache. Redis failures fail closed: lifecycle calls raise and Queue deliveries
 retry without running unfenced work.
 
+## Backends
+
+Configuring a `RedisJobStore` selects the Redis backend above. Without one,
+the integration runs on the Vercel Runtime Cache instead (explicitly:
+`VERCEL_APSCHEDULER_BACKEND=redis|cache`). The two differ in what they can
+guarantee:
+
+| Property | Redis | Runtime Cache |
+| --- | --- | --- |
+| One wake chain, no forks | atomic Lua claims | queue idempotency keys |
+| Job execution | at-least-once | at-least-once, wider duplicate window |
+| Code-declared jobs | durable in Redis | rebuilt from code after eviction |
+| Runtime `add_job()` | durable, revision-checked | best-effort, lost on eviction |
+| `pause()` | durable, fails closed | best-effort flag plus a queue-borne control message |
+
+Under `vercel dev` the cache client falls back to per-process memory, which
+makes the cache backend the zero-infrastructure development mode: the
+queue-serving process drives the schedule, and chain progress travels in the
+messages themselves rather than shared state.
+
 ## v1 restrictions
 
 - APScheduler 3.x only.

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -295,20 +295,43 @@ does not wake periodically to repair an otherwise unobserved ambiguous
 failure. A delayed repair can pass a finite misfire window; jobs that opt
 into one and must remain eligible after repairs should size it accordingly.
 
-## Redis and execution requirements
+## Backends and execution requirements
 
-v1 supports exactly one job store named `default`. It must be APScheduler's
-Redis-backed `RedisJobStore`, and it is also the lifecycle coordinator. The
-integration namespaces the job-store keys with the state scope and the
-scheduler identity, so distinct environments and previews can share a Redis
-database without sharing jobs or driver state.
+v1 supports exactly one job store named `default`. With APScheduler's
+Redis-backed `RedisJobStore` configured, it is also the lifecycle
+coordinator: the integration namespaces the job-store keys with the state
+scope and the scheduler identity, so distinct environments and previews can
+share a Redis database without sharing jobs or driver state. Redis lifecycle
+state has no TTL, so use a durable Redis service rather than an ephemeral
+cache. Redis failures fail closed: lifecycle methods raise instead of
+claiming success, Queue handlers fail and are retried, and no job runs
+without acquiring the Redis owner lease.
 
-Runtime Cache is not suitable. It is evictable and cannot provide the durable
-atomic state needed for a pause to remain paused. Redis lifecycle state has no
-TTL, so use a durable Redis service rather than an ephemeral cache. Redis
-failures fail closed: lifecycle methods raise instead of claiming success,
-Queue handlers fail and are retried, and no job runs without acquiring the
-Redis owner lease.
+Without a `RedisJobStore` (or with `VERCEL_APSCHEDULER_BACKEND=cache`), the
+integration runs on the Vercel Runtime Cache, which is evictable and has no
+compare-and-swap. The cache backend therefore relocates each guarantee to
+something that can actually carry it:
+
+- The single-successor rule moves to the queue: racing finishers compute the
+  same canonical successor and the same idempotency key, and the queue
+  accepts the publication once. Claims become best-effort filters, so
+  duplicate wake *executions* are more likely than under Redis; the contract
+  stays at-least-once.
+- Chain progress travels in the messages: a claim adopts a generation or
+  wake token that is ahead of the local document, so an evicted document —
+  or another process's memory under `vercel dev` — never strands the chain.
+  A `paused` document fences only its own and older generations; a resume's
+  new generation revives it.
+- Job-store writes are owner-fenced best-effort: the fence is checked
+  against the driver document rather than atomically with the write, so a
+  demoted deployment's stale pass aborts with the same error as in Redis
+  mode, but a narrow read-write race remains within the documented
+  best-effort envelope.
+- Code-declared jobs are durable because code is the backup: reconciliation
+  rewrites them from the declarations whenever the documents are missing.
+  Runtime-added jobs and lifecycle flags are best-effort by declared policy;
+  `pause()` additionally publishes a queue-borne control message so the flag
+  reaches the process serving the chain even where cache state does not.
 
 Jobs use the integration's inline executor so that a wake remains active until
 the job has completed and the durable job-store update has happened. Custom

--- a/integrations/vercel-apscheduler/pyproject.toml
+++ b/integrations/vercel-apscheduler/pyproject.toml
@@ -13,10 +13,12 @@ license-files = ["LICENSE", "LICENSE.*"]
 dependencies = [
     "APScheduler>=3.10.4,<4",
     "redis>=5,<7",
+    "vercel-cache>=0.7.1",
     "vercel-queue>=0.6.0",
 ]
 
 [tool.uv.sources]
+vercel-cache = { workspace = true }
 vercel-queue = { workspace = true }
 
 [tool.ruff]
@@ -47,9 +49,22 @@ extend = "../ruff.toml"
 "vercel/integrations/apscheduler/_automatic.py" = [
     "PLC0415",  # runtime-only imports avoid a hard runtime dependency and an adapter cycle.
 ]
-"vercel/integrations/apscheduler/_jobstore.py" = [
+"vercel/integrations/apscheduler/_backends/redis/_jobstore.py" = [
     "S403",  # APScheduler's RedisJobStore persistence format is pickle-based.
     "SLF001",  # coordinated reads must reuse APScheduler's reconstitution hook.
+]
+"vercel/integrations/apscheduler/_backends/redis/__init__.py" = [
+    "SLF001",  # binds to the scheduler's private job-store registry, as the adapter does.
+]
+"vercel/integrations/apscheduler/_backends/cache/*.py" = [
+    "S301",  # job persistence mirrors the Redis store's pickle format.
+    "S311",  # jitter for write retries is not cryptographic.
+    "S403",  # job persistence mirrors the Redis store's pickle format.
+    "SLF001",  # store/coordinator coupling mirrors _jobstore.py's design.
+]
+"vercel/integrations/apscheduler/_backends/__init__.py" = [
+    "PLC0415",  # only the selected backend imports, so its transitive deps load once.
+    "SLF001",  # autodetection reads the scheduler's private job-store registry.
 ]
 "vercel/integrations/apscheduler/_executor.py" = [
     "BLE001",  # mirrors APScheduler BaseExecutor error handling.

--- a/integrations/vercel-apscheduler/pyproject.toml
+++ b/integrations/vercel-apscheduler/pyproject.toml
@@ -62,6 +62,9 @@ extend = "../ruff.toml"
     "S403",  # job persistence mirrors the Redis store's pickle format.
     "SLF001",  # store/coordinator coupling mirrors _jobstore.py's design.
 ]
+"vercel/integrations/apscheduler/_backends/cache/_driver.py" = [
+    "PLR0904",  # the Driver protocol dictates the full public surface.
+]
 "vercel/integrations/apscheduler/_backends/__init__.py" = [
     "PLC0415",  # only the selected backend imports, so its transitive deps load once.
     "SLF001",  # autodetection reads the scheduler's private job-store registry.

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -1,0 +1,727 @@
+"""Cache backend conformance: driver semantics and end-to-end flows.
+
+Runs entirely on the Runtime Cache client's in-memory fallback — no
+infrastructure. The driver-level tests pin the adoption and fencing rules;
+the end-to-end tests drive the real subscription handlers against a real
+``CacheDriver``/``CacheJobCoordinator``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datetime import datetime, timedelta, timezone
+from sys import modules
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+import vercel.cache.runtime_cache as runtime_cache_module
+from vercel.cache import get_cache
+from vercel.integrations.apscheduler import (
+    _adapter as _adapter_module,
+    _subscriber,
+    install_vercel_apscheduler_integration,
+)
+from vercel.integrations.apscheduler._adapter import get_adapter
+from vercel.integrations.apscheduler._backends.cache import CacheDriver, CacheJobStore
+from vercel.integrations.apscheduler._control import LifecyclePayload
+from vercel.integrations.apscheduler._payload import StartPayload, WakeupPayload
+from vercel.integrations.apscheduler._subscriber import register_scheduler
+from vercel.integrations.apscheduler._types import (
+    PROVENANCE_DECLARED,
+    NamespaceFencedError,
+    WakeToken,
+)
+from vercel.queue import Message, MessageMetadata, SanitizedName, get_subscriptions
+from vercel.queue.testing import clear_subscriptions
+
+UTC = timezone.utc
+CACHE_SCHEDULER_MODULE = "cache_test_scheduler"
+# No RedisJobStore and no subscriber env: cache identity falls back to this.
+CACHE_SCHEDULER_ID = "default"
+
+_EXECUTIONS: list[str] = []
+
+
+def durable_cache_job() -> None:
+    _EXECUTIONS.append("ran")
+
+
+@pytest.fixture(autouse=True)
+def runtime(monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("VERCEL_DEPLOYMENT_ID", "dpl_test")
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+    monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
+    monkeypatch.delenv("VERCEL_PYTHON_SUBSCRIBER_ID", raising=False)
+    monkeypatch.delenv("VERCEL_APSCHEDULER_BACKEND", raising=False)
+    monkeypatch.delenv("VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv(
+        "VERCEL_APSCHEDULER_SUBSCRIBERS",
+        (f'[{{"id":"{CACHE_SCHEDULER_ID}","entrypoint":"{CACHE_SCHEDULER_MODULE}:scheduler"}}]'),
+    )
+    monkeypatch.delenv("VERCEL_APSCHEDULER_DISCOVERY", raising=False)
+    monkeypatch.delenv("VERCEL_SERVICE_TYPE", raising=False)
+    monkeypatch.delenv("VERCEL_SERVICE_TRIGGER", raising=False)
+    monkeypatch.delenv("VERCEL_DEV_QUEUE_SERVING", raising=False)
+    monkeypatch.setitem(modules, CACHE_SCHEDULER_MODULE, ModuleType(CACHE_SCHEDULER_MODULE))
+    # A fresh in-memory cache per test: the client caches its fallback
+    # instance in module globals.
+    for attribute in (
+        "_in_memory_cache_instance",
+        "_async_in_memory_cache_instance",
+        "_cached_cache_instance",
+        "_cached_async_cache_instance",
+    ):
+        monkeypatch.setattr(runtime_cache_module, attribute, None)
+    _EXECUTIONS.clear()
+    _clear_registrations()
+    install_vercel_apscheduler_integration(register_queues=False)
+    yield
+    _clear_registrations()
+
+
+def _clear_registrations() -> None:
+    clear_subscriptions()
+    _subscriber._registered_schedulers.clear()
+    _subscriber._registered_callbacks.clear()
+    _adapter_module._ACTIVE_IDENTITIES.clear()
+    _adapter_module._PATCH_STATE.register_queues = False
+
+
+def message(
+    payload: dict[str, Any],
+    *,
+    message_id: str,
+    topic: str,
+    consumer_group: str,
+) -> Message[dict[str, Any]]:
+    return Message(
+        payload=payload,
+        metadata=MessageMetadata(
+            message_id=message_id,
+            delivery_count=1,
+            created_at=datetime.now(UTC),
+            topic=topic,
+            consumer_group=SanitizedName(consumer_group),
+        ),
+    )
+
+
+def cache_driver(deployment: str = "dpl_test") -> CacheDriver:
+    return CacheDriver(
+        scope="prj_test:production",
+        scheduler_id="conformance",
+        deployment=deployment,
+    )
+
+
+def test_cache_driver_start_is_idempotent_and_pause_fences() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    first = driver.start(now)
+    assert first.changed
+    assert first.generation == 1
+    assert first.start_status == "pending"
+
+    again = driver.start(now)
+    assert not again.changed
+    assert again.generation == 1
+
+    assert driver.pause(now)
+    assert driver.snapshot().state == "paused"
+
+    resumed = driver.start(now)
+    assert resumed.changed
+    assert resumed.generation == 2
+
+
+def test_cache_driver_start_claim_finish_reserves_first_wake() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+    next_time = now + timedelta(minutes=5)
+
+    decision = driver.start(now)
+    driver.mark_start_published(decision.generation, now)
+
+    claim = driver.claim_start(decision.generation, "owner-1", now)
+    assert claim.state == "claimed"
+
+    finish = driver.finish_start(decision.generation, "owner-1", next_time, now)
+    assert finish.state == "advanced"
+    assert finish.wake is not None
+    assert finish.wake.sequence == 1
+    assert finish.wake.logical_time == next_time
+
+    # The start is settled: a duplicate delivery must not re-run it.
+    assert driver.claim_start(decision.generation, "owner-2", now).state == "stale"
+
+    driver.mark_wake_published(decision.generation, 1, now)
+    wake_claim = driver.claim_wake(finish.wake, "owner-3", now)
+    assert wake_claim.state == "claimed"
+
+    successor = driver.finish_wake(finish.wake, "owner-3", next_time + timedelta(minutes=5), now)
+    assert successor.state == "advanced"
+    assert successor.wake is not None
+    assert successor.wake.sequence == 2
+
+
+def test_cache_driver_adopts_newer_generation_start() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    # An empty document (eviction, or another process's memory in dev) must
+    # not strand the chain: the message is the authority.
+    claim = driver.claim_start(3, "owner-1", now)
+    assert claim.state == "claimed"
+    snapshot = driver.snapshot()
+    assert snapshot.generation == 3
+    assert snapshot.state == "running"
+
+    # Older start deliveries are fenced by the adopted generation.
+    assert driver.claim_start(2, "owner-2", now).state == "stale"
+
+
+def test_cache_driver_adopts_newer_wake_and_fences_older() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+    token = WakeToken(generation=2, sequence=5, logical_time=now)
+
+    claim = driver.claim_wake(token, "owner-1", now)
+    assert claim.state == "claimed"
+
+    finish = driver.finish_wake(token, "owner-1", now + timedelta(minutes=1), now)
+    assert finish.state == "advanced"
+    assert finish.wake is not None
+    assert finish.wake.sequence == 6
+
+    stale_duplicate = driver.claim_wake(token, "owner-2", now)
+    assert stale_duplicate.state == "stale"
+
+    older = WakeToken(generation=1, sequence=9, logical_time=now)
+    assert driver.claim_wake(older, "owner-3", now).state == "stale"
+
+
+def test_cache_driver_resume_generation_revives_paused_document() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    driver.start(now)
+    driver.pause(now)
+
+    # Same-generation deliveries stay fenced while paused.
+    fenced = WakeToken(generation=1, sequence=1, logical_time=now)
+    assert driver.claim_wake(fenced, "owner-1", now).state == "stale"
+    assert driver.claim_start(1, "owner-2", now).state == "stale"
+
+    # A resume mints generation 2 elsewhere; its deliveries win here.
+    assert driver.claim_start(2, "owner-3", now).state == "claimed"
+    assert driver.snapshot().state == "running"
+
+
+def test_cache_driver_idle_deadline_demotes_at_claim() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now, idle_timeout_seconds=60)
+    driver.mark_start_published(decision.generation, now)
+    claim = driver.claim_start(decision.generation, "owner-1", now)
+    assert claim.state == "claimed"
+    finish = driver.finish_start(decision.generation, "owner-1", now + timedelta(minutes=5), now)
+    assert finish.wake is not None
+
+    after_deadline = now + timedelta(seconds=120)
+    assert driver.claim_wake(finish.wake, "owner-2", after_deadline).state == "stale"
+    assert driver.snapshot().state == "inactive"
+
+
+def test_cache_driver_production_start_clears_idle_deadline() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    driver.start(now, idle_timeout_seconds=60)
+    driver.start(now, idle_timeout_seconds=None)
+
+    much_later = now + timedelta(hours=2)
+    assert not driver._demote_if_idle(driver._read(), much_later)
+    assert driver.snapshot().state == "running"
+
+
+def test_cache_driver_repair_overdue_wake() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.claim_start(decision.generation, "owner-1", now)
+    finish = driver.finish_start(decision.generation, "owner-1", now, now)
+    assert finish.wake is not None
+    driver.mark_wake_published(decision.generation, 1, now)
+
+    too_soon = driver.repair_overdue_wake(now + timedelta(minutes=5))
+    assert too_soon is None
+
+    repaired = driver.repair_overdue_wake(now + timedelta(minutes=11))
+    assert repaired is not None
+    assert repaired.status == "pending"
+
+
+def test_cache_driver_foreign_owner_is_fenced_without_takeover() -> None:
+    ours = cache_driver("dpl_a")
+    theirs = cache_driver("dpl_b")
+    now = datetime.now(UTC)
+
+    ours.start(now)
+    decision = theirs.auto_activate(now)
+    assert not decision.owned
+
+    takeover = theirs.auto_activate(now, takeover_allowed=True)
+    assert takeover.owned
+    assert takeover.generation == 2
+    assert theirs.owner_deployment() == "dpl_b"
+
+
+def test_cache_driver_mark_reconciled_is_owner_fenced() -> None:
+    ours = cache_driver("dpl_a")
+    theirs = cache_driver("dpl_b")
+    store = CacheJobStore()
+    store.bind_namespace(scope="prj_test:production", scheduler_id="conformance")
+    ours.attach_store(store)
+    theirs.attach_store(store)
+    now = datetime.now(UTC)
+
+    ours.start(now)
+    assert not theirs.mark_reconciled("dpl_b", now)
+    assert ours.reconciled_deployment() is None
+
+    assert ours.mark_reconciled("dpl_a", now)
+    assert ours.reconciled_deployment() == "dpl_a"
+
+
+def test_cache_reconcile_marker_shares_the_jobs_document_fate() -> None:
+    driver = cache_driver("dpl_a")
+    store = CacheJobStore()
+    store.bind_namespace(scope="prj_test:production", scheduler_id="conformance")
+    driver.attach_store(store)
+    now = datetime.now(UTC)
+
+    driver.start(now)
+    assert driver.mark_reconciled("dpl_a", now)
+    assert driver.reconciled_deployment() == "dpl_a"
+
+    # Evicting the jobs document must clear the marker with it, so a driver
+    # document kept fresh by bridge hops cannot vouch for a reaped store.
+    assert store.doc_key is not None
+    get_cache().delete(store.doc_key)
+    assert driver.reconciled_deployment() is None
+
+
+def test_cache_paused_document_is_touched_by_the_activation_hook() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    driver.start(now)
+    driver.pause(now)
+    before = driver._read().get("updated_at")
+
+    later = now + timedelta(minutes=7)
+    decision = driver.auto_activate(later)
+    assert decision.state == "paused"
+    assert not decision.changed
+    # The paused document was rewritten: its TTL clock restarted, so pause
+    # survives for as long as the deployment serves traffic.
+    assert driver._read().get("updated_at") != before
+
+
+def started_cache_scheduler() -> tuple[BlockingScheduler, Any, StartPayload]:
+    scheduler = BlockingScheduler(timezone=UTC)
+    scheduler.scheduled_job(
+        "interval",
+        minutes=5,
+        id="tick",
+    )(durable_cache_job)
+    modules[CACHE_SCHEDULER_MODULE].__dict__["scheduler"] = scheduler
+    register_scheduler(scheduler)
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+    assert adapter.backend.name == "cache"
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_start",
+    ) as send:
+        scheduler.start()
+
+    send.assert_called_once()
+    topic, payload = send.call_args.args[0], send.call_args.args[1]
+    assert topic == adapter.identity.start_topic
+    return scheduler, adapter, StartPayload.from_payload(payload)
+
+
+def test_cache_end_to_end_start_activates_and_reserves_first_wake() -> None:
+    _scheduler, adapter, start_payload = started_cache_scheduler()
+    start_subscription = get_subscriptions()[0]
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ) as send:
+        start_subscription.func(
+            message(
+                StartPayload(
+                    scheduler_id=start_payload.scheduler_id,
+                    generation=start_payload.generation,
+                ).to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+
+    send.assert_called_once()
+    wake_payload = WakeupPayload.from_payload(send.call_args.args[1])
+    assert wake_payload.generation == start_payload.generation
+    assert wake_payload.sequence == 1
+
+    snapshot = adapter.driver.snapshot()
+    assert snapshot.state == "running"
+    assert snapshot.start_status == "active"
+
+    jobs, undecodable = adapter.coordinator.get_all_jobs_with_revisions()
+    assert undecodable == []
+    assert [(job.id, provenance) for job, _, provenance in jobs] == [("tick", PROVENANCE_DECLARED)]
+
+
+def test_cache_end_to_end_wake_executes_job_and_reserves_successor() -> None:
+    _scheduler, _adapter, start_payload = started_cache_scheduler()
+    start_subscription, wake_subscription = get_subscriptions()[:2]
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ) as send:
+        start_subscription.func(
+            message(
+                start_payload.to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+    first_wake = WakeupPayload.from_payload(send.call_args.args[1])
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake_2",
+    ) as send:
+        wake_subscription.func(
+            message(
+                first_wake.to_payload(),
+                message_id="wake-1",
+                topic=wake_subscription.topic,
+                consumer_group=wake_subscription.consumer_group,
+            )
+        )
+
+    assert _EXECUTIONS == ["ran"]
+    send.assert_called_once()
+    successor = WakeupPayload.from_payload(send.call_args.args[1])
+    assert successor.sequence == first_wake.sequence + 1
+    assert successor.logical_time > first_wake.logical_time
+
+    # A duplicate delivery of the consumed wake is acknowledged silently.
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+    ) as send:
+        wake_subscription.func(
+            message(
+                first_wake.to_payload(),
+                message_id="wake-1-dup",
+                topic=wake_subscription.topic,
+                consumer_group=wake_subscription.consumer_group,
+            )
+        )
+    send.assert_not_called()
+    assert _EXECUTIONS == ["ran"]
+
+
+def test_cache_pause_publishes_control_message_and_subscriber_applies_it() -> None:
+    scheduler, adapter, _payload = started_cache_scheduler()
+    start_subscription = get_subscriptions()[0]
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_ctl",
+    ) as send:
+        scheduler.pause()
+
+    send.assert_called_once()
+    control = LifecyclePayload.from_payload(send.call_args.args[1])
+    assert control.action == "pause"
+    assert send.call_args.args[0] == adapter.identity.start_topic
+
+    # Simulate the queue-serving process: wipe the local document (its memory
+    # is separate under vercel dev) and apply the control message.
+    get_cache().delete(adapter.driver.key)
+    assert adapter.driver.snapshot().state == "inactive"
+
+    start_subscription.func(
+        message(
+            control.to_payload(),
+            message_id="ctl-1",
+            topic=start_subscription.topic,
+            consumer_group=start_subscription.consumer_group,
+        )
+    )
+    assert adapter.driver.snapshot().state == "paused"
+
+
+def test_cache_eviction_self_heals_from_the_next_wake() -> None:
+    _scheduler, adapter, start_payload = started_cache_scheduler()
+    start_subscription, wake_subscription = get_subscriptions()[:2]
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ) as send:
+        start_subscription.func(
+            message(
+                start_payload.to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+    first_wake = WakeupPayload.from_payload(send.call_args.args[1])
+
+    # Total eviction: both documents disappear.
+    get_cache().delete(adapter.driver.key)
+    get_cache().delete(adapter.coordinator.store.doc_key)
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake_2",
+    ) as send:
+        wake_subscription.func(
+            message(
+                first_wake.to_payload(),
+                message_id="wake-1",
+                topic=wake_subscription.topic,
+                consumer_group=wake_subscription.consumer_group,
+            )
+        )
+
+    # The wake was adopted, the declared job restored from code, and the
+    # chain continued with a successor.
+    assert _EXECUTIONS == ["ran"]
+    send.assert_called_once()
+    successor = WakeupPayload.from_payload(send.call_args.args[1])
+    assert successor.sequence == first_wake.sequence + 1
+
+    jobs, _ = adapter.coordinator.get_all_jobs_with_revisions()
+    assert [job.id for job, _, _ in jobs] == ["tick"]
+
+
+def test_cache_coordinator_cas_and_quarantine() -> None:
+    _scheduler, adapter, start_payload = started_cache_scheduler()
+    start_subscription = get_subscriptions()[0]
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ):
+        start_subscription.func(
+            message(
+                start_payload.to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+
+    coordinator = adapter.coordinator
+    jobs, _ = coordinator.get_all_jobs_with_revisions()
+    (job, revision, _provenance) = jobs[0]
+
+    assert not coordinator.cas_update_job(job, revision + 41)
+    assert coordinator.cas_update_job(job, revision)
+
+    # Corrupt the persisted record: it must be reported undecodable, and due
+    # planning must quarantine rather than crash the chain.
+    store = coordinator.store
+    doc = store._load()
+    doc["jobs"]["tick"]["state"] = "bm90LXBpY2tsZQ=="  # b"not-pickle"
+    store._store(doc)
+
+    jobs, undecodable = coordinator.get_all_jobs_with_revisions()
+    assert jobs == []
+    assert [record[0] for record in undecodable] == ["tick"]
+
+    due = coordinator.get_due_jobs_with_revisions(datetime.now(UTC) + timedelta(days=1))
+    assert due == []
+    assert store._load()["jobs"]["tick"]["quarantined"] is True
+
+
+def test_cache_jobs_document_eviction_alone_triggers_reconcile() -> None:
+    _scheduler, adapter, start_payload = started_cache_scheduler()
+    start_subscription, wake_subscription = get_subscriptions()[:2]
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ) as send:
+        start_subscription.func(
+            message(
+                start_payload.to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+    first_wake = WakeupPayload.from_payload(send.call_args.args[1])
+
+    # Only the jobs document is reaped; the driver document stays fresh
+    # (e.g. kept alive by bridge hops on a sparse schedule). The marker
+    # lives in the jobs document, so reconciliation must re-run.
+    get_cache().delete(adapter.coordinator.store.doc_key)
+    assert adapter.driver.reconciled_deployment() is None
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake_2",
+    ) as send:
+        wake_subscription.func(
+            message(
+                first_wake.to_payload(),
+                message_id="wake-1",
+                topic=wake_subscription.topic,
+                consumer_group=wake_subscription.consumer_group,
+            )
+        )
+
+    assert _EXECUTIONS == ["ran"]
+    jobs, _ = adapter.coordinator.get_all_jobs_with_revisions()
+    assert [job.id for job, _, _ in jobs] == ["tick"]
+
+
+def test_cache_dormant_finish_keeps_the_sequence_watermark() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.claim_start(decision.generation, "owner-1", now)
+    finish = driver.finish_start(decision.generation, "owner-1", now, now)
+    token = finish.wake
+    assert token is not None
+    assert token.sequence == 1
+    driver.mark_wake_published(decision.generation, 1, now)
+    driver.claim_wake(token, "owner-2", now)
+    dormant = driver.finish_wake(token, "owner-2", None, now)
+    assert dormant.state == "advanced"
+    assert dormant.wake is None
+
+    # The consumed position stays fenced even with no current token.
+    assert driver.claim_wake(token, "owner-3", now).state == "stale"
+
+    # A later rearm continues the sequence instead of reusing consumed
+    # idempotency-key positions the queue would silently dedup.
+    driver.rearm_wake(now + timedelta(minutes=5), now)
+    current = driver.snapshot().current_wake
+    assert current is not None
+    assert current.sequence == 2
+
+
+def test_cache_declared_add_rearms_a_dormant_chain() -> None:
+    _scheduler, adapter, start_payload = started_cache_scheduler()
+    start_subscription = get_subscriptions()[0]
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake",
+    ):
+        start_subscription.func(
+            message(
+                start_payload.to_payload(),
+                message_id="start-1",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+
+    # Force dormancy (active generation, consumed watermark, no token) and
+    # evict the jobs document — a declaration restored by reconciliation
+    # must mint the wake nothing else will.
+    doc = adapter.driver._read()
+    doc["current"] = None
+    doc["last_sequence"] = 4
+    adapter.driver._write(doc, datetime.now(UTC))
+    assert adapter.coordinator.store.doc_key is not None
+    get_cache().delete(adapter.coordinator.store.doc_key)
+
+    declared = adapter._declared_jobs["tick"]
+    adapter.coordinator.add_job(declared)
+
+    current = adapter.driver.snapshot().current_wake
+    assert current is not None
+    assert current.sequence == 5
+    assert current.status == "pending"
+
+
+def test_cache_rearm_during_processing_folds_into_the_successor() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.claim_start(decision.generation, "owner-1", now)
+    finish = driver.finish_start(decision.generation, "owner-1", now + timedelta(minutes=10), now)
+    token = finish.wake
+    assert token is not None
+    driver.mark_wake_published(decision.generation, 1, now)
+    assert driver.claim_wake(token, "owner-2", now).state == "claimed"
+
+    # A mutation racing the in-flight wake must not replace its token: both
+    # sides would publish different payloads under one idempotency key.
+    earlier = now + timedelta(minutes=2)
+    driver.rearm_wake(earlier, now)
+    current = driver.snapshot().current_wake
+    assert current is not None
+    assert current.sequence == 1
+    assert current.status == "processing"
+
+    # The finisher folds the earlier candidate into the one successor.
+    successor = driver.finish_wake(token, "owner-2", now + timedelta(minutes=20), now)
+    assert successor.wake is not None
+    assert successor.wake.sequence == 2
+    assert successor.wake.logical_time == earlier
+
+
+def test_cache_demoted_deployment_job_writes_are_fenced() -> None:
+    _scheduler, adapter, _payload = started_cache_scheduler()
+
+    doc = adapter.driver._read()
+    doc["owner_deployment"] = "dpl_other"
+    adapter.driver._write(doc, datetime.now(UTC))
+
+    with pytest.raises(NamespaceFencedError):
+        adapter.coordinator.remove_job("tick")
+
+
+def test_cache_processing_claim_is_busy_until_the_grace_lapses() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.claim_start(decision.generation, "owner-1", now)
+    finish = driver.finish_start(decision.generation, "owner-1", now, now)
+    token = finish.wake
+    assert token is not None
+    driver.mark_wake_published(decision.generation, 1, now)
+    assert driver.claim_wake(token, "owner-2", now).state == "claimed"
+
+    # A redelivery while the handler is alive retries instead of re-running.
+    assert driver.claim_wake(token, "owner-3", now).state == "busy"
+
+    # Past the grace the owner is presumed crashed and the claim is retaken.
+    late = now + timedelta(minutes=16)
+    assert driver.claim_wake(token, "owner-4", late).state == "claimed"

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -223,6 +223,26 @@ def test_cache_driver_resume_generation_revives_paused_document() -> None:
     assert driver.snapshot().state == "running"
 
 
+def test_cache_driver_remote_pause_drops_stale_but_honors_evicted_issuer() -> None:
+    driver = cache_driver()
+    t0 = datetime.now(UTC)
+
+    driver.start(t0)  # generation 1
+    driver.pause(t0)
+    resumed = driver.start(t0 + timedelta(seconds=10))
+    assert resumed.generation == 2
+
+    # The queue redelivers the generation-1 pause after the resume: both
+    # indicators date it before the current activation, so it is dropped.
+    assert not driver.apply_remote_pause(1, t0, t0 + timedelta(seconds=20))
+    assert driver.snapshot().state == "running"
+
+    # A pause from an issuer whose own document was evicted under-reads the
+    # generation as 0, but its fresh issue time proves it is not stale.
+    assert driver.apply_remote_pause(0, t0 + timedelta(seconds=30), t0 + timedelta(seconds=30))
+    assert driver.snapshot().state == "paused"
+
+
 def test_cache_driver_idle_deadline_demotes_at_claim() -> None:
     driver = cache_driver()
     now = datetime.now(UTC)
@@ -505,6 +525,7 @@ def test_cache_pause_publishes_control_message_and_subscriber_applies_it() -> No
     send.assert_called_once()
     control = LifecyclePayload.from_payload(send.call_args.args[1])
     assert control.action == "pause"
+    assert control.generation == 1
     assert send.call_args.args[0] == adapter.identity.start_topic
 
     # Simulate the queue-serving process: wipe the local document (its memory
@@ -521,6 +542,37 @@ def test_cache_pause_publishes_control_message_and_subscriber_applies_it() -> No
         )
     )
     assert adapter.driver.snapshot().state == "paused"
+
+    # A resume elsewhere arrives as a start message minting generation 2; a
+    # late redelivery of the generation-1 pause must not settle the chain
+    # back to paused.
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_wake_after_resume",
+    ):
+        start_subscription.func(
+            message(
+                StartPayload(
+                    scheduler_id=adapter.identity.scheduler_id,
+                    generation=2,
+                ).to_payload(),
+                message_id="start-2",
+                topic=start_subscription.topic,
+                consumer_group=start_subscription.consumer_group,
+            )
+        )
+    assert adapter.driver.snapshot().state == "running"
+    assert adapter.driver.snapshot().generation == 2
+
+    start_subscription.func(
+        message(
+            control.to_payload(),
+            message_id="ctl-1-dup",
+            topic=start_subscription.topic,
+            consumer_group=start_subscription.consumer_group,
+        )
+    )
+    assert adapter.driver.snapshot().state == "running"
 
 
 def test_cache_eviction_self_heals_from_the_next_wake() -> None:

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -269,6 +269,50 @@ def test_cache_driver_repair_overdue_wake() -> None:
     assert repaired.status == "pending"
 
 
+def test_cache_driver_repairs_overdue_published_start() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.mark_start_published(decision.generation, now)
+
+    # Within the grace the message is presumed in flight or merely delayed.
+    touched = driver.auto_activate(now + timedelta(minutes=5))
+    assert touched.start_status == "published"
+
+    # Past it the activation touch demotes the start so the regular publish
+    # path resends it under the same generation.
+    repaired = driver.auto_activate(now + timedelta(minutes=11))
+    assert not repaired.changed
+    assert repaired.generation == decision.generation
+    assert repaired.start_status == "pending"
+
+
+def test_cache_driver_repairs_stranded_processing_start() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    decision = driver.start(now)
+    driver.mark_start_published(decision.generation, now)
+    assert driver.claim_start(decision.generation, "owner-1", now).state == "claimed"
+
+    # Steady traffic keeps rewriting the document, so updated_at never ages
+    # out; the grace must run from the claim's own timestamp instead.
+    touched = driver.auto_activate(now + timedelta(minutes=5))
+    assert touched.start_status == "processing"
+
+    repaired = driver.auto_activate(now + timedelta(minutes=11))
+    assert repaired.start_status == "pending"
+
+    # The republished start is claimable again, and the fresh claim is not
+    # instantly demoted by the very next touch.
+    driver.mark_start_published(decision.generation, now + timedelta(minutes=11))
+    reclaim = driver.claim_start(decision.generation, "owner-2", now + timedelta(minutes=12))
+    assert reclaim.state == "claimed"
+    after = driver.auto_activate(now + timedelta(minutes=13))
+    assert after.start_status == "processing"
+
+
 def test_cache_driver_foreign_owner_is_fenced_without_takeover() -> None:
     ours = cache_driver("dpl_a")
     theirs = cache_driver("dpl_b")

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
+from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.jobstores.redis import RedisJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import STATE_PAUSED, STATE_RUNNING
@@ -25,21 +26,19 @@ from vercel.integrations.apscheduler import (
     is_scheduler_subscriber,
 )
 from vercel.integrations.apscheduler._adapter import SchedulerAdapter, get_adapter
-from vercel.integrations.apscheduler._driver import (
+from vercel.integrations.apscheduler._backends.redis import RedisJobCoordinator
+from vercel.integrations.apscheduler._options import VercelAPSchedulerOptions
+from vercel.integrations.apscheduler._payload import StartPayload, WakeupPayload
+from vercel.integrations.apscheduler._subscriber import register_scheduler
+from vercel.integrations.apscheduler._types import (
+    PROVENANCE_DECLARED,
+    PROVENANCE_RUNTIME,
     ClaimResult,
     DriverSnapshot,
     FinishResult,
     StartDecision,
     WakeToken,
 )
-from vercel.integrations.apscheduler._jobstore import (
-    PROVENANCE_DECLARED,
-    PROVENANCE_RUNTIME,
-    RedisJobCoordinator,
-)
-from vercel.integrations.apscheduler._options import VercelAPSchedulerOptions
-from vercel.integrations.apscheduler._payload import StartPayload, WakeupPayload
-from vercel.integrations.apscheduler._subscriber import register_scheduler
 from vercel.queue import (
     Message,
     MessageMetadata,
@@ -565,13 +564,13 @@ def scheduler_with_driver(
     adapter = get_adapter(scheduler)
     assert adapter is not None
     with patch(
-        "vercel.integrations.apscheduler._adapter.RedisJobCoordinator",
+        "vercel.integrations.apscheduler._backends.redis.RedisJobCoordinator",
         InMemoryJobCoordinator,
     ):
         adapter._bind_runtime()
     driver = FakeDriver()
     adapter._driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-    adapter.coordinator.driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    adapter.coordinator.driver = driver
     return scheduler, adapter, driver
 
 
@@ -594,7 +593,22 @@ def message(
     )
 
 
-def test_memory_job_store_is_rejected() -> None:
+def test_memory_job_store_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduler = BlockingScheduler(
+        timezone=UTC,
+        jobstores={"default": MemoryJobStore()},
+    )
+    bind_test_scheduler(scheduler)
+
+    with pytest.raises(
+        APSchedulerConfigurationError,
+        match="not suitable for the cache backend",
+    ):
+        scheduler.start()
+
+
+def test_redis_backend_requires_a_redis_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERCEL_APSCHEDULER_BACKEND", "redis")
     scheduler = BlockingScheduler(timezone=UTC)
     bind_test_scheduler(scheduler)
 
@@ -855,12 +869,12 @@ def test_takeover_reconciles_declared_jobs_and_keeps_dynamic_ones(
     second_adapter = get_adapter(second)
     assert second_adapter is not None
     with patch(
-        "vercel.integrations.apscheduler._adapter.RedisJobCoordinator",
+        "vercel.integrations.apscheduler._backends.redis.RedisJobCoordinator",
         InMemoryJobCoordinator,
     ):
         second_adapter._bind_runtime()
     second_adapter._driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-    second_adapter.coordinator.driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    second_adapter.coordinator.driver = driver
     # The new deployment holds its own driver handle on the shared hash.
     driver.deployment = "dpl_two"
     with patch(
@@ -942,12 +956,12 @@ def test_stale_deployment_touches_are_inert(
     stale_adapter = get_adapter(stale)
     assert stale_adapter is not None
     with patch(
-        "vercel.integrations.apscheduler._adapter.RedisJobCoordinator",
+        "vercel.integrations.apscheduler._backends.redis.RedisJobCoordinator",
         InMemoryJobCoordinator,
     ):
         stale_adapter._bind_runtime()
     stale_adapter._driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-    stale_adapter.coordinator.driver = driver  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    stale_adapter.coordinator.driver = driver
     driver.deployment = "dpl_stale"
     driver.owner_deployment_value = "dpl_test"  # the promoted deployment
 
@@ -978,7 +992,7 @@ def test_two_schedulers_sharing_a_store_key_collide_loudly() -> None:
         assert second_adapter is not None
         _ = second_adapter.identity
 
-    with pytest.raises(APSchedulerConfigurationError, match="distinct jobs_key"):
+    with pytest.raises(APSchedulerConfigurationError, match="distinct durable identity"):
         build_second_scheduler_and_use_its_identity()
 
 

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_redis.py
@@ -21,11 +21,8 @@ from vercel.integrations.apscheduler import (
     install_vercel_apscheduler_integration,
 )
 from vercel.integrations.apscheduler._adapter import SchedulerAdapter, get_adapter
-from vercel.integrations.apscheduler._driver import (
-    NamespaceFencedError,
-    RedisDriver,
-    StartDecision,
-)
+from vercel.integrations.apscheduler._backends.redis import RedisDriver
+from vercel.integrations.apscheduler._types import NamespaceFencedError, StartDecision
 
 UTC = timezone.utc
 REDIS_URL = environ.get("APSCHEDULER_TEST_REDIS_URL")
@@ -667,7 +664,8 @@ def _real_scheduler(
     adapter = get_adapter(scheduler)
     assert adapter is not None
     adapter._bind_runtime()
-    keys = adapter.coordinator.keys
+    coordinator: Any = adapter.coordinator
+    keys = coordinator.keys
     store.redis.delete(*keys)
     return scheduler, adapter, store.redis, keys
 
@@ -1042,7 +1040,7 @@ def test_real_redis_demoted_deployment_writes_are_fenced(
         # The demoted deployment's in-flight handler writes with its own
         # bound identity; only the environment is restored for the lookup.
         monkeypatch.setenv("VERCEL_DEPLOYMENT_ID", "dpl_fence_one")
-        first_coordinator = first_adapter.coordinator
+        first_coordinator: Any = first_adapter.coordinator
         with pytest.raises(NamespaceFencedError):
             first_coordinator.cas_update_job(job, revision)
         with pytest.raises(NamespaceFencedError):
@@ -1086,7 +1084,7 @@ def test_real_redis_reconciliation_retries_revision_races(
             first_scheduler.start()
 
         second, second_adapter = _take_over_scheduler(monkeypatch, "dpl_retry_two")
-        coordinator = second_adapter.coordinator
+        coordinator: Any = second_adapter.coordinator
         original_remove = coordinator.cas_remove_job
         calls: list[str] = []
 
@@ -1140,7 +1138,7 @@ def test_real_redis_unconverged_reconciliation_defers_and_retries(
             first_scheduler.start()
 
         second, second_adapter = _take_over_scheduler(monkeypatch, "dpl_defer_two")
-        coordinator = second_adapter.coordinator
+        coordinator: Any = second_adapter.coordinator
         original_remove = coordinator.cas_remove_job
 
         def always_racing_remove(job_id: str, expected_revision: int) -> bool:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/__init__.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/__init__.py
@@ -4,7 +4,7 @@ from ._adapter import (
     install_vercel_apscheduler_integration,
     is_scheduler_subscriber,
 )
-from ._driver import APSchedulerConfigurationError
+from ._types import APSchedulerConfigurationError
 from .version import __version__
 
 __all__ = [

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -391,6 +391,7 @@ class SchedulerAdapter:
             scheduler_id=self.identity.scheduler_id,
             action=action,
             issued_at=now,
+            generation=self.driver.snapshot().generation,
         ).to_payload()
         try:
             vqs_sync.send(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -16,13 +16,8 @@ from weakref import WeakValueDictionary
 import vercel.queue as vqs
 import vercel.queue.sync as vqs_sync
 
-from ._driver import (
-    APSchedulerConfigurationError,
-    NamespaceFencedError,
-    RedisDriver,
-    StartDecision,
-    WakeToken,
-)
+from ._backends import Backend, Driver, JobCoordinator, resolve_backend
+from ._control import LifecyclePayload
 from ._executor import VercelInlineExecutor
 from ._imports import (
     EVENT_JOB_MAX_INSTANCES,
@@ -34,9 +29,7 @@ from ._imports import (
     IntervalTrigger,
     JobSubmissionEvent,
     MaxInstancesReachedError,
-    RedisJobStore,
 )
-from ._jobstore import PROVENANCE_DECLARED, RedisJobCoordinator
 from ._options import (
     VercelAPSchedulerOptions,
     _SchedulerIdentity,
@@ -47,6 +40,13 @@ from ._options import (
 )
 from ._payload import StartPayload, WakeupPayload
 from ._time import as_utc, canonical_scheduled_logical_time, earliest
+from ._types import (
+    PROVENANCE_DECLARED,
+    APSchedulerConfigurationError,
+    NamespaceFencedError,
+    StartDecision,
+    WakeToken,
+)
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 UTC = timezone.utc
@@ -54,7 +54,6 @@ ADAPTER_ATTR = "_vercel_apscheduler_adapter"
 DEPLOYMENT_ENV = "VERCEL_DEPLOYMENT_ID"
 SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 WAKEUP_KEY_PREFIX = "aps"
-RAW_STORE_KEY_ATTR = "_vercel_apscheduler_raw_jobs_key"
 # Queue delivery rounds wake delays up to whole seconds and adds dispatch
 # latency, so a grace below this cannot be met and skips occurrences.
 MIN_QUEUE_MISFIRE_GRACE_SECONDS = 5
@@ -185,8 +184,9 @@ class SchedulerAdapter:
         self._registration_deferred = False
         self._declared_jobs: dict[str, Any] = {}
         self._reconciled = False
-        self._driver: RedisDriver | None = None
-        self._coordinator: RedisJobCoordinator | None = None
+        self._driver: Driver | None = None
+        self._coordinator: JobCoordinator | None = None
+        self._backend: Backend | None = None
         self._job_definitions: dict[str, _JobDefinition] = {}
         self._current_add_explicit = False
         self._runtime_mutation_depth = 0
@@ -216,23 +216,14 @@ class SchedulerAdapter:
                 return _SchedulerIdentity.from_scheduler_id(self.options.scheduler_id)
             except ValueError as exc:
                 raise APSchedulerConfigurationError(str(exc)) from exc
-        store = self.scheduler._jobstores.get("default")
-        if not isinstance(store, RedisJobStore):
-            raise APSchedulerConfigurationError(
-                "vercel-apscheduler requires a configured default RedisJobStore"
-            )
-        raw_key = store.__dict__.setdefault(RAW_STORE_KEY_ATTR, store.jobs_key)
-        try:
-            return _SchedulerIdentity.from_store_key(raw_key)
-        except ValueError as exc:
-            raise APSchedulerConfigurationError(str(exc)) from exc
+        return cast("_SchedulerIdentity", self.backend.derive_identity(self.scheduler))
 
     def _claim_identity(self, identity: _SchedulerIdentity) -> _SchedulerIdentity:
         existing = _ACTIVE_IDENTITIES.get(identity.scheduler_id)
         if existing is not None and existing is not self:
             raise APSchedulerConfigurationError(
                 f'two schedulers derive the durable identity "{identity.scheduler_id}"; '
-                "give each scheduler's RedisJobStore a distinct jobs_key"
+                "give each scheduler a distinct durable identity"
             )
         _ACTIVE_IDENTITIES[identity.scheduler_id] = self
         return identity
@@ -253,14 +244,14 @@ class SchedulerAdapter:
         return cast("str", self._scope)
 
     @property
-    def driver(self) -> RedisDriver:
+    def driver(self) -> Driver:
         self._bind_runtime()
-        return cast("RedisDriver", self._driver)
+        return cast("Driver", self._driver)
 
     @property
-    def coordinator(self) -> RedisJobCoordinator:
+    def coordinator(self) -> JobCoordinator:
         self._bind_runtime()
-        return cast("RedisJobCoordinator", self._coordinator)
+        return cast("JobCoordinator", self._coordinator)
 
     def _owns_namespace(self) -> bool:
         """Whether this deployment currently drives the shared chain.
@@ -276,11 +267,15 @@ class SchedulerAdapter:
 
     @property
     def _scope_outlives_deployments(self) -> bool:
-        """Whether this namespace is shared by successive deployments.
+        """Whether the namespace can outlive this code's view of it.
 
-        True for named environments; previews and development get a fresh
-        namespace per deployment, so takeover reconciliation never applies.
+        True for named environments (shared by successive deployments). Also
+        always true for the cache backend: its documents are evictable in
+        every scope, so reconciliation-from-code is the durability story
+        regardless of scoping.
         """
+        if self.backend.name == "cache":
+            return True
         return self._scope != self._deployment
 
     @property
@@ -323,6 +318,7 @@ class SchedulerAdapter:
         now = datetime.now(UTC)
         if paused:
             self.driver.pause(now)
+            self._publish_lifecycle_control("pause", now)
             self._pause_local()
             return
         decision = self.driver.start(
@@ -377,8 +373,38 @@ class SchedulerAdapter:
         """Durably fence the current generation."""
         self._lifecycle_called = True
         self.ensure_local_started()
-        self.driver.pause(datetime.now(UTC))
+        now = datetime.now(UTC)
+        self.driver.pause(now)
+        self._publish_lifecycle_control("pause", now)
         self._pause_local()
+
+    def _publish_lifecycle_control(self, action: str, now: datetime) -> None:
+        """Carry a lifecycle flag over the queue where the cache cannot.
+
+        Cache-backend documents are per-process under ``vercel dev`` and
+        per-region in deployments, so the flag also rides the start topic to
+        whichever process serves the chain. Redis needs no counterpart.
+        """
+        if self.backend.name != "cache":
+            return
+        payload = LifecyclePayload(
+            scheduler_id=self.identity.scheduler_id,
+            action=action,
+            issued_at=now,
+        ).to_payload()
+        try:
+            vqs_sync.send(
+                self.identity.start_topic,
+                payload,
+                deployment=self.deployment,
+                retention=self.options.retention_seconds,
+            )
+        except Exception:
+            LOGGER.exception(
+                "Failed to publish the %s control message; the flag is "
+                "recorded in the cache document only",
+                action,
+            )
 
     def resume(self) -> None:
         """Resume by creating one new durable generation."""
@@ -463,7 +489,7 @@ class SchedulerAdapter:
         )
 
     def publish_pending_wakeup(self) -> PublishedWakeup | None:
-        """Repair a wake reserved in Redis before a failed Queue send."""
+        """Repair a wake reserved durably before a failed Queue send."""
         if not self._owns_namespace():
             return None
         snapshot = self.driver.snapshot()
@@ -631,10 +657,10 @@ class SchedulerAdapter:
         replace_existing: bool,
     ) -> bool:
         jobstore = self.scheduler._lookup_jobstore(jobstore_alias)
-        if not isinstance(jobstore, RedisJobStore):
+        if not self.backend.supports_store(jobstore):
             raise APSchedulerConfigurationError(
-                "vercel-apscheduler v1 supports RedisJobStore only; "
-                f'job store "{jobstore_alias}" is {type(jobstore).__name__}'
+                f"the {self.backend.name} backend does not support job store "
+                f'"{jobstore_alias}" ({type(jobstore).__name__})'
             )
         definition = self._job_definitions.get(str(job.id))
         explicit_id = (
@@ -679,7 +705,8 @@ class SchedulerAdapter:
             return True
         if not replace_existing:
             raise APSchedulerConfigurationError(
-                f'job "{job.id}" already exists in Redis; declare it with replace_existing=True'
+                f'job "{job.id}" already exists in the durable store; '
+                "declare it with replace_existing=True"
             )
         if self.is_runtime_mutation or self.is_wake_mutation:
             return True
@@ -734,60 +761,26 @@ class SchedulerAdapter:
                 "one scheduler object cannot be shared across Vercel deployments"
             )
         self._deployment = deployment
-        stores = self._validate_durable_configuration()
+        backend = self.backend
+        self._validate_durable_configuration()
         try:
             scope = resolve_state_scope(deployment)
         except ValueError as exc:
             raise APSchedulerConfigurationError(str(exc)) from exc
         self._scope = scope
-        tag = f"{{{scope}:{self.identity.scheduler_id}}}"
-        for alias, store in stores.items():
-            namespace = getattr(store, "_vercel_apscheduler_namespace", None)
-            expected_namespace = (scope, self.identity.scheduler_id)
-            if namespace is not None and namespace != expected_namespace:
-                raise APSchedulerConfigurationError(
-                    f'job store "{alias}" is already bound to another scheduler'
-                )
-            if namespace is None:
-                if any(character in store.jobs_key + store.run_times_key for character in "{}"):
-                    raise APSchedulerConfigurationError(
-                        "custom Redis job-store keys cannot contain Redis hash tags"
-                    )
-                store.jobs_key = f"{store.jobs_key}:{tag}:jobs"
-                store.run_times_key = f"{store.run_times_key}:{tag}:run_times"
-                store.__dict__["_vercel_apscheduler_namespace"] = expected_namespace
-        if self._driver is None:
-            self._driver = RedisDriver(
-                stores["default"].redis,
-                scope=scope,
-                scheduler_id=self.identity.scheduler_id,
-                deployment=deployment,
-            )
-        if self._coordinator is None:
-            self._coordinator = RedisJobCoordinator(
-                stores["default"],
-                self._driver,
-                self,
-            )
-            self._coordinator.install()
+        if self._driver is None or self._coordinator is None:
+            bound = backend.bind(self, scope=scope, deployment=deployment)
+            self._driver = bound.driver
+            self._coordinator = bound.coordinator
 
-    def _validate_durable_configuration(self) -> dict[str, RedisJobStore]:
-        stores = self.scheduler._jobstores
-        if "default" not in stores:
-            raise APSchedulerConfigurationError(
-                "vercel-apscheduler requires a configured default RedisJobStore"
-            )
-        if set(stores) != {"default"}:
-            aliases = ", ".join(sorted(stores))
-            raise APSchedulerConfigurationError(
-                "vercel-apscheduler v1 supports exactly one job store named "
-                f'"default"; configured: {aliases}'
-            )
-        if not isinstance(stores["default"], RedisJobStore):
-            raise APSchedulerConfigurationError(
-                "vercel-apscheduler requires a configured default RedisJobStore"
-            )
-        return cast("dict[str, RedisJobStore]", stores)
+    @property
+    def backend(self) -> Backend:
+        if self._backend is None:
+            self._backend = resolve_backend(self.scheduler)
+        return self._backend
+
+    def _validate_durable_configuration(self) -> dict[str, Any]:
+        return self.backend.validate_configuration(self.scheduler)
 
     def _inject_inline_executor(self) -> None:
         existing = self.scheduler._executors.get("default")
@@ -819,13 +812,17 @@ class SchedulerAdapter:
         declaration. ``runtime`` jobs belong to the store and are never
         touched; an unloadable one is quarantined.
         """
-        if self._reconciled or not self._scope_outlives_deployments:
+        if not self._scope_outlives_deployments:
             return
         if not self._owns_namespace():
             return
+        # The durable marker is the authority; the in-process flag is only a
+        # cache of it. Consulting the marker first means a rollback onto a
+        # warm instance re-reconciles, and an evicted cache document heals.
         if self.driver.reconciled_deployment() == self.deployment:
             self._reconciled = True
             return
+        self._reconciled = False
         try:
             for _ in range(RECONCILE_PASS_LIMIT):
                 if not self._reconcile_pass(now):
@@ -1170,8 +1167,10 @@ def _register_queues_when_ready(
     """
     if not (is_vercel_runtime() and (_PATCH_STATE.register_queues or is_queue_serving_runtime())):
         return
-    store = scheduler._jobstores.get("default")
-    if adapter.options.scheduler_id is None and not isinstance(store, RedisJobStore):
+    if adapter.options.scheduler_id is None and not adapter.backend.identity_ready(scheduler):
+        # The backend cannot derive a durable identity yet (e.g. Redis needs
+        # the store's jobs_key, which may only arrive through a later
+        # add_jobstore()); registration re-runs when it can.
         adapter._registration_deferred = True
         return
     from ._subscriber import register_scheduler

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -10,7 +10,6 @@ import logging
 from os import environ
 from time import monotonic
 
-from ._driver import APSchedulerConfigurationError
 from ._imports import BaseScheduler
 from ._options import (
     is_discovery_runtime,
@@ -18,6 +17,7 @@ from ._options import (
     is_vercel_runtime,
     resolve_environment,
 )
+from ._types import APSchedulerConfigurationError
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/__init__.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/__init__.py
@@ -1,0 +1,50 @@
+"""Durable-backend selection for the APScheduler integration.
+
+Selection order:
+
+1. ``VERCEL_APSCHEDULER_BACKEND`` (``redis`` | ``cache``), injected by the
+   builder once it detects the project's store configuration.
+2. Autodetection: a configured default ``RedisJobStore`` selects ``redis``;
+   anything else selects ``cache`` (Vercel Runtime Cache, which itself falls
+   back to per-process memory outside deployed environments, e.g. under
+   ``vercel dev``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from os import environ
+
+from .._imports import RedisJobStore
+from .._types import APSchedulerConfigurationError
+from ._protocols import Backend, BoundRuntime, Driver, JobCoordinator
+
+BACKEND_ENV = "VERCEL_APSCHEDULER_BACKEND"
+
+__all__ = [
+    "BACKEND_ENV",
+    "Backend",
+    "BoundRuntime",
+    "Driver",
+    "JobCoordinator",
+    "resolve_backend",
+]
+
+
+def resolve_backend(scheduler: Any) -> Backend:
+    configured = (environ.get(BACKEND_ENV) or "").strip().casefold()
+    if configured and configured not in {"redis", "cache"}:
+        raise APSchedulerConfigurationError(
+            f'{BACKEND_ENV} must be "redis" or "cache", not "{configured}"'
+        )
+    if not configured:
+        store = scheduler._jobstores.get("default")
+        configured = "redis" if isinstance(store, RedisJobStore) else "cache"
+    if configured == "redis":
+        from .redis import RedisBackend
+
+        return RedisBackend()
+    from .cache import CacheBackend
+
+    return CacheBackend()

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
@@ -49,6 +49,20 @@ class Driver(Protocol):
 
     def pause(self, now: datetime) -> bool: ...
 
+    def apply_remote_pause(
+        self,
+        generation: int,
+        issued_at: datetime,
+        now: datetime,
+    ) -> bool:
+        """Apply a queue-borne pause unless it is provably stale.
+
+        False iff the pause was dropped because a newer generation was
+        activated after it was issued (only the cache backend ever receives
+        these; see ``_control``).
+        """
+        ...
+
     def mark_start_published(self, generation: int, now: datetime) -> None: ...
 
     def claim_start(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
@@ -1,0 +1,183 @@
+"""The durable-coordination contract every backend satisfies.
+
+A backend supplies two collaborators to the adapter:
+
+- a *driver*: the lifecycle state machine (start/pause/resume, wake tokens,
+  ownership, the reconciliation marker), and
+- a *job coordinator*: atomic-as-possible job writes coupled to wake rearming.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from contextlib import AbstractContextManager
+from datetime import datetime
+
+from .._types import (
+    ClaimResult,
+    DriverSnapshot,
+    FinishResult,
+    StartDecision,
+    WakeToken,
+)
+
+__all__ = ["Backend", "BoundRuntime", "Driver", "JobCoordinator"]
+
+
+class Driver(Protocol):
+    """Durable lifecycle and single-chain coordination."""
+
+    scope: str
+    scheduler_id: str
+    deployment: str
+
+    def start(
+        self,
+        now: datetime,
+        *,
+        idle_timeout_seconds: int | None = None,
+    ) -> StartDecision: ...
+
+    def auto_activate(
+        self,
+        now: datetime,
+        *,
+        idle_timeout_seconds: int | None = None,
+        takeover_allowed: bool = False,
+    ) -> StartDecision: ...
+
+    def pause(self, now: datetime) -> bool: ...
+
+    def mark_start_published(self, generation: int, now: datetime) -> None: ...
+
+    def claim_start(
+        self,
+        generation: int,
+        owner: str,
+        now: datetime,
+    ) -> ClaimResult: ...
+
+    def finish_start(
+        self,
+        generation: int,
+        owner: str,
+        next_time: datetime | None,
+        now: datetime,
+    ) -> FinishResult: ...
+
+    def mark_wake_published(
+        self,
+        generation: int,
+        sequence: int,
+        now: datetime,
+    ) -> None: ...
+
+    def claim_wake(self, token: WakeToken, owner: str, now: datetime) -> ClaimResult: ...
+
+    def finish_wake(
+        self,
+        token: WakeToken,
+        owner: str,
+        next_time: datetime | None,
+        now: datetime,
+    ) -> FinishResult: ...
+
+    def snapshot(self) -> DriverSnapshot: ...
+
+    def repair_overdue_wake(self, now: datetime) -> WakeToken | bool | None:
+        """Demote an overdue published wake back to pending.
+
+        Truthy iff a repair actually happened (the adapter logs it loudly);
+        a merely-pending wake is not a repair.
+        """
+        ...
+
+    def owner_deployment(self) -> str | None: ...
+
+    def reconciled_deployment(self) -> str | None: ...
+
+    def mark_reconciled(self, deployment: str, now: datetime) -> bool: ...
+
+    def renew(self, owner: str, now: datetime) -> bool: ...
+
+    def release(self, owner: str) -> None: ...
+
+    def renewing(self, owner: str) -> AbstractContextManager[None]: ...
+
+
+class JobCoordinator(Protocol):
+    """Job persistence coupled to atomic wake rearming."""
+
+    store: Any
+    driver: Any
+
+    def install(self) -> None: ...
+
+    def add_job(self, job: Any) -> None: ...
+
+    def update_job(self, job: Any) -> None: ...
+
+    def remove_job(self, job_id: str) -> None: ...
+
+    def remove_all_jobs(self) -> None: ...
+
+    def get_due_jobs_with_revisions(
+        self,
+        now: datetime,
+    ) -> list[tuple[Any, int]]: ...
+
+    def get_all_jobs_with_revisions(
+        self,
+    ) -> tuple[list[tuple[Any, int, str]], list[tuple[str, int, str]]]: ...
+
+    def cas_update_job(self, job: Any, expected_revision: int) -> bool: ...
+
+    def cas_remove_job(self, job_id: str, expected_revision: int) -> bool: ...
+
+    def quarantine_job(self, job_id: str) -> None: ...
+
+
+class BoundRuntime(Protocol):
+    """What a backend hands the adapter after binding to a scheduler."""
+
+    driver: Driver
+    coordinator: JobCoordinator
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """Selects and constructs the durable substrate for one scheduler."""
+
+    name: str
+
+    def validate_configuration(self, scheduler: Any) -> dict[str, Any]:
+        """Check the scheduler's job stores fit this backend; return them.
+
+        Raises ``APSchedulerConfigurationError`` with a backend-specific
+        message otherwise (e.g. Redis requires a default ``RedisJobStore``;
+        cache mode rejects an explicitly configured Redis store).
+        """
+        ...
+
+    def supports_store(self, store: Any) -> bool:
+        """Whether ``store`` is one of this backend's durable store types."""
+        ...
+
+    def identity_ready(self, scheduler: Any) -> bool:
+        """Whether a durable identity can already be derived for ``scheduler``."""
+        ...
+
+    def derive_identity(self, scheduler: Any) -> Any:
+        """Derive the durable scheduler identity, or raise a configuration error."""
+        ...
+
+    def bind(
+        self,
+        adapter: Any,
+        *,
+        scope: str,
+        deployment: str,
+    ) -> BoundRuntime:
+        """Namespace the stores and construct driver + coordinator."""
+        ...

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/__init__.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/__init__.py
@@ -1,0 +1,102 @@
+"""Runtime Cache backend: redis-less coordination with documented tradeoffs.
+
+The Vercel Runtime Cache offers ``get``/``set``/``delete`` with TTLs and tags
+— no compare-and-swap, no transactions, and entries may be evicted. This
+backend therefore divides responsibility differently from Redis:
+
+- **Chain integrity** does not live here at all. The single-successor
+  guarantee comes from the queue's idempotency keys: racing finishers compute
+  identical successor payloads (logical times are canonical), and the queue
+  accepts the publication once. Claims are best-effort filters that shrink,
+  but cannot eliminate, duplicate wake *executions*; the contract is
+  at-least-once with a wider duplicate window than Redis mode.
+- **Declared jobs are reconstructable, not durable.** Code is the backup: a
+  missing driver or job document is rebuilt from declarations by the existing
+  reconcile/materialize machinery, so eviction can only cost state that code
+  cannot restate (runtime-added jobs, lifecycle flags).
+- **Runtime mutations and lifecycle flags are best-effort** by declared
+  policy: read-merge-write with bounded retries; last writer wins. ``pause()``
+  additionally rides the queue as a control message.
+
+Outside deployed environments (``vercel dev``) the cache client falls back to
+per-process memory, which makes this backend the in-memory dev mode with the
+queue-serving sidecar as the effective scheduler process.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dataclasses import dataclass
+from os import environ
+
+from ..._options import SUBSCRIBER_ID_ENV, _SchedulerIdentity
+from ..._types import APSchedulerConfigurationError
+from .._protocols import Driver, JobCoordinator
+from ._driver import CacheDriver
+from ._jobstore import CacheJobCoordinator, CacheJobStore
+
+__all__ = ["CacheBackend", "CacheDriver", "CacheJobCoordinator", "CacheJobStore"]
+
+
+@dataclass
+class _Bound:
+    driver: Driver
+    coordinator: JobCoordinator
+
+
+class CacheBackend:
+    name = "cache"
+
+    def validate_configuration(self, scheduler: Any) -> dict[str, Any]:
+        stores = dict(scheduler._jobstores)
+        extra = set(stores) - {"default"}
+        if extra:
+            aliases = ", ".join(sorted(extra))
+            raise APSchedulerConfigurationError(
+                "vercel-apscheduler v1 supports exactly one job store named "
+                f'"default"; configured: {aliases}'
+            )
+        default = stores.get("default")
+        if default is not None and not isinstance(default, CacheJobStore):
+            raise APSchedulerConfigurationError(
+                f'job store "{type(default).__name__}" is not suitable for the '
+                "cache backend, which injects its own store; remove the "
+                "explicit default store, or select the matching backend via "
+                "VERCEL_APSCHEDULER_BACKEND"
+            )
+        return stores
+
+    def supports_store(self, store: Any) -> bool:
+        return isinstance(store, CacheJobStore)
+
+    def identity_ready(self, scheduler: Any) -> bool:
+        return True
+
+    def derive_identity(self, scheduler: Any) -> _SchedulerIdentity:
+        # No store key to derive from; the builder-assigned subscriber id is
+        # the durable identity, "default" outside Vercel.
+        subscriber_id = environ.get(SUBSCRIBER_ID_ENV) or "default"
+        try:
+            return _SchedulerIdentity.from_scheduler_id(subscriber_id)
+        except ValueError as exc:
+            raise APSchedulerConfigurationError(str(exc)) from exc
+
+    def bind(self, adapter: Any, *, scope: str, deployment: str) -> _Bound:
+        stores = self.validate_configuration(adapter.scheduler)
+        store = stores.get("default")
+        if store is None:
+            store = CacheJobStore()
+            with adapter.scheduler._jobstores_lock:
+                adapter.scheduler._jobstores["default"] = store
+                store.start(adapter.scheduler, "default")
+        store.bind_namespace(scope=scope, scheduler_id=adapter.identity.scheduler_id)
+        driver = CacheDriver(
+            scope=scope,
+            scheduler_id=adapter.identity.scheduler_id,
+            deployment=deployment,
+        )
+        driver.attach_store(store)
+        coordinator = CacheJobCoordinator(store, driver, adapter)
+        coordinator.install()
+        return _Bound(driver=driver, coordinator=coordinator)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_doc.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_doc.py
@@ -1,0 +1,29 @@
+"""Shared Runtime Cache document plumbing for the cache backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datetime import datetime
+
+from ..._time import as_utc
+
+# 35 days. Docs are rewritten on every touch (wakes, activation-hook runs),
+# so an active, paused, or dormant scheduler on a traffic-serving deployment
+# never expires; the TTL only reaps abandoned namespaces (and, with them,
+# runtime-added jobs and lifecycle flags — declared jobs come back from code).
+# LRU eviction is the space-based reaper; this is the time-based one.
+DOC_TTL_SECONDS = 35 * 24 * 3600
+_INDEX_MERGE_ATTEMPTS = 4
+
+__all__ = ["DOC_TTL_SECONDS"]
+
+
+def iso(value: datetime | None) -> str | None:
+    return None if value is None else as_utc(value, name="value").isoformat()
+
+
+def from_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return datetime.fromisoformat(value)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import logging
 from contextlib import AbstractContextManager, nullcontext
 from datetime import datetime, timedelta, timezone
 
@@ -25,6 +26,8 @@ from ..._types import (
 from ._doc import DOC_TTL_SECONDS, from_iso, iso
 
 UTC = timezone.utc
+
+LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
 # A processing claim younger than this is treated as live (busy); past it,
 # the owner is presumed crashed and the claim is retaken (redis lease parity).
@@ -170,10 +173,15 @@ class CacheDriver:
                 state="paused",
             )
         if state == "running" and not foreign:
+            repaired = self._repair_overdue_start(doc, now)
             if idle_timeout_seconds is not None:
                 doc["idle_expires_at"] = iso(now + timedelta(seconds=idle_timeout_seconds))
                 self._write(doc, now)
-            elif doc.pop("idle_expires_at", None) is not None or self._token(doc) is None:
+            elif (
+                doc.pop("idle_expires_at", None) is not None
+                or self._token(doc) is None
+                or repaired
+            ):
                 # A dormant chain (no current wake) has no wakes refreshing
                 # its TTL; the activation hook's touch is what keeps it alive.
                 self._write(doc, now)
@@ -189,6 +197,7 @@ class CacheDriver:
             generation=generation,
             owner_deployment=self.deployment,
             start_status="pending",
+            start_claimed_at=None,
             activation_time=iso(now),
             current=None,
             last_sequence=0,
@@ -205,6 +214,39 @@ class CacheDriver:
             start_status="pending",
             current_wake=None,
         )
+
+    def _repair_overdue_start(self, doc: dict[str, Any], now: datetime) -> bool:
+        """Demote a presumed-lost start publication back to ``pending``.
+
+        A ``published`` start whose message died (a rollback strands it in a
+        queue with no forward alias; alias or retention expiry drops it) has
+        no wake token yet, so the overdue-wake repair cannot see it. The
+        recurring activation touch is the only signal left on such a chain,
+        so it doubles as the repairer: past the grace the status drops back
+        to ``pending`` and the regular publish path resends the start under
+        its unchanged idempotency key (a still-live original makes the
+        resend a dedup no-op). A stranded ``processing`` claim gets the same
+        treatment — its liveness cannot be judged by ``updated_at``, which
+        every activation touch refreshes, so the grace runs from the claim's
+        own ``start_claimed_at`` (the generation's ``activation_time`` before
+        any claim exists).
+        """
+        status = doc.get("start_status")
+        if status not in ("published", "processing"):
+            return False
+        anchor = from_iso(doc.get("start_claimed_at")) or from_iso(doc.get("activation_time"))
+        if anchor is None:
+            return False
+        if now < anchor + timedelta(seconds=WAKE_REPAIR_GRACE_SECONDS):
+            return False
+        doc["start_status"] = "pending"
+        LOGGER.warning(
+            'Republishing the start of generation %s for scheduler "%s": its '
+            "queue message is overdue and presumed lost",
+            doc.get("generation"),
+            self.scheduler_id,
+        )
+        return True
 
     def pause(self, now: datetime) -> bool:
         now = as_utc(now, name="now")
@@ -248,6 +290,7 @@ class CacheDriver:
                 return ClaimResult(state="busy")
             activation_time = from_iso(doc.get("activation_time")) or now
             doc["start_status"] = "processing"
+            doc["start_claimed_at"] = iso(now)
             self._write(doc, now)
             return ClaimResult(state="claimed", activation_time=activation_time)
         doc.update(
@@ -255,6 +298,7 @@ class CacheDriver:
             generation=generation,
             owner_deployment=self.deployment,
             start_status="processing",
+            start_claimed_at=iso(now),
             activation_time=iso(now),
             current=None,
             last_sequence=0,
@@ -281,6 +325,7 @@ class CacheDriver:
         ):
             return FinishResult(state="fenced")
         doc["start_status"] = "active"
+        doc["start_claimed_at"] = None
         wake: WakeToken | None = None
         if next_time is not None:
             wake = WakeToken(generation=generation, sequence=1, logical_time=next_time)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
@@ -178,9 +178,7 @@ class CacheDriver:
                 doc["idle_expires_at"] = iso(now + timedelta(seconds=idle_timeout_seconds))
                 self._write(doc, now)
             elif (
-                doc.pop("idle_expires_at", None) is not None
-                or self._token(doc) is None
-                or repaired
+                doc.pop("idle_expires_at", None) is not None or self._token(doc) is None or repaired
             ):
                 # A dormant chain (no current wake) has no wakes refreshing
                 # its TTL; the activation hook's touch is what keeps it alive.
@@ -232,7 +230,7 @@ class CacheDriver:
         any claim exists).
         """
         status = doc.get("start_status")
-        if status not in ("published", "processing"):
+        if status not in {"published", "processing"}:
             return False
         anchor = from_iso(doc.get("start_claimed_at")) or from_iso(doc.get("activation_time"))
         if anchor is None:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
@@ -257,6 +257,30 @@ class CacheDriver:
         self._write(doc, now)
         return changed
 
+    def apply_remote_pause(self, generation: int, issued_at: datetime, now: datetime) -> bool:
+        """Apply a queue-borne pause unless it is provably stale.
+
+        Control messages race starts and wakes on the topic and may be
+        redelivered after a resume minted a newer generation; pausing
+        whatever is current would let a stale pause overturn the resume. The
+        pause is dropped only when both indicators agree it is stale: the
+        issuer fenced an older generation than the local one *and* issued
+        before the local generation activated. Neither alone can decide —
+        the issuer reads the generation from its own evictable document and
+        may under-read it, and the timestamps come from different clocks.
+        """
+        issued_at = as_utc(issued_at, name="issued_at")
+        doc = self._read()
+        activation_time = from_iso(doc.get("activation_time"))
+        if (
+            generation < int(doc.get("generation") or 0)
+            and activation_time is not None
+            and issued_at < activation_time
+        ):
+            return False
+        self.pause(now)
+        return True
+
     def mark_start_published(self, generation: int, now: datetime) -> None:
         doc = self._read()
         if int(doc.get("generation") or 0) == generation and doc.get("start_status") == "pending":

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
@@ -1,0 +1,519 @@
+"""Cache driver: lifecycle state in one JSON document.
+
+Single-writer-mostly semantics; the queue's idempotency keys carry the
+single-successor guarantee. See the package docstring for the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contextlib import AbstractContextManager, nullcontext
+from datetime import datetime, timedelta, timezone
+
+from vercel.cache import get_cache
+
+from ..._time import as_utc
+from ..._types import (
+    WAKE_REPAIR_GRACE_SECONDS,
+    ClaimResult,
+    DriverSnapshot,
+    FinishResult,
+    StartDecision,
+    WakeToken,
+)
+from ._doc import DOC_TTL_SECONDS, from_iso, iso
+
+UTC = timezone.utc
+
+# A processing claim younger than this is treated as live (busy); past it,
+# the owner is presumed crashed and the claim is retaken (redis lease parity).
+_PROCESSING_GRACE_SECONDS = 15 * 60
+
+_LIFECYCLE_STATES = {"running", "paused", "inactive"}
+
+__all__ = ["CacheDriver"]
+
+
+def _lifecycle_state(value: Any) -> Any:
+    return value if value in _LIFECYCLE_STATES else None
+
+
+def _processing_is_live(doc: dict[str, Any], now: datetime) -> bool:
+    updated_at = from_iso(doc.get("updated_at"))
+    if updated_at is None:
+        return False
+    return (now - updated_at).total_seconds() < _PROCESSING_GRACE_SECONDS
+
+
+class CacheDriver:
+    """Driver state in one JSON document; single-writer-mostly semantics."""
+
+    def __init__(self, *, scope: str, scheduler_id: str, deployment: str) -> None:
+        self.scope = scope
+        self.scheduler_id = scheduler_id
+        self.deployment = deployment
+        self.key = f"aps:{scope}:{scheduler_id}:driver"
+        self.tag = f"aps:{scope}:{scheduler_id}"
+        self._store: Any = None
+
+    def _read(self) -> dict[str, Any]:
+        doc = get_cache().get(self.key)
+        if not isinstance(doc, dict):
+            return {}
+        return dict(doc)
+
+    def _write(self, doc: dict[str, Any], now: datetime) -> None:
+        doc["updated_at"] = iso(now)
+        get_cache().set(self.key, doc, {"ttl": DOC_TTL_SECONDS, "tags": [self.tag]})
+
+    def _token(self, doc: dict[str, Any]) -> WakeToken | None:
+        current = doc.get("current")
+        if not isinstance(current, dict):
+            return None
+        logical_time = from_iso(current.get("logical_time"))
+        if logical_time is None:
+            return None
+        return WakeToken(
+            generation=int(doc.get("generation") or 0),
+            sequence=int(current.get("sequence") or 0),
+            logical_time=logical_time,
+            status=str(current.get("status") or "pending"),
+        )
+
+    def _idle_lapsed(self, doc: dict[str, Any], now: datetime) -> bool:
+        deadline = from_iso(doc.get("idle_expires_at"))
+        return deadline is not None and doc.get("state") == "running" and now >= deadline
+
+    def _demote_if_idle(self, doc: dict[str, Any], now: datetime) -> bool:
+        if not self._idle_lapsed(doc, now):
+            return False
+        doc["state"] = "inactive"
+        doc["current"] = None
+        doc["start_status"] = None
+        self._write(doc, now)
+        return True
+
+    def start(
+        self,
+        now: datetime,
+        *,
+        idle_timeout_seconds: int | None = None,
+    ) -> StartDecision:
+        return self._activate(
+            now,
+            manual=True,
+            takeover_allowed=True,
+            idle_timeout_seconds=idle_timeout_seconds,
+        )
+
+    def auto_activate(
+        self,
+        now: datetime,
+        *,
+        idle_timeout_seconds: int | None = None,
+        takeover_allowed: bool = False,
+    ) -> StartDecision:
+        return self._activate(
+            now,
+            manual=False,
+            takeover_allowed=takeover_allowed,
+            idle_timeout_seconds=idle_timeout_seconds,
+        )
+
+    def _activate(
+        self,
+        now: datetime,
+        *,
+        manual: bool,
+        takeover_allowed: bool,
+        idle_timeout_seconds: int | None,
+    ) -> StartDecision:
+        now = as_utc(now, name="now")
+        doc = self._read()
+        self._demote_if_idle(doc, now)
+        state = doc.get("state")
+        owner = doc.get("owner_deployment")
+        foreign = owner is not None and owner != self.deployment
+        if foreign and not (manual or takeover_allowed):
+            return StartDecision(
+                generation=int(doc.get("generation") or 0),
+                changed=False,
+                start_status=str(doc.get("start_status") or ""),
+                current_wake=self._token(doc),
+                state=_lifecycle_state(state) or "running",
+                owned=False,
+            )
+        if state == "paused" and not manual:
+            if foreign:
+                return StartDecision(
+                    generation=int(doc.get("generation") or 0),
+                    changed=False,
+                    start_status=str(doc.get("start_status") or ""),
+                    current_wake=self._token(doc),
+                    state="paused",
+                    owned=False,
+                )
+            if idle_timeout_seconds is not None:
+                doc["idle_expires_at"] = iso(now + timedelta(seconds=idle_timeout_seconds))
+            # A paused chain publishes no wakes, so nothing else refreshes the
+            # document's TTL. Rewriting it here means the repeating activation
+            # hook keeps a paused scheduler's flag alive for as long as the
+            # deployment serves any traffic; only a fully abandoned namespace
+            # is reaped by the TTL.
+            self._write(doc, now)
+            return StartDecision(
+                generation=int(doc.get("generation") or 0),
+                changed=False,
+                start_status=str(doc.get("start_status") or ""),
+                current_wake=self._token(doc),
+                state="paused",
+            )
+        if state == "running" and not foreign:
+            if idle_timeout_seconds is not None:
+                doc["idle_expires_at"] = iso(now + timedelta(seconds=idle_timeout_seconds))
+                self._write(doc, now)
+            elif doc.pop("idle_expires_at", None) is not None or self._token(doc) is None:
+                # A dormant chain (no current wake) has no wakes refreshing
+                # its TTL; the activation hook's touch is what keeps it alive.
+                self._write(doc, now)
+            return StartDecision(
+                generation=int(doc.get("generation") or 0),
+                changed=False,
+                start_status=str(doc.get("start_status") or "active"),
+                current_wake=self._token(doc),
+            )
+        generation = int(doc.get("generation") or 0) + 1
+        doc.update(
+            state="running",
+            generation=generation,
+            owner_deployment=self.deployment,
+            start_status="pending",
+            activation_time=iso(now),
+            current=None,
+            last_sequence=0,
+            dirty_logical_time=None,
+        )
+        if idle_timeout_seconds is not None:
+            doc["idle_expires_at"] = iso(now + timedelta(seconds=idle_timeout_seconds))
+        else:
+            doc.pop("idle_expires_at", None)
+        self._write(doc, now)
+        return StartDecision(
+            generation=generation,
+            changed=True,
+            start_status="pending",
+            current_wake=None,
+        )
+
+    def pause(self, now: datetime) -> bool:
+        now = as_utc(now, name="now")
+        doc = self._read()
+        changed = doc.get("state") != "paused"
+        doc["state"] = "paused"
+        doc.setdefault("generation", 0)
+        self._write(doc, now)
+        return changed
+
+    def mark_start_published(self, generation: int, now: datetime) -> None:
+        doc = self._read()
+        if int(doc.get("generation") or 0) == generation and doc.get("start_status") == "pending":
+            doc["start_status"] = "published"
+            self._write(doc, as_utc(now, name="now"))
+
+    def claim_start(self, generation: int, owner: str, now: datetime) -> ClaimResult:
+        """Claim a start delivery, adopting newer generations from the message.
+
+        Cache documents are reconstructable hints — evictable in deployments,
+        per-process under ``vercel dev`` — so the message is the authority on
+        chain progress. A generation ahead of the local document is adopted
+        wholesale; ``paused`` fences only its own and older generations, so a
+        resume (which mints a new generation) revives a paused document.
+        """
+        now = as_utc(now, name="now")
+        doc = self._read()
+        if self._demote_if_idle(doc, now):
+            return ClaimResult(state="stale")
+        local_generation = int(doc.get("generation") or 0)
+        if generation < local_generation:
+            return ClaimResult(state="stale")
+        if generation == local_generation:
+            if (
+                doc.get("state") != "running"
+                or doc.get("owner_deployment") != self.deployment
+                or doc.get("start_status") in {None, "active"}
+            ):
+                return ClaimResult(state="stale")
+            if doc.get("start_status") == "processing" and _processing_is_live(doc, now):
+                return ClaimResult(state="busy")
+            activation_time = from_iso(doc.get("activation_time")) or now
+            doc["start_status"] = "processing"
+            self._write(doc, now)
+            return ClaimResult(state="claimed", activation_time=activation_time)
+        doc.update(
+            state="running",
+            generation=generation,
+            owner_deployment=self.deployment,
+            start_status="processing",
+            activation_time=iso(now),
+            current=None,
+            last_sequence=0,
+            dirty_logical_time=None,
+        )
+        self._write(doc, now)
+        return ClaimResult(state="claimed", activation_time=now)
+
+    def finish_start(
+        self,
+        generation: int,
+        owner: str,
+        next_time: datetime | None,
+        now: datetime,
+    ) -> FinishResult:
+        now = as_utc(now, name="now")
+        doc = self._read()
+        if self._demote_if_idle(doc, now):
+            return FinishResult(state="fenced")
+        if (
+            doc.get("state") != "running"
+            or int(doc.get("generation") or 0) != generation
+            or doc.get("owner_deployment") != self.deployment
+        ):
+            return FinishResult(state="fenced")
+        doc["start_status"] = "active"
+        wake: WakeToken | None = None
+        if next_time is not None:
+            wake = WakeToken(generation=generation, sequence=1, logical_time=next_time)
+            doc["current"] = {
+                "sequence": 1,
+                "logical_time": iso(next_time),
+                "status": "pending",
+            }
+            doc["last_sequence"] = 1
+        else:
+            doc["current"] = None
+            doc["last_sequence"] = 0
+        doc["dirty_logical_time"] = None
+        self._write(doc, now)
+        return FinishResult(state="advanced", wake=wake)
+
+    def mark_wake_published(self, generation: int, sequence: int, now: datetime) -> None:
+        doc = self._read()
+        current = doc.get("current")
+        if (
+            isinstance(current, dict)
+            and int(doc.get("generation") or 0) == generation
+            and int(current.get("sequence") or 0) == sequence
+            and current.get("status") == "pending"
+        ):
+            current["status"] = "published"
+            self._write(doc, as_utc(now, name="now"))
+
+    def _current_record(self, doc: dict[str, Any], token: WakeToken) -> dict[str, Any] | None:
+        """Return the mutable current-wake record iff owned and matching ``token``."""
+        if doc.get("state") != "running" or doc.get("owner_deployment") != self.deployment:
+            return None
+        current = self._token(doc)
+        record = doc.get("current")
+        if current is None or not isinstance(record, dict):
+            return None
+        actual = (current.generation, current.sequence, current.logical_time)
+        expected = (token.generation, token.sequence, token.logical_time)
+        return record if actual == expected else None
+
+    def claim_wake(self, token: WakeToken, owner: str, now: datetime) -> ClaimResult:
+        """Claim a wake delivery, adopting chain progress from the message.
+
+        Same authority rule as ``claim_start``: the local document loses to a
+        strictly newer ``(generation, sequence)``. An exact match claims the
+        recorded token; anything older is stale. ``paused`` fences its own
+        generation only.
+        """
+        now = as_utc(now, name="now")
+        doc = self._read()
+        if self._demote_if_idle(doc, now):
+            return ClaimResult(state="stale")
+        record = self._current_record(doc, token)
+        if record is not None:
+            if record.get("status") == "processing" and _processing_is_live(doc, now):
+                return ClaimResult(state="busy")
+            record["status"] = "processing"
+            self._write(doc, now)
+            activation_time = from_iso(doc.get("activation_time")) or now
+            return ClaimResult(state="claimed", activation_time=activation_time)
+        local_generation = int(doc.get("generation") or 0)
+        current = self._token(doc)
+        # The watermark survives dormancy, so a redelivered consumed wake is
+        # stale even when no current token exists.
+        watermark = max(
+            int(doc.get("last_sequence") or 0),
+            current.sequence if current is not None else 0,
+        )
+        if (token.generation, token.sequence) <= (local_generation, watermark):
+            return ClaimResult(state="stale")
+        if token.generation == local_generation and doc.get("state") != "running":
+            # Same-generation pause fences its remaining wakes.
+            return ClaimResult(state="stale")
+        activation_time = from_iso(doc.get("activation_time")) or now
+        doc.update(
+            state="running",
+            generation=token.generation,
+            owner_deployment=self.deployment,
+            start_status="active",
+            activation_time=iso(activation_time),
+            current={
+                "sequence": token.sequence,
+                "logical_time": iso(token.logical_time),
+                "status": "processing",
+            },
+            last_sequence=token.sequence,
+            dirty_logical_time=doc.get("dirty_logical_time"),
+        )
+        self._write(doc, now)
+        return ClaimResult(state="claimed", activation_time=activation_time)
+
+    def finish_wake(
+        self,
+        token: WakeToken,
+        owner: str,
+        next_time: datetime | None,
+        now: datetime,
+    ) -> FinishResult:
+        now = as_utc(now, name="now")
+        doc = self._read()
+        if self._demote_if_idle(doc, now):
+            return FinishResult(state="fenced")
+        if self._current_record(doc, token) is None:
+            return FinishResult(state="fenced")
+        dirty = from_iso(doc.get("dirty_logical_time"))
+        if dirty is not None and (next_time is None or dirty < next_time):
+            next_time = dirty
+        doc["dirty_logical_time"] = None
+        wake: WakeToken | None = None
+        if next_time is not None:
+            wake = WakeToken(
+                generation=token.generation,
+                sequence=token.sequence + 1,
+                logical_time=next_time,
+            )
+            doc["current"] = {
+                "sequence": token.sequence + 1,
+                "logical_time": iso(next_time),
+                "status": "pending",
+            }
+            doc["last_sequence"] = token.sequence + 1
+        else:
+            # Dormant, but the consumed position must stay recorded: a rearm
+            # that restarted at 1 would republish under already-used
+            # idempotency keys and the queue would silently drop the wake.
+            doc["current"] = None
+            doc["last_sequence"] = max(int(doc.get("last_sequence") or 0), token.sequence)
+        self._write(doc, now)
+        return FinishResult(state="advanced", wake=wake)
+
+    def snapshot(self) -> DriverSnapshot:
+        doc = self._read()
+        state = doc.get("state")
+        return DriverSnapshot(
+            state=_lifecycle_state(state) or "inactive",
+            generation=int(doc.get("generation") or 0),
+            start_status=doc.get("start_status"),
+            current_wake=self._token(doc),
+        )
+
+    def repair_overdue_wake(self, now: datetime) -> WakeToken | None:
+        now = as_utc(now, name="now")
+        doc = self._read()
+        if doc.get("state") != "running" or doc.get("owner_deployment") != self.deployment:
+            return None
+        current = self._token(doc)
+        if current is None or current.status == "pending":
+            # A pending wake needs publishing, not repairing; returning None
+            # keeps the loud presumed-lost warning honest.
+            return None
+        overdue_after = current.logical_time + timedelta(seconds=WAKE_REPAIR_GRACE_SECONDS)
+        record = doc.get("current")
+        if now < overdue_after or not isinstance(record, dict):
+            return None
+        record["status"] = "pending"
+        self._write(doc, now)
+        return self._token(doc)
+
+    def owner_deployment(self) -> str | None:
+        value = self._read().get("owner_deployment")
+        return value if isinstance(value, str) and value else None
+
+    def attach_store(self, store: Any) -> None:
+        self._store = store
+
+    def reconciled_deployment(self) -> str | None:
+        if self._store is None:
+            return None
+        value = self._store._load().get("reconciled_deployment")
+        return value if isinstance(value, str) and value else None
+
+    def mark_reconciled(self, deployment: str, now: datetime) -> bool:
+        del now
+        # Same fence as Redis mode: a demoted straggler must not stamp the
+        # marker (best-effort here, exact there). The marker is written into
+        # the jobs document so eviction clears them together and the next
+        # wake re-runs reconciliation instead of trusting a reaped store.
+        if self._store is None or self._read().get("owner_deployment") != deployment:
+            return False
+        doc = self._store._load()
+        doc["reconciled_deployment"] = deployment
+        self._store._store(doc)
+        return True
+
+    def renew(self, owner: str, now: datetime) -> bool:
+        return True
+
+    def release(self, owner: str) -> None:
+        return None
+
+    def renewing(self, owner: str) -> AbstractContextManager[None]:
+        return nullcontext()
+
+    def rearm_wake(self, candidate: datetime, now: datetime) -> None:
+        """Best-effort mirror of the Redis write fragment's rearm branch."""
+        now = as_utc(now, name="now")
+        candidate = as_utc(candidate, name="candidate")
+        doc = self._read()
+        if (
+            doc.get("state") != "running"
+            or doc.get("owner_deployment") != self.deployment
+            or doc.get("start_status") != "active"
+        ):
+            return
+        current = self._token(doc)
+        record = doc.get("current")
+        if (
+            current is not None
+            and isinstance(record, dict)
+            and record.get("status") == "processing"
+        ):
+            # An in-flight wake owns the token; replacing it would race its
+            # finish into a divergent payload under the same idempotency key.
+            # Fold the candidate into the successor instead (redis dirty
+            # parity): finish_wake takes min(dirty, computed next).
+            dirty = from_iso(doc.get("dirty_logical_time"))
+            if dirty is None or candidate < dirty:
+                doc["dirty_logical_time"] = iso(candidate)
+                self._write(doc, now)
+            return
+        if current is not None and current.logical_time <= candidate:
+            return
+        sequence = (
+            max(
+                int(doc.get("last_sequence") or 0),
+                current.sequence if current is not None else 0,
+            )
+            + 1
+        )
+        doc["current"] = {
+            "sequence": sequence,
+            "logical_time": iso(candidate),
+            "status": "pending",
+        }
+        doc["last_sequence"] = sequence
+        self._write(doc, now)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_jobstore.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_jobstore.py
@@ -1,0 +1,375 @@
+"""Cache job store and coordinator: best-effort, provenance-tagged."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import base64
+import logging
+import operator
+import pickle
+import random
+import time
+from datetime import datetime, timezone
+
+from apscheduler.job import Job  # type: ignore[import-untyped]
+from apscheduler.jobstores.base import (  # type: ignore[import-untyped]
+    BaseJobStore,
+    ConflictingIdError,
+    JobLookupError,
+)
+from apscheduler.util import (  # type: ignore[import-untyped]
+    datetime_to_utc_timestamp,
+    utc_timestamp_to_datetime,
+)
+from vercel.cache import get_cache
+
+from ..._types import (
+    PROVENANCE_DECLARED,
+    PROVENANCE_RUNTIME,
+    APSchedulerConfigurationError,
+    NamespaceFencedError,
+)
+from ._doc import _INDEX_MERGE_ATTEMPTS, DOC_TTL_SECONDS
+from ._driver import CacheDriver
+
+LOGGER = logging.getLogger("vercel.integrations.apscheduler")
+UTC = timezone.utc
+
+_UNCHANGED = object()
+
+__all__ = ["CacheJobCoordinator", "CacheJobStore"]
+
+
+class CacheJobStore(BaseJobStore):  # type: ignore[misc]
+    """APScheduler job store over one Runtime Cache document.
+
+    All jobs live in a single JSON document so every mutation is one
+    read-merge-write; the write methods are replaced by the coordinator at
+    bind time, exactly like the Redis store. Scaling note: this bounds the
+    practical job count by the cache's value-size limit; sharding is a
+    follow-up if real projects hit it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pickle_protocol = pickle.HIGHEST_PROTOCOL
+        self.doc_key: str | None = None
+        self.tag: str | None = None
+
+    def bind_namespace(self, *, scope: str, scheduler_id: str) -> None:
+        expected = (scope, scheduler_id)
+        namespace = getattr(self, "_vercel_apscheduler_namespace", None)
+        if namespace is not None and namespace != expected:
+            raise APSchedulerConfigurationError("job store is already bound to another scheduler")
+        self.doc_key = f"aps:{scope}:{scheduler_id}:jobs"
+        self.tag = f"aps:{scope}:{scheduler_id}"
+        self._vercel_apscheduler_namespace = expected
+
+    def _load(self) -> dict[str, Any]:
+        if self.doc_key is None:
+            raise APSchedulerConfigurationError("cache job store is not bound yet")
+        doc = get_cache().get(self.doc_key)
+        if not isinstance(doc, dict) or not isinstance(doc.get("jobs"), dict):
+            return {"revision_counter": 0, "jobs": {}}
+        normalized = {
+            "revision_counter": int(doc.get("revision_counter") or 0),
+            "jobs": dict(doc["jobs"]),
+        }
+        # The reconcile marker shares this document (and its eviction fate).
+        if isinstance(doc.get("reconciled_deployment"), str):
+            normalized["reconciled_deployment"] = doc["reconciled_deployment"]
+        return normalized
+
+    def _store(self, doc: dict[str, Any]) -> None:
+        if self.doc_key is None:
+            raise APSchedulerConfigurationError("cache job store is not bound yet")
+        get_cache().set(self.doc_key, doc, {"ttl": DOC_TTL_SECONDS, "tags": [self.tag]})
+
+    def _reconstitute_job(self, job_state: dict[str, Any]) -> Any:
+        """Rebuild a Job exactly as the upstream Redis store does."""
+        job = Job.__new__(Job)
+        job.__setstate__(job_state)
+        job._scheduler = self._scheduler
+        job._jobstore_alias = self._alias
+        return job
+
+    def _decode(self, record: dict[str, Any]) -> Any | None:
+        try:
+            state = pickle.loads(base64.b64decode(record["state"]))
+            return self._reconstitute_job(state)
+        except Exception:  # noqa: BLE001 - any unpickling failure quarantines
+            return None
+
+    @staticmethod
+    def _run_time(record: dict[str, Any]) -> float | None:
+        value = record.get("next_run_time_ts")
+        return float(value) if value is not None else None
+
+    def lookup_job(self, job_id: str) -> Any | None:
+        record = self._load()["jobs"].get(str(job_id))
+        if record is None:
+            return None
+        job = self._decode(record)
+        if job is not None:
+            job.id = str(job_id)
+        return job
+
+    def get_due_jobs(self, now: datetime) -> list[Any]:
+        timestamp = datetime_to_utc_timestamp(now)
+        jobs = []
+        for record in self._load()["jobs"].values():
+            run_time = self._run_time(record)
+            if record.get("quarantined") or run_time is None or run_time > timestamp:
+                continue
+            job = self._decode(record)
+            if job is not None:
+                jobs.append((run_time, job))
+        return [job for _, job in sorted(jobs, key=operator.itemgetter(0))]
+
+    def get_next_run_time(self) -> datetime | None:
+        run_times = [
+            run_time
+            for record in self._load()["jobs"].values()
+            if not record.get("quarantined") and (run_time := self._run_time(record)) is not None
+        ]
+        if not run_times:
+            return None
+        return utc_timestamp_to_datetime(min(run_times))
+
+    def get_all_jobs(self) -> list[Any]:
+        jobs = []
+        for record in self._load()["jobs"].values():
+            job = self._decode(record)
+            if job is not None:
+                jobs.append(job)
+        jobs.sort(
+            key=lambda job: (
+                job.next_run_time is None,
+                job.next_run_time or datetime.max.replace(tzinfo=UTC),
+            )
+        )
+        return jobs
+
+    def add_job(self, job: Any) -> None:  # pragma: no cover - replaced by install()
+        raise APSchedulerConfigurationError("cache job store used before binding")
+
+    def update_job(self, job: Any) -> None:  # pragma: no cover - replaced by install()
+        raise APSchedulerConfigurationError("cache job store used before binding")
+
+    def remove_job(self, job_id: str) -> None:  # pragma: no cover - replaced by install()
+        raise APSchedulerConfigurationError("cache job store used before binding")
+
+    def remove_all_jobs(self) -> None:  # pragma: no cover - replaced by install()
+        raise APSchedulerConfigurationError("cache job store used before binding")
+
+
+class CacheJobCoordinator:
+    """Couples the cache job store to its driver, best-effort.
+
+    Same surface as ``RedisJobCoordinator``; the revision counter and CAS
+    checks are read-merge-write rather than atomic, which shrinks but cannot
+    eliminate lost updates under concurrency. Declared jobs are protected by
+    reconciliation-from-code; runtime jobs accept the documented risk.
+    """
+
+    def __init__(self, store: CacheJobStore, driver: CacheDriver, adapter: Any) -> None:
+        self.store = store
+        self.driver = driver
+        self.adapter = adapter
+
+    def install(self) -> None:
+        self.store.add_job = self.add_job  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        self.store.update_job = self.update_job  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        self.store.remove_job = self.remove_job  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        self.store.remove_all_jobs = self.remove_all_jobs  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        self.store.__dict__["_vercel_apscheduler_coordinator"] = self
+
+    def _record(self, job: Any, revision: int, provenance: str) -> dict[str, Any]:
+        state = pickle.dumps(job.__getstate__(), self.store.pickle_protocol)
+        next_run_time = getattr(job, "next_run_time", None)
+        return {
+            "state": base64.b64encode(state).decode(),
+            "next_run_time_ts": (
+                datetime_to_utc_timestamp(next_run_time) if next_run_time is not None else None
+            ),
+            "revision": revision,
+            "provenance": provenance,
+            "quarantined": False,
+        }
+
+    def _provenance(self) -> str:
+        if self.adapter.is_runtime_mutation or self.adapter.is_wake_mutation:
+            return PROVENANCE_RUNTIME
+        return PROVENANCE_DECLARED
+
+    def _mutate(self, apply: Any, *, fenced: bool = True) -> Any:
+        """Read-merge-write with bounded retries against transient failures.
+
+        The owner fence is best-effort (checked against the driver document,
+        not atomically with the write), but it keeps the adapter's
+        ``NamespaceFencedError`` paths live: a demoted deployment's stale
+        pass aborts instead of resurrecting old declarations.
+        """
+        last_error: Exception | None = None
+        for attempt in range(_INDEX_MERGE_ATTEMPTS):
+            if fenced:
+                owner = self.driver.owner_deployment()
+                if owner is not None and owner != self.driver.deployment:
+                    raise NamespaceFencedError(
+                        f'deployment "{self.driver.deployment}" no longer drives '
+                        "this scheduler; the job-store write was fenced"
+                    )
+            try:
+                doc = self.store._load()
+                result = apply(doc)
+                if result is not _UNCHANGED:
+                    self.store._store(doc)
+            except APSchedulerConfigurationError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - cache I/O is best-effort
+                last_error = exc
+                time.sleep(random.uniform(0.02, 0.1) * (attempt + 1))
+            else:
+                return result
+        raise RuntimeError("cache job store write failed") from last_error
+
+    def _rearm(self, job: Any, *, always: bool = False) -> None:
+        # Adds rearm unconditionally, exactly like the Redis add script: a
+        # declaration restored onto a dormant chain (reconcile after jobs-doc
+        # eviction) must mint the wake nothing else will. rearm_wake's own
+        # guards make cold-start adds a no-op.
+        if not (always or self.adapter.is_runtime_mutation):
+            return
+        next_run_time = getattr(job, "next_run_time", None)
+        if next_run_time is None:
+            return
+        candidate = self.adapter.canonical_wakeup_time(next_run_time)
+        self.driver.rearm_wake(candidate, datetime.now(UTC))
+
+    def add_job(self, job: Any) -> None:
+        provenance = self._provenance()
+
+        def apply(doc: dict[str, Any]) -> Any:
+            if str(job.id) in doc["jobs"]:
+                return "conflict"
+            doc["revision_counter"] += 1
+            doc["jobs"][str(job.id)] = self._record(job, doc["revision_counter"], provenance)
+            return None
+
+        if self._mutate(apply) == "conflict":
+            # Declarations are insert-if-absent; runtime adds surface the
+            # conflict so replace_existing can route through update_job.
+            if self.adapter.is_runtime_mutation or self.adapter.is_wake_mutation:
+                raise ConflictingIdError(job.id)
+            return
+        self._rearm(job, always=True)
+
+    def update_job(self, job: Any) -> None:
+        def apply(doc: dict[str, Any]) -> Any:
+            record = doc["jobs"].get(str(job.id))
+            if record is None:
+                return "missing"
+            doc["revision_counter"] += 1
+            updated = self._record(job, doc["revision_counter"], record.get("provenance") or "")
+            doc["jobs"][str(job.id)] = updated
+            return None
+
+        if self._mutate(apply) == "missing":
+            raise JobLookupError(job.id)
+        self._rearm(job)
+
+    def remove_job(self, job_id: str) -> None:
+        def apply(doc: dict[str, Any]) -> Any:
+            if doc["jobs"].pop(str(job_id), None) is None:
+                return "missing"
+            doc["revision_counter"] += 1
+            return None
+
+        if self._mutate(apply) == "missing":
+            raise JobLookupError(job_id)
+
+    def remove_all_jobs(self) -> None:
+        def apply(doc: dict[str, Any]) -> Any:
+            doc["jobs"].clear()
+            doc["revision_counter"] += 1
+            return None
+
+        self._mutate(apply)
+
+    def get_due_jobs_with_revisions(self, now: datetime) -> list[tuple[Any, int]]:
+        timestamp = datetime_to_utc_timestamp(now)
+        due: list[tuple[float, Any, int]] = []
+        for job_id, record in self.store._load()["jobs"].items():
+            run_time = CacheJobStore._run_time(record)
+            if record.get("quarantined") or run_time is None or run_time > timestamp:
+                continue
+            job = self.store._decode(record)
+            if job is None:
+                self.quarantine_job(job_id)
+                continue
+            due.append((run_time, job, int(record.get("revision") or 0)))
+        due.sort(key=operator.itemgetter(0))
+        return [(job, revision) for _, job, revision in due]
+
+    def get_all_jobs_with_revisions(
+        self,
+    ) -> tuple[list[tuple[Any, int, str]], list[tuple[str, int, str]]]:
+        jobs: list[tuple[Any, int, str]] = []
+        undecodable: list[tuple[str, int, str]] = []
+        for job_id, record in self.store._load()["jobs"].items():
+            revision = int(record.get("revision") or 0)
+            provenance = str(record.get("provenance") or "")
+            job = self.store._decode(record)
+            if job is None:
+                undecodable.append((job_id, revision, provenance))
+                continue
+            jobs.append((job, revision, provenance))
+        jobs.sort(
+            key=lambda item: (
+                item[0].next_run_time is None,
+                item[0].next_run_time or datetime.max.replace(tzinfo=UTC),
+            ),
+        )
+        return jobs, undecodable
+
+    def cas_update_job(self, job: Any, expected_revision: int) -> bool:
+        def apply(doc: dict[str, Any]) -> Any:
+            record = doc["jobs"].get(str(job.id))
+            if record is None or int(record.get("revision") or 0) != expected_revision:
+                return False
+            doc["revision_counter"] += 1
+            doc["jobs"][str(job.id)] = self._record(
+                job,
+                doc["revision_counter"],
+                record.get("provenance") or "",
+            )
+            return True
+
+        return bool(self._mutate(apply) is True)
+
+    def cas_remove_job(self, job_id: str, expected_revision: int) -> bool:
+        def apply(doc: dict[str, Any]) -> Any:
+            record = doc["jobs"].get(str(job_id))
+            if record is None or int(record.get("revision") or 0) != expected_revision:
+                return False
+            del doc["jobs"][str(job_id)]
+            doc["revision_counter"] += 1
+            return True
+
+        return bool(self._mutate(apply) is True)
+
+    def quarantine_job(self, job_id: str) -> None:
+        def apply(doc: dict[str, Any]) -> Any:
+            record = doc["jobs"].get(str(job_id))
+            if record is None or record.get("quarantined"):
+                return _UNCHANGED
+            record["quarantined"] = True
+            return None
+
+        self._mutate(apply, fenced=False)
+        LOGGER.error(
+            'Quarantined APScheduler job "%s": its persisted definition can '
+            "no longer be loaded by this deployment's code",
+            job_id,
+        )

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/__init__.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/__init__.py
@@ -1,0 +1,99 @@
+"""Redis backend: the fully-guaranteed substrate (Lua CAS, fenced ownership)."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from dataclasses import dataclass
+
+from ..._imports import RedisJobStore
+from ..._options import _SchedulerIdentity
+from ..._types import APSchedulerConfigurationError
+from .._protocols import Driver, JobCoordinator
+from ._driver import RedisDriver
+from ._jobstore import RedisJobCoordinator
+
+RAW_STORE_KEY_ATTR = "_vercel_apscheduler_raw_jobs_key"
+
+__all__ = ["RAW_STORE_KEY_ATTR", "RedisBackend", "RedisDriver", "RedisJobCoordinator"]
+
+
+@dataclass
+class _Bound:
+    driver: Driver
+    coordinator: JobCoordinator
+
+
+class RedisBackend:
+    name = "redis"
+
+    def validate_configuration(self, scheduler: Any) -> dict[str, Any]:
+        stores = scheduler._jobstores
+        if "default" not in stores:
+            raise APSchedulerConfigurationError(
+                "vercel-apscheduler requires a configured default RedisJobStore"
+            )
+        if set(stores) != {"default"}:
+            aliases = ", ".join(sorted(stores))
+            raise APSchedulerConfigurationError(
+                "vercel-apscheduler v1 supports exactly one job store named "
+                f'"default"; configured: {aliases}'
+            )
+        if not isinstance(stores["default"], RedisJobStore):
+            raise APSchedulerConfigurationError(
+                "vercel-apscheduler requires a configured default RedisJobStore"
+            )
+        return cast("dict[str, Any]", dict(stores))
+
+    def supports_store(self, store: Any) -> bool:
+        return isinstance(store, RedisJobStore)
+
+    def identity_ready(self, scheduler: Any) -> bool:
+        """Whether the jobs_key-derived identity is already derivable.
+
+        It may only arrive through a later ``add_jobstore()``.
+        """
+        return isinstance(scheduler._jobstores.get("default"), RedisJobStore)
+
+    def derive_identity(self, scheduler: Any) -> _SchedulerIdentity:
+        store = scheduler._jobstores.get("default")
+        if not isinstance(store, RedisJobStore):
+            raise APSchedulerConfigurationError(
+                "vercel-apscheduler requires a configured default RedisJobStore"
+            )
+        raw_key = store.__dict__.setdefault(RAW_STORE_KEY_ATTR, store.jobs_key)
+        try:
+            return _SchedulerIdentity.from_store_key(raw_key)
+        except ValueError as exc:
+            raise APSchedulerConfigurationError(str(exc)) from exc
+
+    def bind(self, adapter: Any, *, scope: str, deployment: str) -> _Bound:
+        stores = self.validate_configuration(adapter.scheduler)
+        tag = f"{{{scope}:{adapter.identity.scheduler_id}}}"
+        expected_namespace = (scope, adapter.identity.scheduler_id)
+        for alias, store in stores.items():
+            namespace = getattr(store, "_vercel_apscheduler_namespace", None)
+            if namespace is not None and namespace != expected_namespace:
+                raise APSchedulerConfigurationError(
+                    f'job store "{alias}" is already bound to another scheduler'
+                )
+            if namespace is None:
+                if any(character in store.jobs_key + store.run_times_key for character in "{}"):
+                    raise APSchedulerConfigurationError(
+                        "custom Redis job-store keys cannot contain Redis hash tags"
+                    )
+                store.jobs_key = f"{store.jobs_key}:{tag}:jobs"
+                store.run_times_key = f"{store.run_times_key}:{tag}:run_times"
+                store.__dict__["_vercel_apscheduler_namespace"] = expected_namespace
+        driver = RedisDriver(
+            stores["default"].redis,
+            scope=scope,
+            scheduler_id=adapter.identity.scheduler_id,
+            deployment=deployment,
+        )
+        coordinator = RedisJobCoordinator(stores["default"], driver, adapter)
+        coordinator.install()
+        return _Bound(
+            driver=cast("Driver", driver),
+            coordinator=cast("JobCoordinator", coordinator),
+        )

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_driver.py
@@ -653,6 +653,14 @@ class RedisDriver:
         )
         return bool(int(result))
 
+    def apply_remote_pause(self, generation: int, issued_at: datetime, now: datetime) -> bool:
+        # Lifecycle control messages are only ever published in cache mode;
+        # the redis document is the single authority, so no staleness gate
+        # is needed if one were somehow delivered.
+        del generation, issued_at
+        self.pause(now)
+        return True
+
     def mark_start_published(self, generation: int, now: datetime) -> None:
         self._eval(
             _MARK_START_PUBLISHED_SCRIPT,

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_driver.py
@@ -2,114 +2,34 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import re
 import threading
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from ._time import as_utc
+from ..._time import as_utc
+from ..._types import (
+    WAKE_REPAIR_GRACE_SECONDS,
+    ClaimResult,
+    ClaimState,
+    DriverSnapshot,
+    FinishResult,
+    FinishState,
+    LifecycleState,
+    StartDecision,
+    WakeToken,
+)
 
 UTC = timezone.utc
 DRIVER_LEASE_SECONDS = 15 * 60
 DRIVER_RENEW_INTERVAL_SECONDS = 60
-# Long enough that a merely slow delivery or an in-progress retry cycle is
-# never declared dead, short enough that a stranded chain heals within one
-# activation sweep.
-WAKE_REPAIR_GRACE_SECONDS = 10 * 60
 _IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 # Scopes are either a deployment id or "<project>:<environment>".
 _SCOPE_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]+$")
 
-ClaimState = Literal["claimed", "busy", "stale"]
-FinishState = Literal["advanced", "fenced", "lost"]
-LifecycleState = Literal["running", "paused", "inactive"]
-
-__all__ = [
-    "APSchedulerConfigurationError",
-    "ClaimResult",
-    "DriverSnapshot",
-    "FinishResult",
-    "NamespaceFencedError",
-    "RedisDriver",
-    "StartDecision",
-    "WakeToken",
-]
-
-
-class APSchedulerConfigurationError(RuntimeError):
-    """Raised when a scheduler cannot satisfy the Vercel runtime contract."""
-
-
-class NamespaceFencedError(APSchedulerConfigurationError):
-    """Raised when a write is refused because another deployment owns the chain."""
-
-
-@dataclass(frozen=True, slots=True)
-class WakeToken:
-    """The one wake message currently allowed to advance a scheduler."""
-
-    generation: int
-    sequence: int
-    logical_time: datetime
-    status: str = "pending"
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "logical_time",
-            as_utc(self.logical_time, name="logical_time"),
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class StartDecision:
-    """Atomic result of starting or resuming a scheduler."""
-
-    generation: int
-    changed: bool
-    start_status: str
-    current_wake: WakeToken | None
-    state: LifecycleState = "running"
-    # False when another deployment owns the chain and the caller was not
-    # allowed to take it; every action besides serving must then be skipped.
-    owned: bool = True
-
-
-@dataclass(frozen=True, slots=True)
-class ClaimResult:
-    """Result of trying to own a start or wake delivery."""
-
-    state: ClaimState
-    activation_time: datetime | None = None
-
-    def __post_init__(self) -> None:
-        if self.activation_time is not None:
-            object.__setattr__(
-                self,
-                "activation_time",
-                as_utc(self.activation_time, name="activation_time"),
-            )
-
-
-@dataclass(frozen=True, slots=True)
-class FinishResult:
-    """Atomic outcome of completing a claimed start or wake."""
-
-    state: FinishState
-    wake: WakeToken | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class DriverSnapshot:
-    """Current durable driver state."""
-
-    state: LifecycleState
-    generation: int
-    start_status: str | None
-    current_wake: WakeToken | None
+__all__ = ["RedisDriver"]
 
 
 def _idle_demotion_block(*, now_ts: str, updated_at: str, clear_owner: bool, result: str) -> str:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_jobstore.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/redis/_jobstore.py
@@ -17,22 +17,22 @@ from apscheduler.util import (  # type: ignore[import-untyped]
     datetime_to_utc_timestamp,
 )
 
-from ._driver import NamespaceFencedError
-from ._imports import RedisJobStore
+from ..._imports import RedisJobStore
+from ..._types import (
+    PROVENANCE_DECLARED,
+    PROVENANCE_RUNTIME,
+    NamespaceFencedError,
+)
 
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
 if TYPE_CHECKING:
-    from ._adapter import SchedulerAdapter
+    from ..._adapter import SchedulerAdapter
     from ._driver import RedisDriver
 
 UTC = timezone.utc
-# Code owns "declared" jobs across deployments; the store owns "runtime" jobs.
-# Takeover reconciliation reads this on promote.
-PROVENANCE_DECLARED = "declared"
-PROVENANCE_RUNTIME = "runtime"
 
-__all__ = ["PROVENANCE_DECLARED", "PROVENANCE_RUNTIME", "RedisJobCoordinator"]
+__all__ = ["RedisJobCoordinator"]
 
 
 # Shared head of the job write scripts: refuse the whole write when another

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_control.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_control.py
@@ -1,0 +1,70 @@
+"""Queue-borne lifecycle control messages.
+
+The cache backend's lifecycle flags are only as visible as the cache is —
+per-process under ``vercel dev``, per-region in deployments. A ``pause()``
+therefore also rides the queue: a small control message on the start topic,
+applied to the local driver document by whichever subscriber processes it.
+Redelivery is harmless (pausing a paused chain is a no-op), so these carry
+no idempotency key. Resume needs no counterpart: it publishes a regular
+start message whose new generation is adopted by ``claim_start``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._payload import _envelope
+from ._time import as_utc
+
+LIFECYCLE_KIND = "apscheduler.lifecycle"
+LIFECYCLE_VERSION = 1
+LIFECYCLE_ACTIONS = frozenset({"pause"})
+
+__all__ = ["LIFECYCLE_ACTIONS", "LifecyclePayload"]
+
+
+@dataclass(frozen=True, slots=True)
+class LifecyclePayload:
+    scheduler_id: str
+    action: str
+    issued_at: datetime
+
+    def __post_init__(self) -> None:
+        if not self.scheduler_id:
+            raise ValueError("scheduler_id must be non-empty")
+        if self.action not in LIFECYCLE_ACTIONS:
+            raise ValueError(f"action must be one of {sorted(LIFECYCLE_ACTIONS)}")
+        object.__setattr__(
+            self,
+            "issued_at",
+            as_utc(self.issued_at, name="issued_at"),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "vercel": {"kind": LIFECYCLE_KIND, "version": LIFECYCLE_VERSION},
+            "scheduler_id": self.scheduler_id,
+            "action": self.action,
+            "issued_at": self.issued_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> LifecyclePayload:
+        envelope = _envelope(payload, kind=LIFECYCLE_KIND, version=LIFECYCLE_VERSION)
+        scheduler_id = envelope.get("scheduler_id")
+        if not isinstance(scheduler_id, str) or not scheduler_id:
+            raise ValueError("Invalid lifecycle payload: missing scheduler_id")
+        action = envelope.get("action")
+        if action not in LIFECYCLE_ACTIONS:
+            raise ValueError("Invalid lifecycle payload: unsupported action")
+        issued_at_raw = envelope.get("issued_at")
+        if not isinstance(issued_at_raw, str) or not issued_at_raw:
+            raise ValueError("Invalid lifecycle payload: missing issued_at")
+        try:
+            issued_at = datetime.fromisoformat(issued_at_raw)
+        except ValueError as exc:
+            raise ValueError("Invalid lifecycle payload: issued_at must be ISO-8601") from exc
+        return cls(scheduler_id=scheduler_id, action=action, issued_at=issued_at)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_control.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_control.py
@@ -4,9 +4,12 @@ The cache backend's lifecycle flags are only as visible as the cache is —
 per-process under ``vercel dev``, per-region in deployments. A ``pause()``
 therefore also rides the queue: a small control message on the start topic,
 applied to the local driver document by whichever subscriber processes it.
-Redelivery is harmless (pausing a paused chain is a no-op), so these carry
-no idempotency key. Resume needs no counterpart: it publishes a regular
-start message whose new generation is adopted by ``claim_start``.
+These carry no idempotency key, so a delivery may be late or repeated —
+including after a resume already minted a newer generation. The payload
+therefore carries the generation the issuer fenced and the issue time, and
+the applier drops a pause that both indicators date before the current
+activation. Resume needs no counterpart: it publishes a regular start
+message whose new generation is adopted by ``claim_start``.
 """
 
 from __future__ import annotations
@@ -31,12 +34,18 @@ class LifecyclePayload:
     scheduler_id: str
     action: str
     issued_at: datetime
+    # The generation the issuer's local document fenced. Zero when that
+    # document was evicted or never activated — the issuer cannot know more,
+    # which is exactly why the applier's staleness gate also weighs issued_at.
+    generation: int
 
     def __post_init__(self) -> None:
         if not self.scheduler_id:
             raise ValueError("scheduler_id must be non-empty")
         if self.action not in LIFECYCLE_ACTIONS:
             raise ValueError(f"action must be one of {sorted(LIFECYCLE_ACTIONS)}")
+        if self.generation < 0:
+            raise ValueError("generation must be greater than or equal to 0")
         object.__setattr__(
             self,
             "issued_at",
@@ -49,6 +58,7 @@ class LifecyclePayload:
             "scheduler_id": self.scheduler_id,
             "action": self.action,
             "issued_at": self.issued_at.isoformat(),
+            "generation": self.generation,
         }
 
     @classmethod
@@ -67,4 +77,12 @@ class LifecyclePayload:
             issued_at = datetime.fromisoformat(issued_at_raw)
         except ValueError as exc:
             raise ValueError("Invalid lifecycle payload: issued_at must be ISO-8601") from exc
-        return cls(scheduler_id=scheduler_id, action=action, issued_at=issued_at)
+        generation = envelope.get("generation")
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+            raise ValueError("Invalid lifecycle payload: generation must be a non-negative integer")
+        return cls(
+            scheduler_id=scheduler_id,
+            action=action,
+            issued_at=issued_at,
+            generation=generation,
+        )

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_payload.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_payload.py
@@ -7,8 +7,8 @@ from typing import Any
 from dataclasses import dataclass
 from datetime import datetime
 
-from ._driver import WakeToken
 from ._time import as_utc
+from ._types import WakeToken
 
 START_KIND = "apscheduler.start"
 START_VERSION = 1

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
@@ -180,17 +180,29 @@ def _process_lifecycle(
 ) -> None:
     """Apply a queue-borne lifecycle flag to the local driver document.
 
-    Only the cache backend publishes these; pausing an already-paused chain
-    is a no-op, so redelivery needs no dedup.
+    Only the cache backend publishes these. They carry no idempotency key,
+    so a delivery may arrive late or twice — including after a resume minted
+    a newer generation; the driver drops a pause that is provably stale for
+    the currently activated generation.
     """
     if not _targets_adapter(adapter, payload.scheduler_id, message, "lifecycle"):
         return
     if payload.action == "pause":
-        adapter.driver.pause(datetime.now(UTC))
-        LOGGER.info(
-            'Applied queue-borne pause to scheduler "%s"',
-            payload.scheduler_id,
+        applied = adapter.driver.apply_remote_pause(
+            payload.generation,
+            payload.issued_at,
+            datetime.now(UTC),
         )
+        if applied:
+            LOGGER.info(
+                'Applied queue-borne pause to scheduler "%s"',
+                payload.scheduler_id,
+            )
+        else:
+            LOGGER.info(
+                'Dropped a stale queue-borne pause for scheduler "%s"',
+                payload.scheduler_id,
+            )
 
 
 def _targets_adapter(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import vercel.queue as vqs
 
 from ._adapter import SchedulerAdapter, adopt_scheduler
+from ._control import LifecyclePayload
 from ._imports import BaseScheduler
 from ._options import VercelAPSchedulerOptions
 from ._payload import StartPayload, WakeupPayload
@@ -70,12 +71,17 @@ def _process_start(
 ) -> None:
     try:
         payload = StartPayload.from_payload(message.payload)
-    except ValueError as exc:
-        LOGGER.warning(
-            "Ignoring invalid APScheduler start message %s: %s",
-            message.metadata.message_id,
-            exc,
-        )
+    except ValueError as start_error:
+        try:
+            control = LifecyclePayload.from_payload(message.payload)
+        except ValueError:
+            LOGGER.warning(
+                "Ignoring invalid APScheduler start message %s: %s",
+                message.metadata.message_id,
+                start_error,
+            )
+            return
+        _process_lifecycle(adapter, control, message)
         return
     if not _targets_adapter(adapter, payload.scheduler_id, message, "start"):
         return
@@ -93,7 +99,7 @@ def _process_start(
         return
     activation_time = claim.activation_time
     if activation_time is None:
-        raise RuntimeError("Redis start claim omitted its activation time")
+        raise RuntimeError("durable start claim omitted its activation time")
 
     try:
         with adapter.driver.renewing(owner):
@@ -165,6 +171,26 @@ def _process_wakeup(
                 adapter.publish_wakeup(finish.wake)
     finally:
         adapter.driver.release(owner)
+
+
+def _process_lifecycle(
+    adapter: SchedulerAdapter,
+    payload: LifecyclePayload,
+    message: vqs.Message[dict[str, Any]],
+) -> None:
+    """Apply a queue-borne lifecycle flag to the local driver document.
+
+    Only the cache backend publishes these; pausing an already-paused chain
+    is a no-op, so redelivery needs no dedup.
+    """
+    if not _targets_adapter(adapter, payload.scheduler_id, message, "lifecycle"):
+        return
+    if payload.action == "pause":
+        adapter.driver.pause(datetime.now(UTC))
+        LOGGER.info(
+            'Applied queue-borne pause to scheduler "%s"',
+            payload.scheduler_id,
+        )
 
 
 def _targets_adapter(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_types.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_types.py
@@ -1,0 +1,116 @@
+"""Backend-neutral durable-contract types.
+
+These are the vocabulary the adapter, subscriber, and payloads speak with
+whichever backend coordinates the chain; nothing here knows how state is
+stored.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._time import as_utc
+
+# Long enough that a merely slow delivery or an in-progress retry cycle is
+# never declared dead, short enough that a stranded chain heals within one
+# activation sweep.
+WAKE_REPAIR_GRACE_SECONDS = 10 * 60
+
+PROVENANCE_DECLARED = "declared"
+PROVENANCE_RUNTIME = "runtime"
+
+ClaimState = Literal["claimed", "busy", "stale"]
+FinishState = Literal["advanced", "fenced", "lost"]
+LifecycleState = Literal["running", "paused", "inactive"]
+
+__all__ = [
+    "PROVENANCE_DECLARED",
+    "PROVENANCE_RUNTIME",
+    "WAKE_REPAIR_GRACE_SECONDS",
+    "APSchedulerConfigurationError",
+    "ClaimResult",
+    "ClaimState",
+    "DriverSnapshot",
+    "FinishResult",
+    "FinishState",
+    "LifecycleState",
+    "NamespaceFencedError",
+    "StartDecision",
+    "WakeToken",
+]
+
+
+class APSchedulerConfigurationError(RuntimeError):
+    """Raised when a scheduler cannot satisfy the Vercel runtime contract."""
+
+
+class NamespaceFencedError(APSchedulerConfigurationError):
+    """Raised when a write is refused because another deployment owns the chain."""
+
+
+@dataclass(frozen=True, slots=True)
+class WakeToken:
+    """The one wake message currently allowed to advance a scheduler."""
+
+    generation: int
+    sequence: int
+    logical_time: datetime
+    status: str = "pending"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "logical_time",
+            as_utc(self.logical_time, name="logical_time"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StartDecision:
+    """Atomic result of starting or resuming a scheduler."""
+
+    generation: int
+    changed: bool
+    start_status: str
+    current_wake: WakeToken | None
+    state: LifecycleState = "running"
+    # False when another deployment owns the chain and the caller was not
+    # allowed to take it; every action besides serving must then be skipped.
+    owned: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimResult:
+    """Result of trying to own a start or wake delivery."""
+
+    state: ClaimState
+    activation_time: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.activation_time is not None:
+            object.__setattr__(
+                self,
+                "activation_time",
+                as_utc(self.activation_time, name="activation_time"),
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class FinishResult:
+    """Atomic outcome of completing a claimed start or wake."""
+
+    state: FinishState
+    wake: WakeToken | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DriverSnapshot:
+    """Current durable driver state."""
+
+    state: LifecycleState
+    generation: int
+    start_status: str | None
+    current_wake: WakeToken | None

--- a/uv.lock
+++ b/uv.lock
@@ -2524,6 +2524,7 @@ source = { editable = "integrations/vercel-apscheduler" }
 dependencies = [
     { name = "apscheduler" },
     { name = "redis" },
+    { name = "vercel-cache" },
     { name = "vercel-queue" },
 ]
 
@@ -2531,6 +2532,7 @@ dependencies = [
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.4,<4" },
     { name = "redis", specifier = ">=5,<7" },
+    { name = "vercel-cache", editable = "src/vercel-cache" },
     { name = "vercel-queue", editable = "src/vercel-queue" },
 ]
 


### PR DESCRIPTION
Adds another backend for APScheduler integration based on Vercel Runtime Cache.

---

Redis backend stays the fully-guaranteed backend, but it is no longer the entry fee. A project with no `RedisJobStore` now runs on the Vercel Runtime Cache:

```python
scheduler = BlockingScheduler()   # no jobstores, no REDIS_URL

@scheduler.scheduled_job("cron", hour=4, id="cleanup", replace_existing=True)
def cleanup() -> None: ...
```

```toml
[[tool.vercel.subscribers]]
entrypoint = "scheduler:scheduler"
```

Backend selection is automatic (a configured `RedisJobStore` selects redis; anything else selects cache) and overridable with `VERCEL_APSCHEDULER_BACKEND=redis|cache`. The Redis path is byte-for-byte the existing behavior.

The integration core (_adapter, _subscriber, payloads) no longer contains backend-specific code. Shared contract types moved to _types.py; the Redis driver and coordinator moved (git mv, history preserved) under `_backends/redis/`; the new backend lives under `_backends/cache/`. Backends satisfy three protocols — `Driver`, `JobCoordinator`, `Backend`

---

### How it works


The Runtime Cache has no compare-and-swap and its entries are evictable, so none of the Redis invariants can live in storage. Each guarantee is relocated to something that can actually carry it:

```
in redis mode, the store is the authority and messages point into it
in cache mode, the messages are the authority and the store is a hint
```

- Single successor moves to the queue. Racing finishers compute identical canonical logical times and identical idempotency keys (`aps:wake:{scope}:{sid}:{gen}:{seq}`); the queue accepts the publication once. The chain cannot fork even when claims race. Claims themselves become best-effort filters, so the contract is `at-least-once` with a wider duplicate window than redis mode.
- Chain progress travels in the messages. A claim adopts any generation or wake token strictly ahead of the local document, so an evicted document never strands the chain. `paused` fences only its own and older generations; a `resume's new generation revives a paused document.
- Declared jobs are reconstructable, not durable. Code is the backup: takeover reconciliation doubles as the eviction repairer, rewriting the declared set (provenance-tagged, fingerprint-compared) whenever the reconciled marker is missing. A fully evicted namespace heals on the next wake.
- Runtime mutations and lifecycle flags are best-effort by design: `read-merge-write` with bounded jittered retries, last writer wins, lost on eviction. `pause()` additionally rides the queue as a control message on the start topic, because a cache write is only as visible as the cache — the queue is the one bus both backends share.

Comparasion table:

| Property            | Redis                 | Runtime Cache                                  |
|---------------------|-----------------------|------------------------------------------------|
| One chain, no forks | atomic Lua claims     | queue idempotency keys                         |
| Execution           | at-least-once         | at-least-once, wider duplicate window          |
| Declared jobs       | durable               | rebuilt from code after eviction               |
| Runtime add_job()   | durable, revision-CAS | best-effort                                    |
| pause()             | durable, fails closed | best-effort flag + queue-borne control message |

---

### Adapter changes

Two deliberate behavior changes while wiring the seam. Reconciliation gating is now durable-marker-first (`reconciled_deployment` consulted before the in-process flag, which becomes a cache of it) — required for eviction self-heal, and it also fixes re-reconciliation when a rollback lands on a warm instance. And `_scope_outlives_deployments` is always true for the cache backend: its documents are evictable in every scope, so reconciliation-from-code applies even to deployment-scoped previews.
