### PR TITLE
workflow: honour the workflow-server and proxy URL overrides

### DIFF
--- a/changes/vercel/workflow-server-url.bugfix.md
+++ b/changes/vercel/workflow-server-url.bugfix.md
@@ -1,0 +1,3 @@
+The Vercel world now honours `VERCEL_WORKFLOW_SERVER_URL` and
+`WORKFLOW_VERCEL_BACKEND_URL`, which previously had no effect in Python, so a
+preview deployment reaches the same workflow-server as its TypeScript peers.

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -17,25 +17,6 @@ from vercel.oidc.aio import get_vercel_oidc_token
 
 from .. import world as w
 
-# Hard-coded workflow-server URL override for testing.
-# Set this to test against a different workflow-server version, or leave it
-# empty and set VERCEL_WORKFLOW_SERVER_URL in the environment instead.
-# Empty and unset means production (uses default vercel-workflow.com).
-#
-# Example: 'https://workflow-server-git-branch-name.vercel.sh'
-#
-WORKFLOW_SERVER_URL_OVERRIDE = ""
-
-
-def _workflow_server_url_override() -> str:
-    """Resolve the workflow-server URL override, or "" for the default.
-
-    Mirrors world-vercel's precedence in utils.ts: the hard-coded constant
-    wins, then VERCEL_WORKFLOW_SERVER_URL.
-    """
-    return WORKFLOW_SERVER_URL_OVERRIDE or os.getenv("VERCEL_WORKFLOW_SERVER_URL", "")
-
-
 MAX_DELAY_SECONDS = float(
     os.getenv("VERCEL_QUEUE_MAX_DELAY_SECONDS", "82800")
 )  # 23 hours - leave 1h buffer before 24h retention limit
@@ -91,7 +72,11 @@ class VercelWorld(w.World):
     ) -> None:
         self._token = token
         self._queue_callbacks: list[Any] = []
-        server_url_override = _workflow_server_url_override()
+        # Points the world at a workflow-server other than production, e.g. a
+        # branch deployment. world-vercel also has an inline constant that
+        # wins over this; there is nothing here to rewrite one, so the
+        # environment is the only way in.
+        server_url_override = os.getenv("VERCEL_WORKFLOW_SERVER_URL", "")
 
         # utils.ts, getHttpUrl
         # Use proxy when we have project config (for authentication via Vercel API)

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -100,7 +100,11 @@ class VercelWorld(w.World):
         # header if override is set)
         # When not using proxy, use the default workflow-server URL (with /api path appended)
         if self._using_proxy:
-            self._base_url = "https://api.vercel.com/v1/workflow"
+            # WORKFLOW_VERCEL_BACKEND_URL swaps the proxy itself, independently
+            # of the workflow-server override above.
+            self._base_url = (
+                os.getenv("WORKFLOW_VERCEL_BACKEND_URL") or "https://api.vercel.com/v1/workflow"
+            )
         else:
             default_host = server_url_override or "https://vercel-workflow.com"
             self._base_url = f"{default_host}/api"

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -18,12 +18,23 @@ from vercel.oidc.aio import get_vercel_oidc_token
 from .. import world as w
 
 # Hard-coded workflow-server URL override for testing.
-# Set this to test against a different workflow-server version.
-# Leave empty string for production (uses default vercel-workflow.com).
+# Set this to test against a different workflow-server version, or leave it
+# empty and set VERCEL_WORKFLOW_SERVER_URL in the environment instead.
+# Empty and unset means production (uses default vercel-workflow.com).
 #
 # Example: 'https://workflow-server-git-branch-name.vercel.sh'
 #
 WORKFLOW_SERVER_URL_OVERRIDE = ""
+
+
+def _workflow_server_url_override() -> str:
+    """Resolve the workflow-server URL override, or "" for the default.
+
+    Mirrors world-vercel's precedence in utils.ts: the hard-coded constant
+    wins, then VERCEL_WORKFLOW_SERVER_URL.
+    """
+    return WORKFLOW_SERVER_URL_OVERRIDE or os.getenv("VERCEL_WORKFLOW_SERVER_URL", "")
+
 
 MAX_DELAY_SECONDS = float(
     os.getenv("VERCEL_QUEUE_MAX_DELAY_SECONDS", "82800")
@@ -80,6 +91,7 @@ class VercelWorld(w.World):
     ) -> None:
         self._token = token
         self._queue_callbacks: list[Any] = []
