### PR TITLE
workflow: don't call Future.set_result without checking for cancellation

### DIFF
--- a/changes/vercel/238.bugfix.md
+++ b/changes/vercel/238.bugfix.md
@@ -1,0 +1,1 @@
+Prevent errors when tasks waiting on steps or hooks are cancelled.

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -468,28 +468,33 @@ class WorkflowOrchestratorContext:
                     sus = self.suspensions.pop(event.correlation_id)
                     assert isinstance(sus, Suspension)
                     result = ser.hydrate(data, what=f"the result of step {event.correlation_id}")
-                    sus.future.set_result(result)
+                    if not sus.future.cancelled():
+                        sus.future.set_result(result)
 
                 case w.WaitCompletedEvent():
                     wait = self.suspensions.pop(event.correlation_id)
                     assert isinstance(wait, Wait)
-                    wait.future.set_result(None)
+                    if not wait.future.cancelled():
+                        wait.future.set_result(None)
 
                 case w.StepFailedEvent(event_data=w.StepFailedEventData(error=e)):
                     sus = self.suspensions.pop(event.correlation_id)
                     assert isinstance(sus, Suspension)
-                    sus.future.set_exception(RuntimeError(e))
+                    if not sus.future.cancelled():
+                        sus.future.set_exception(RuntimeError(e))
 
                 case w.HookConflictEvent(event_data=w.HookConflictEventData(token=token)):
                     hook = self.suspensions.pop(event.correlation_id, None)
                     if hook is not None:
                         assert isinstance(hook, Hook)
                         while hook.futures:
-                            hook.futures.popleft().set_exception(
-                                RuntimeError(
-                                    f'Hook token "{token}" is already in use by another workflow'
+                            future = hook.futures.popleft()
+                            if not future.cancelled():
+                                future.set_exception(
+                                    RuntimeError(
+                                        f'Hook token "{token}" is already in use by another workflow'
+                                    )
                                 )
-                            )
 
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]

--- a/src/vercel/tests/unit/test_workflow_determinism.py
+++ b/src/vercel/tests/unit/test_workflow_determinism.py
@@ -127,6 +127,32 @@ def _completed(cid: str, result: Any) -> w.Event:
     return w.StepCompletedEventData(result=ser.dehydrate(result)).into_event(cid)
 
 
+async def test_cancelled_step_ignores_later_completion() -> None:
+    """A launched step can be cancelled before its completion is replayed.
+
+    The completion event still needs to be consumed, but setting a result on
+    the cancelled future would raise ``InvalidStateError``.
+    """
+    step = core.Step(_greet)
+    events: list[w.Event] = [_created(step, "step_1")]
+    ctx = _context(events)
+    sus = _suspension("step_1", _ARGS)
+    ctx.suspensions["step_1"] = sus
+
+    # Replay the launch, then model the workflow task being cancelled while
+    # the step is in flight. The completion arrives in a later event batch.
+    with pytest.raises(runtime._SuspendException):
+        ctx.resume()
+    assert sus.has_created_event
+    assert sus.future.cancel()
+
+    events.append(_completed("step_1", "one"))
+    ctx.resume()
+
+    assert sus.future.cancelled()
+    assert "step_1" not in ctx.suspensions
+
+
 async def test_single_step_delivers_one_completion_per_pass() -> None:
     """Two concurrently-issued steps both have results in the log, but a single
     resume() pass resolves only the first; the rest is left for the next pass."""


### PR DESCRIPTION
If a task waiting on one of these hooks was cancelled, then the future
gets cancelled and the set_result call will blow up.

This bug has been around forever but was made quite a bit worse by
it would get blown up, but it was fine because it had already
registered its follow-up call. There would be a traceback but life
would go on. Now an idle_hook failure actually blows up the loop.

We *could* make it so that we swallow idle_hook failures, but I think
it is actually probably better to let them fail, since they *are* bugs
that we should fix, and most of them won't be as benign as this one
previously was.
