### PR TITLE
[apscheduler] fix Runtime Cache backend to work under vc dev

### DIFF
--- a/changes/vercel-apscheduler/253.bugfix.md
+++ b/changes/vercel-apscheduler/253.bugfix.md
@@ -1,0 +1,1 @@
+Fix the Runtime Cache backend to work under `vc dev`.

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -354,6 +354,31 @@ the declaration does not overwrite the persisted runtime value. The
 `scheduled_job()` decorator enables replacement automatically; declaration
 calls to `add_job()` should pass `replace_existing=True`.
 
+## Development under `vercel dev`
+
+`vercel dev` runs each declared subscriber as a local queue-serving sidecar
+against the CLI's in-process queue broker, which honors the same delays and
+idempotency keys as the hosted queue. Without deployed cache credentials the
+Runtime Cache client falls back to per-process memory, so the cache backend
+becomes a zero-infrastructure development mode with the sidecar as the
+effective scheduler process.
+
+Activation follows the production rule: the first request to the app
+registers and runs the activation hook, which publishes the durable start,
+and the hook re-runs on the heal cadence while traffic continues. Declared
+jobs therefore start ticking after the app is hit once per `vercel dev`
+session. `vercel dev` deliberately sets no
+`VERCEL_DEPLOYMENT_ID` (SDKs read its presence as "deployed"), so the
+integration derives a stable synthetic id from the project directory every
+dev process is spawned in. It is shared by the web process and every
+sidecar, names the development state scope, and keeps two projects apart
+when development points them at one shared Redis database.
+
+Identity is builder-assigned in every mode: sidecars receive their
+subscriber id directly, and publishing processes (web functions) resolve it
+from the declared `{id, entrypoint}` mapping, so a `pause()` from a request
+handler reaches the same topics the sidecar serves.
+
 ## Deployment behavior
 
 Production and custom environments share one durable namespace, owned by

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_automatic.py
@@ -21,6 +21,7 @@ from vercel.integrations.apscheduler._options import is_queue_serving_runtime
         ("production", None, 300.0),
         ("preview", "1800", 300.0),
         ("preview", "60", 20.0),