+        server_url_override = _workflow_server_url_override()
 
         # utils.ts, getHttpUrl
         # Use proxy when we have project config (for authentication via Vercel API)
@@ -90,7 +102,7 @@ class VercelWorld(w.World):
         if self._using_proxy:
             self._base_url = "https://api.vercel.com/v1/workflow"
         else:
-            default_host = WORKFLOW_SERVER_URL_OVERRIDE or "https://vercel-workflow.com"
+            default_host = server_url_override or "https://vercel-workflow.com"
             self._base_url = f"{default_host}/api"
 
         # utils.ts, getUserAgent
@@ -111,8 +123,8 @@ class VercelWorld(w.World):
         # Only set workflow-api-url header when using the proxy, since the proxy
         # forwards it to the workflow-server. When not using proxy, requests go
         # directly to the workflow-server so this header has no effect.
-        if WORKFLOW_SERVER_URL_OVERRIDE and self._using_proxy:
-            self._headers["x-vercel-workflow-api-url"] = WORKFLOW_SERVER_URL_OVERRIDE
+        if server_url_override and self._using_proxy:
+            self._headers["x-vercel-workflow-api-url"] = server_url_override
 
         self._queue_clients: dict[object, vqs.QueueClient] = {}
 

--- a/src/vercel/tests/unit/test_workflow_server_url_override.py
+++ b/src/vercel/tests/unit/test_workflow_server_url_override.py
@@ -1,13 +1,11 @@
 """Tests for the URL overrides VercelWorld reads, mirroring world-vercel's
 ``utils.ts``.
 
-Two independent knobs:
+Two independent knobs, one per hop:
 
-- the workflow-server override — the hard-coded ``WORKFLOW_SERVER_URL_OVERRIDE``
-  constant wins, then the ``VERCEL_WORKFLOW_SERVER_URL`` environment variable,
-  then the production default. Preview deployments carry the env var, so a
-  Python app has to honour it to reach the same workflow-server as its
-  TypeScript peers.
+- ``VERCEL_WORKFLOW_SERVER_URL``, the workflow-server itself. Preview
+  deployments carry it, so a Python app has to honour it to reach the same
+  workflow-server as its TypeScript peers.
 - ``WORKFLOW_VERCEL_BACKEND_URL``, which swaps the api.vercel.com proxy the
   world talks to when it has project config.
 """
@@ -19,14 +17,12 @@ import pytest
 from vercel._internal.workflow.worlds import vercel as vercel_mod
 
 BRANCH_URL = "https://workflow-server-git-branch.vercel.sh"
