### PR TITLE
workflow: serve steps on the workflow queue

### DIFF
--- a/changes/vercel/merge-step-queue.breaking.md
+++ b/changes/vercel/merge-step-queue.breaking.md
@@ -1,0 +1,3 @@
+Workflow steps now ride the `__wkf_workflow_*` queue as a `stepId` on the
+workflow invoke payload, matching the TypeScript SDK; the separate
+`__wkf_step_*` queue is gone.

--- a/src/vercel/_internal/workflow/core.py
+++ b/src/vercel/_internal/workflow/core.py
@@ -285,7 +285,6 @@ class Workflows:
             from . import runtime
 
             runtime.workflow_entrypoint(self)
-            runtime.step_entrypoint(self)
 
     @property
     def namespace(self) -> str | None:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -525,7 +525,11 @@ async def workflow_handler(
     namespace: str | None = None,
 ) -> w.QueueContinuation | None:
     world = w.get_world()
-    run_id = w.WorkflowInvokePayload.model_validate(message).run_id
+    req = w.WorkflowInvokePayload.model_validate(message)
+    if req.step_id is not None:
+        return await _execute_step(req, queue_name=queue_name, registry=registry)
+
+    run_id = req.run_id
     workflow_run = await world.runs_get(run_id)
     if workflow_run.status == "pending":
         try:
