### PR TITLE
Check news fragments in CI

### DIFF
--- a/.github/workflows/news-fragments.yml
+++ b/.github/workflows/news-fragments.yml
@@ -1,0 +1,29 @@
+name: News Fragments
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  check-news-fragments:
+    name: Check news fragments
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Check news fragments
+        run: uv run --locked poe check-news-fragments
+        env:
+          WORKSPACE_POE_GIT_BASE: ${{ github.event.pull_request.base.sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ include = "../../scripts/poe/poe.toml"
 verbosity = -1
 ```
 
+# News Fragments
+
+- Before opening a pull request or handing work back to the user, run
+  `uv run poe check-news-fragments`.
+- If the check reports missing fragments, add them with `uv run poe changelog`
+  or explicitly tell the user that the pull request requires them to pass CI.
+  Do not silently hand off package-code changes without the required fragments.
+
 # Commit Message Guidance
 
 - Keep commit messages short and specific.

--- a/scripts/githooks/helpers/pre-push-commit.sh
+++ b/scripts/githooks/helpers/pre-push-commit.sh
@@ -1,6 +1,31 @@
 #!/usr/bin/env sh
 
-if [ "${WORKSPACE_POE_GIT_SCOPE:-}" != commit ] || [ -n "${WORKSPACE_POE_GIT_COMMIT:-}" ]; then
+if [ "${WORKSPACE_POE_GIT_SCOPE:-}" != commit ]; then
+  return 0
+fi
+
+set_pre_push_base() {
+  if [ -n "${WORKSPACE_POE_GIT_BASE:-}" ] || [ -z "${1:-}" ]; then
+    return 0
+  fi
+
+  configured_base=$(git config --get "branch.$1.gh-merge-base" 2>/dev/null || true)
+  if [ -z "$configured_base" ]; then
+    return 0
+  fi
+
+  candidate="origin/$configured_base"
+  if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+    WORKSPACE_POE_GIT_BASE=$candidate
+    export WORKSPACE_POE_GIT_BASE
+  else
+    printf 'Configured pre-push base %s is unavailable; falling back to the default base.\n' "$candidate" >&2
+  fi
+}
+
+if [ -n "${WORKSPACE_POE_GIT_COMMIT:-}" ]; then
+  current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  set_pre_push_base "$current_branch"
   return 0
 fi
 
@@ -10,6 +35,9 @@ if [ ! -t 0 ]; then
     if [ -n "$local_ref" ] && [ "$local_sha" != "$zero_sha" ]; then
       WORKSPACE_POE_GIT_COMMIT=$local_sha
       export WORKSPACE_POE_GIT_COMMIT
+      case "$local_ref" in
+        refs/heads/*) set_pre_push_base "${local_ref#refs/heads/}" ;;
+      esac
       return 0
     fi
   done || true
@@ -17,3 +45,5 @@ fi
 
 WORKSPACE_POE_GIT_COMMIT=$(git rev-parse HEAD)
 export WORKSPACE_POE_GIT_COMMIT
+current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+set_pre_push_base "$current_branch"

--- a/scripts/poe/README.md
+++ b/scripts/poe/README.md
@@ -207,6 +207,11 @@ Commit mode materializes `git archive` for `WORKSPACE_POE_GIT_COMMIT`, or
 hooks use this mode and set `WORKSPACE_POE_GIT_COMMIT` from Git's pre-push
 input so checks run against the commit tree being pushed.
 
+For stacked branches, the pre-push hook follows the local
+`branch.<name>.gh-merge-base` signal used by GitHub's tooling when available.
+Otherwise it falls back to `origin/main` or `origin/master`; CI uses the pull
+request's exact base commit and remains authoritative.
+
 The managed `pre-push.checks` hook invokes `uv run poe pre-push`, which runs
 news-fragment, lint, typecheck, and test checks concurrently through the
 Python/lograil runner.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -701,7 +701,7 @@ def check_fragments(base: str | None = None) -> int:
     fragments = parse_fragments(set(packages_by_name))
     head = os.environ.get("WORKSPACE_POE_GIT_COMMIT")
     if base is None:
-        base = _default_base_ref()
+        base = os.environ.get("WORKSPACE_POE_GIT_BASE") or _default_base_ref()
     if base is None:
         print("Could not detect a base branch for news fragment enforcement.")
         return 1

--- a/tests/unit/test_pre_push_hook.py
+++ b/tests/unit/test_pre_push_hook.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+HELPER = Path(__file__).resolve().parents[2] / "scripts/githooks/helpers/pre-push-commit.sh"
+ZERO_SHA = "0" * 40
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(("git", *args), cwd=repo, text=True).strip()
+
+
+def init_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.check_call(("git", "init", "-q", "-b", "feature"), cwd=repo)
+    subprocess.check_call(("git", "config", "user.name", "Test User"), cwd=repo)
+    subprocess.check_call(("git", "config", "user.email", "test@example.com"), cwd=repo)
+    subprocess.check_call(("git", "config", "commit.gpgsign", "false"), cwd=repo)
+    (repo / "file.txt").write_text("content\n", encoding="utf-8")
+    subprocess.check_call(("git", "add", "file.txt"), cwd=repo)
+    subprocess.check_call(("git", "commit", "-q", "-m", "Initial"), cwd=repo)
+    return repo, git(repo, "rev-parse", "HEAD")
+
+
+def run_helper(repo: Path, stdin: str) -> subprocess.CompletedProcess[str]:
+    script = f"""
+WORKSPACE_POE_GIT_SCOPE=commit
+unset WORKSPACE_POE_GIT_COMMIT WORKSPACE_POE_GIT_BASE
+. {shlex.quote(str(HELPER))}
+printf '%s\\n' "$WORKSPACE_POE_GIT_COMMIT" "${{WORKSPACE_POE_GIT_BASE:-}}"
+"""
+    return subprocess.run(
+        ("sh", "-c", script),
+        cwd=repo,
+        env=os.environ.copy(),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def test_pre_push_uses_configured_github_merge_base(tmp_path: Path) -> None:
+    repo, head = init_repo(tmp_path)
+    subprocess.check_call(("git", "update-ref", "refs/remotes/origin/parent", head), cwd=repo)
+    subprocess.check_call(("git", "config", "branch.feature.gh-merge-base", "parent"), cwd=repo)
+
+    result = run_helper(repo, f"refs/heads/feature {head} refs/heads/feature {ZERO_SHA}\n")
+
+    assert result.stdout.splitlines() == [head, "origin/parent"]
+    assert result.stderr == ""
+
+
+def test_pre_push_falls_back_when_configured_base_is_unavailable(tmp_path: Path) -> None:
+    repo, head = init_repo(tmp_path)
+    subprocess.check_call(("git", "config", "branch.feature.gh-merge-base", "missing"), cwd=repo)
+
+    result = run_helper(repo, f"refs/heads/feature {head} refs/heads/feature {ZERO_SHA}\n")
+
+    assert result.stdout.splitlines() == [head, ""]
+    assert "falling back to the default base" in result.stderr
+
+
+def test_pre_push_ignores_branch_deletions(tmp_path: Path) -> None:
+    repo, head = init_repo(tmp_path)
+
+    result = run_helper(repo, f"(delete) {ZERO_SHA} refs/heads/feature {head}\n")
+
+    assert result.stdout.splitlines() == [head, ""]

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -790,6 +790,42 @@ def test_check_fragments_requires_changed_package_fragment(
     assert "Run `poe changelog`" in output
 
 
+def test_check_fragments_uses_environment_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, str | None]] = []
+
+    def changed_paths(*, base: str, head: str | None) -> set[Path]:
+        seen.append((base, head))
+        return set()
+
+    monkeypatch.setattr(workspace, "packages", lambda: {})
+    monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
+    monkeypatch.setenv("WORKSPACE_POE_GIT_BASE", "stack-base")
+    monkeypatch.setenv("WORKSPACE_POE_GIT_COMMIT", "pushed-head")
+    monkeypatch.setattr(release, "_default_base_ref", lambda: pytest.fail("unexpected fallback"))
+    monkeypatch.setattr(release, "_changed_paths", changed_paths)
+
+    assert release.check_fragments() == 0
+    assert seen == [("stack-base", "pushed-head")]
+
+
+def test_check_fragments_explicit_base_overrides_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+
+    def changed_paths(*, base: str, head: str | None) -> set[Path]:
+        seen.append(base)
+        return set()
+
+    monkeypatch.setattr(workspace, "packages", lambda: {})
+    monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
+    monkeypatch.setenv("WORKSPACE_POE_GIT_BASE", "environment-base")
+    monkeypatch.setattr(release, "_changed_paths", changed_paths)
+
+    assert release.check_fragments(base="explicit-base") == 0
+    assert seen == ["explicit-base"]
+
+
 def test_check_fragments_exempts_release_prep_version_bumps(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Add a standalone PR check that compares package changes with the pull request's exact base commit.

Honor GitHub's local merge-base signal in pre-push checks so stacked branches receive the same validation before CI.