-PINNED_URL = "https://workflow-server-pinned.vercel.sh"
 BACKEND_URL = "https://api-vercel-git-branch.vercel.sh/v1/workflow"
 
 
 @pytest.fixture(autouse=True)
 def _clean_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Start every test from "no constant, no env var"."""
-    monkeypatch.setattr(vercel_mod, "WORKFLOW_SERVER_URL_OVERRIDE", "")
+    """Start every test from "neither variable set"."""
     monkeypatch.delenv("VERCEL_WORKFLOW_SERVER_URL", raising=False)
     monkeypatch.delenv("WORKFLOW_VERCEL_BACKEND_URL", raising=False)
 
@@ -55,15 +51,6 @@ def test_env_var_reaches_the_proxy_as_a_header(monkeypatch: pytest.MonkeyPatch) 
     # forwards to the workflow-server.
     assert world._base_url == "https://api.vercel.com/v1/workflow"
     assert world._headers["x-vercel-workflow-api-url"] == BRANCH_URL
-
-
-def test_hard_coded_constant_wins_over_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(vercel_mod, "WORKFLOW_SERVER_URL_OVERRIDE", PINNED_URL)
-    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
-
-    world = vercel_mod.VercelWorld(token="tok")
-
-    assert world._base_url == f"{PINNED_URL}/api"
 
 
 def test_backend_url_swaps_the_proxy(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/vercel/tests/unit/test_workflow_server_url_override.py
+++ b/src/vercel/tests/unit/test_workflow_server_url_override.py
@@ -1,0 +1,70 @@
+"""Tests for the workflow-server URL override on VercelWorld.
+
+The override mirrors world-vercel's ``utils.ts`` precedence: the hard-coded
+``WORKFLOW_SERVER_URL_OVERRIDE`` constant wins, then the
+``VERCEL_WORKFLOW_SERVER_URL`` environment variable, then the production
+default. Preview deployments carry the env var, so a Python app has to honour
+it to reach the same workflow-server as its TypeScript peers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vercel._internal.workflow.worlds import vercel as vercel_mod
+
+BRANCH_URL = "https://workflow-server-git-branch.vercel.sh"
+PINNED_URL = "https://workflow-server-pinned.vercel.sh"
+
+
+@pytest.fixture(autouse=True)
+def _clean_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from "no constant, no env var"."""
+    monkeypatch.setattr(vercel_mod, "WORKFLOW_SERVER_URL_OVERRIDE", "")
+    monkeypatch.delenv("VERCEL_WORKFLOW_SERVER_URL", raising=False)
+
+
+def test_defaults_to_production_without_an_override() -> None:
+    world = vercel_mod.VercelWorld(token="tok")
+
+    assert world._base_url == "https://vercel-workflow.com/api"
+    assert "x-vercel-workflow-api-url" not in world._headers
+
+
+def test_env_var_redirects_the_direct_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
+
+    world = vercel_mod.VercelWorld(token="tok")
+
+    assert world._base_url == f"{BRANCH_URL}/api"
+
+
+def test_env_var_reaches_the_proxy_as_a_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
+
+    world = vercel_mod.VercelWorld(token="tok", project_id="prj_1", team_id="team_1")
+
+    # The proxy is still api.vercel.com; the override travels in the header it
+    # forwards to the workflow-server.
+    assert world._base_url == "https://api.vercel.com/v1/workflow"
+    assert world._headers["x-vercel-workflow-api-url"] == BRANCH_URL
+
+
+def test_hard_coded_constant_wins_over_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vercel_mod, "WORKFLOW_SERVER_URL_OVERRIDE", PINNED_URL)
+    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
+
+    world = vercel_mod.VercelWorld(token="tok")
+
+    assert world._base_url == f"{PINNED_URL}/api"
+
+
+def test_override_is_read_per_world_not_at_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env var is resolved when a world is built, so a process that sets it
+    after importing this module still picks it up."""
+    before = vercel_mod.VercelWorld(token="tok")
+    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
+    after = vercel_mod.VercelWorld(token="tok")
+
+    assert before._base_url == "https://vercel-workflow.com/api"
+    assert after._base_url == f"{BRANCH_URL}/api"

--- a/src/vercel/tests/unit/test_workflow_server_url_override.py
+++ b/src/vercel/tests/unit/test_workflow_server_url_override.py
@@ -1,10 +1,15 @@
-"""Tests for the workflow-server URL override on VercelWorld.
+"""Tests for the URL overrides VercelWorld reads, mirroring world-vercel's
+``utils.ts``.
 
-The override mirrors world-vercel's ``utils.ts`` precedence: the hard-coded
-``WORKFLOW_SERVER_URL_OVERRIDE`` constant wins, then the
-``VERCEL_WORKFLOW_SERVER_URL`` environment variable, then the production
-default. Preview deployments carry the env var, so a Python app has to honour
-it to reach the same workflow-server as its TypeScript peers.
+Two independent knobs:
+
+- the workflow-server override — the hard-coded ``WORKFLOW_SERVER_URL_OVERRIDE``
+  constant wins, then the ``VERCEL_WORKFLOW_SERVER_URL`` environment variable,
+  then the production default. Preview deployments carry the env var, so a
+  Python app has to honour it to reach the same workflow-server as its
+  TypeScript peers.
+- ``WORKFLOW_VERCEL_BACKEND_URL``, which swaps the api.vercel.com proxy the
+  world talks to when it has project config.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ from vercel._internal.workflow.worlds import vercel as vercel_mod
 
 BRANCH_URL = "https://workflow-server-git-branch.vercel.sh"
 PINNED_URL = "https://workflow-server-pinned.vercel.sh"