@@ -669,12 +673,11 @@ async def workflow_handler(
                     # Instead we use an idempotency_key to pervent
                     # duplicate queueing.
                     await world.queue(
-                        w.get_queue_name("step", s.step.name, namespace),
-                        w.StepInvokePayload(
-                            workflowName=workflow_run.workflow_name,
-                            workflowRunId=run_id,
-                            workflowStartedAt=workflow_started_at,
+                        w.get_queue_name(workflow_run.workflow_name, namespace),
+                        w.WorkflowInvokePayload(
+                            runId=run_id,
                             stepId=s.correlation_id,
+                            stepName=s.step.name,
                             requestedAt=datetime.now(UTC),
                         ),
                         idempotency_key=s.correlation_id,
@@ -754,34 +757,26 @@ async def workflow_handler(
     return w.QueueContinuation(delay_seconds=delay, idempotency_key=key)
 
 
-def _step_name_from_queue(queue_name: str, namespace: str | None = None) -> str:
-    """The step name encoded in a step queue topic."""
-    prefix = w.get_queue_topic_prefix("step", namespace)
-    if not queue_name.startswith(prefix):
-        raise ValueError(f'Invalid step queue name "{queue_name}": expected prefix "{prefix}"')
-    return queue_name.removeprefix(prefix)
-
-
-async def step_handler(
-    message: Any,
+async def _execute_step(
+    req: w.WorkflowInvokePayload,
     *,
-    attempt: int,
     queue_name: str,
-    message_id: str,
     registry: core.Workflows,
-    namespace: str | None = None,
 ) -> w.QueueContinuation | None:
     world = w.get_world()
-    req = w.StepInvokePayload.model_validate(message)
 
-    step = registry._get_step(_step_name_from_queue(queue_name, namespace))
+    if req.step_id is None:
+        raise ValueError(f"Step invocation for run '{req.run_id}' is missing 'stepId'")
+    if req.step_name is None:
+        raise ValueError(f"Step invocation for '{req.step_id}' is missing 'stepName'")
+    step = registry._get_step(req.step_name)
 
     # step_started validates state (terminal -> EntityConflictError, retryAfter
     # not reached -> TooEarlyError), increments the attempt, and returns the
     # updated step entity, so no step pre-read is needed.
     try:
         start_result = await world.events_create(
-            req.workflow_run_id,
+            req.run_id,
             w.StepStartedEvent(correlationId=req.step_id),
         )
     except w.TooEarlyError as e:
@@ -789,7 +784,7 @@ async def step_handler(
         timeout_seconds = max(1, e.retry_after or 1)
         logger.debug(
             "[Workflows] '%s' - step '%s' retryAfter not reached, deferring %ds",
-            req.workflow_run_id,
+            req.run_id,
             step.name,
             timeout_seconds,
         )
@@ -801,9 +796,9 @@ async def step_handler(
         # but whose handler died before re-invoking the workflow.
         logger.debug("Tried starting step %r, but it has already finished", req.step_id)
         await world.queue(
-            w.get_queue_name("workflow", req.workflow_name, namespace),
+            queue_name,
             w.WorkflowInvokePayload(
-                runId=req.workflow_run_id,
+                runId=req.run_id,
                 requestedAt=datetime.now(UTC),
             ),
         )
@@ -823,11 +818,11 @@ async def step_handler(
             f"Step '{step.name}' exceeded max retries "
             f"({retry_count} {'retry' if retry_count == 1 else 'retries'})"
         )
-        logger.error("[Workflows] '%s' - %s", req.workflow_run_id, error_message)
+        logger.error("[Workflows] '%s' - %s", req.run_id, error_message)
 
         # Fail the step via event
         await world.events_create(
-            req.workflow_run_id,
+            req.run_id,
             w.StepFailedEventData(
                 error=error_message, stack=step_run.error.stack if step_run.error else None
             ).into_event(req.step_id),
@@ -835,9 +830,9 @@ async def step_handler(
 
         # Re-invoke the workflow to handle the failed step
         await world.queue(
-            w.get_queue_name("workflow", req.workflow_name, namespace),
+            queue_name,
             w.WorkflowInvokePayload(
-                runId=req.workflow_run_id,
+                runId=req.run_id,
                 requestedAt=datetime.now(UTC),
             ),
         )
@@ -855,14 +850,14 @@ async def step_handler(
 
         logger.debug(
             "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
-            req.workflow_run_id,
+            req.run_id,
             step.name,
             req.step_id,
             current_attempt,
         )
         token = _step_ctx.set(
             StepInfo(
-                run_id=req.workflow_run_id,
+                run_id=req.run_id,
                 step_id=req.step_id,
                 step_name=step.name,
                 attempt=current_attempt,
@@ -879,7 +874,7 @@ async def step_handler(
 
         # Complete the step via event
         await world.events_create(
-            req.workflow_run_id,
+            req.run_id,
             w.StepCompletedEventData(result=output).into_event(req.step_id),
         )
 
@@ -903,7 +898,7 @@ async def step_handler(
                 "[Workflows] '%s' - Encountered Error "
                 "while executing step '%s' (attempt %d, "
                 "%d %s): %s\n\n  Max retries reached\n  Bubbling error to parent workflow",
-                req.workflow_run_id,
+                req.run_id,
                 step.name,
                 step_run.attempt,
                 retry_count,
@@ -914,7 +909,7 @@ async def step_handler(
             # Fail the step via event
             error_stack = traceback.format_exc()
             await world.events_create(
-                req.workflow_run_id,
+                req.run_id,
                 w.StepFailedEventData(error=error_message, stack=error_stack).into_event(
                     req.step_id
                 ),
@@ -925,7 +920,7 @@ async def step_handler(
                 "[Workflows] '%s' - Encountered Error "
                 "while executing step '%s' (attempt %d): "
                 "%s\n\n  This step has failed but will be retried",
-                req.workflow_run_id,
+                req.run_id,
                 step.name,
                 current_attempt,
                 e,
@@ -934,7 +929,7 @@ async def step_handler(
             # Set step to pending for retry
             error_stack = traceback.format_exc()
             await world.events_create(
-                req.workflow_run_id,
+                req.run_id,
                 w.StepRetryingEventData(error=error_text, stack=error_stack).into_event(
                     req.step_id
                 ),
@@ -945,9 +940,9 @@ async def step_handler(
 
     # Re-invoke the workflow to continue execution
     await world.queue(
-        w.get_queue_name("workflow", req.workflow_name, namespace),
+        queue_name,
         w.WorkflowInvokePayload(
-            runId=req.workflow_run_id,
+            runId=req.run_id,
             requestedAt=datetime.now(UTC),
         ),
     )
@@ -957,16 +952,8 @@ async def step_handler(
 def workflow_entrypoint(registry: core.Workflows) -> w.HTTPHandler:
     namespace = registry.namespace
     return w.get_world().create_queue_handler(
-        w.get_queue_topic_prefix("workflow", namespace),
+        w.get_queue_topic_prefix(namespace),
         functools.partial(workflow_handler, registry=registry, namespace=namespace),
-    )
-
-
-def step_entrypoint(registry: core.Workflows) -> w.HTTPHandler:
-    namespace = registry.namespace
-    return w.get_world().create_queue_handler(
-        w.get_queue_topic_prefix("step", namespace),
-        functools.partial(step_handler, registry=registry, namespace=namespace),
     )
 
 
@@ -1111,7 +1098,7 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
 
     run_id = result.run.run_id
     await world.queue(
-        w.get_queue_name("workflow", wf.workflow_id, namespace),
+        w.get_queue_name(wf.workflow_id, namespace),
         w.WorkflowInvokePayload(runId=run_id),
         deployment_id=deployment_id,
     )
@@ -1133,7 +1120,7 @@ async def resume_hook(token_or_hook: str | w.Hook, payload: Any) -> w.Hook:
     if namespace is not None and not isinstance(namespace, str):
         raise RuntimeError("Workflow run has an invalid queue namespace")
     await world.queue(
-        w.get_queue_name("workflow", run.workflow_name, namespace),
+        w.get_queue_name(run.workflow_name, namespace),
         w.WorkflowInvokePayload(runId=hook.run_id),
     )
     return hook

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -29,7 +29,6 @@ from vercel._internal.core.polyfills import Self
 from vercel.queue import SanitizedName
 
 T = TypeVar("T")
-QueueKind: TypeAlias = Literal["workflow", "step"]
 QueuePrefix: TypeAlias = str
 # OpenTelemetry trace context for distributed tracing
 TraceCarrier: TypeAlias = dict[str, str]
@@ -46,23 +45,20 @@ def validate_queue_namespace(namespace: str | None) -> None:
         )
 
 
-def get_queue_topic_prefix(kind: QueueKind, namespace: str | None = None) -> QueuePrefix:
-    """Build the workflow or step queue prefix for an optional namespace."""
-    if kind not in ("workflow", "step"):
-        raise ValueError(f"Invalid queue kind: {kind}")
+def get_queue_topic_prefix(namespace: str | None = None) -> QueuePrefix:
+    """Build the workflow queue prefix for an optional namespace."""
     validate_queue_namespace(namespace)
     if namespace is not None:
-        return f"__{namespace}_wkf_{kind}_"
-    return f"__wkf_{kind}_"
+        return f"__{namespace}_wkf_workflow_"
+    return "__wkf_workflow_"
 
 
 def get_queue_name(
-    kind: QueueKind,
     identifier: str,
     namespace: str | None = None,
 ) -> str:
     """Build a queue name for an optional namespace."""
-    return f"{get_queue_topic_prefix(kind, namespace)}{identifier}"
+    return f"{get_queue_topic_prefix(namespace)}{identifier}"
 
 
 # The consumer group our subscribers register under. The Python builder
@@ -114,30 +110,24 @@ class BaseModel(pydantic.BaseModel):
 
 
 class WorkflowInvokePayload(BaseModel):
-    """Payload for invoking a workflow."""
+    """Payload for invoking a workflow.
+
+    Step invocations ride this same payload on the workflow topic: a message
+    carrying ``stepId`` asks the receiver to execute that step before the run
+    is replayed, rather than to replay straight away.
+    """
 
     run_id: str = pydantic.Field(alias="runId")
-    trace_carrier: TraceCarrier | None = pydantic.Field(
-        default=None, alias="traceCarrier", exclude_if=lambda e: e is None
+    # Step ID for step execution on the combined handler. When present, the
+    # receiver executes that step instead of replaying the run.
+    step_id: str | None = pydantic.Field(
+        default=None, alias="stepId", exclude_if=lambda e: e is None
     )
-    requested_at: datetime | None = pydantic.Field(
-        default=None, alias="requestedAt", exclude_if=lambda e: e is None
+    # Step name, sent alongside stepId because the merged topic no longer
+    # encodes it: the queue name identifies the workflow, not the step.
+    step_name: str | None = pydantic.Field(
+        default=None, alias="stepName", exclude_if=lambda e: e is None
     )
-
-    @pydantic.field_serializer("requested_at", mode="plain")
-    def ser_requested_at(self, value: Any) -> Any:
-        if isinstance(value, datetime):
-            return value.isoformat()
-        return value
-
-
-class StepInvokePayload(BaseModel):
-    """Payload for invoking a step within a workflow."""
-
-    workflow_name: str = pydantic.Field(alias="workflowName")
-    workflow_run_id: str = pydantic.Field(alias="workflowRunId")
-    workflow_started_at: float = pydantic.Field(alias="workflowStartedAt")
-    step_id: str = pydantic.Field(alias="stepId")
     trace_carrier: TraceCarrier | None = pydantic.Field(
         default=None, alias="traceCarrier", exclude_if=lambda e: e is None
     )
@@ -155,14 +145,14 @@ class StepInvokePayload(BaseModel):
 class HealthCheckPayload(BaseModel):
     """
     Health check payload - used to verify that the queue pipeline
-    can deliver messages to workflow/step endpoints.
+    can deliver messages to the combined workflow endpoint.
     """
 
     health_check: Literal[True] = pydantic.Field(default=True, alias="__healthCheck")
     correlation_id: str = pydantic.Field(alias="correlationId")
 
 
-QueuePayload: TypeAlias = WorkflowInvokePayload | StepInvokePayload | HealthCheckPayload
+QueuePayload: TypeAlias = WorkflowInvokePayload | HealthCheckPayload
 QueuePayloadAdaptor: pydantic.TypeAdapter[QueuePayload] = pydantic.TypeAdapter(QueuePayload)
 
 

--- a/src/vercel/tests/integration/test_workflow_cli_interop.py
+++ b/src/vercel/tests/integration/test_workflow_cli_interop.py
@@ -246,17 +246,16 @@ async def py_run(tmp_path, monkeypatch) -> tuple[Path, str]:
     """Execute the workflow for real and return its data dir and run id.
 
     Nothing is faked. `LocalWorld` runs an embedded queue service in-process,
-    and `workflow_entrypoint` / `step_entrypoint` subscribe the real handlers
-    to it -- which is what `Workflows()` does for itself outside a test, and
-    what a developer gets from `vercel dev`. Doing it here rather than at
-    import is what lets the run land in this test's `tmp_path`: those
-    entrypoints bind whichever world is installed when they are called.
+    and `workflow_entrypoint` subscribes the real combined handler to it --
+    which is what `Workflows()` does for itself outside a test, and what a
+    developer gets from `vercel dev`. Doing it here rather than at import is
+    what lets the run land in this test's `tmp_path`: the entrypoint binds
+    whichever world is installed when it is called.
     """
     monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
     world = local_mod.LocalWorld()
     w.set_world(world)
     runtime.workflow_entrypoint(registry)
-    runtime.step_entrypoint(registry)
 
     try:
         run = await runtime.start(checkout, 21)

--- a/src/vercel/tests/unit/test_workflow_queue_namespace.py
+++ b/src/vercel/tests/unit/test_workflow_queue_namespace.py
@@ -109,14 +109,12 @@ def _run_created_contexts(world: FakeWorld) -> list[dict[str, Any] | None]:
 
 
 def test_queue_names_default_to_unnamespaced_prefixes() -> None:
-    assert w.get_queue_topic_prefix("workflow") == "__wkf_workflow_"
-    assert w.get_queue_topic_prefix("step") == "__wkf_step_"
-    assert w.get_queue_name("workflow", "example") == "__wkf_workflow_example"
+    assert w.get_queue_topic_prefix() == "__wkf_workflow_"
+    assert w.get_queue_name("example") == "__wkf_workflow_example"
 
 
 def test_queue_names_accept_explicit_namespace() -> None:
-    assert w.get_queue_name("workflow", "example", "python2") == "__python2_wkf_workflow_example"
-    assert w.get_queue_name("step", "example", "python2") == "__python2_wkf_step_example"
+    assert w.get_queue_name("example", "python2") == "__python2_wkf_workflow_example"
 
 
 def test_physical_topic_keeps_the_wkf_prefix_intact() -> None:
@@ -126,7 +124,7 @@ def test_physical_topic_keeps_the_wkf_prefix_intact() -> None:
     # result outside the `__wkf_*` prefix that the builder's trigger pattern
     # and platform service resolution key on.
     assert w.get_physical_topic("__wkf_workflow_") == "__wkf_workflow_"
-    assert w.get_physical_topic("__python2_wkf_step_") == "__python2_wkf_step_"
+    assert w.get_physical_topic("__python2_wkf_workflow_") == "__python2_wkf_workflow_"
     assert (
         w.get_physical_topic(f"__wkf_workflow_{WORKFLOW_NAME}")
         == "__wkf_workflow_workflow--tests-example"
@@ -165,20 +163,14 @@ def test_registries_subscribe_to_distinct_namespaced_topics() -> None:
     core.Workflows(namespace="python1")
     core.Workflows(namespace="python2")
 
+    # One subscription per registry, not two: steps share the workflow topic.
     assert world.prefixes == [
         "__python1_wkf_workflow_",
-        "__python1_wkf_step_",
         "__python2_wkf_workflow_",
-        "__python2_wkf_step_",
     ]
 
 
-def test_step_queue_rejects_mismatched_namespace() -> None:
-    with pytest.raises(ValueError, match="expected prefix"):
-        runtime._step_name_from_queue("__wkf_step_step//tests.add", "python")
-
-
-async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
+async def test_step_requeues_on_the_topic_it_arrived_on() -> None:
     world = FakeWorld(start_error=w.EntityConflictError("already finished"))
     w.set_world(world)
     registry = core.Workflows(namespace="python", as_vercel_job=False)
@@ -187,21 +179,23 @@ async def test_step_handler_requeues_on_namespaced_workflow_topic() -> None:
     async def add() -> None:
         pass
 
-    await runtime.step_handler(
-        w.StepInvokePayload(
-            workflowName=WORKFLOW_NAME,
-            workflowRunId=RUN_ID,
-            workflowStartedAt=0,
+    queue_name = f"__python_wkf_workflow_{WORKFLOW_NAME}"
+    await runtime.workflow_handler(
+        w.WorkflowInvokePayload(
+            runId=RUN_ID,
             stepId="step_test",
+            stepName=add.name,
         ).model_dump(by_alias=True),
         attempt=1,
-        queue_name=f"__python_wkf_step_{add.name}",
+        queue_name=queue_name,
         message_id="msg_test",
         registry=registry,
         namespace=registry.namespace,
     )
 
-    assert world.queued[0][0] == f"__python_wkf_workflow_{WORKFLOW_NAME}"
+    # The wake-up goes back to the namespaced topic the step came in on, which
+    # is how the namespace survives without being re-derived from the payload.
+    assert world.queued[0][0] == queue_name
 
 
 async def test_start_without_namespace_uses_unnamespaced_topic() -> None:

--- a/src/vercel/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel/tests/unit/test_workflow_step_handler.py
@@ -1,10 +1,15 @@
-"""Tests for step_handler's start-first control flow and the too-early/terminal paths.
+"""Tests for the step path's start-first control flow and too-early/terminal paths.
 
-step_handler mirrors the upstream JS step-handler: it issues ``step_started``
-first and lets the world surface state as typed errors — ``TooEarlyError``
-(retryAfter not reached, HTTP 425) and ``EntityConflictError`` (terminal step,
-HTTP 409) — instead of pre-reading the step. A too-early step defers via a queue
-timeout; a terminal step re-enqueues the parent workflow and acks.
+Steps arrive on the workflow topic as a ``WorkflowInvokePayload`` carrying a
+``stepId``, and ``workflow_handler`` dispatches those to its step path instead
+of replaying. That path issues ``step_started`` first and lets the world surface
+state as typed errors — ``TooEarlyError`` (retryAfter not reached, HTTP 425) and
+``EntityConflictError`` (terminal step, HTTP 409) — instead of pre-reading the
+step. A too-early step defers via a queue timeout; a terminal step re-enqueues
+the parent workflow and acks.
+
+``FakeWorld.runs_get`` raises, which also pins down the dispatch order: the step
+path must be taken before the run is ever read.
 """
 
 from __future__ import annotations
@@ -40,7 +45,7 @@ def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
 
 
 class FakeWorld(w.World):
-    """In-memory world driving step_handler.
+    """In-memory world driving the handler's step path.
 
     ``step`` is the persisted step ``steps_get`` returns (the pre-read snapshot).
     ``step_started`` then raises ``start_error`` if set — modelling the step's
@@ -106,17 +111,19 @@ def registry() -> core.Workflows:
     return core.Workflows(as_vercel_job=False)
 
 
+WORKFLOW_QUEUE = f"__wkf_workflow_{WORKFLOW_NAME}"
+
+
 async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
-    payload = w.StepInvokePayload(
-        workflowName=WORKFLOW_NAME,
-        workflowRunId=RUN_ID,
-        workflowStartedAt=0.0,
+    payload = w.WorkflowInvokePayload(
+        runId=RUN_ID,
         stepId=STEP_ID,
+        stepName=step_name,
     )
-    return await runtime.step_handler(
+    return await runtime.workflow_handler(
         payload.model_dump(by_alias=True),
         attempt=1,
-        queue_name=f"__wkf_step_{step_name}",
+        queue_name=WORKFLOW_QUEUE,
         message_id="msg_1",
         registry=registry,
     )
@@ -127,7 +134,7 @@ def _event_types(fake: FakeWorld) -> list[str]:
 
 
 def _workflow_enqueues(fake: FakeWorld) -> list[tuple[str, Any]]:
-    return [q for q in fake.queued if q[0] == f"__wkf_workflow_{WORKFLOW_NAME}"]
+    return [q for q in fake.queued if q[0] == WORKFLOW_QUEUE]
 
 
 async def test_too_early_defers_without_running(registry: core.Workflows) -> None:

--- a/src/vercel/tests/unit/test_workflow_step_metadata.py
+++ b/src/vercel/tests/unit/test_workflow_step_metadata.py
@@ -73,16 +73,15 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
         ),
     )
 
-    payload = w.StepInvokePayload(
-        workflowName="test-wf",
-        workflowRunId=run_id,
-        workflowStartedAt=0.0,
+    payload = w.WorkflowInvokePayload(
+        runId=run_id,
         stepId=step_id,
+        stepName=greet.name,
     )
-    await runtime.step_handler(
+    await runtime.workflow_handler(
         payload.model_dump(by_alias=True),
         attempt=1,
-        queue_name=f"__wkf_step_{greet.name}",
+        queue_name="__wkf_workflow_test-wf",
         message_id="msg_1",
         registry=registry,
     )

--- a/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/src/vercel/tests/unit/test_workflow_step_retry_dispatch.py
@@ -1,18 +1,15 @@
 """Regression test for step-retry dispatch in the queue-handler wrapper.
 
-When a step fails below ``max_retries``, ``step_handler`` returns a retry timeout
-(``return 1.0``). The wrapper registered by ``World.create_queue_handler``
-(``async_handler``) is responsible for rescheduling the step after that delay.
+When a step fails below ``max_retries``, the handler's step path returns a retry
+timeout. The wrapper registered by ``World.create_queue_handler``
+(``async_handler``) is responsible for rescheduling it after that delay.
 
-``async_handler`` must re-enqueue the retry preserving the message's payload type.
-Previously it re-enqueued *every* timeout return as a ``WorkflowInvokePayload``,
-which raised ``ValidationError`` for a ``StepInvokePayload`` → the handler 500'd and
-the step only retried via un-acked redelivery (wrong cadence, no backoff). The fix
-validates against the ``QueuePayload`` union, so a step retry re-enqueues a
-``StepInvokePayload`` on its own queue with the delay.
-
-This drives the real ``async_handler`` closure with a step payload and a handler
-that asks to retry.
+Steps and orchestration share one topic, so what distinguishes a step message is
+the ``stepId`` on its ``WorkflowInvokePayload``. ``async_handler`` re-enqueues the
+continuation by round-tripping the raw payload through ``QueuePayload``, which
+means a dropped ``stepId`` would silently turn the retry into a plain replay: the
+step would never run again, and the run would stall until redelivery. These tests
+drive the real ``async_handler`` closure and assert what survives that round trip.
 """
 
 from __future__ import annotations
@@ -47,35 +44,34 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions: None)
     async def handler(
         message: object, *, queue_name: str, attempt: int, message_id: str
     ) -> w.QueueContinuation:
-        # Stand in for step_handler deciding to retry: a non-None continuation.
+        # Stand in for the step path deciding to retry: a non-None continuation.
         del message, queue_name, attempt, message_id
         return w.QueueContinuation(delay_seconds=1.0)
 
     # Registers async_handler into the global subscription registry as a side effect.
-    world.create_queue_handler("__wkf_step_", handler)
+    world.create_queue_handler("__wkf_workflow_", handler)
     subscriptions = list(get_subscriptions())
     assert len(subscriptions) == 1
-    assert subscriptions[0].topic == "__wkf_step_*"
+    assert subscriptions[0].topic == "__wkf_workflow_*"
     assert subscriptions[0].consumer_group == "default"
     async_handler = subscriptions[0].func
     assert async_handler is not None
 
-    step_payload = w.StepInvokePayload(
-        workflowName="wf",
-        workflowRunId="wrun_1",
-        workflowStartedAt=0.0,
+    step_payload = w.WorkflowInvokePayload(
+        runId="wrun_1",
         stepId="step_1",
+        stepName="step//tests.add",
     ).model_dump()
     body = {
         "payload": step_payload,
-        "queueName": "__wkf_step_wf",
+        "queueName": "__wkf_workflow_wf",
         "deploymentId": "<local>",
     }
     metadata = MessageMetadata(
         message_id="m1",
         delivery_count=1,
         created_at=CREATED_AT,
-        topic="__wkf_step_wf",
+        topic="__wkf_workflow_wf",
         consumer_group=SanitizedName("tests"),
     )
 
@@ -83,11 +79,12 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions: None)
 
     assert world.queued, "step retry was not re-enqueued"
     qn, msg, delay, _idem = world.queued[-1]
-    assert qn == "__wkf_step_wf"
-    step_id = getattr(msg, "step_id", None) or (
-        msg.get("stepId") if isinstance(msg, dict) else None
-    )
-    assert step_id == "step_1"
+    assert qn == "__wkf_workflow_wf"
+    assert isinstance(msg, w.WorkflowInvokePayload)
+    # Without both of these the redelivery replays the run instead of retrying
+    # the step, since that is the only thing telling the two message kinds apart.
+    assert msg.step_id == "step_1"
+    assert msg.step_name == "step//tests.add"
     assert delay == 1.0
 
 

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -32,8 +32,8 @@ durable wait in a workflow run.
 
 ## Queue namespaces
 
-Pass a namespace to a workflow registry to isolate its workflow and step
-messages on dedicated queue topics:
+Pass a namespace to a workflow registry to isolate its messages on a dedicated
+queue topic:
 
 ```python
 workflows = Workflows(namespace="billing")


### PR DESCRIPTION
Step invocations used to travel on a dedicated `__wkf_step_*` topic consumed by their own handler. They now ride the workflow topic as a stepId/stepName pair on WorkflowInvokePayload, and workflow_handler dispatches those to step execution instead of replay. stepName has to be on the payload because the merged topic no longer encodes it: the queue name identifies the workflow, not the step.

This matches the TypeScript SDK, which retired its step route in vercel/workflow#3061, and halves the queue triggers deployed for a workflow function -- the Python builder emits one per registered subscription, and a registry now registers one.

Steps are still their own queue hop; the eager inline execution the TypeScript SDK gained alongside this is not ported.