### PR TITLE
sandbox: Add support for `images`

### DIFF
--- a/changes/vercel-sandbox/201.breaking.md
+++ b/changes/vercel-sandbox/201.breaking.md
@@ -1,0 +1,4 @@
+Replace the legacy `runtime` selector with `image` when creating sandboxes.
+Sandbox creation now uses API v3, defaults to
+`vercel/sandbox/universal:latest`, and supports custom Vercel Container
+Registry images.

--- a/changes/vercel-sandbox/201.feature.md
+++ b/changes/vercel-sandbox/201.feature.md
@@ -1,1 +1,0 @@
-Support creating sandboxes from custom Vercel Container Registry images.

--- a/changes/vercel-sandbox/201.feature.md
+++ b/changes/vercel-sandbox/201.feature.md
@@ -1,0 +1,1 @@
+Support creating sandboxes from custom Vercel Container Registry images.

--- a/src/vercel-sandbox/README.md
+++ b/src/vercel-sandbox/README.md
@@ -14,6 +14,9 @@ async with session():
 
 The package can be installed independently with `pip install vercel-sandbox`.
 
+When no image is provided, the Sandbox API uses
+`vercel/sandbox/universal:latest`.
+
 The same promoted API is available synchronously:
 
 ```python
@@ -60,10 +63,9 @@ with session():
 Image references may be a bare repository (`my-repository`), a tagged image
 (`my-repository:latest`), a digest-pinned image
 (`my-repository@sha256:<digest>`), or a fully qualified VCR reference such as
-`vcr.vercel.com/team-slug/project-slug/my-repository:latest`. Use `image`
-instead of `runtime`; the two options are mutually exclusive. For an
-image-backed sandbox, `Sandbox.image` contains the returned image metadata and
-`Sandbox.runtime` remains `None`.
+`vcr.vercel.com/team-slug/project-slug/my-repository:latest`. The backend
+resolves the selected image, and `Sandbox.image` contains the resolved image
+metadata.
 
 Installing this package also provides the `vercel-sandbox` and `sandbox`
 console commands. Both are aliases that delegate all arguments to `npx sandbox`;

--- a/src/vercel-sandbox/README.md
+++ b/src/vercel-sandbox/README.md
@@ -65,7 +65,7 @@ Image references may be a bare repository (`my-repository`), a tagged image
 (`my-repository@sha256:<digest>`), or a fully qualified VCR reference such as
 `vcr.vercel.com/team-slug/project-slug/my-repository:latest`. The backend
 resolves the selected image, and `Sandbox.image` contains the resolved image
-metadata.
+reference.
 
 Installing this package also provides the `vercel-sandbox` and `sandbox`
 console commands. Both are aliases that delegate all arguments to `npx sandbox`;

--- a/src/vercel-sandbox/README.md
+++ b/src/vercel-sandbox/README.md
@@ -26,6 +26,45 @@ with session():
         print(process.stdout)
 ```
 
+## Custom images
+
+Create a sandbox from a Vercel Container Registry (VCR) image with the
+`image` keyword. The image reference is sent to the Sandbox API unchanged;
+the backend validates access, resolves the image, and waits for it to be
+ready.
+
+```python
+from vercel import sandbox
+from vercel.api import session
+
+async with session():
+    async with sandbox.create_sandbox(image="my-repository:latest") as instance:
+        result = await instance.run_process("my-command", capture_output=True)
+        print(result.stdout)
+        print(instance.image)  # The resolved digest-pinned image reference
+```
+
+The same option is available synchronously:
+
+```python
+from vercel.api import session
+from vercel.sandbox import sync as sandbox
+
+with session():
+    with sandbox.create_sandbox(image="my-repository:latest") as instance:
+        result = instance.run_process("my-command", capture_output=True)
+        print(result.stdout)
+        print(instance.image)  # The resolved digest-pinned image reference
+```
+
+Image references may be a bare repository (`my-repository`), a tagged image
+(`my-repository:latest`), a digest-pinned image
+(`my-repository@sha256:<digest>`), or a fully qualified VCR reference such as
+`vcr.vercel.com/team-slug/project-slug/my-repository:latest`. Use `image`
+instead of `runtime`; the two options are mutually exclusive. For an
+image-backed sandbox, `Sandbox.image` contains the returned image metadata and
+`Sandbox.runtime` remains `None`.
+
 Installing this package also provides the `vercel-sandbox` and `sandbox`
 console commands. Both are aliases that delegate all arguments to `npx sandbox`;
 they require Node.js with npm and `npx` installed. Node.js is not required when

--- a/src/vercel-sandbox/examples/sandbox_01_async_code_review.py
+++ b/src/vercel-sandbox/examples/sandbox_01_async_code_review.py
@@ -50,7 +50,6 @@ async def review_code(
     #
     #     box = await sandbox.create_sandbox(name="foo-box", ...)
     async with sandbox.create_sandbox(
-        runtime="python3.13",
         execution_time_limit=timedelta(minutes=1),
         # The token is injected into requests to api.github.com by the network
         # policy. It is never exposed to the sandbox process or filesystem.

--- a/src/vercel-sandbox/examples/sandbox_02_sync_script_runner.py
+++ b/src/vercel-sandbox/examples/sandbox_02_sync_script_runner.py
@@ -28,7 +28,6 @@ def run_script(input_text: str, script: str) -> str:
         session(),
         sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=1),
         ) as box,
     ):

--- a/src/vercel-sandbox/examples/sandbox_03_snapshot_restore.py
+++ b/src/vercel-sandbox/examples/sandbox_03_snapshot_restore.py
@@ -25,14 +25,13 @@ async def _main() -> None:
     restored = None
     snapshot = None
 
-    async with sandbox.create_sandbox(name=base_name, runtime="python3.13") as base:
+    async with sandbox.create_sandbox(name=base_name) as base:
         try:
             await base.fs.write_text("state/message.txt", "restored from snapshot\n")
             snapshot = await base.snapshot()
 
             restored = await sandbox.create_sandbox(
                 name=restored_name,
-                runtime="python3.13",
                 source=SnapshotSource(snapshot_id=snapshot.id),
             )
             content = await restored.fs.read_text("state/message.txt")

--- a/src/vercel-sandbox/examples/sandbox_04_dev_server.py
+++ b/src/vercel-sandbox/examples/sandbox_04_dev_server.py
@@ -22,7 +22,6 @@ from vercel.sandbox import (
 load_dotenv()
 
 DEFAULT_REPO = "https://github.com/vercel/sandbox-example-next.git"
-DEFAULT_CWD = "/vercel/sandbox"
 DEFAULT_INSTALL = "npm install --loglevel info"
 DEFAULT_IMAGE = "vercel/sandbox/universal:latest"
 MARKER_PATH = ".vercel-py-dev-server/install.json"
@@ -37,7 +36,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--install", default=DEFAULT_INSTALL)
     parser.add_argument("--entrypoint")
     parser.add_argument("--name")
-    parser.add_argument("--cwd", default=DEFAULT_CWD)
+    parser.add_argument(
+        "--cwd",
+        help="working directory (defaults to the image working directory)",
+    )
     parser.add_argument("--reinstall", action="store_true")
     parser.add_argument("--destroy", action="store_true")
     return parser.parse_args()
@@ -242,7 +244,7 @@ async def _main() -> None:
     install: str = args.install
     entrypoint: str | None = args.entrypoint
     name: str | None = args.name
-    cwd: str = args.cwd
+    cwd_override: str | None = args.cwd
     reinstall: bool = args.reinstall
     destroy: bool = args.destroy
 
@@ -261,6 +263,10 @@ async def _main() -> None:
     )
 
     try:
+        cwd = cwd_override if cwd_override is not None else box.cwd
+        if cwd is None:
+            raise RuntimeError("sandbox did not report a working directory; pass --cwd")
+
         await install_dependencies(
             box,
             repo=repo,

--- a/src/vercel-sandbox/examples/sandbox_04_dev_server.py
+++ b/src/vercel-sandbox/examples/sandbox_04_dev_server.py
@@ -24,6 +24,7 @@ load_dotenv()
 DEFAULT_REPO = "https://github.com/vercel/sandbox-example-next.git"
 DEFAULT_CWD = "/vercel/sandbox"
 DEFAULT_INSTALL = "npm install --loglevel info"
+DEFAULT_IMAGE = "vercel/sandbox/universal:latest"
 MARKER_PATH = ".vercel-py-dev-server/install.json"
 
 
@@ -31,7 +32,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--ref")
-    parser.add_argument("--runtime", default="node22")
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--port", type=int, default=3000)
     parser.add_argument("--install", default=DEFAULT_INSTALL)
     parser.add_argument("--entrypoint")
@@ -42,12 +43,12 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def sandbox_name(*, repo: str, ref: str | None, runtime: str, port: int) -> str:
+def sandbox_name(*, repo: str, ref: str | None, image: str, port: int) -> str:
     key = json.dumps(
         {
             "repo": repo,
             "ref": ref,
-            "runtime": runtime,
+            "image": image,
             "port": port,
         },
         sort_keys=True,
@@ -61,7 +62,7 @@ async def get_or_create_sandbox(
     name: str,
     repo: str,
     ref: str | None,
-    runtime: str,
+    image: str,
     port: int,
 ) -> Sandbox:
     try:
@@ -75,7 +76,7 @@ async def get_or_create_sandbox(
     source = GitSource(url=repo, revision=ref)
     box = await sandbox.create_sandbox(
         name=name,
-        runtime=runtime,
+        image=image,
         source=source,
         ports=[port],
         persistent=True,
@@ -83,7 +84,7 @@ async def get_or_create_sandbox(
         tags={
             "example": "dev-server",
             "sdk": "vercel-py",
-            "runtime": runtime,
+            "image": image,
         },
     )
     print(f"created sandbox {box.name}")
@@ -95,7 +96,7 @@ async def should_install(
     *,
     repo: str,
     ref: str | None,
-    runtime: str,
+    image: str,
     install: str,
     cwd: str,
     reinstall: bool,
@@ -106,7 +107,7 @@ async def should_install(
     expected = marker_payload(
         repo=repo,
         ref=ref,
-        runtime=runtime,
+        image=image,
         install=install,
         cwd=cwd,
     )
@@ -124,14 +125,14 @@ def marker_payload(
     *,
     repo: str,
     ref: str | None,
-    runtime: str,
+    image: str,
     install: str,
     cwd: str,
 ) -> dict[str, object]:
     return {
         "repo": repo,
         "ref": ref,
-        "runtime": runtime,
+        "image": image,
         "install": install,
         "cwd": cwd,
     }
@@ -146,7 +147,7 @@ async def install_dependencies(
     *,
     repo: str,
     ref: str | None,
-    runtime: str,
+    image: str,
     install: str,
     cwd: str,
     reinstall: bool,
@@ -155,7 +156,7 @@ async def install_dependencies(
         box,
         repo=repo,
         ref=ref,
-        runtime=runtime,
+        image=image,
         install=install,
         cwd=cwd,
         reinstall=reinstall,
@@ -172,7 +173,7 @@ async def install_dependencies(
             marker_payload(
                 repo=repo,
                 ref=ref,
-                runtime=runtime,
+                image=image,
                 install=install,
                 cwd=cwd,
             ),
@@ -236,7 +237,7 @@ async def _main() -> None:
     args = parse_args()
     repo: str = args.repo
     ref: str | None = args.ref
-    runtime: str = args.runtime
+    image: str = args.image
     port: int = args.port
     install: str = args.install
     entrypoint: str | None = args.entrypoint
@@ -248,14 +249,14 @@ async def _main() -> None:
     sandbox_id = name or sandbox_name(
         repo=repo,
         ref=ref,
-        runtime=runtime,
+        image=image,
         port=port,
     )
     box = await get_or_create_sandbox(
         name=sandbox_id,
         repo=repo,
         ref=ref,
-        runtime=runtime,
+        image=image,
         port=port,
     )
 
@@ -264,7 +265,7 @@ async def _main() -> None:
             box,
             repo=repo,
             ref=ref,
-            runtime=runtime,
+            image=image,
             install=install,
             cwd=cwd,
             reinstall=reinstall,

--- a/src/vercel-sandbox/examples/sandbox_05_sessions_and_resume.py
+++ b/src/vercel-sandbox/examples/sandbox_05_sessions_and_resume.py
@@ -27,7 +27,6 @@ async def _main() -> None:
     # sandbox several times before destroying it.
     box = await sandbox.create_sandbox(
         name=name,
-        runtime="python3.13",
         persistent=True,
         execution_time_limit=timedelta(minutes=2),
     )

--- a/src/vercel-sandbox/examples/sandbox_06_streaming_files.py
+++ b/src/vercel-sandbox/examples/sandbox_06_streaming_files.py
@@ -35,7 +35,6 @@ async def _main() -> None:
 
         async with sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=2),
         ) as box:
             async with (

--- a/src/vercel-sandbox/tests/live/_sandbox_scenarios.py
+++ b/src/vercel-sandbox/tests/live/_sandbox_scenarios.py
@@ -226,7 +226,6 @@ class AsyncDriver(_ScenarioDriver):
     async def ephemeral_sandbox(self, name: str) -> AsyncIterator[Any]:
         async with sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=2),
         ) as box:
             yield box
@@ -234,7 +233,6 @@ class AsyncDriver(_ScenarioDriver):
     async def create_persistent(self, name: str, tags: dict[str, str]) -> Any:
         return await sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             persistent=True,
             ports=[3000],
             execution_time_limit=timedelta(minutes=2),
@@ -244,7 +242,6 @@ class AsyncDriver(_ScenarioDriver):
     async def create_with_network_policy(self, name: str, network_policy: NetworkPolicy) -> Any:
         return await sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=2),
             network_policy=network_policy,
         )
@@ -264,7 +261,6 @@ class AsyncDriver(_ScenarioDriver):
     async def restore(self, name: str, snapshot_id: str) -> Any:
         return await sandbox.create_sandbox(
             name=name,
-            runtime="python3.13",
             source=SnapshotSource(snapshot_id=snapshot_id),
         )
 
@@ -424,7 +420,6 @@ class SyncDriver(_ScenarioDriver):
     async def ephemeral_sandbox(self, name: str) -> AsyncIterator[Any]:
         with sandbox_sync.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=2),
         ) as box:
             yield box
@@ -432,7 +427,6 @@ class SyncDriver(_ScenarioDriver):
     async def create_persistent(self, name: str, tags: dict[str, str]) -> Any:
         return sandbox_sync.create_sandbox(
             name=name,
-            runtime="python3.13",
             persistent=True,
             ports=[3000],
             execution_time_limit=timedelta(minutes=2),
@@ -442,7 +436,6 @@ class SyncDriver(_ScenarioDriver):
     async def create_with_network_policy(self, name: str, network_policy: NetworkPolicy) -> Any:
         return sandbox_sync.create_sandbox(
             name=name,
-            runtime="python3.13",
             execution_time_limit=timedelta(minutes=2),
             network_policy=network_policy,
         )
@@ -462,7 +455,6 @@ class SyncDriver(_ScenarioDriver):
     async def restore(self, name: str, snapshot_id: str) -> Any:
         return sandbox_sync.create_sandbox(
             name=name,
-            runtime="python3.13",
             source=sandbox_sync.SnapshotSource(snapshot_id=snapshot_id),
         )
 

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -709,12 +709,12 @@ async def test_filesystem_open_rejects_invalid_options(
     options: dict[str, object],
     error_type: type[Exception],
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(error_type):
             box.fs.open("data.bin", mode, **options)  # type: ignore[call-overload]
 
@@ -723,7 +723,7 @@ async def test_filesystem_open_rejects_invalid_options(
 async def test_async_filesystem_native_operations_and_write_composition(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     mkdir = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/mkdir").mock(
@@ -737,7 +737,7 @@ async def test_async_filesystem_native_operations_and_write_composition(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         assert isinstance(box.fs, sandbox.SandboxFilesystem)
         assert box.current_session is not None
         assert isinstance(box.current_session.fs, sandbox.SandboxFilesystem)
@@ -775,7 +775,7 @@ async def test_async_filesystem_native_operations_and_write_composition(
 async def test_async_unknown_size_writer_publishes_temporary_spool(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -786,7 +786,7 @@ async def test_async_unknown_size_writer_publishes_temporary_spool(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         async with box.fs.open("spooled.bin", "wb") as writer:
             await writer.write(b"spooled")
             await writer.write(b" data")
@@ -802,7 +802,7 @@ async def test_async_unknown_size_writer_publishes_temporary_spool(
 async def test_async_binary_writer_rejects_incomplete_declared_size(
     mock_env_clear: None, content: bytes
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -813,7 +813,7 @@ async def test_async_binary_writer_rejects_incomplete_declared_size(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(SandboxUploadSizeMismatchError) as exc_info:
             async with box.fs.open("data.bin", "wb", size=4) as writer:
                 await writer.write(content)
@@ -829,7 +829,7 @@ async def test_async_binary_writer_rejects_incomplete_declared_size(
 
 @respx.mock
 async def test_filesystem_write_wraps_api_error(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
@@ -839,7 +839,7 @@ async def test_filesystem_write_wraps_api_error(mock_env_clear: None) -> None:
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(SandboxFilesystemWriteError) as exc_info:
             async with box.fs.batch(cwd=PurePosixPath("workspace")) as batch:
                 batch.write_text(PurePosixPath("a.txt"), "a")
@@ -855,7 +855,7 @@ async def test_filesystem_write_wraps_api_error(mock_env_clear: None) -> None:
 async def test_filesystem_target_binding_tracks_sandbox_but_not_runtime_session(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response("sbx_1"))
     )
     respx.patch("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -884,7 +884,7 @@ async def test_filesystem_target_binding_tracks_sandbox_but_not_runtime_session(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         retained_box_fs = box.fs
         assert box.current_session is not None
         retained_session_fs = box.current_session.fs
@@ -912,7 +912,7 @@ async def test_filesystem_target_binding_tracks_sandbox_but_not_runtime_session(
 async def test_async_filesystem_batch_stages_one_request_and_skips_aborted_or_empty_batches(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     writes = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
@@ -920,7 +920,7 @@ async def test_async_filesystem_batch_stages_one_request_and_skips_aborted_or_em
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         staged = box.fs.batch(cwd="workspace")
         with pytest.raises(RuntimeError):
             staged.write_text("outside.txt", "no")
@@ -951,7 +951,7 @@ async def test_async_filesystem_batch_stages_one_request_and_skips_aborted_or_em
 async def test_command_backed_filesystem_operations_parse_output_and_pass_paths_as_args(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     requested: list[dict[str, object]] = []
@@ -978,7 +978,7 @@ async def test_command_backed_filesystem_operations_parse_output_and_pass_paths_
 
     unsafe_path = "-a; printf injected"
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         assert await box.fs.exists(unsafe_path)
         assert not await box.fs.is_file("missing")
         assert await box.fs.listdir("directory") == [
@@ -998,7 +998,7 @@ async def test_command_backed_filesystem_operations_parse_output_and_pass_paths_
 
 @respx.mock
 async def test_filesystem_failures_use_filesystem_error_contract(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     read = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/read")
@@ -1019,7 +1019,7 @@ async def test_filesystem_failures_use_filesystem_error_contract(mock_env_clear:
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(SandboxPathNotFoundError) as missing:
             await box.fs.read_bytes("missing")
         assert missing.value.path == "missing"
@@ -1039,7 +1039,7 @@ async def test_filesystem_failures_use_filesystem_error_contract(mock_env_clear:
 
 @respx.mock
 def test_sync_filesystem_capability_uses_sync_boundary(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -1053,7 +1053,7 @@ def test_sync_filesystem_capability_uses_sync_boundary(mock_env_clear: None) -> 
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         assert isinstance(box.fs, sandbox_sync.SyncSandboxFilesystem)
         assert box.current_session is not None
         assert isinstance(box.current_session.fs, sandbox_sync.SyncSandboxFilesystem)
@@ -1065,7 +1065,7 @@ def test_sync_filesystem_capability_uses_sync_boundary(mock_env_clear: None) -> 
 
 @respx.mock
 def test_sync_unknown_size_writer_publishes_temporary_spool(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -1076,7 +1076,7 @@ def test_sync_unknown_size_writer_publishes_temporary_spool(mock_env_clear: None
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with box.fs.open("spooled.bin", "wb") as writer:
             writer.write(b"spooled")
             writer.write(b" data")
@@ -1092,7 +1092,7 @@ def test_sync_unknown_size_writer_publishes_temporary_spool(mock_env_clear: None
 def test_sync_binary_writer_rejects_incomplete_declared_size(
     mock_env_clear: None, content: bytes
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -1103,7 +1103,7 @@ def test_sync_binary_writer_rejects_incomplete_declared_size(
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with pytest.raises(SandboxUploadSizeMismatchError) as exc_info:
             with box.fs.open("data.bin", "wb", size=4) as writer:
                 writer.write(content)
@@ -1119,7 +1119,7 @@ def test_sync_binary_writer_rejects_incomplete_declared_size(
 
 @respx.mock
 def test_sync_filesystem_batch_stages_one_request(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     writes = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/write").mock(
@@ -1127,7 +1127,7 @@ def test_sync_filesystem_batch_stages_one_request(mock_env_clear: None) -> None:
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         staged = box.fs.batch(cwd="/tmp")
         with staged as batch:
             batch.write_text("message.txt", "hello")
@@ -1206,7 +1206,7 @@ async def test_text_reader_preserves_crlf_split_across_chunks(
     ]
 
     with respx.mock:
-        respx.post("https://sandbox.test/v2/sandboxes").mock(
+        respx.post("https://sandbox.test/v3/sandboxes").mock(
             return_value=httpx.Response(200, json=_sandbox_response())
         )
         respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -1217,7 +1217,7 @@ async def test_text_reader_preserves_crlf_split_across_chunks(
         )
 
         async with session(service_options=_session_options()):
-            box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+            box = await sandbox.create_sandbox(name="preview")
             async with box.fs.open("data.txt", "r", newline="") as reader:
                 assert await reader.readline() == f"{prefix}\r\n"
                 assert await reader.read() == suffix
@@ -1225,7 +1225,7 @@ async def test_text_reader_preserves_crlf_split_across_chunks(
 
 @respx.mock
 async def test_read_bytes_response_closed_after_streaming_read(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackedAsyncStream([b"bytes"])
@@ -1234,7 +1234,7 @@ async def test_read_bytes_response_closed_after_streaming_read(mock_env_clear: N
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.fs.read_bytes(PurePosixPath("data.bin"))
         assert result == b"bytes"
 
@@ -1243,7 +1243,7 @@ async def test_read_bytes_response_closed_after_streaming_read(mock_env_clear: N
 
 @respx.mock
 def test_sync_read_bytes_uses_and_closes_unread_stream(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackedSyncStream([b"abc", b"", b"def"])
@@ -1252,7 +1252,7 @@ def test_sync_read_bytes_uses_and_closes_unread_stream(mock_env_clear: None) -> 
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         assert box.fs.read_bytes("data.bin") == b"abcdef"
 
     assert stream.close_called
@@ -1260,7 +1260,7 @@ def test_sync_read_bytes_uses_and_closes_unread_stream(mock_env_clear: None) -> 
 
 @respx.mock
 def test_sync_read_bytes_closes_response_after_stream_failure(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     failure = RuntimeError("stream failed")
@@ -1270,7 +1270,7 @@ def test_sync_read_bytes_closes_response_after_stream_failure(mock_env_clear: No
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with pytest.raises(RuntimeError) as exc_info:
             box.fs.read_bytes("data.bin")
         assert exc_info.value is failure
@@ -1280,7 +1280,7 @@ def test_sync_read_bytes_closes_response_after_stream_failure(mock_env_clear: No
 
 @respx.mock
 async def test_read_bytes_multiple_chunks(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/read").mock(
@@ -1288,14 +1288,14 @@ async def test_read_bytes_multiple_chunks(mock_env_clear: None) -> None:
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.fs.read_bytes(PurePosixPath("data.bin"))
         assert result == b"abcdefghi"
 
 
 @respx.mock
 async def test_read_bytes_empty_file(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/read").mock(
@@ -1303,14 +1303,14 @@ async def test_read_bytes_empty_file(mock_env_clear: None) -> None:
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.fs.read_bytes(PurePosixPath("empty.txt"))
         assert result == b""
 
 
 @respx.mock
 async def test_read_bytes_missing_path(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/fs/read").mock(
@@ -1320,7 +1320,7 @@ async def test_read_bytes_missing_path(mock_env_clear: None) -> None:
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(SandboxPathNotFoundError) as exc_info:
             await box.fs.read_bytes(PurePosixPath("missing.txt"))
         assert exc_info.value.path == "missing.txt"
@@ -1330,7 +1330,7 @@ async def test_read_bytes_missing_path(mock_env_clear: None) -> None:
 
 @respx.mock
 async def test_read_bytes_and_read_text_still_work(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     response_count = 0
@@ -1345,7 +1345,7 @@ async def test_read_bytes_and_read_text_still_work(mock_env_clear: None) -> None
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
 
         raw = await box.fs.read_bytes(PurePosixPath("data.bin"))
         assert raw == b"content"

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -185,7 +185,7 @@ def test_public_process_exports() -> None:
 
 @respx.mock
 async def test_async_process_readers_wait_and_signals(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -211,7 +211,7 @@ async def test_async_process_readers_wait_and_signals(mock_env_clear: None) -> N
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         process = await box.create_process("python")
         assert process.name == "python"
         assert process.args == []
@@ -243,7 +243,7 @@ async def test_async_process_readers_wait_and_signals(mock_env_clear: None) -> N
 
 @respx.mock
 def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -266,7 +266,7 @@ def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         process = box.create_process("python")
         assert process.communicate() == ("out-1\nout-2", "err\n")
         assert process.returncode == 0
@@ -280,7 +280,7 @@ def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
 async def test_async_create_process_merges_stderr_into_stdout_reader(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -294,7 +294,7 @@ async def test_async_create_process_merges_stderr_into_stdout_reader(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         process = await box.create_process("python", stderr=subprocess.STDOUT)
         assert process.stderr is None
         assert process.stdout is not None
@@ -306,7 +306,7 @@ async def test_async_create_process_merges_stderr_into_stdout_reader(
 
 @respx.mock
 async def test_async_create_process_devnull_drops_reader(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -320,7 +320,7 @@ async def test_async_create_process_devnull_drops_reader(mock_env_clear: None) -
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         process = await box.create_process("python", stderr=subprocess.DEVNULL)
         assert process.stderr is None
         assert await process.communicate() == ("out-1\nout-2", None)
@@ -331,7 +331,7 @@ async def test_async_create_process_devnull_drops_reader(mock_env_clear: None) -
 async def test_async_create_process_with_no_readers_never_requests_logs(
     mock_env_clear: None, stderr: int
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -343,7 +343,7 @@ async def test_async_create_process_with_no_readers_never_requests_logs(
     logs = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs")
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         process = await box.create_process("python", stdout=subprocess.DEVNULL, stderr=stderr)
         assert process.stdout is None
         assert process.stderr is None
@@ -369,13 +369,13 @@ async def test_async_create_process_with_no_readers_never_requests_logs(
 async def test_create_process_rejects_output_options_before_request(
     mock_env_clear: None, kwargs: dict[str, object]
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     create = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd")
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises((TypeError, ValueError)):
             await box.create_process("python", **kwargs)  # type: ignore[arg-type]
 
@@ -384,7 +384,7 @@ async def test_create_process_rejects_output_options_before_request(
 
 @respx.mock
 def test_sync_create_process_merges_stderr_into_stdout_reader(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -398,7 +398,7 @@ def test_sync_create_process_merges_stderr_into_stdout_reader(mock_env_clear: No
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         process = box.create_process("python", stderr=subprocess.STDOUT)
         assert process.stderr is None
         assert process.stdout is not None
@@ -413,7 +413,7 @@ def test_sync_create_process_merges_stderr_into_stdout_reader(mock_env_clear: No
 def test_sync_create_process_with_no_readers_never_requests_logs(
     mock_env_clear: None, stderr: int
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -425,7 +425,7 @@ def test_sync_create_process_with_no_readers_never_requests_logs(
     logs = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs")
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         process = box.create_process("python", stdout=subprocess.DEVNULL, stderr=stderr)
         assert process.stdout is None
         assert process.stderr is None
@@ -439,13 +439,13 @@ def test_sync_create_process_with_no_readers_never_requests_logs(
 def test_sync_create_process_rejects_output_options_before_request(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     create = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd")
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with pytest.raises(ValueError, match="STDOUT is only supported for stderr"):
             box.create_process("python", stdout=subprocess.STDOUT)
 
@@ -456,7 +456,7 @@ def test_sync_create_process_rejects_output_options_before_request(
 async def test_run_process_routes_output_checks_and_uses_one_request(
     mock_env_clear: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     run = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -470,7 +470,7 @@ async def test_run_process_routes_output_checks_and_uses_one_request(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.run_process("python", ("-c", "print('out')"))
         assert isinstance(result, sandbox.CompletedProcess)
         assert result.args == ("python", "-c", "print('out')")
@@ -507,7 +507,7 @@ async def test_run_process_routes_output_checks_and_uses_one_request(
 async def test_async_run_process_explicit_and_discarded_destinations(
     mock_env_clear: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     run = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -521,7 +521,7 @@ async def test_async_run_process_explicit_and_discarded_destinations(
     sink = _RecordingTextIO()
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.run_process("python", stdout=sink, stderr=subprocess.STDOUT)
         assert result.stdout is None
         assert result.stderr is None
@@ -552,7 +552,7 @@ async def test_async_run_process_explicit_and_discarded_destinations(
 def test_sync_run_process_routes_and_captures(
     mock_env_clear: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     run = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -560,7 +560,7 @@ def test_sync_run_process_routes_and_captures(
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         inherited = box.run_process("python")
         assert inherited.stdout is None
         assert inherited.stderr is None
@@ -575,7 +575,7 @@ def test_sync_run_process_routes_and_captures(
 
 @respx.mock
 async def test_async_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackingAsyncStream(
@@ -591,7 +591,7 @@ async def test_async_run_process_reads_chunked_ndjson(mock_env_clear: None) -> N
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.run_process("python", capture_output=True)
 
     assert result.stdout == "café\n"
@@ -604,7 +604,7 @@ async def test_async_run_process_replays_pre_stream_stopped_session_error(
     mock_env_clear: None,
 ) -> None:
     events: list[str] = []
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
 
@@ -634,7 +634,7 @@ async def test_async_run_process_replays_pre_stream_stopped_session_error(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         result = await box.run_process("python", capture_output=True)
 
     assert result.session_id == "sbx_new"
@@ -647,7 +647,7 @@ def test_sync_run_process_replays_pre_stream_stopped_session_error(
     mock_env_clear: None,
 ) -> None:
     events: list[str] = []
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
 
@@ -677,7 +677,7 @@ def test_sync_run_process_replays_pre_stream_stopped_session_error(
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         result = box.run_process("python", capture_output=True)
 
     assert result.session_id == "sbx_new"
@@ -687,7 +687,7 @@ def test_sync_run_process_replays_pre_stream_stopped_session_error(
 
 @respx.mock
 def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackingSyncStream(
@@ -703,7 +703,7 @@ def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         result = box.run_process("python", capture_output=True)
 
     assert result.stdout == "café\n"
@@ -713,7 +713,7 @@ def test_sync_run_process_reads_chunked_ndjson(mock_env_clear: None) -> None:
 
 @respx.mock
 async def test_async_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -733,7 +733,7 @@ async def test_async_process_readers_read_chunked_ndjson(mock_env_clear: None) -
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         process = await box.create_process("python")
         output = await process.communicate()
 
@@ -743,7 +743,7 @@ async def test_async_process_readers_read_chunked_ndjson(mock_env_clear: None) -
 
 @respx.mock
 def test_sync_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -763,7 +763,7 @@ def test_sync_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         process = box.create_process("python")
         output = process.communicate()
 
@@ -787,13 +787,13 @@ def test_sync_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
 async def test_run_process_rejects_output_options_before_request(
     mock_env_clear: None, kwargs: dict[str, object]
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     run = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd")
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises((TypeError, ValueError)):
             await box.run_process("python", **kwargs)  # type: ignore[arg-type]
 
@@ -804,7 +804,7 @@ async def test_run_process_rejects_output_options_before_request(
 async def test_async_run_process_closes_response_when_sink_write_fails(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackingAsyncStream(_completed_body())
@@ -813,7 +813,7 @@ async def test_async_run_process_closes_response_when_sink_write_fails(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(OSError, match="sink write failed"):
             await box.run_process("python", stdout=_FailingTextIO(fail_on="write"))
 
@@ -824,7 +824,7 @@ async def test_async_run_process_closes_response_when_sink_write_fails(
 def test_sync_run_process_closes_response_when_sink_flush_fails(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stream = _TrackingSyncStream(_completed_body())
@@ -833,7 +833,7 @@ def test_sync_run_process_closes_response_when_sink_flush_fails(
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with pytest.raises(OSError, match="sink flush failed"):
             box.run_process("python", stdout=_FailingTextIO(fail_on="flush"))
 
@@ -867,7 +867,7 @@ async def test_run_process_rejects_invalid_streams(
     error: type[Exception],
     match: str,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -881,7 +881,7 @@ async def test_run_process_rejects_invalid_streams(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(error, match=match):
             await box.run_process("python")
 
@@ -890,7 +890,7 @@ async def test_run_process_rejects_invalid_streams(
 async def test_async_run_process_does_not_replay_lifecycle_stream_errors(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -913,7 +913,7 @@ async def test_async_run_process_does_not_replay_lifecycle_stream_errors(
     )
 
     async with session(service_options=_session_options()):
-        box = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        box = await sandbox.create_sandbox(name="preview")
         with pytest.raises(sandbox.SandboxStreamError, match="stream stopped") as exc_info:
             await box.run_process("python")
 
@@ -925,7 +925,7 @@ async def test_async_run_process_does_not_replay_lifecycle_stream_errors(
 def test_sync_run_process_does_not_replay_lifecycle_stream_errors(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
@@ -948,7 +948,7 @@ def test_sync_run_process_does_not_replay_lifecycle_stream_errors(
     )
 
     with session(service_options=_session_options()):
-        box = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        box = sandbox_sync.create_sandbox(name="preview")
         with pytest.raises(sandbox.SandboxStreamError, match="stream stopped") as exc_info:
             box.run_process("python")
 

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -72,9 +72,9 @@ def _sandbox_response(
         "sandbox": {
             "name": name,
             "currentSessionId": session_id,
+            "image": "vercel/sandbox/universal:latest",
             "status": status,
             "persistent": True,
-            "runtime": "python3.13",
             "timeout": 300000,
             "snapshotExpiration": 0,
             "keepLastSnapshots": {
@@ -90,7 +90,6 @@ def _sandbox_response(
             "sourceSandboxName": name,
             "projectId": project_id,
             "status": session_status or status,
-            "runtime": "python3.13",
             "cwd": "/vercel/sandbox",
             "memory": 2048,
             "vcpus": 1,
@@ -121,11 +120,8 @@ def _image_sandbox_response(
         project_id=project_id,
     )
     sandbox_payload = response["sandbox"]
-    session_payload = response["session"]
     assert isinstance(sandbox_payload, dict)
-    assert isinstance(session_payload, dict)
     sandbox_payload["image"] = image
-    sandbox_payload["runtime"] = None
     return response
 
 
@@ -311,7 +307,7 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
-        assert request.url.path == "/v2/sandboxes"
+        assert request.url.path == "/v3/sandboxes"
         assert dict(request.url.params) == {"teamId": "team_123"}
         assert request.headers["authorization"] == "Bearer token"
         assert request.headers["user-agent"].startswith("vercel-sandbox/")
@@ -319,7 +315,6 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
         assert json.loads(request.content) == {
             "projectId": "prj_other",
             "name": "preview",
-            "runtime": "python3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vercel/vercel-py",
@@ -341,7 +336,7 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
         payload["tags"] = {"env": "test"}
         return httpx.Response(200, json=response)
 
-    route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=handler)
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=handler)
     update_responses = iter(
         [
             {
@@ -382,7 +377,6 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
         handle = await sandbox.create_sandbox(
             project_id="prj_other",
             name="preview",
-            runtime="python3.13",
             source=GitSource(
                 url="https://github.com/vercel/vercel-py",
                 revision="main",
@@ -397,6 +391,10 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
             ),
             tags={"env": "test"},
         )
+        assert handle.image == "vercel/sandbox/universal:latest"
+        assert not hasattr(handle, "runtime")
+        assert handle.current_session is not None
+        assert not hasattr(handle.current_session, "runtime")
 
         with pytest.raises(AttributeError):
             handle.status = SandboxStatus.STOPPED  # type: ignore[misc]
@@ -454,7 +452,7 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
 
 @respx.mock
 async def test_network_policy_async_public_flow(mock_env_clear: None) -> None:
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -514,7 +512,6 @@ async def test_network_policy_async_public_flow(mock_env_clear: None) -> None:
     async with session(service_options=_session_options()):
         handle = await sandbox.create_sandbox(
             name="preview",
-            runtime="python3.13",
             network_policy=NetworkPolicy.allow_all(),
         )
         assert handle.network_policy == NetworkPolicy.allow_all()
@@ -584,7 +581,7 @@ async def test_network_policy_async_public_flow(mock_env_clear: None) -> None:
 
 @respx.mock
 def test_network_policy_sync_public_parity(mock_env_clear: None) -> None:
-    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -604,7 +601,6 @@ def test_network_policy_sync_public_parity(mock_env_clear: None) -> None:
     with session(service_options=_session_options()):
         handle = sandbox_sync.create_sandbox(
             name="preview",
-            runtime="python3.13",
             network_policy=_authored_network_policy(),
         )
 
@@ -724,7 +720,7 @@ async def test_network_policy_structural_validation(mock_env_clear: None) -> Non
     update_route = respx.post(
         "https://sandbox.test/v2/sandboxes/sessions/sbx_123/network-policy"
     ).mock(return_value=httpx.Response(200, json={"session": _sandbox_response()["session"]}))
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
 
@@ -785,12 +781,12 @@ async def test_public_create_sandbox_serializes_source_variants(
     source: SandboxSource,
     expected: dict[str, str],
 ) -> None:
-    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
 
     async with session(service_options=_session_options()):
-        await sandbox.create_sandbox(name="preview", runtime="python3.13", source=source)
+        await sandbox.create_sandbox(name="preview", source=source)
 
     assert json.loads(route.calls.last.request.content)["source"] == expected
 
@@ -809,7 +805,7 @@ async def test_public_create_sandbox_serializes_image_without_runtime(
     mock_env_clear: None,
     image: str,
 ) -> None:
-    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_image_sandbox_response())
     )
 
@@ -822,15 +818,15 @@ async def test_public_create_sandbox_serializes_image_without_runtime(
         "image": image,
     }
     assert handle.image == "my-repository@sha256:resolved"
-    assert handle.runtime is None
+    assert not hasattr(handle, "runtime")
     assert handle.current_session is not None
-    assert handle.current_session.runtime == "python3.13"
+    assert not hasattr(handle.current_session, "runtime")
 
 
 @respx.mock
 def test_sync_create_sandbox_serializes_image_without_runtime(mock_env_clear: None) -> None:
     image = "my-repository:latest"
-    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_image_sandbox_response())
     )
 
@@ -843,25 +839,25 @@ def test_sync_create_sandbox_serializes_image_without_runtime(mock_env_clear: No
         "image": image,
     }
     assert handle.image == "my-repository@sha256:resolved"
-    assert handle.runtime is None
+    assert not hasattr(handle, "runtime")
     assert handle.current_session is not None
-    assert handle.current_session.runtime == "python3.13"
+    assert not hasattr(handle.current_session, "runtime")
 
 
 @respx.mock
 async def test_public_create_rejects_malformed_success_response(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(return_value=httpx.Response(200, json={}))
+    respx.post("https://sandbox.test/v3/sandboxes").mock(return_value=httpx.Response(200, json={}))
 
     async with session(service_options=_session_options()):
         with pytest.raises(SandboxResponseError):
-            await sandbox.create_sandbox(name="preview", runtime="python3.13")
+            await sandbox.create_sandbox(name="preview")
 
 
 @respx.mock
 async def test_public_snapshot_expiration_validation_happens_before_requests(
     mock_env_clear: None,
 ) -> None:
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -893,7 +889,7 @@ async def test_public_snapshot_expiration_validation_happens_before_requests(
 
 @respx.mock
 async def test_public_create_rejects_terminal_initial_state(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json=_sandbox_response(status="stopped", session_status="stopped"),
@@ -902,7 +898,7 @@ async def test_public_create_rejects_terminal_initial_state(mock_env_clear: None
 
     async with session(service_options=_session_options()):
         with pytest.raises(SandboxTerminalStateError) as exc_info:
-            await sandbox.create_sandbox(name="preview", runtime="python3.13")
+            await sandbox.create_sandbox(name="preview")
 
     assert exc_info.value.status is SandboxStatus.STOPPED
     assert isinstance(exc_info.value.sandbox, sandbox.Sandbox)
@@ -911,7 +907,7 @@ async def test_public_create_rejects_terminal_initial_state(mock_env_clear: None
 
 @respx.mock
 def test_sync_create_terminal_error_contains_sync_handle(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json=_sandbox_response(status="stopped", session_status="stopped"),
@@ -920,7 +916,7 @@ def test_sync_create_terminal_error_contains_sync_handle(mock_env_clear: None) -
 
     with session(service_options=_session_options()):
         with pytest.raises(SandboxTerminalStateError) as exc_info:
-            sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+            sandbox_sync.create_sandbox(name="preview")
 
     assert exc_info.value.status is SandboxStatus.STOPPED
     assert isinstance(exc_info.value.sandbox, sandbox_sync.SyncSandbox)
@@ -1109,7 +1105,7 @@ def test_sync_command_kill_after_encodes_seconds_and_omits_none(mock_env_clear: 
 
 @respx.mock
 async def test_session_closure_during_create_polling_is_rejected(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json=_sandbox_response(status="pending", session_status="pending"),
@@ -1119,7 +1115,7 @@ async def test_session_closure_during_create_polling_is_rejected(mock_env_clear:
     async with session(service_options=_session_options()):
         active_session = get_active_session()
         operation = asyncio.create_task(
-            get_sandbox_service(active_session).create_sandbox(name="preview", runtime="python3.13")
+            get_sandbox_service(active_session).create_sandbox(name="preview")
         )
         await asyncio.sleep(0)
         await active_session.aclose()
@@ -1308,7 +1304,7 @@ async def test_public_api_error_propagates_status_code_code_and_data(mock_env_cl
 
 @respx.mock
 async def test_create_sandbox_operation_invariants(mock_env_clear: None) -> None:
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     resume_route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -1329,7 +1325,7 @@ async def test_create_sandbox_operation_invariants(mock_env_clear: None) -> None
     )
 
     async with session(service_options=_session_options()):
-        operation = sandbox.create_sandbox(name="preview", runtime="python3.13")
+        operation = sandbox.create_sandbox(name="preview")
         created = await operation
         assert created.current_session is not None
         with pytest.raises(RuntimeError, match="can only be used once"):
@@ -1347,7 +1343,7 @@ async def test_create_sandbox_operation_invariants(mock_env_clear: None) -> None
     assert not destroy_route.called
 
     async with session():
-        captured = sandbox.create_sandbox(name="preview", runtime="python3.13")
+        captured = sandbox.create_sandbox(name="preview")
         captured_resume = sandbox.resume_sandbox(name="preview")
 
     with pytest.raises(VercelSessionClosedError):
@@ -1356,7 +1352,7 @@ async def test_create_sandbox_operation_invariants(mock_env_clear: None) -> None
         await captured_resume
 
     with pytest.warns(RuntimeWarning, match="never awaited or entered"):
-        unconsumed = sandbox.create_sandbox(name="preview", runtime="python3.13")
+        unconsumed = sandbox.create_sandbox(name="preview")
         del unconsumed
         gc.collect()
     with pytest.warns(RuntimeWarning, match="never awaited or entered"):
@@ -1387,7 +1383,6 @@ async def test_async_get_or_create_returns_existing_or_created_sandbox(
         assert body == {
             "projectId": "prj_other",
             "name": "missing",
-            "runtime": "python3.13",
             "persistent": True,
             "tags": {"purpose": "test"},
         }
@@ -1396,7 +1391,7 @@ async def test_async_get_or_create_returns_existing_or_created_sandbox(
             json=_sandbox_response(name="missing", session_id="sbx_missing"),
         )
 
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=create_handler)
 
     async with session(service_options=_session_options()):
         existing, existing_created = await sandbox.get_or_create_sandbox(
@@ -1407,7 +1402,6 @@ async def test_async_get_or_create_returns_existing_or_created_sandbox(
         created, was_created = await sandbox.get_or_create_sandbox(
             name="missing",
             project_id="prj_other",
-            runtime="python3.13",
             persistent=True,
             tags={"purpose": "test"},
         )
@@ -1440,7 +1434,7 @@ async def test_async_get_or_create_forwards_image_only_when_creating(
             json={"error": {"code": "not_found", "message": "not found"}},
         )
     )
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(
             200,
             json=_image_sandbox_response(name="missing-image", session_id="sbx_missing"),
@@ -1527,7 +1521,7 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
             json=_image_sandbox_response(name="stale", session_id="sbx_recreated"),
         )
 
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=create_handler)
 
     async with session(service_options=_session_options()):
         recreated, created = await sandbox.get_or_create_sandbox(
@@ -1537,7 +1531,7 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
     assert recreated.name == "stale"
     assert created is True
     assert recreated.image == "my-repository@sha256:resolved"
-    assert recreated.runtime is None
+    assert not hasattr(recreated, "runtime")
     assert get_route.calls.last.request.url.params["resume"] == "true"
     assert delete_route.call_count == 1
     assert create_route.call_count == 1
@@ -1551,7 +1545,7 @@ async def test_async_get_or_create_propagates_other_get_errors(mock_env_clear: N
             json={"error": {"code": "forbidden", "message": "nope"}},
         )
     )
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(500)
     )
 
@@ -1596,7 +1590,7 @@ def test_sync_get_or_create_defaults_to_resume_and_returns_created_flag(
             json=_image_sandbox_response(name="missing", session_id="sbx_missing"),
         )
 
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=create_handler)
 
     with session(service_options=_session_options()):
         existing, existing_created = sandbox_sync.get_or_create_sandbox(
@@ -1615,64 +1609,6 @@ def test_sync_get_or_create_defaults_to_resume_and_returns_created_flag(
     assert created.image == "my-repository@sha256:resolved"
     assert [request.url.params["resume"] for request in requests] == ["true", "true"]
     assert create_route.call_count == 1
-
-
-@respx.mock
-async def test_async_create_rejects_image_with_runtime_before_requests(
-    mock_env_clear: None,
-) -> None:
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
-    )
-    get_route = respx.get("https://sandbox.test/v2/sandboxes/conflict").mock(
-        return_value=httpx.Response(200, json=_sandbox_response(name="conflict"))
-    )
-
-    async with session(service_options=_session_options()):
-        with pytest.raises(ValueError, match="image and runtime"):
-            sandbox.create_sandbox(
-                name="conflict",
-                image="my-repository:latest",
-                runtime="python3.13",
-            )
-        with pytest.raises(ValueError, match="image and runtime"):
-            await sandbox.get_or_create_sandbox(
-                name="conflict",
-                image="my-repository:latest",
-                runtime="python3.13",
-            )
-
-    assert not create_route.called
-    assert not get_route.called
-
-
-@respx.mock
-def test_sync_create_rejects_image_with_runtime_before_requests(
-    mock_env_clear: None,
-) -> None:
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
-    )
-    get_route = respx.get("https://sandbox.test/v2/sandboxes/conflict").mock(
-        return_value=httpx.Response(200, json=_sandbox_response(name="conflict"))
-    )
-
-    with session(service_options=_session_options()):
-        with pytest.raises(ValueError, match="image and runtime"):
-            sandbox_sync.create_sandbox(
-                name="conflict",
-                image="my-repository:latest",
-                runtime="python3.13",
-            )
-        with pytest.raises(ValueError, match="image and runtime"):
-            sandbox_sync.get_or_create_sandbox(
-                name="conflict",
-                image="my-repository:latest",
-                runtime="python3.13",
-            )
-
-    assert not create_route.called
-    assert not get_route.called
 
 
 @respx.mock
@@ -1735,7 +1671,7 @@ def test_sync_get_is_plain_handle_and_create_resume_are_managed(
         return httpx.Response(200, json=_sandbox_response())
 
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(side_effect=get_handler)
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
@@ -1754,12 +1690,16 @@ def test_sync_get_is_plain_handle_and_create_resume_are_managed(
 
     with session(service_options=_session_options()):
         fetched = sandbox_sync.get_sandbox(name="preview")
-        created = sandbox_sync.create_sandbox(name="preview", runtime="python3.13")
+        created = sandbox_sync.create_sandbox(name="preview")
         resumed = sandbox_sync.resume_sandbox(name="preview")
 
     assert not hasattr(fetched, "__enter__")
     assert hasattr(created, "__enter__")
     assert hasattr(resumed, "__enter__")
+    assert created.image == "vercel/sandbox/universal:latest"
+    assert not hasattr(created, "runtime")
+    assert created.current_session is not None
+    assert not hasattr(created.current_session, "runtime")
     assert [request.url.params["resume"] for request in requests] == ["false", "true"]
     assert not stop_route.called
     assert not destroy_route.called
@@ -1767,7 +1707,7 @@ def test_sync_get_is_plain_handle_and_create_resume_are_managed(
 
 @respx.mock
 async def test_closed_session_rejects_handles_and_lazy_readers(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -1785,7 +1725,7 @@ async def test_closed_session_rejects_handles_and_lazy_readers(mock_env_clear: N
 
     async with session(service_options=_session_options()):
         service = get_sandbox_service(get_active_session())
-        handle = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        handle = await sandbox.create_sandbox(name="preview")
         resumed = await sandbox.resume_sandbox(name="preview")
         assert resumed.current_session is not None
         runtime_session = resumed.current_session
@@ -1818,7 +1758,7 @@ async def test_async_managed_sandbox_cleanup_modes(mock_env_clear: None) -> None
         name = body["name"]
         return httpx.Response(200, json=_sandbox_response(name=name, session_id=f"sbx_{name}"))
 
-    respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
+    respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=create_handler)
     respx.get("https://sandbox.test/v2/sandboxes/resumed").mock(
         return_value=httpx.Response(
             200, json=_sandbox_response(name="resumed", session_id="sbx_resumed")
@@ -1867,11 +1807,9 @@ async def test_async_managed_sandbox_cleanup_modes(mock_env_clear: None) -> None
     )
 
     async with session(service_options=_session_options()):
-        async with sandbox.create_sandbox(name="default", runtime="python3.13") as default:
+        async with sandbox.create_sandbox(name="default") as default:
             pass
-        async with sandbox.create_sandbox(
-            name="retained", runtime="python3.13", destroy=False
-        ) as retained:
+        async with sandbox.create_sandbox(name="retained", destroy=False) as retained:
             pass
         async with sandbox.resume_sandbox(name="resumed") as resumed:
             pass
@@ -1902,7 +1840,7 @@ def test_sync_managed_sandbox_cleanup_modes(mock_env_clear: None) -> None:
         name = body["name"]
         return httpx.Response(200, json=_sandbox_response(name=name, session_id=f"sbx_{name}"))
 
-    respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
+    respx.post("https://sandbox.test/v3/sandboxes").mock(side_effect=create_handler)
     respx.get("https://sandbox.test/v2/sandboxes/resumed").mock(
         return_value=httpx.Response(
             200, json=_sandbox_response(name="resumed", session_id="sbx_resumed")
@@ -1951,11 +1889,9 @@ def test_sync_managed_sandbox_cleanup_modes(mock_env_clear: None) -> None:
     )
 
     with session(service_options=_session_options()):
-        with sandbox_sync.create_sandbox(name="default", runtime="python3.13") as default:
+        with sandbox_sync.create_sandbox(name="default") as default:
             pass
-        with sandbox_sync.create_sandbox(
-            name="retained", runtime="python3.13", destroy=False
-        ) as retained:
+        with sandbox_sync.create_sandbox(name="retained", destroy=False) as retained:
             pass
         with sandbox_sync.resume_sandbox(name="resumed") as resumed:
             pass
@@ -1979,7 +1915,7 @@ def test_sync_managed_sandbox_cleanup_modes(mock_env_clear: None) -> None:
 
 @respx.mock
 async def test_async_context_cleanup_wraps_api_failure(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
@@ -1999,7 +1935,7 @@ async def test_async_context_cleanup_wraps_api_failure(mock_env_clear: None) -> 
 
     async with session(service_options=_session_options()):
         with pytest.raises(SandboxCleanupError) as exc_info:
-            async with sandbox.create_sandbox(name="preview", runtime="python3.13"):
+            async with sandbox.create_sandbox(name="preview"):
                 pass
 
     assert exc_info.value.resource_type == "sandbox"
@@ -2010,7 +1946,7 @@ async def test_async_context_cleanup_wraps_api_failure(mock_env_clear: None) -> 
 
 @respx.mock
 def test_sync_context_cleanup_wraps_api_failure(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
@@ -2030,7 +1966,7 @@ def test_sync_context_cleanup_wraps_api_failure(mock_env_clear: None) -> None:
 
     with session(service_options=_session_options()):
         with pytest.raises(SandboxCleanupError) as exc_info:
-            with sandbox_sync.create_sandbox(name="preview", runtime="python3.13"):
+            with sandbox_sync.create_sandbox(name="preview"):
                 pass
 
     assert exc_info.value.resource_type == "sandbox"
@@ -2043,7 +1979,7 @@ def test_sync_context_cleanup_wraps_api_failure(mock_env_clear: None) -> None:
 async def test_create_cleanup_attempts_destroy_after_stop_failure(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
@@ -2060,7 +1996,7 @@ async def test_create_cleanup_attempts_destroy_after_stop_failure(
 
     async with session(service_options=_session_options()):
         with pytest.raises(SandboxCleanupError) as exc_info:
-            async with sandbox.create_sandbox(name="preview", runtime="python3.13"):
+            async with sandbox.create_sandbox(name="preview"):
                 pass
 
     assert destroy_route.called
@@ -2072,7 +2008,7 @@ async def test_create_cleanup_attempts_destroy_after_stop_failure(
 def test_sync_create_cleanup_attempts_destroy_after_stop_failure(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_123/stop").mock(
@@ -2089,7 +2025,7 @@ def test_sync_create_cleanup_attempts_destroy_after_stop_failure(
 
     with session(service_options=_session_options()):
         with pytest.raises(SandboxCleanupError) as exc_info:
-            with sandbox_sync.create_sandbox(name="preview", runtime="python3.13"):
+            with sandbox_sync.create_sandbox(name="preview"):
                 pass
 
     assert destroy_route.called
@@ -2411,7 +2347,7 @@ async def test_async_sandbox_recovery_preserves_route_projection(
 
 async def _run_async_unrecovered_operation(handle: sandbox.Sandbox, operation: str) -> object:
     if operation == "update":
-        return await handle.update(runtime="node22")
+        return await handle.update(ports=[3001])
     if operation == "stop":
         return await handle.stop()
     if operation == "destroy":
@@ -2540,7 +2476,7 @@ async def test_async_transition_poll_failure_propagates_without_resuming(
 
 def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation: str) -> object:
     if operation == "update":
-        return handle.update(runtime="node22")
+        return handle.update(ports=[3001])
     if operation == "stop":
         return handle.stop()
     if operation == "destroy":
@@ -2554,7 +2490,7 @@ def _run_sync_unrecovered_operation(handle: sandbox_sync.SyncSandbox, operation:
 
 @respx.mock
 async def test_mutating_handles_reject_mismatched_response_identity(mock_env_clear: None) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
     respx.patch("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -2577,9 +2513,9 @@ async def test_mutating_handles_reject_mismatched_response_identity(mock_env_cle
     )
 
     async with session(service_options=_session_options()):
-        handle = await sandbox.create_sandbox(name="preview", runtime="python3.13")
+        handle = await sandbox.create_sandbox(name="preview")
         with pytest.raises(SandboxResponseError):
-            await handle.update(runtime="node22")
+            await handle.update(ports=[3001])
 
         command = await handle.create_process("python", ["--version"])
         with pytest.raises(SandboxResponseError):
@@ -3490,7 +3426,7 @@ def test_sync_managed_resume_sandbox_stops_adopted_replacement(
 async def test_managed_create_sandbox_stops_replacement_before_destroy(
     mock_env_clear: None,
 ) -> None:
-    respx.post("https://sandbox.test/v2/sandboxes").mock(
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response(session_id="sbx_old"))
     )
     respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
@@ -3521,7 +3457,7 @@ async def test_managed_create_sandbox_stops_replacement_before_destroy(
     )
 
     async with session(service_options=_session_options()):
-        async with sandbox.create_sandbox(name="preview", runtime="python3.13") as box:
+        async with sandbox.create_sandbox(name="preview") as box:
             assert await box.query_processes() == []
 
     assert old_stop.call_count == 0

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -108,6 +108,27 @@ def _sandbox_response(
     }
 
 
+def _image_sandbox_response(
+    *,
+    image: str = "my-repository@sha256:resolved",
+    name: str = "preview",
+    session_id: str = "sbx_123",
+    project_id: str = "prj_123",
+) -> dict[str, Any]:
+    response = _sandbox_response(
+        name=name,
+        session_id=session_id,
+        project_id=project_id,
+    )
+    sandbox_payload = response["sandbox"]
+    session_payload = response["session"]
+    assert isinstance(sandbox_payload, dict)
+    assert isinstance(session_payload, dict)
+    sandbox_payload["image"] = image
+    sandbox_payload["runtime"] = None
+    return response
+
+
 def _command_response(
     *,
     command_id: str = "cmd_123",
@@ -775,6 +796,59 @@ async def test_public_create_sandbox_serializes_source_variants(
 
 
 @respx.mock
+@pytest.mark.parametrize(
+    "image",
+    [
+        "my-repository",
+        "my-repository:latest",
+        "my-repository@sha256:request-digest",
+        "vcr.vercel.com/team-slug/project-slug/my-repository:latest",
+    ],
+)
+async def test_public_create_sandbox_serializes_image_without_runtime(
+    mock_env_clear: None,
+    image: str,
+) -> None:
+    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_image_sandbox_response())
+    )
+
+    async with session(service_options=_session_options()):
+        handle = await sandbox.create_sandbox(name="preview", image=image)
+
+    assert json.loads(route.calls.last.request.content) == {
+        "projectId": "prj_123",
+        "name": "preview",
+        "image": image,
+    }
+    assert handle.image == "my-repository@sha256:resolved"
+    assert handle.runtime is None
+    assert handle.current_session is not None
+    assert handle.current_session.runtime == "python3.13"
+
+
+@respx.mock
+def test_sync_create_sandbox_serializes_image_without_runtime(mock_env_clear: None) -> None:
+    image = "my-repository:latest"
+    route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_image_sandbox_response())
+    )
+
+    with session(service_options=_session_options()):
+        handle = sandbox_sync.create_sandbox(name="preview", image=image)
+
+    assert json.loads(route.calls.last.request.content) == {
+        "projectId": "prj_123",
+        "name": "preview",
+        "image": image,
+    }
+    assert handle.image == "my-repository@sha256:resolved"
+    assert handle.runtime is None
+    assert handle.current_session is not None
+    assert handle.current_session.runtime == "python3.13"
+
+
+@respx.mock
 async def test_public_create_rejects_malformed_success_response(mock_env_clear: None) -> None:
     respx.post("https://sandbox.test/v2/sandboxes").mock(return_value=httpx.Response(200, json={}))
 
@@ -1328,6 +1402,7 @@ async def test_async_get_or_create_returns_existing_or_created_sandbox(
         existing, existing_created = await sandbox.get_or_create_sandbox(
             name="existing",
             project_id="prj_other",
+            image="existing-repository:latest",
         )
         created, was_created = await sandbox.get_or_create_sandbox(
             name="missing",
@@ -1344,6 +1419,56 @@ async def test_async_get_or_create_returns_existing_or_created_sandbox(
     assert existing_get.calls.last.request.url.params["resume"] == "true"
     assert missing_get.calls.last.request.url.params["resume"] == "true"
     assert create_route.call_count == 1
+
+
+@respx.mock
+async def test_async_get_or_create_forwards_image_only_when_creating(
+    mock_env_clear: None,
+) -> None:
+    existing_get = respx.get("https://sandbox.test/v2/sandboxes/existing-image").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                **_image_sandbox_response(name="existing-image", session_id="sbx_existing"),
+                "resumed": True,
+            },
+        )
+    )
+    missing_get = respx.get("https://sandbox.test/v2/sandboxes/missing-image").mock(
+        return_value=httpx.Response(
+            404,
+            json={"error": {"code": "not_found", "message": "not found"}},
+        )
+    )
+    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(
+            200,
+            json=_image_sandbox_response(name="missing-image", session_id="sbx_missing"),
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        existing, existing_created = await sandbox.get_or_create_sandbox(
+            name="existing-image",
+            image="ignored-repository:latest",
+        )
+        created, created_flag = await sandbox.get_or_create_sandbox(
+            name="missing-image",
+            image="requested-repository:latest",
+        )
+
+    assert existing_created is False
+    assert existing.image == "my-repository@sha256:resolved"
+    assert created_flag is True
+    assert created.image == "my-repository@sha256:resolved"
+    assert existing_get.called
+    assert missing_get.called
+    assert create_route.call_count == 1
+    assert json.loads(create_route.calls.last.request.content) == {
+        "projectId": "prj_123",
+        "name": "missing-image",
+        "image": "requested-repository:latest",
+    }
 
 
 @respx.mock
@@ -1390,18 +1515,29 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
             json={"error": {"code": "not_found", "message": "already deleted"}},
         )
     )
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(
+
+    def create_handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content) == {
+            "projectId": "prj_123",
+            "name": "stale",
+            "image": "stale-repository:latest",
+        }
+        return httpx.Response(
             200,
-            json=_sandbox_response(name="stale", session_id="sbx_recreated"),
+            json=_image_sandbox_response(name="stale", session_id="sbx_recreated"),
         )
-    )
+
+    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
 
     async with session(service_options=_session_options()):
-        recreated, created = await sandbox.get_or_create_sandbox(name="stale")
+        recreated, created = await sandbox.get_or_create_sandbox(
+            name="stale", image="stale-repository:latest"
+        )
 
     assert recreated.name == "stale"
     assert created is True
+    assert recreated.image == "my-repository@sha256:resolved"
+    assert recreated.runtime is None
     assert get_route.calls.last.request.url.params["resume"] == "true"
     assert delete_route.call_count == 1
     assert create_route.call_count == 1
@@ -1448,16 +1584,27 @@ def test_sync_get_or_create_defaults_to_resume_and_returns_created_flag(
 
     respx.get("https://sandbox.test/v2/sandboxes/existing").mock(side_effect=get_handler)
     respx.get("https://sandbox.test/v2/sandboxes/missing").mock(side_effect=get_handler)
-    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
-        return_value=httpx.Response(
+
+    def create_handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content) == {
+            "projectId": "prj_123",
+            "name": "missing",
+            "image": "missing-repository:latest",
+        }
+        return httpx.Response(
             200,
-            json=_sandbox_response(name="missing", session_id="sbx_missing"),
+            json=_image_sandbox_response(name="missing", session_id="sbx_missing"),
         )
-    )
+
+    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(side_effect=create_handler)
 
     with session(service_options=_session_options()):
-        existing, existing_created = sandbox_sync.get_or_create_sandbox(name="existing")
-        created, was_created = sandbox_sync.get_or_create_sandbox(name="missing")
+        existing, existing_created = sandbox_sync.get_or_create_sandbox(
+            name="existing", image="existing-repository:latest"
+        )
+        created, was_created = sandbox_sync.get_or_create_sandbox(
+            name="missing", image="missing-repository:latest"
+        )
 
     assert existing.name == "existing"
     assert existing_created is False
@@ -1465,8 +1612,67 @@ def test_sync_get_or_create_defaults_to_resume_and_returns_created_flag(
     assert was_created is True
     assert not hasattr(existing, "__enter__")
     assert not hasattr(created, "__enter__")
+    assert created.image == "my-repository@sha256:resolved"
     assert [request.url.params["resume"] for request in requests] == ["true", "true"]
     assert create_route.call_count == 1
+
+
+@respx.mock
+async def test_async_create_rejects_image_with_runtime_before_requests(
+    mock_env_clear: None,
+) -> None:
+    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    get_route = respx.get("https://sandbox.test/v2/sandboxes/conflict").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="conflict"))
+    )
+
+    async with session(service_options=_session_options()):
+        with pytest.raises(ValueError, match="image and runtime"):
+            sandbox.create_sandbox(
+                name="conflict",
+                image="my-repository:latest",
+                runtime="python3.13",
+            )
+        with pytest.raises(ValueError, match="image and runtime"):
+            await sandbox.get_or_create_sandbox(
+                name="conflict",
+                image="my-repository:latest",
+                runtime="python3.13",
+            )
+
+    assert not create_route.called
+    assert not get_route.called
+
+
+@respx.mock
+def test_sync_create_rejects_image_with_runtime_before_requests(
+    mock_env_clear: None,
+) -> None:
+    create_route = respx.post("https://sandbox.test/v2/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    get_route = respx.get("https://sandbox.test/v2/sandboxes/conflict").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="conflict"))
+    )
+
+    with session(service_options=_session_options()):
+        with pytest.raises(ValueError, match="image and runtime"):
+            sandbox_sync.create_sandbox(
+                name="conflict",
+                image="my-repository:latest",
+                runtime="python3.13",
+            )
+        with pytest.raises(ValueError, match="image and runtime"):
+            sandbox_sync.get_or_create_sandbox(
+                name="conflict",
+                image="my-repository:latest",
+                runtime="python3.13",
+            )
+
+    assert not create_route.called
+    assert not get_route.called
 
 
 @respx.mock

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -93,7 +93,6 @@ def create_sandbox(
     *,
     project_id: str | None = None,
     name: str | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -117,9 +116,8 @@ def create_sandbox(
         project_id: Project that owns the sandbox. Uses the active credentials
             when omitted.
         name: Requested sandbox name. The service generates one when omitted.
-        runtime: Runtime image or runtime identifier.
-        image: Vercel Container Registry image reference. Mutually exclusive
-            with ``runtime``; the backend validates and resolves the reference.
+        image: Vercel Container Registry image reference. The backend validates
+            and resolves the reference.
         source: Git, tarball, or snapshot source used to initialize the sandbox.
         ports: Ports to expose from the sandbox.
         execution_time_limit: Maximum session runtime in seconds or as a
@@ -146,7 +144,6 @@ def create_sandbox(
         _service(),
         project_id=project_id,
         name=name,
-        runtime=runtime,
         image=image,
         source=source,
         ports=ports,
@@ -168,7 +165,6 @@ async def get_or_create_sandbox(
     project_id: str | None = None,
     resume: bool = True,
     include_system_routes: bool | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -188,7 +184,7 @@ async def get_or_create_sandbox(
 
     Args:
         image: Vercel Container Registry image reference used only when the
-            sandbox must be created. Mutually exclusive with ``runtime``.
+            sandbox must be created.
 
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call
@@ -201,7 +197,6 @@ async def get_or_create_sandbox(
         project_id=project_id,
         resume=resume,
         include_system_routes=include_system_routes,
-        runtime=runtime,
         image=image,
         source=source,
         ports=ports,

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -94,6 +94,7 @@ def create_sandbox(
     project_id: str | None = None,
     name: str | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -117,6 +118,8 @@ def create_sandbox(
             when omitted.
         name: Requested sandbox name. The service generates one when omitted.
         runtime: Runtime image or runtime identifier.
+        image: Vercel Container Registry image reference. Mutually exclusive
+            with ``runtime``; the backend validates and resolves the reference.
         source: Git, tarball, or snapshot source used to initialize the sandbox.
         ports: Ports to expose from the sandbox.
         execution_time_limit: Maximum session runtime in seconds or as a
@@ -144,6 +147,7 @@ def create_sandbox(
         project_id=project_id,
         name=name,
         runtime=runtime,
+        image=image,
         source=source,
         ports=ports,
         execution_time_limit=execution_time_limit,
@@ -165,6 +169,7 @@ async def get_or_create_sandbox(
     resume: bool = True,
     include_system_routes: bool | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -181,6 +186,10 @@ async def get_or_create_sandbox(
     The existing-sandbox lookup resumes by default. If its latest snapshot is
     missing, the stale named sandbox is destroyed and recreated.
 
+    Args:
+        image: Vercel Container Registry image reference used only when the
+            sandbox must be created. Mutually exclusive with ``runtime``.
+
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call
         created or recreated the sandbox, and false when it returned an
@@ -193,6 +202,7 @@ async def get_or_create_sandbox(
         resume=resume,
         include_system_routes=include_system_routes,
         runtime=runtime,
+        image=image,
         source=source,
         ports=ports,
         execution_time_limit=execution_time_limit,

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -181,10 +181,29 @@ async def get_or_create_sandbox(
 
     The existing-sandbox lookup resumes by default. If its latest snapshot is
     missing, the stale named sandbox is destroyed and recreated.
+    Creation options are used only when the sandbox must be created or
+    recreated.
 
     Args:
-        image: Vercel Container Registry image reference used only when the
-            sandbox must be created.
+        name: Sandbox name to retrieve or create.
+        project_id: Project that owns the sandbox. Uses the active credentials
+            when omitted.
+        resume: Whether to resume an existing stopped sandbox during lookup.
+        include_system_routes: Whether to include platform-managed routes.
+        image: Vercel Container Registry image reference. The backend validates
+            and resolves the reference.
+        source: Git, tarball, or snapshot source used to initialize the sandbox.
+        ports: Ports to expose from the sandbox.
+        execution_time_limit: Maximum session runtime in seconds or as a
+            duration.
+        resources: Requested CPU and memory resources.
+        persistent: Whether the sandbox persists beyond its current session.
+        network_policy: Network access policy sent to the Sandbox API.
+        env: Environment variables for the sandbox.
+        tags: Metadata tags used to organize and query sandboxes.
+        snapshot_expiration: Default lifetime for snapshots created from this
+            sandbox.
+        snapshot_retention: Automatic snapshot retention policy.
 
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -134,6 +134,7 @@ class _CreateSandboxRequest(_ApiRequestModel):
     project_id: str = Field(serialization_alias="projectId")
     name: str | None = None
     runtime: str | None = None
+    image: str | None = None
     source: SandboxSource | None = None
     ports: list[int] | None = None
     timeout: timedelta | None = None
@@ -373,6 +374,7 @@ class _SandboxPayload(_ApiModel):
         validation_alias=AliasChoices("current_session_id", "currentSessionId"),
         serialization_alias="currentSessionId",
     )
+    image: str | None = None
     runtime: str | None = None
     status: SandboxStatus | None = None
     persistent: bool | None = None
@@ -573,6 +575,8 @@ class _SandboxResponse(_ApiModel):
                 "execution_time_limit",
                 "network_policy",
             ):
+                if name == "runtime" and payload.image is not None:
+                    continue
                 if getattr(payload, name) is None:
                     updates[name] = getattr(session, name)
         payload = payload.model_copy(update=updates)
@@ -683,6 +687,7 @@ def _sandbox_state(
     return SandboxState(
         name=payload.name,
         current_session_id=payload.current_session_id,
+        image=payload.image,
         runtime=payload.runtime,
         status=payload.status,
         persistent=payload.persistent,
@@ -909,6 +914,7 @@ class SandboxApiClient:
         project_id: str | None = None,
         name: str | None = None,
         runtime: str | None = None,
+        image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
         execution_time_limit: timedelta | None = None,
@@ -925,6 +931,7 @@ class SandboxApiClient:
             project_id=project_id or credentials.project_id,
             name=name,
             runtime=runtime,
+            image=image,
             source=source,
             ports=ports,
             timeout=execution_time_limit,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -1,4 +1,4 @@
-"""Internal Sandbox v2 API client."""
+"""Internal Sandbox API client."""
 
 import json
 import platform
@@ -133,7 +133,6 @@ class _ApiRequestModel(_ApiModel):
 class _CreateSandboxRequest(_ApiRequestModel):
     project_id: str = Field(serialization_alias="projectId")
     name: str | None = None
-    runtime: str | None = None
     image: str | None = None
     source: SandboxSource | None = None
     ports: list[int] | None = None
@@ -175,7 +174,6 @@ class _CreateSandboxRequest(_ApiRequestModel):
 
 
 class _UpdateSandboxRequest(_ApiRequestModel):
-    runtime: str | None = None
     ports: list[int] | None = None
     timeout: timedelta | None = None
     resources: SandboxResources | None = None
@@ -326,7 +324,6 @@ class _RuntimeSessionPayload(_ApiModel):
         serialization_alias="projectId",
     )
     status: SandboxStatus | None = None
-    runtime: str | None = None
     cwd: str | None = None
     region: str | None = None
     memory: int | None = None
@@ -375,7 +372,6 @@ class _SandboxPayload(_ApiModel):
         serialization_alias="currentSessionId",
     )
     image: str | None = None
-    runtime: str | None = None
     status: SandboxStatus | None = None
     persistent: bool | None = None
     current_snapshot_id: str | None = Field(
@@ -566,7 +562,6 @@ class _SandboxResponse(_ApiModel):
             if payload.project_id is None and session.project_id is not None:
                 updates["project_id"] = session.project_id
             for name in (
-                "runtime",
                 "status",
                 "cwd",
                 "region",
@@ -575,8 +570,6 @@ class _SandboxResponse(_ApiModel):
                 "execution_time_limit",
                 "network_policy",
             ):
-                if name == "runtime" and payload.image is not None:
-                    continue
                 if getattr(payload, name) is None:
                     updates[name] = getattr(session, name)
         payload = payload.model_copy(update=updates)
@@ -661,7 +654,6 @@ def _runtime_session_state(payload: _RuntimeSessionPayload) -> SandboxRuntimeSes
         sandbox_name=payload.sandbox_name,
         project_id=payload.project_id,
         status=payload.status,
-        runtime=payload.runtime,
         cwd=payload.cwd,
         region=payload.region,
         memory=payload.memory,
@@ -688,7 +680,6 @@ def _sandbox_state(
         name=payload.name,
         current_session_id=payload.current_session_id,
         image=payload.image,
-        runtime=payload.runtime,
         status=payload.status,
         persistent=payload.persistent,
         current_snapshot_id=payload.current_snapshot_id,
@@ -756,7 +747,7 @@ def _validate_response(model: type[ResponseModelT], data: JSONObject) -> Respons
         return model.model_validate(data)
     except ValidationError as exc:
         raise SandboxResponseError(
-            "Sandbox API response did not match the expected v2 shape",
+            "Sandbox API response did not match the expected shape",
             data=data,
         ) from exc
 
@@ -913,7 +904,6 @@ class SandboxApiClient:
         *,
         project_id: str | None = None,
         name: str | None = None,
-        runtime: str | None = None,
         image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
@@ -930,7 +920,6 @@ class SandboxApiClient:
         request = _CreateSandboxRequest(
             project_id=project_id or credentials.project_id,
             name=name,
-            runtime=runtime,
             image=image,
             source=source,
             ports=ports,
@@ -944,7 +933,7 @@ class SandboxApiClient:
             keep_last_snapshots=snapshot_retention,
         )
         data = await self._request_json(
-            "POST", "v2/sandboxes", credentials=credentials, body=request.to_api_dict()
+            "POST", "v3/sandboxes", credentials=credentials, body=request.to_api_dict()
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -1027,7 +1016,6 @@ class SandboxApiClient:
         *,
         name: str,
         project_id: str | None = None,
-        runtime: str | None = None,
         ports: list[int] | None = None,
         execution_time_limit: timedelta | None = None,
         resources: SandboxResources | None = None,
@@ -1042,7 +1030,6 @@ class SandboxApiClient:
         credentials = await self._credentials_factory()
         effective_project_id = project_id or credentials.project_id
         request = _UpdateSandboxRequest(
-            runtime=runtime,
             ports=ports,
             timeout=execution_time_limit,
             resources=resources,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -53,6 +53,7 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     _parse_snapshot_expiration,
+    _validate_image_and_runtime,
     _WriteFile,
 )
 from vercel.sandbox._internal.pagination import (
@@ -1411,6 +1412,7 @@ class _CreateSandboxParams:
     project_id: str | None = None
     name: str | None = None
     runtime: str | None = None
+    image: str | None = None
     source: SandboxSource | None = None
     ports: list[int] | None = None
     execution_time_limit: timedelta | None = None
@@ -1457,6 +1459,7 @@ class CreateSandboxOperation:
             project_id=self._params.project_id,
             name=self._params.name,
             runtime=self._params.runtime,
+            image=self._params.image,
             source=self._params.source,
             ports=self._params.ports,
             execution_time_limit=self._params.execution_time_limit,
@@ -1599,6 +1602,7 @@ def create_sandbox_operation(
     project_id: str | None = None,
     name: str | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -1611,12 +1615,14 @@ def create_sandbox_operation(
     snapshot_retention: SnapshotRetention | None = None,
     destroy: bool = True,
 ) -> CreateSandboxOperation:
+    _validate_image_and_runtime(image=image, runtime=runtime)
     return CreateSandboxOperation(
         service=service,
         params=_CreateSandboxParams(
             project_id=project_id,
             name=name,
             runtime=runtime,
+            image=image,
             source=source,
             ports=ports,
             execution_time_limit=parse_duration_seconds(execution_time_limit),
@@ -1660,6 +1666,7 @@ async def get_or_create_sandbox(
     resume: bool = True,
     include_system_routes: bool | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -1678,6 +1685,7 @@ async def get_or_create_sandbox(
             resume=resume,
             include_system_routes=include_system_routes,
             runtime=runtime,
+            image=image,
             source=source,
             ports=ports,
             execution_time_limit=parse_duration_seconds(execution_time_limit),

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -53,7 +53,6 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     _parse_snapshot_expiration,
-    _validate_image_and_runtime,
     _WriteFile,
 )
 from vercel.sandbox._internal.pagination import (
@@ -1277,7 +1276,6 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
     async def update(
         self,
         *,
-        runtime: str | None = None,
         ports: list[int] | None = None,
         execution_time_limit: DurationInput = None,
         resources: SandboxResources | None = None,
@@ -1304,7 +1302,6 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         payload = await self._service.update_sandbox(
             name=self.name,
             project_id=self.project_id,
-            runtime=runtime,
             ports=ports,
             execution_time_limit=parse_duration_seconds(execution_time_limit),
             resources=resources,
@@ -1411,7 +1408,6 @@ class SandboxSessionOperation:
 class _CreateSandboxParams:
     project_id: str | None = None
     name: str | None = None
-    runtime: str | None = None
     image: str | None = None
     source: SandboxSource | None = None
     ports: list[int] | None = None
@@ -1458,7 +1454,6 @@ class CreateSandboxOperation:
             self._service,
             project_id=self._params.project_id,
             name=self._params.name,
-            runtime=self._params.runtime,
             image=self._params.image,
             source=self._params.source,
             ports=self._params.ports,
@@ -1601,7 +1596,6 @@ def create_sandbox_operation(
     *,
     project_id: str | None = None,
     name: str | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -1615,13 +1609,11 @@ def create_sandbox_operation(
     snapshot_retention: SnapshotRetention | None = None,
     destroy: bool = True,
 ) -> CreateSandboxOperation:
-    _validate_image_and_runtime(image=image, runtime=runtime)
     return CreateSandboxOperation(
         service=service,
         params=_CreateSandboxParams(
             project_id=project_id,
             name=name,
-            runtime=runtime,
             image=image,
             source=source,
             ports=ports,
@@ -1665,7 +1657,6 @@ async def get_or_create_sandbox(
     project_id: str | None = None,
     resume: bool = True,
     include_system_routes: bool | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -1684,7 +1675,6 @@ async def get_or_create_sandbox(
             project_id=project_id,
             resume=resume,
             include_system_routes=include_system_routes,
-            runtime=runtime,
             image=image,
             source=source,
             ports=ports,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/models.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/models.py
@@ -26,11 +26,6 @@ _MAX_SNAPSHOT_EXPIRATION = timedelta(days=365 * 10)
 _ZERO_DELTA = timedelta(0)
 
 
-def _validate_image_and_runtime(*, image: str | None, runtime: str | None) -> None:
-    if image is not None and runtime is not None:
-        raise ValueError("image and runtime are mutually exclusive")
-
-
 @dataclass(frozen=True, slots=True)
 class NetworkPolicyMatcher:
     """Match one request value using one comparison strategy."""

--- a/src/vercel-sandbox/vercel/sandbox/_internal/models.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/models.py
@@ -26,6 +26,11 @@ _MAX_SNAPSHOT_EXPIRATION = timedelta(days=365 * 10)
 _ZERO_DELTA = timedelta(0)
 
 
+def _validate_image_and_runtime(*, image: str | None, runtime: str | None) -> None:
+    if image is not None and runtime is not None:
+        raise ValueError("image and runtime are mutually exclusive")
+
+
 @dataclass(frozen=True, slots=True)
 class NetworkPolicyMatcher:
     """Match one request value using one comparison strategy."""

--- a/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
@@ -443,6 +443,10 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
         return self._payload.runtime
 
     @property
+    def image(self) -> str | None:
+        return self._payload.image
+
+    @property
     def status(self) -> SandboxStatus | None:
         return self._payload.status
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/runtime_common.py
@@ -327,10 +327,6 @@ class RuntimeSessionHandleBase:
         return self._payload.status
 
     @property
-    def runtime(self) -> str | None:
-        return self._payload.runtime
-
-    @property
     def cwd(self) -> str | None:
         return self._payload.cwd
 
@@ -437,10 +433,6 @@ class SandboxHandleBase(Generic[RuntimeSessionHandleT]):
     @property
     def current_session_id(self) -> str:
         return self._payload.current_session_id
-
-    @property
-    def runtime(self) -> str | None:
-        return self._payload.runtime
 
     @property
     def image(self) -> str | None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -37,7 +37,6 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     TagFilter,
-    _validate_image_and_runtime,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -254,7 +253,6 @@ class SandboxService:
         *,
         project_id: str | None = None,
         name: str | None = None,
-        runtime: str | None = None,
         image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
@@ -267,12 +265,10 @@ class SandboxService:
         snapshot_expiration: SnapshotExpiration | None = None,
         snapshot_retention: SnapshotRetention | None = None,
     ) -> SandboxState:
-        _validate_image_and_runtime(image=image, runtime=runtime)
         self._ensure_open()
         sandbox = await self._api_client.create_sandbox(
             project_id=project_id,
             name=name,
-            runtime=runtime,
             image=image,
             source=source,
             ports=ports,
@@ -310,7 +306,6 @@ class SandboxService:
         project_id: str | None = None,
         resume: bool = True,
         include_system_routes: bool | None = None,
-        runtime: str | None = None,
         image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
@@ -324,7 +319,6 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
     ) -> tuple[SandboxState, bool]:
         """Return a named sandbox and whether it had to be created."""
-        _validate_image_and_runtime(image=image, runtime=runtime)
         try:
             sandbox = await self.get_sandbox(
                 name=name,
@@ -349,7 +343,6 @@ class SandboxService:
         sandbox = await self.create_sandbox(
             name=name,
             project_id=project_id,
-            runtime=runtime,
             image=image,
             source=source,
             ports=ports,
@@ -393,7 +386,6 @@ class SandboxService:
         *,
         name: str,
         project_id: str | None = None,
-        runtime: str | None = None,
         ports: list[int] | None = None,
         execution_time_limit: timedelta | None = None,
         resources: SandboxResources | None = None,
@@ -409,7 +401,6 @@ class SandboxService:
         return await self._api_client.update_sandbox(
             name=name,
             project_id=project_id,
-            runtime=runtime,
             ports=ports,
             execution_time_limit=execution_time_limit,
             resources=resources,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -37,6 +37,7 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     TagFilter,
+    _validate_image_and_runtime,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -254,6 +255,7 @@ class SandboxService:
         project_id: str | None = None,
         name: str | None = None,
         runtime: str | None = None,
+        image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
         execution_time_limit: timedelta | None = None,
@@ -265,11 +267,13 @@ class SandboxService:
         snapshot_expiration: SnapshotExpiration | None = None,
         snapshot_retention: SnapshotRetention | None = None,
     ) -> SandboxState:
+        _validate_image_and_runtime(image=image, runtime=runtime)
         self._ensure_open()
         sandbox = await self._api_client.create_sandbox(
             project_id=project_id,
             name=name,
             runtime=runtime,
+            image=image,
             source=source,
             ports=ports,
             execution_time_limit=execution_time_limit,
@@ -307,6 +311,7 @@ class SandboxService:
         resume: bool = True,
         include_system_routes: bool | None = None,
         runtime: str | None = None,
+        image: str | None = None,
         source: SandboxSource | None = None,
         ports: list[int] | None = None,
         execution_time_limit: timedelta | None = None,
@@ -319,6 +324,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
     ) -> tuple[SandboxState, bool]:
         """Return a named sandbox and whether it had to be created."""
+        _validate_image_and_runtime(image=image, runtime=runtime)
         try:
             sandbox = await self.get_sandbox(
                 name=name,
@@ -344,6 +350,7 @@ class SandboxService:
             name=name,
             project_id=project_id,
             runtime=runtime,
+            image=image,
             source=source,
             ports=ports,
             execution_time_limit=execution_time_limit,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/state.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/state.py
@@ -39,7 +39,6 @@ class SandboxRuntimeSessionState:
     sandbox_name: str | None = None
     project_id: str | None = None
     status: SandboxStatus | None = None
-    runtime: str | None = None
     cwd: str | None = None
     region: str | None = None
     memory: int | None = None
@@ -65,7 +64,6 @@ class SandboxState:
     name: str
     current_session_id: str
     image: str | None = None
-    runtime: str | None = None
     status: SandboxStatus | None = None
     persistent: bool | None = None
     current_snapshot_id: str | None = None

--- a/src/vercel-sandbox/vercel/sandbox/_internal/state.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/state.py
@@ -64,6 +64,7 @@ class SnapshotRetentionState:
 class SandboxState:
     name: str
     current_session_id: str
+    image: str | None = None
     runtime: str | None = None
     status: SandboxStatus | None = None
     persistent: bool | None = None

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -46,6 +46,7 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     _parse_snapshot_expiration,
+    _validate_image_and_runtime,
     _WriteFile,
 )
 from vercel.sandbox._internal.pagination import (
@@ -1499,6 +1500,7 @@ def create_sandbox(
     project_id: str | None = None,
     name: str | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -1517,6 +1519,7 @@ def create_sandbox(
                 project_id=project_id,
                 name=name,
                 runtime=runtime,
+                image=image,
                 source=source,
                 ports=ports,
                 execution_time_limit=parse_duration_seconds(execution_time_limit),
@@ -1568,6 +1571,7 @@ def get_or_create_sandbox(
     resume: bool = True,
     include_system_routes: bool | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -1579,6 +1583,7 @@ def get_or_create_sandbox(
     snapshot_expiration: SnapshotExpirationInput = None,
     snapshot_retention: SnapshotRetention | None = None,
 ) -> tuple[SyncSandbox, bool]:
+    _validate_image_and_runtime(image=image, runtime=runtime)
     try:
         state, created = iter_coroutine(
             service.get_or_create_sandbox(
@@ -1587,6 +1592,7 @@ def get_or_create_sandbox(
                 resume=resume,
                 include_system_routes=include_system_routes,
                 runtime=runtime,
+                image=image,
                 source=source,
                 ports=ports,
                 execution_time_limit=parse_duration_seconds(execution_time_limit),

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -46,7 +46,6 @@ from vercel.sandbox._internal.models import (
     SnapshotRetention,
     SnapshotRetentionUpdate,
     _parse_snapshot_expiration,
-    _validate_image_and_runtime,
     _WriteFile,
 )
 from vercel.sandbox._internal.pagination import (
@@ -1396,7 +1395,6 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
     def update(
         self,
         *,
-        runtime: str | None = None,
         ports: list[int] | None = None,
         execution_time_limit: DurationInput = None,
         resources: SandboxResources | None = None,
@@ -1424,7 +1422,6 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
             self._service.update_sandbox(
                 name=self.name,
                 project_id=self.project_id,
-                runtime=runtime,
                 ports=ports,
                 execution_time_limit=parse_duration_seconds(execution_time_limit),
                 resources=resources,
@@ -1499,7 +1496,6 @@ def create_sandbox(
     *,
     project_id: str | None = None,
     name: str | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -1518,7 +1514,6 @@ def create_sandbox(
             service.create_sandbox(
                 project_id=project_id,
                 name=name,
-                runtime=runtime,
                 image=image,
                 source=source,
                 ports=ports,
@@ -1570,7 +1565,6 @@ def get_or_create_sandbox(
     project_id: str | None = None,
     resume: bool = True,
     include_system_routes: bool | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -1583,7 +1577,6 @@ def get_or_create_sandbox(
     snapshot_expiration: SnapshotExpirationInput = None,
     snapshot_retention: SnapshotRetention | None = None,
 ) -> tuple[SyncSandbox, bool]:
-    _validate_image_and_runtime(image=image, runtime=runtime)
     try:
         state, created = iter_coroutine(
             service.get_or_create_sandbox(
@@ -1591,7 +1584,6 @@ def get_or_create_sandbox(
                 project_id=project_id,
                 resume=resume,
                 include_system_routes=include_system_routes,
-                runtime=runtime,
                 image=image,
                 source=source,
                 ports=ports,

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -90,6 +90,7 @@ def create_sandbox(
     project_id: str | None = None,
     name: str | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -113,6 +114,8 @@ def create_sandbox(
             when omitted.
         name: Requested sandbox name. The service generates one when omitted.
         runtime: Runtime image or runtime identifier.
+        image: Vercel Container Registry image reference. Mutually exclusive
+            with ``runtime``; the backend validates and resolves the reference.
         source: Git, tarball, or snapshot source used to initialize the sandbox.
         ports: Ports to expose from the sandbox.
         execution_time_limit: Maximum session runtime in seconds or as a
@@ -139,6 +142,7 @@ def create_sandbox(
         project_id=project_id,
         name=name,
         runtime=runtime,
+        image=image,
         source=source,
         ports=ports,
         execution_time_limit=execution_time_limit,
@@ -160,6 +164,7 @@ def get_or_create_sandbox(
     resume: bool = True,
     include_system_routes: bool | None = None,
     runtime: str | None = None,
+    image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
     execution_time_limit: DurationInput = None,
@@ -176,6 +181,10 @@ def get_or_create_sandbox(
     The existing-sandbox lookup resumes by default. If its latest snapshot is
     missing, the stale named sandbox is destroyed and recreated.
 
+    Args:
+        image: Vercel Container Registry image reference used only when the
+            sandbox must be created. Mutually exclusive with ``runtime``.
+
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call
         created or recreated the sandbox, and false when it returned an
@@ -188,6 +197,7 @@ def get_or_create_sandbox(
         resume=resume,
         include_system_routes=include_system_routes,
         runtime=runtime,
+        image=image,
         source=source,
         ports=ports,
         execution_time_limit=execution_time_limit,

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -176,10 +176,29 @@ def get_or_create_sandbox(
 
     The existing-sandbox lookup resumes by default. If its latest snapshot is
     missing, the stale named sandbox is destroyed and recreated.
+    Creation options are used only when the sandbox must be created or
+    recreated.
 
     Args:
-        image: Vercel Container Registry image reference used only when the
-            sandbox must be created.
+        name: Sandbox name to retrieve or create.
+        project_id: Project that owns the sandbox. Uses the active credentials
+            when omitted.
+        resume: Whether to resume an existing stopped sandbox during lookup.
+        include_system_routes: Whether to include platform-managed routes.
+        image: Vercel Container Registry image reference. The backend validates
+            and resolves the reference.
+        source: Git, tarball, or snapshot source used to initialize the sandbox.
+        ports: Ports to expose from the sandbox.
+        execution_time_limit: Maximum session runtime in seconds or as a
+            duration.
+        resources: Requested CPU and memory resources.
+        persistent: Whether the sandbox persists beyond its current session.
+        network_policy: Network access policy sent to the Sandbox API.
+        env: Environment variables for the sandbox.
+        tags: Metadata tags used to organize and query sandboxes.
+        snapshot_expiration: Default lifetime for snapshots created from this
+            sandbox.
+        snapshot_retention: Automatic snapshot retention policy.
 
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -89,7 +89,6 @@ def create_sandbox(
     *,
     project_id: str | None = None,
     name: str | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -113,9 +112,8 @@ def create_sandbox(
         project_id: Project that owns the sandbox. Uses the active credentials
             when omitted.
         name: Requested sandbox name. The service generates one when omitted.
-        runtime: Runtime image or runtime identifier.
-        image: Vercel Container Registry image reference. Mutually exclusive
-            with ``runtime``; the backend validates and resolves the reference.
+        image: Vercel Container Registry image reference. The backend validates
+            and resolves the reference.
         source: Git, tarball, or snapshot source used to initialize the sandbox.
         ports: Ports to expose from the sandbox.
         execution_time_limit: Maximum session runtime in seconds or as a
@@ -141,7 +139,6 @@ def create_sandbox(
         _service(),
         project_id=project_id,
         name=name,
-        runtime=runtime,
         image=image,
         source=source,
         ports=ports,
@@ -163,7 +160,6 @@ def get_or_create_sandbox(
     project_id: str | None = None,
     resume: bool = True,
     include_system_routes: bool | None = None,
-    runtime: str | None = None,
     image: str | None = None,
     source: SandboxSource | None = None,
     ports: list[int] | None = None,
@@ -183,7 +179,7 @@ def get_or_create_sandbox(
 
     Args:
         image: Vercel Container Registry image reference used only when the
-            sandbox must be created. Mutually exclusive with ``runtime``.
+            sandbox must be created.
 
     Returns:
         A ``(sandbox, created)`` tuple. ``created`` is true when this call
@@ -196,7 +192,6 @@ def get_or_create_sandbox(
         project_id=project_id,
         resume=resume,
         include_system_routes=include_system_routes,
-        runtime=runtime,
         image=image,
         source=source,
         ports=ports,


### PR DESCRIPTION
Replace the legacy `runtime` selector with `image` when creating sandboxes. Sandbox creation now uses API v3, defaults to `vercel/sandbox/universal:latest`, and supports custom Vercel Container Registry images.

Closes #201 