+BACKEND_URL = "https://api-vercel-git-branch.vercel.sh/v1/workflow"
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +28,7 @@ def _clean_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """Start every test from "no constant, no env var"."""
     monkeypatch.setattr(vercel_mod, "WORKFLOW_SERVER_URL_OVERRIDE", "")
     monkeypatch.delenv("VERCEL_WORKFLOW_SERVER_URL", raising=False)
+    monkeypatch.delenv("WORKFLOW_VERCEL_BACKEND_URL", raising=False)
 
 
 def test_defaults_to_production_without_an_override() -> None:
@@ -57,6 +64,36 @@ def test_hard_coded_constant_wins_over_the_env_var(monkeypatch: pytest.MonkeyPat
     world = vercel_mod.VercelWorld(token="tok")
 
     assert world._base_url == f"{PINNED_URL}/api"
+
+
+def test_backend_url_swaps_the_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOW_VERCEL_BACKEND_URL", BACKEND_URL)
+
+    world = vercel_mod.VercelWorld(token="tok", project_id="prj_1", team_id="team_1")
+
+    assert world._base_url == BACKEND_URL
+    assert world._queue_client().base_url == f"{BACKEND_URL}/queues-proxy"
+
+
+def test_backend_url_is_ignored_without_project_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No project config means no proxy, so there is nothing to swap."""
+    monkeypatch.setenv("WORKFLOW_VERCEL_BACKEND_URL", BACKEND_URL)
+
+    world = vercel_mod.VercelWorld(token="tok")
+
+    assert world._base_url == "https://vercel-workflow.com/api"
+
+
+def test_the_two_overrides_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The proxy moves, and the workflow-server it should route to still
+    travels in the header."""
+    monkeypatch.setenv("WORKFLOW_VERCEL_BACKEND_URL", BACKEND_URL)
+    monkeypatch.setenv("VERCEL_WORKFLOW_SERVER_URL", BRANCH_URL)
+
+    world = vercel_mod.VercelWorld(token="tok", project_id="prj_1", team_id="team_1")
+
+    assert world._base_url == BACKEND_URL
+    assert world._headers["x-vercel-workflow-api-url"] == BRANCH_URL
 
 
 def test_override_is_read_per_world_not_at_import(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
`VercelWorld` hard-coded both hops to the workflow API, so two documented environment variables did nothing in Python:

- `VERCEL_WORKFLOW_SERVER_URL` — the workflow-server itself.
- `WORKFLOW_VERCEL_BACKEND_URL` — the api.vercel.com proxy in front of it.

They are how a deployment gets pointed at something other than production `vercel-workflow.com`. Ignoring them means a Python app writes its runs to a different server than the rest of the toolchain reads them from.

```console
$ VERCEL_WORKFLOW_SERVER_URL=https://workflow-server-git-branch.vercel.sh uv run python -c "
from vercel._internal.workflow.worlds.vercel import VercelWorld
print(VercelWorld(token='t')._base_url)
print(VercelWorld(token='t', project_id='prj_1', team_id='team_1')._headers['x-vercel-workflow-api-url'])
"
https://workflow-server-git-branch.vercel.sh/api    # was https://vercel-workflow.com/api
https://workflow-server-git-branch.vercel.sh        # was absent
```

Also drops the unused `WORKFLOW_SERVER_URL_OVERRIDE` constant. It mirrored an inline escape hatch in `world-vercel`, which is only safe there because a lint job fails the build unless it is empty; with no such guard here, a hand-edited value could reach `main` unnoticed.

7 new tests; `uv run poe qa vercel` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)