+        ("development", None, 300.0),
     ],
 )
 def test_registers_request_driven_automatic_activation(

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -26,12 +26,18 @@ from vercel.integrations.apscheduler import (
     install_vercel_apscheduler_integration,
 )
 from vercel.integrations.apscheduler._adapter import get_adapter
-from vercel.integrations.apscheduler._backends.cache import CacheDriver, CacheJobStore
+from vercel.integrations.apscheduler._backends.cache import (
+    CacheBackend,
+    CacheDriver,
+    CacheJobStore,
+)
 from vercel.integrations.apscheduler._control import LifecyclePayload
+from vercel.integrations.apscheduler._options import development_deployment_id
 from vercel.integrations.apscheduler._payload import StartPayload, WakeupPayload
 from vercel.integrations.apscheduler._subscriber import register_scheduler
 from vercel.integrations.apscheduler._types import (
     PROVENANCE_DECLARED,
+    APSchedulerConfigurationError,
     NamespaceFencedError,
     WakeToken,
 )
@@ -821,3 +827,100 @@ def test_cache_processing_claim_is_busy_until_the_grace_lapses() -> None:
     # Past the grace the owner is presumed crashed and the claim is retaken.
     late = now + timedelta(minutes=16)
     assert driver.claim_wake(token, "owner-4", late).state == "claimed"
+
+
+def test_cache_identity_resolves_from_declared_subscriber_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A publishing process has no VERCEL_PYTHON_SUBSCRIBER_ID; the identity
+    # must come from the builder's declared mapping so its start and wake
+    # publishes land on the topics the sidecar actually serves.
+    monkeypatch.setenv(
+        "VERCEL_APSCHEDULER_SUBSCRIBERS",
+        f'[{{"id":"jobs_scheduler","entrypoint":"{CACHE_SCHEDULER_MODULE}:scheduler"}}]',
+    )
+    scheduler = BlockingScheduler()
+    monkeypatch.setattr(modules[CACHE_SCHEDULER_MODULE], "scheduler", scheduler, raising=False)
+
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+    assert adapter.identity.scheduler_id == "jobs_scheduler"
+    assert adapter.identity.start_topic == "__aps_jobs_scheduler_start"
+
+
+def test_cache_identity_prefers_the_builder_assigned_subscriber_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERCEL_PYTHON_SUBSCRIBER_ID", "sidecar_identity")
+    monkeypatch.setenv(
+        "VERCEL_APSCHEDULER_SUBSCRIBERS",
+        f'[{{"id":"jobs_scheduler","entrypoint":"{CACHE_SCHEDULER_MODULE}:scheduler"}}]',
+    )
+    scheduler = BlockingScheduler()
+    monkeypatch.setattr(modules[CACHE_SCHEDULER_MODULE], "scheduler", scheduler, raising=False)
+
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+    assert adapter.identity.scheduler_id == "sidecar_identity"
+
+
+def test_cache_identity_ready_waits_for_the_declared_module_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "VERCEL_APSCHEDULER_SUBSCRIBERS",
+        f'[{{"id":"jobs_scheduler","entrypoint":"{CACHE_SCHEDULER_MODULE}:scheduler"}}]',
+    )
+    backend = CacheBackend()
+    scheduler = BlockingScheduler()
+
+    # While the declaring module is importing, the variable is unbound and
+    # registration must defer rather than cache the "default" fallback.
+    assert backend.identity_ready(scheduler) is False
+
+    monkeypatch.setattr(modules[CACHE_SCHEDULER_MODULE], "scheduler", scheduler, raising=False)
+    assert backend.identity_ready(scheduler) is True
+    assert backend.derive_identity(scheduler).scheduler_id == "jobs_scheduler"
+
+
+def test_development_derives_a_stable_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `vercel dev` sets no VERCEL_DEPLOYMENT_ID (SDKs read its presence as
+    # "deployed"); development derives a stable synthetic id instead, so the
+    # web process and the sidecar share one state scope.
+    monkeypatch.delenv("VERCEL_DEPLOYMENT_ID", raising=False)
+    monkeypatch.setenv("VERCEL_ENV", "development")
+
+    scheduler = BlockingScheduler()
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+
+    assert adapter.deployment == development_deployment_id()
+    assert adapter.deployment.startswith("dpl_dev_")
+    assert adapter.scope == adapter.deployment
+
+
+def test_missing_deployment_id_still_fails_when_deployed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERCEL_DEPLOYMENT_ID", raising=False)
+    monkeypatch.setenv("VERCEL_ENV", "preview")
+
+    scheduler = BlockingScheduler()
+    adapter = get_adapter(scheduler)
+    assert adapter is not None
+
+    with pytest.raises(APSchedulerConfigurationError, match="VERCEL_DEPLOYMENT_ID"):
+        _ = adapter.deployment
+
+
+def test_cache_identity_defaults_without_a_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERCEL_APSCHEDULER_SUBSCRIBERS", raising=False)
+    backend = CacheBackend()
+    scheduler = BlockingScheduler()
+
+    assert backend.identity_ready(scheduler) is True
+    assert backend.derive_identity(scheduler).scheduler_id == "default"

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -33,9 +33,11 @@ from ._imports import (
 from ._options import (
     VercelAPSchedulerOptions,
     _SchedulerIdentity,
+    development_deployment_id,
     is_discovery_runtime,
     is_queue_serving_runtime,
     is_vercel_runtime,
+    resolve_environment,
     resolve_state_scope,
 )
 from ._payload import StartPayload, WakeupPayload
@@ -52,7 +54,6 @@ LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 UTC = timezone.utc
 ADAPTER_ATTR = "_vercel_apscheduler_adapter"
 DEPLOYMENT_ENV = "VERCEL_DEPLOYMENT_ID"
-SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 WAKEUP_KEY_PREFIX = "aps"
 # Queue delivery rounds wake delays up to whole seconds and adds dispatch
 # latency, so a grace below this cannot be met and skips occurrences.
@@ -753,6 +754,11 @@ class SchedulerAdapter:
 
     def _bind_runtime(self) -> None:
         deployment = environ.get(DEPLOYMENT_ENV)
+        if not deployment and resolve_environment().casefold() == "development":
+            # `vercel dev` does not set a deployment id (SDKs read its mere
+            # presence as "deployed"); development derives a stable synthetic
+            # one instead.
+            deployment = development_deployment_id()
         if not deployment:
             raise APSchedulerConfigurationError(
                 f"{DEPLOYMENT_ENV} is required to run an APScheduler subscriber"

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_automatic.py
@@ -12,6 +12,7 @@ from time import monotonic
 
 from ._imports import BaseScheduler
 from ._options import (
+    SUBSCRIBERS_ENV,
     is_discovery_runtime,
     is_queue_serving_runtime,
     is_vercel_runtime,
@@ -22,7 +23,6 @@ from ._types import APSchedulerConfigurationError
 LOGGER = logging.getLogger("vercel.integrations.apscheduler")
 
 PREVIEW_IDLE_TIMEOUT_ENV = "VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS"
-SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 ACTIVATION_HOOK_NAME = "vercel-apscheduler:auto-activate"
 MAX_PREVIEW_RENEW_INTERVAL_SECONDS = 5 * 60
 # Activation is idempotent; the periodic re-run renews preview deadlines and
@@ -144,14 +144,16 @@ def _automatic_environment() -> bool:
     Named environments (production and custom environments) share one durable
     chain that must start and take over without a manual call, so they always
     activate. Previews activate only when idling is configured, so a preview
-    chain cannot outlive its usefulness. The resolution must match
+    chain cannot outlive its usefulness. Development (``vercel dev``) follows
+    the production rule: the first request activates, and the local processes
+    only live while requests can reach them anyway. The resolution must match
     ``resolve_state_scope``: a custom environment reports
     ``VERCEL_ENV=preview`` but is a named environment.
     """
     if not is_vercel_runtime() or not environ.get(SUBSCRIBERS_ENV):
         return False
     environment = resolve_environment().casefold()
-    if environment in {"", "development"}:
+    if not environment:
         return False
     if environment == "preview":
         return PREVIEW_IDLE_TIMEOUT_ENV in environ

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/__init__.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/__init__.py
@@ -30,7 +30,12 @@ from typing import Any
 from dataclasses import dataclass
 from os import environ
 
-from ..._options import SUBSCRIBER_ID_ENV, _SchedulerIdentity
+from ..._options import (
+    SUBSCRIBER_ID_ENV,
+    SUBSCRIBERS_ENV,
+    _SchedulerIdentity,
+    resolve_declared_subscriber_id,
+)
 from ..._types import APSchedulerConfigurationError
 from .._protocols import Driver, JobCoordinator
 from ._driver import CacheDriver
@@ -71,12 +76,27 @@ class CacheBackend:
         return isinstance(store, CacheJobStore)
 
     def identity_ready(self, scheduler: Any) -> bool:
-        return True
+        # Queue-serving and discovery processes are told their id outright.
+        # A publishing process with a declared-subscriber mapping must wait
+        # until the declaring module finishes importing, or import-time
+        # registration would cache the "default" fallback and publish to
+        # topics nothing serves. Without a mapping the fallback is the
+        # identity everywhere, so it is always ready.
+        if environ.get(SUBSCRIBER_ID_ENV):
+            return True
+        if not environ.get(SUBSCRIBERS_ENV):
+            return True
+        return resolve_declared_subscriber_id(scheduler) is not None
 
     def derive_identity(self, scheduler: Any) -> _SchedulerIdentity:
         # No store key to derive from; the builder-assigned subscriber id is
-        # the durable identity, "default" outside Vercel.
-        subscriber_id = environ.get(SUBSCRIBER_ID_ENV) or "default"
+        # the durable identity. Sidecars receive it as an environment
+        # variable; publishing processes reverse-look it up from the declared
+        # {id, entrypoint} mapping; "default" covers undeclared schedulers
+        # and use outside Vercel.
+        subscriber_id = (
+            environ.get(SUBSCRIBER_ID_ENV) or resolve_declared_subscriber_id(scheduler) or "default"
+        )
         try:
             return _SchedulerIdentity.from_scheduler_id(subscriber_id)
         except ValueError as exc:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_options.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_options.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import json
 import re
 from dataclasses import dataclass
+from hashlib import sha256
 from os import environ
+from pathlib import Path
+from sys import modules
 
 DEFAULT_MAX_DELAY_SECONDS = 23 * 60 * 60
 DEFAULT_RETRY_AFTER_SECONDS = 30
@@ -18,6 +22,7 @@ VQS_MAX_DELAY_SECONDS = 5 * 24 * 60 * 60
 VQS_MAX_RETENTION_SECONDS = 7 * 24 * 60 * 60
 DISCOVERY_ENV = "VERCEL_APSCHEDULER_DISCOVERY"
 SUBSCRIBER_ID_ENV = "VERCEL_PYTHON_SUBSCRIBER_ID"
+SUBSCRIBERS_ENV = "VERCEL_APSCHEDULER_SUBSCRIBERS"
 _SCHEDULER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 # The identity slug maps "." to "-", so both charsets collapse into the VQS
 # name alphabet. Two keys that collapse to the same slug are rejected as an
@@ -28,10 +33,13 @@ __all__ = [
     "DEFAULT_MAX_DELAY_SECONDS",
     "DEFAULT_RETRY_AFTER_SECONDS",
     "RETENTION_MARGIN_SECONDS",
+    "SUBSCRIBERS_ENV",
     "VercelAPSchedulerOptions",
+    "development_deployment_id",
     "is_discovery_runtime",
     "is_queue_serving_runtime",
     "is_vercel_runtime",
+    "resolve_declared_subscriber_id",
     "resolve_environment",
     "resolve_state_scope",
 ]
@@ -85,6 +93,62 @@ def resolve_environment() -> str:
     activation can never disagree about what a deployment is.
     """
     return (environ.get("VERCEL_TARGET_ENV") or environ.get("VERCEL_ENV") or "").strip()
+
+
+def resolve_declared_subscriber_id(scheduler: Any) -> str | None:
+    """Reverse-look up a scheduler's builder-assigned subscriber id.
+
+    The builder writes the ``{id, entrypoint}`` mapping into every process of
+    a deployment, but only queue-serving sidecars additionally receive
+    ``VERCEL_PYTHON_SUBSCRIBER_ID`` (which doubles as the queue-serving
+    marker). A publishing process finds its durable identity by matching the
+    declared entrypoint that names this exact scheduler object. Returns None
+    while the declaring module is still importing (its variable is not bound
+    yet) or when the scheduler is not declared; the loud validation of the
+    mapping itself stays with automatic activation.
+    """
+    raw = environ.get(SUBSCRIBERS_ENV)
+    if not raw:
+        return None
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        subscriber_id = entry.get("id")
+        entrypoint = entry.get("entrypoint")
+        if not isinstance(subscriber_id, str) or not isinstance(entrypoint, str):
+            continue
+        module_name, separator, variable_name = entrypoint.partition(":")
+        if not separator:
+            continue
+        module = modules.get(module_name)
+        if module is not None and getattr(module, variable_name, None) is scheduler:
+            return subscriber_id
+    return None
+
+
+# Captured at import, before user module code could chdir: every python
+# process of one `vercel dev` project starts in the project directory.
+_DEV_PROJECT_DIR = str(Path.cwd())
+
+
+def development_deployment_id() -> str:
+    """Return a stable synthetic deployment id for ``vercel dev``.
+
+    ``vercel dev`` deliberately does not set ``VERCEL_DEPLOYMENT_ID`` — its
+    mere presence makes SDKs believe they are deployed. Development state is
+    deployment-scoped, and the web process and queue sidecars of one project
+    must agree on the scope, so the id is derived from the project directory
+    they are all spawned in. The hash also keeps two projects apart when
+    development points them at one shared Redis database.
+    """
+    digest = sha256(_DEV_PROJECT_DIR.encode()).hexdigest()[:12]
+    return f"dpl_dev_{digest}"
 
 
 def resolve_state_scope(deployment: str) -> str:


### PR DESCRIPTION
Adds support for running the APScheduler integration with Runtime Cache backend under vc dev