### PR TITLE
workflow: streaming (1/2)

### DIFF
--- a/changes/vercel/20260803160000.feature.md
+++ b/changes/vercel/20260803160000.feature.md
@@ -1,0 +1,2 @@
+A step can now stream output while it runs with `get_writable()`, readable
+from the TypeScript SDK, the dashboard and `workflow inspect stream`.

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -974,7 +974,7 @@ async def _execute_step(
 
     # Bound before the try so the failure path can flush whatever the step
     # managed to write before it raised.
-    step_streams = _StepStreams(run_id=req.workflow_run_id)
+    step_streams = _StepStreams(run_id=req.run_id)
 
     try:
         if not step_run.started_at:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import contextvars
 import dataclasses
 import functools
@@ -10,7 +11,7 @@ import re
 import sys
 import traceback
 from collections import deque
-from collections.abc import Callable, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine
 from datetime import datetime, timedelta
 from typing import Any, Generic, Literal, ParamSpec, TypeVar
 
@@ -151,6 +152,45 @@ class _StepStreams:
 
     run_id: str
     writers: dict[str, streams.WorkflowStreamWriter] = dataclasses.field(default_factory=dict)
+    _task_group: anyio.abc.TaskGroup | None = None
+
+    @contextlib.asynccontextmanager
+    async def dispatching(self) -> AsyncIterator[None]:
+        """Own the writers' background sends for the duration of the block.
+
+        A writer sends from a task rather than from `write()`, so those tasks
+        need a group whose lifetime covers every write *and* the flush that
+        follows. Leaving the block waits for them, so nothing is still in
+        flight once it returns.
+
+        If the block raises, the chunks the step did manage to stream are
+        flushed first: those are as real as any other, and a reader tailing the
+        run should see the progress that led up to the failure. Best-effort by
+        construction -- the step is already failing, and a flush error here
+        would replace the cause with a symptom. (`@workflow/core` does not do
+        this at all: its `ops` flush lives only on the success path, so a
+        throwing step's buffered chunks are never awaited.)
+
+        The error comes back out as itself rather than wrapped in the task
+        group's exception group, because callers up the stack switch on
+        `FatalError` and count retries.
+        """
+        error: BaseException | None = None
+        async with anyio.create_task_group() as task_group:
+            self._task_group = task_group
+            try:
+                yield
+            except Exception as exc:
+                error = exc
+                await self.drain_quietly()
+            except BaseException as exc:
+                # Cancellation, or the interpreter going down. Draining would
+                # need a shield and could stall the teardown it is racing.
+                error = exc
+            finally:
+                self._task_group = None
+        if error is not None:
+            raise error
 
     def writer(
         self, namespace: str | None, *, reentrant_ctx_on_err: bool = True
@@ -164,6 +204,8 @@ class _StepStreams:
         scramble the order the caller wrote in. Sharing one serial sink makes
         that pattern correct instead of subtly wrong.
         """
+        if self._task_group is None:
+            raise RuntimeError("stream writers are only available while a step is running")
         name = streams.workflow_run_stream_id(self.run_id, namespace)
         writer = self.writers.get(name)
         if writer is None:
@@ -171,6 +213,7 @@ class _StepStreams:
                 world=w.get_world(),
                 run_id=self.run_id,
                 name=name,
+                task_group=self._task_group,
                 reentrant_ctx_on_err=reentrant_ctx_on_err,
             )
             self.writers[name] = writer
@@ -1007,27 +1050,30 @@ async def _execute_step(
             )
         )
         streams_token = _step_streams_ctx.set(step_streams)
-        # Execute the step function
-        try:
-            result = await step.func(*args, **kwargs)
-        finally:
-            _step_ctx.reset(token)
-            _step_streams_ctx.reset(streams_token)
+        async with step_streams.dispatching():
+            # Execute the step function
+            try:
+                result = await step.func(*args, **kwargs)
+            finally:
+                _step_ctx.reset(token)
+                _step_streams_ctx.reset(streams_token)
 
-        # A stream write returns as soon as it is buffered, so the chunks this
-        # step wrote are not durable yet. Force them out before recording the
-        # step as complete, so "the step finished" keeps implying "everything it
-        # streamed is readable" -- and so a failure to write fails the step
-        # rather than being discovered by a reader that never sees the chunk.
-        #
-        # Stricter than `@workflow/core`, deliberately. Its step executor caps
-        # the same flush at 500ms and completes the step regardless, handing the
-        # rest to `waitUntil`, because its `ops` include lock-release polling on
-        # a `WritableStream` the user may hold open across steps -- that can
-        # never settle, so it cannot be awaited unbounded. Nothing here waits on
-        # a lock: `drain()` waits only for chunks already handed over, so it
-        # always terminates and needs no escape hatch.
-        await step_streams.drain()
+            # A stream write returns as soon as it is buffered, so the chunks
+            # this step wrote are not durable yet. Force them out before
+            # recording the step as complete, so "the step finished" keeps
+            # implying "everything it streamed is readable" -- and so a failure
+            # to write fails the step rather than being discovered by a reader
+            # that never sees the chunk.
+            #
+            # Stricter than `@workflow/core`, deliberately. Its step executor
+            # caps the same flush at 500ms and completes the step regardless,
+            # handing the rest to `waitUntil`, because its `ops` include
+            # lock-release polling on a `WritableStream` the user may hold open
+            # across steps -- that can never settle, so it cannot be awaited
+            # unbounded. Nothing here waits on a lock: `drain()` waits only for
+            # chunks already handed over, so it always terminates and needs no
+            # escape hatch.
+            await step_streams.drain()
 
         # Serialize the result
         output = ser.dehydrate(result)
@@ -1039,16 +1085,6 @@ async def _execute_step(
         )
 
     except Exception as e:
-        # Flush what the step did stream before failing: those chunks are as
-        # real as any other, and a reader tailing the run should see the
-        # progress that led up to the failure. Best-effort by construction --
-        # the step is already failing, and a drain error here would replace the
-        # cause with a symptom.
-        #
-        # `@workflow/core` does not do this: its `ops` flush lives only on the
-        # success path, so a throwing step's buffered chunks are never awaited.
-        await step_streams.drain_quietly()
-
         # step.attempt was incremented by step_started
         current_attempt = step_run.attempt
         error_text = "".join(traceback.format_exception_only(type(e), e)).strip()

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -152,7 +152,9 @@ class _StepStreams:
     run_id: str
     writers: dict[str, streams.WorkflowStreamWriter] = dataclasses.field(default_factory=dict)
 
-    def writer(self, namespace: str | None) -> streams.WorkflowStreamWriter:
+    def writer(
+        self, namespace: str | None, *, reentrant_ctx_on_err: bool = True
+    ) -> streams.WorkflowStreamWriter:
         """The writer for this run's *namespace* stream, created on first use.
 
         One writer per stream per step, deliberately. Handing out a fresh writer
@@ -165,7 +167,12 @@ class _StepStreams:
         name = streams.workflow_run_stream_id(self.run_id, namespace)
         writer = self.writers.get(name)
         if writer is None:
-            writer = streams.WorkflowStreamWriter(w.get_world(), self.run_id, name)
+            writer = streams.WorkflowStreamWriter(
+                world=w.get_world(),
+                run_id=self.run_id,
+                name=name,
+                reentrant_ctx_on_err=reentrant_ctx_on_err,
+            )
             self.writers[name] = writer
         return writer
 
@@ -202,7 +209,11 @@ def get_step_metadata() -> StepInfo:
         raise RuntimeError("get_step_metadata() can only be called inside a step") from None
 
 
-def get_writable(*, namespace: str | None = None) -> streams.WorkflowStreamWriter:
+def get_writable(
+    *,
+    namespace: str | None = None,
+    reentrant_ctx_on_err: bool = True,
+) -> streams.WorkflowStreamWriter:
     """The run's writable stream, for streaming output as the step runs.
 
     Chunks become readable immediately -- through ``run.readable`` on the
@@ -220,6 +231,10 @@ def get_writable(*, namespace: str | None = None) -> streams.WorkflowStreamWrite
 
     Nothing closes the stream implicitly. Call :meth:`close` on the writer when
     the run has nothing more to say, or readers will wait until the run expires.
+
+    When used as an asynchronous context in ``async with`` statements, the stream
+    will be closed on a clean exit by default. Exceptions will not close the
+    stream on exit of the context, unless ``reentrant_ctx_on_err`` is ``False``.
     """
     try:
         state = _step_streams_ctx.get()
@@ -228,7 +243,7 @@ def get_writable(*, namespace: str | None = None) -> streams.WorkflowStreamWrite
             "get_writable() can only be called inside a step; a workflow body "
             "cannot write to a stream directly"
         ) from None
-    return state.writer(namespace)
+    return state.writer(namespace, reentrant_ctx_on_err=reentrant_ctx_on_err)
 
 
 if sys.version_info >= (3, 11):
@@ -1029,6 +1044,9 @@ async def _execute_step(
         # progress that led up to the failure. Best-effort by construction --
         # the step is already failing, and a drain error here would replace the
         # cause with a symptom.
+        #
+        # `@workflow/core` does not do this: its `ops` flush lives only on the
+        # success path, so a throwing step's buffered chunks are never awaited.
         await step_streams.drain_quietly()
 
         # step.attempt was incremented by step_started

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -19,7 +19,7 @@ import pydantic
 
 from vercel._internal.core.polyfills import UTC, Self
 
-from . import core, errors, loop, nanoid, serialization as ser, ulid, world as w
+from . import core, errors, loop, nanoid, serialization as ser, streams, ulid, world as w
 from .py_sandbox import workflow_sandbox
 
 P = ParamSpec("P")
@@ -141,6 +141,56 @@ class StepInfo:
 _step_ctx: contextvars.ContextVar[StepInfo] = contextvars.ContextVar("WorkflowStepContext")
 
 
+@dataclasses.dataclass
+class _StepStreams:
+    """The stream writers one step invocation opened.
+
+    Kept out of :class:`StepInfo` because that is public, frozen metadata; this
+    is mutable bookkeeping the handler owns.
+    """
+
+    run_id: str
+    writers: dict[str, streams.WorkflowStreamWriter] = dataclasses.field(default_factory=dict)
+
+    def writer(self, namespace: str | None) -> streams.WorkflowStreamWriter:
+        """The writer for this run's *namespace* stream, created on first use.
+
+        One writer per stream per step, deliberately. Handing out a fresh writer
+        each call would give each its own buffer over the same stream, and two
+        buffers flushing independently interleave their chunks by whichever
+        request happens to win -- so `get_writable()` twice in a loop would
+        scramble the order the caller wrote in. Sharing one serial sink makes
+        that pattern correct instead of subtly wrong.
+        """
+        name = streams.workflow_run_stream_id(self.run_id, namespace)
+        writer = self.writers.get(name)
+        if writer is None:
+            writer = streams.WorkflowStreamWriter(w.get_world(), self.run_id, name)
+            self.writers[name] = writer
+        return writer
+
+    async def drain(self) -> None:
+        for writer in self.writers.values():
+            await writer.drain()
+
+    async def drain_quietly(self) -> None:
+        for writer in self.writers.values():
+            try:
+                await writer.drain()
+            except Exception:
+                logger.debug(
+                    "[Workflows] '%s' - could not flush stream %r while failing",
+                    self.run_id,
+                    writer.name,
+                    exc_info=True,
+                )
+
+
+_step_streams_ctx: contextvars.ContextVar[_StepStreams] = contextvars.ContextVar(
+    "WorkflowStepStreams"
+)
+
+
 def get_step_metadata() -> StepInfo:
     """Return metadata for the step currently executing.
 
@@ -150,6 +200,35 @@ def get_step_metadata() -> StepInfo:
         return _step_ctx.get()
     except LookupError:
         raise RuntimeError("get_step_metadata() can only be called inside a step") from None
+
+
+def get_writable(*, namespace: str | None = None) -> streams.WorkflowStreamWriter:
+    """The run's writable stream, for streaming output as the step runs.
+
+    Chunks become readable immediately -- through ``run.readable`` on the
+    TypeScript side, the dashboard, or ``workflow inspect stream`` -- without
+    waiting for the step or the run to finish. This SDK has no reader of its own
+    yet; :meth:`vercel._internal.workflow.world.World.streams_get` is the
+    unstable way in.
+
+    Pass *namespace* to write to a second, independent stream on the same run.
+
+    Must be called from within a step body; raises ``RuntimeError`` otherwise.
+    A workflow body cannot stream: unlike the TypeScript SDK it cannot even take
+    a handle to pass into a step, which is why a streaming step calls this
+    itself.
+
+    Nothing closes the stream implicitly. Call :meth:`close` on the writer when
+    the run has nothing more to say, or readers will wait until the run expires.
+    """
+    try:
+        state = _step_streams_ctx.get()
+    except LookupError:
+        raise RuntimeError(
+            "get_writable() can only be called inside a step; a workflow body "
+            "cannot write to a stream directly"
+        ) from None
+    return state.writer(namespace)
 
 
 if sys.version_info >= (3, 11):
@@ -878,6 +957,10 @@ async def _execute_step(
         )
         return None
 
+    # Bound before the try so the failure path can flush whatever the step
+    # managed to write before it raised.
+    step_streams = _StepStreams(run_id=req.workflow_run_id)
+
     try:
         if not step_run.started_at:
             raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
@@ -908,11 +991,28 @@ async def _execute_step(
                 attempt=current_attempt,
             )
         )
+        streams_token = _step_streams_ctx.set(step_streams)
         # Execute the step function
         try:
             result = await step.func(*args, **kwargs)
         finally:
             _step_ctx.reset(token)
+            _step_streams_ctx.reset(streams_token)
+
+        # A stream write returns as soon as it is buffered, so the chunks this
+        # step wrote are not durable yet. Force them out before recording the
+        # step as complete, so "the step finished" keeps implying "everything it
+        # streamed is readable" -- and so a failure to write fails the step
+        # rather than being discovered by a reader that never sees the chunk.
+        #
+        # Stricter than `@workflow/core`, deliberately. Its step executor caps
+        # the same flush at 500ms and completes the step regardless, handing the
+        # rest to `waitUntil`, because its `ops` include lock-release polling on
+        # a `WritableStream` the user may hold open across steps -- that can
+        # never settle, so it cannot be awaited unbounded. Nothing here waits on
+        # a lock: `drain()` waits only for chunks already handed over, so it
+        # always terminates and needs no escape hatch.
+        await step_streams.drain()
 
         # Serialize the result
         output = ser.dehydrate(result)
@@ -924,6 +1024,13 @@ async def _execute_step(
         )
 
     except Exception as e:
+        # Flush what the step did stream before failing: those chunks are as
+        # real as any other, and a reader tailing the run should see the
+        # progress that led up to the failure. Best-effort by construction --
+        # the step is already failing, and a drain error here would replace the
+        # cause with a symptom.
+        await step_streams.drain_quietly()
+
         # step.attempt was incremented by step_started
         current_attempt = step_run.attempt
         error_text = "".join(traceback.format_exception_only(type(e), e)).strip()

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -44,17 +44,10 @@ class SerializationError(RuntimeError):
     """A payload could not be encoded, or arrived in a format we cannot read."""
 
 
-def dehydrate(value: Any, *, reducers: dict[str, Any] | None = None) -> bytes:
-    """Encode *value* as a ``devl``-prefixed devalue payload.
-
-    *reducers* replaces the default set, for a boundary whose consumer needs a
-    different shape than a payload's -- see :data:`.streams.CHUNK_REDUCERS`.
-    """
+def dehydrate(value: Any) -> bytes:
+    """Encode *value* as a ``devl``-prefixed devalue payload."""
     try:
-        return (
-            DEVALUE_V1
-            + devalue.stringify(value, serde.REDUCERS if reducers is None else reducers).encode()
-        )
+        return DEVALUE_V1 + devalue.stringify(value, serde.REDUCERS).encode()
     except devalue.DevalueError as error:
         at = f" at {error.path}" if error.path else ""
         raise SerializationError(

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -44,10 +44,17 @@ class SerializationError(RuntimeError):
     """A payload could not be encoded, or arrived in a format we cannot read."""
 
 
-def dehydrate(value: Any) -> bytes:
-    """Encode *value* as a ``devl``-prefixed devalue payload."""
+def dehydrate(value: Any, *, reducers: dict[str, Any] | None = None) -> bytes:
+    """Encode *value* as a ``devl``-prefixed devalue payload.
+
+    *reducers* replaces the default set, for a boundary whose consumer needs a
+    different shape than a payload's -- see :data:`.streams.CHUNK_REDUCERS`.
+    """
     try:
-        return DEVALUE_V1 + devalue.stringify(value, serde.REDUCERS).encode()
+        return (
+            DEVALUE_V1
+            + devalue.stringify(value, serde.REDUCERS if reducers is None else reducers).encode()
+        )
     except devalue.DevalueError as error:
         at = f" at {error.path}" if error.path else ""
         raise SerializationError(

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -22,11 +22,16 @@ frame boundaries without understanding the payload format at all.
 
 from __future__ import annotations
 
+import asyncio
 import base64
-from collections.abc import Iterator
-from typing import Any
+import os
+from collections.abc import AsyncIterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any
 
 from . import serialization as ser
+
+if TYPE_CHECKING:
+    from . import world as w
 
 FRAME_HEADER_SIZE = 4
 """Bytes of big-endian length prefix in front of every frame."""
@@ -38,6 +43,23 @@ A length header advertising more than this is refused rather than allocated:
 past a certain size the far more likely explanation is a misframed wire than a
 100 MB chunk.
 """
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    """Read a positive-integer knob, falling back to *default* when unusable.
+
+    Mirrors `@workflow/world`'s ``envNumber``: an unset, non-numeric or
+    out-of-range value is ignored rather than fatal, since these are
+    operational overrides and a typo should not take a deployment down.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= minimum else default
 
 
 def workflow_run_stream_id(run_id: str, namespace: str | None = None) -> str:
@@ -115,3 +137,265 @@ class FrameDecoder:
                 f"Stream ended with {len(self._buffer)} bytes of incomplete frame data; "
                 f"it was truncated mid-frame"
             )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# writer
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Ported from `@workflow/core`'s `WorkflowServerWritableStream`, whose shape is
+# not obvious and is worth restating.
+#
+# `write()` returns once the chunk is *buffered*, not once it is durable. That
+# early acknowledgement is what makes batching work at all: the producer keeps
+# handing over chunks while a request is in flight, so they accumulate and the
+# next request carries the whole group. If `write()` waited for the server, a
+# producer writing in a loop would serialize into one request per chunk.
+#
+# Durability gets its own barrier, `drain()`, which the step handler awaits
+# before recording the step as complete -- so "the step finished" still implies
+# "its chunks are durable", and a caller who needs that guarantee mid-step can
+# ask for it.
+
+MAX_INFLIGHT_CHUNKS = 1000
+"""Chunks that may sit buffered-but-not-durable before ``write()`` blocks."""
+
+MAX_BUFFERED_BYTES = 8 * 1024 * 1024
+"""Byte-denominated counterpart of :data:`MAX_INFLIGHT_CHUNKS`.
+
+Count alone is not a bound: 1,000 small chunks are ~100 KB, 1,000 file-sized
+ones are hundreds of MB.
+"""
+
+MAX_CHUNKS_PER_BATCH = 1000
+"""Chunks in one write request, matching the server's per-batch cap."""
+
+MAX_BYTES_PER_BATCH = 1024 * 1024
+"""Cumulative bytes in one write request, under platform body limits."""
+
+
+class WorkflowStreamWriter:
+    """A group-committing writer for one ``(run_id, name)`` stream.
+
+    Not safe to use from more than one event loop; within one loop, concurrent
+    writers are fine and their chunks land in call order.
+    """
+
+    def __init__(self, world: w.World, run_id: str, name: str) -> None:
+        if not name:
+            raise ValueError(f'"name" is required, got {name!r}')
+        self._world = world
+        self._run_id = run_id
+        self._name = name
+
+        self._buffer: list[bytes] = []
+        self._buffered_bytes = 0
+        # Counted against the buffer bound as well, so the bound keeps its
+        # documented meaning -- a cap on everything read but not yet durable,
+        # not just on the queued follow-up group.
+        self._inflight_chunks = 0
+        self._inflight_bytes = 0
+        self._dispatch: asyncio.Task[None] | None = None
+        # Sticky: once a request fails, its group stays at the head of the
+        # buffer and every later call raises the original error. Chunks whose
+        # `write()` already returned surface their failure at the barrier --
+        # that is the contract of an early-acknowledging sink.
+        self._sink_error: BaseException | None = None
+        self._closed = False
+        self._condition = asyncio.Condition()
+
+        self._max_inflight_chunks = _env_int(
+            "WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", MAX_INFLIGHT_CHUNKS
+        )
+        self._max_buffered_bytes = _env_int(
+            "WORKFLOW_STREAM_MAX_BUFFERED_BYTES", MAX_BUFFERED_BYTES
+        )
+        self._max_chunks_per_batch = _env_int(
+            "WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", MAX_CHUNKS_PER_BATCH
+        )
+        self._max_bytes_per_batch = _env_int(
+            "WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", MAX_BYTES_PER_BATCH
+        )
+
+    @property
+    def name(self) -> str:
+        """The stream this writer appends to."""
+        return self._name
+
+    @property
+    def run_id(self) -> str:
+        """The run that owns the stream."""
+        return self._run_id
+
+    async def write(self, value: Any) -> None:
+        """Append *value* as one chunk.
+
+        Returns once the chunk is buffered and ordered, which is not yet
+        durable; await :meth:`drain` or :meth:`close` for that. Blocks while
+        the buffer is full, so a fast producer cannot grow it without bound.
+        """
+        await self._enqueue(encode_value(value))
+
+    async def write_from(self, source: AsyncIterable[Any]) -> None:
+        """Append every item *source* yields, in order.
+
+        The counterpart of piping a stream into this one: a step forwarding an
+        upstream async iterator (LLM tokens, an HTTP body) wants this rather
+        than a hand-rolled loop, and it keeps the group-commit buffer fed
+        without the caller thinking about batching.
+        """
+        async for value in source:
+            await self.write(value)
+
+    async def _enqueue(self, frame: bytes) -> None:
+        async with self._condition:
+            self._raise_if_unusable()
+            while self._at_capacity():
+                await self._condition.wait()
+                self._raise_if_unusable()
+            self._buffer.append(frame)
+            self._buffered_bytes += len(frame)
+            self._start_dispatch()
+
+    def _raise_if_unusable(self) -> None:
+        if self._sink_error is not None:
+            raise self._sink_error
+        if self._closed:
+            raise ser.SerializationError(f"Stream {self._name!r} is closed")
+
+    def _at_capacity(self) -> bool:
+        chunks = len(self._buffer) + self._inflight_chunks
+        octets = self._buffered_bytes + self._inflight_bytes
+        # A single chunk over the byte bound would deadlock against it, so an
+        # empty buffer always accepts one.
+        if chunks == 0:
+            return False
+        return chunks >= self._max_inflight_chunks or octets >= self._max_buffered_bytes
+
+    def _start_dispatch(self) -> None:
+        """Start the dispatch loop unless one is already running.
+
+        Exactly one runs at a time, which is what keeps groups reaching the
+        server in write order. Called with the condition held.
+        """
+        if self._dispatch is None and self._sink_error is None and self._buffer:
+            self._dispatch = asyncio.ensure_future(self._dispatch_loop())
+
+    def _take_group(self) -> tuple[list[bytes], int]:
+        """The largest leading group that fits one request.
+
+        A single chunk larger than the byte cap still goes out alone -- the
+        alternative is refusing to send it at all.
+        """
+        count = 0
+        octets = 0
+        for frame in self._buffer:
+            if count >= self._max_chunks_per_batch:
+                break
+            if count > 0 and octets + len(frame) > self._max_bytes_per_batch:
+                break
+            count += 1
+            octets += len(frame)
+        group = self._buffer[:count]
+        del self._buffer[:count]
+        self._buffered_bytes -= octets
+        return group, octets
+
+    async def _dispatch_loop(self) -> None:
+        try:
+            while True:
+                async with self._condition:
+                    if not self._buffer:
+                        self._dispatch = None
+                        # Nothing buffered and nothing in flight: the
+                        # durability barrier is satisfied.
+                        self._condition.notify_all()
+                        return
+                    group, octets = self._take_group()
+                    self._inflight_chunks = len(group)
+                    self._inflight_bytes = octets
+
+                try:
+                    await self._send(group)
+                except BaseException as error:
+                    cancelled = isinstance(error, asyncio.CancelledError)
+                    async with self._condition:
+                        # The group did not land, so it goes back at the head
+                        # either way: the buffer holds everything not known to
+                        # be durable, and dropping it here would lose chunks
+                        # whose `write()` had already returned.
+                        self._buffer[:0] = group
+                        self._buffered_bytes += octets
+                        self._inflight_chunks = 0
+                        self._inflight_bytes = 0
+                        self._dispatch = None
+                        # Cancellation is this task being torn down, not the
+                        # stream failing. Recording it as the sink error would
+                        # make a later `write()` raise `CancelledError` inside
+                        # a caller that was never cancelled.
+                        if not cancelled:
+                            self._sink_error = error
+                        self._condition.notify_all()
+                    if cancelled:
+                        raise
+                    return
+
+                async with self._condition:
+                    self._inflight_chunks = 0
+                    self._inflight_bytes = 0
+                    # This group is durable: release writers blocked on the
+                    # bound. They re-check it and may block again.
+                    self._condition.notify_all()
+        except BaseException as error:
+            # Cancellation, or a bug in the loop itself. Either way no one is
+            # driving this buffer any more, so waiters have to be released --
+            # and for anything that is not cancellation the sink is poisoned
+            # too, because `drain()` would otherwise see an idle buffer, start
+            # a fresh loop, and hit the same bug forever.
+            async with self._condition:
+                self._dispatch = None
+                if not isinstance(error, asyncio.CancelledError):
+                    self._sink_error = error
+                self._condition.notify_all()
+            raise
+
+    async def _send(self, group: Sequence[bytes]) -> None:
+        if len(group) == 1:
+            await self._world.streams_write(self._run_id, self._name, group[0])
+        else:
+            await self._world.streams_write_multi(self._run_id, self._name, group)
+
+    async def drain(self) -> None:
+        """Wait until every accepted chunk is durably written.
+
+        Raises the sink's error if any request failed -- including one whose
+        ``write()`` had already returned.
+        """
+        async with self._condition:
+            while True:
+                if self._sink_error is not None:
+                    raise self._sink_error
+                if not self._buffer and self._inflight_chunks == 0 and self._dispatch is None:
+                    return
+                self._start_dispatch()
+                await self._condition.wait()
+
+    async def close(self) -> None:
+        """Drain, then mark the stream complete so readers see the end.
+
+        Idempotent. Nothing closes a run's stream implicitly -- not the end of
+        a step, not the end of the run -- so a stream a workflow never closes
+        leaves its readers waiting until the run expires.
+        """
+        if self._closed and self._sink_error is None:
+            return
+        await self.drain()
+        await self._world.streams_close(self._run_id, self._name)
+        self._closed = True
+
+    async def __aenter__(self) -> WorkflowStreamWriter:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if exc_type is None:
+            await self.close()

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -28,7 +28,7 @@ import os
 from collections.abc import AsyncIterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from . import serialization as ser
+from . import serde, serialization as ser
 
 if TYPE_CHECKING:
     from . import world as w
@@ -87,9 +87,43 @@ def encode_frame(payload: bytes) -> bytes:
     return len(payload).to_bytes(FRAME_HEADER_SIZE, "big") + payload
 
 
+def _reduce_uint8array(value: Any) -> Any:
+    """devalue reducer sending a chunk's ``bytes`` as a view. Falsy declines.
+
+    Only the emitted *form* differs: devalue writes a typed array as a view
+    onto its own buffer entry, ``["Uint8Array", <buffer>]``, where the payload
+    boundary writes the bare ``["ArrayBuffer", …]``. Both carry the same bytes
+    and both read back here as ``bytes``.
+
+    It matters because of what reads a stream. The pattern the TypeScript docs
+    lead with pipes a run's readable straight into a `Response`, and a body
+    stream takes `Uint8Array` chunks only -- an `ArrayBuffer` chunk raises
+    ``Received non-Uint8Array chunk``. So a step writing ``b"..."`` has to
+    frame it as a view or every consumer doing that breaks.
+
+    Chunk-local on purpose. Python has one bytes type, so whichever form the
+    encoder picks the other becomes a one-way landing; the payload boundary
+    already chose ``ArrayBuffer`` and has tests pinning it. Nothing downstream
+    of a payload cares which form a ``bytes`` *field* took, so there is no
+    reason to move that.
+    """
+    if type(value) is not bytes:
+        return False
+    # A `memoryview` rather than the `bytes` itself, and not for speed: devalue
+    # indexes by identity, so returning the same object would make the view
+    # reference its own slot instead of a buffer. A distinct object flattens to
+    # the `["ArrayBuffer", …]` entry the view is supposed to point at -- and a
+    # view over the same memory copies nothing to get one.
+    return memoryview(value)
+
+
+CHUNK_REDUCERS: dict[str, Any] = {**serde.REDUCERS, "Uint8Array": _reduce_uint8array}
+"""Reducers for a stream chunk, as opposed to a run/step/hook payload."""
+
+
 def encode_value(value: Any) -> bytes:
     """The frame a single user write becomes."""
-    return encode_frame(ser.dehydrate(value))
+    return encode_frame(ser.dehydrate(value, reducers=CHUNK_REDUCERS))
 
 
 class FrameDecoder:

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -1,0 +1,117 @@
+"""Run-scoped streams: the wire framing, and the writer steps use.
+
+A run's stream is an append-only, indexed log of chunks that a reader can tail
+live and resume at an index. Steps write to it with
+:func:`vercel.workflow.get_writable`; anything holding the run id reads it back
+through the world's ``streams_get``.
+
+Each user write becomes exactly one length-prefixed frame, and each frame is
+stored under exactly one chunk index::
+
+    [4-byte big-endian length][format-prefixed payload]
+
+That one-write-one-frame-one-index correspondence is what makes
+``start_index + frames_consumed`` a correct resume position, so nothing along
+this path may coalesce or split frames. The payload is whatever
+:mod:`.serialization` writes -- a ``devl``-prefixed devalue payload -- which is
+the format `@workflow/core`'s ``getDeserializeStream`` reads, so a stream
+written here is readable by the TypeScript SDK, the ``workflow`` CLI and the
+dashboard. The length header stays outside the payload so a reader can find
+frame boundaries without understanding the payload format at all.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from typing import Any
+
+from . import serialization as ser
+
+FRAME_HEADER_SIZE = 4
+"""Bytes of big-endian length prefix in front of every frame."""
+
+MAX_FRAME_SIZE = 100_000_000
+"""Largest single frame payload, matching `@workflow/core`'s ``MAX_FRAME_SIZE``.
+
+A length header advertising more than this is refused rather than allocated:
+past a certain size the far more likely explanation is a misframed wire than a
+100 MB chunk.
+"""
+
+
+def workflow_run_stream_id(run_id: str, namespace: str | None = None) -> str:
+    """The name of a run's default user stream.
+
+    Mirrors `@workflow/core`'s ``getWorkflowRunStreamId``. A namespace is
+    base64url-encoded because it reaches Redis keys on the Vercel world, where
+    arbitrary user text is not safe as a key segment.
+    """
+    # JS `String.replace` with a string pattern replaces the first match only.
+    name = run_id.replace("wrun_", "strm_", 1) + "_user"
+    if not namespace:
+        return name
+    encoded = base64.urlsafe_b64encode(namespace.encode()).decode("ascii").rstrip("=")
+    return f"{name}_{encoded}"
+
+
+def encode_frame(payload: bytes) -> bytes:
+    """Wrap *payload* in its length header."""
+    if len(payload) > MAX_FRAME_SIZE:
+        raise ser.SerializationError(
+            f"Stream chunk of {len(payload)} bytes exceeds the maximum frame size "
+            f"({MAX_FRAME_SIZE}); split the data into smaller chunks before writing"
+        )
+    return len(payload).to_bytes(FRAME_HEADER_SIZE, "big") + payload
+
+
+def encode_value(value: Any) -> bytes:
+    """The frame a single user write becomes."""
+    return encode_frame(ser.dehydrate(value))
+
+
+class FrameDecoder:
+    """Reassembles frames from transport reads of arbitrary size.
+
+    The transport decides where its own read boundaries fall: one frame may
+    arrive split across three reads, and three frames may arrive in one. Feed
+    every read in and take whatever whole frames come out.
+    """
+
+    __slots__ = ("_buffer",)
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+
+    @property
+    def pending(self) -> int:
+        """Bytes buffered as part of a frame that has not fully arrived."""
+        return len(self._buffer)
+
+    def feed(self, data: bytes) -> Iterator[bytes]:
+        """Yield the payload of every frame completed by *data*."""
+        self._buffer += data
+        while len(self._buffer) >= FRAME_HEADER_SIZE:
+            length = int.from_bytes(self._buffer[:FRAME_HEADER_SIZE], "big")
+            if length > MAX_FRAME_SIZE:
+                raise ser.SerializationError(
+                    f"Stream frame length {length} exceeds the maximum ({MAX_FRAME_SIZE}); "
+                    f"this usually means a non-framed stream is being read as framed"
+                )
+            end = FRAME_HEADER_SIZE + length
+            if len(self._buffer) < end:
+                return
+            yield bytes(self._buffer[FRAME_HEADER_SIZE:end])
+            del self._buffer[:end]
+
+    def finish(self) -> None:
+        """Assert the stream ended on a frame boundary.
+
+        Leftover bytes mean the stream was truncated mid-frame. Reporting that
+        beats silently dropping the tail, which would look like a short stream.
+        """
+        if self._buffer:
+            raise ser.SerializationError(
+                f"Stream ended with {len(self._buffer)} bytes of incomplete frame data; "
+                f"it was truncated mid-frame"
+            )

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -28,7 +28,7 @@ import os
 from collections.abc import AsyncIterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from . import serde, serialization as ser
+from . import serialization as ser
 
 if TYPE_CHECKING:
     from . import world as w
@@ -87,45 +87,9 @@ def encode_frame(payload: bytes) -> bytes:
     return len(payload).to_bytes(FRAME_HEADER_SIZE, "big") + payload
 
 
-def _reduce_uint8array(value: Any) -> Any:
-    """devalue reducer framing a chunk's ``bytes`` as a ``Uint8Array``.
-
-    devalue writes a typed array as a view onto a separate buffer entry,
-    ``["Uint8Array", <buffer>]``, where the stringifier's own ``bytes`` branch
-    writes the bare ``["ArrayBuffer", …]``. Both carry the same bytes and both
-    read back here as ``bytes``; only the tag differs.
-
-    It matters because of what reads a stream. The pattern the TypeScript docs
-    lead with pipes a run's readable straight into a `Response`, and a body
-    stream takes `Uint8Array` chunks only -- an `ArrayBuffer` chunk raises
-    ``Received non-Uint8Array chunk``. So a step writing ``b"..."`` has to
-    frame it as a view or every consumer doing that breaks.
-
-    Chunk-local for now. Teaching the stringifier that ``bytes`` means
-    ``Uint8Array`` (and ``bytearray`` means ``ArrayBuffer``) is the better fix
-    and would delete this, but it changes the payload wire format and what a JS
-    ``ArrayBuffer`` field lands as, so it wants its own change.
-    """
-    # Exact type on purpose: `bytearray` and `memoryview` must fall through to
-    # the stringifier's `ArrayBuffer` branch, or this would re-enter on the
-    # view it returns below and recurse.
-    if type(value) is not bytes:
-        return False
-    # A `memoryview` rather than the `bytes` itself, and not for speed: devalue
-    # indexes by identity, so returning the same object would make the view
-    # reference its own slot instead of a buffer. A distinct object flattens to
-    # the `["ArrayBuffer", …]` entry the view is supposed to point at -- and a
-    # view over the same memory copies nothing to get one.
-    return memoryview(value)
-
-
-CHUNK_REDUCERS: dict[str, Any] = {**serde.REDUCERS, "Uint8Array": _reduce_uint8array}
-"""Reducers for a stream chunk, as opposed to a run/step/hook payload."""
-
-
 def encode_value(value: Any) -> bytes:
     """The frame a single user write becomes."""
-    return encode_frame(ser.dehydrate(value, reducers=CHUNK_REDUCERS))
+    return encode_frame(ser.dehydrate(value))
 
 
 class FrameDecoder:

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -22,15 +22,18 @@ frame boundaries without understanding the payload format at all.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import os
 from collections.abc import AsyncIterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
+import anyio
+
 from . import serialization as ser
 
 if TYPE_CHECKING:
+    from anyio.abc import TaskGroup
+
     from . import world as w
 
 FRAME_HEADER_SIZE = 4
@@ -176,6 +179,11 @@ MAX_BYTES_PER_BATCH = 1024 * 1024
 class WorkflowStreamWriter:
     """A stream that workflow steps can write to.
 
+    Sending happens in a task of *task_group*, not in ``write()``, which is
+    what lets a producer keep filling the buffer while a request is in flight.
+    The group therefore has to outlive every write and the final
+    :meth:`drain` -- the step handler owns one for exactly that span.
+
     Not safe to use from more than one event loop; within one loop, concurrent
     writers are fine and their chunks land in call order.
     """
@@ -186,6 +194,7 @@ class WorkflowStreamWriter:
         world: w.World,
         run_id: str,
         name: str,
+        task_group: TaskGroup,
         reentrant_ctx_on_err: bool = True,
     ) -> None:
         if not name:
@@ -193,6 +202,7 @@ class WorkflowStreamWriter:
         self._world = world
         self._run_id = run_id
         self._name = name
+        self._task_group = task_group
 
         self._buffer: list[bytes] = []
         self._buffered_bytes = 0
@@ -201,7 +211,7 @@ class WorkflowStreamWriter:
         # not just on the queued follow-up group.
         self._inflight_chunks = 0
         self._inflight_bytes = 0
-        self._dispatch: asyncio.Task[None] | None = None
+        self._dispatching = False
         # Sticky: once a request fails, its group stays at the head of the
         # buffer and every later call raises the original error. Chunks whose
         # `write()` already returned surface their failure at the barrier --
@@ -209,11 +219,11 @@ class WorkflowStreamWriter:
         self._sink_error: BaseException | None = None
         self._closed = False
         # Every critical section under this condition is await-free -- the only
-        # `await` taken while holding it is `wait()`, which releases it. The
-        # cancellation handler in `_dispatch_loop` depends on that: re-acquiring
-        # there must not suspend, or a second cancel could land mid-restore and
-        # drop the in-flight group.
-        self._condition = asyncio.Condition()
+        # `await` taken while holding it is `wait()`, which releases it. That
+        # keeps the restore in `_dispatch_loop`'s cancellation handler short
+        # enough to run under a shield without holding cancellation off for
+        # anything that can block.
+        self._condition = anyio.Condition()
 
         self._max_inflight_chunks = _env_int(
             "WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", MAX_INFLIGHT_CHUNKS
@@ -289,8 +299,9 @@ class WorkflowStreamWriter:
         Exactly one runs at a time, which is what keeps groups reaching the
         server in write order. Called with the condition held.
         """
-        if self._dispatch is None and self._sink_error is None and self._buffer:
-            self._dispatch = asyncio.ensure_future(self._dispatch_loop())
+        if not self._dispatching and self._sink_error is None and self._buffer:
+            self._dispatching = True
+            self._task_group.start_soon(self._dispatch_loop)
 
     def _take_group(self) -> tuple[list[bytes], int]:
         """The largest leading group that fits one request.
@@ -317,14 +328,22 @@ class WorkflowStreamWriter:
         self._buffered_bytes += octets
         self._inflight_chunks = 0
         self._inflight_bytes = 0
-        self._dispatch = None
+        self._dispatching = False
 
     async def _dispatch_loop(self) -> None:
+        """Send buffered groups until the buffer runs dry.
+
+        Runs as a task in the owner's group, so raising here would tear down
+        the step that is writing. It doesn't: a send failure is reported by
+        poisoning the sink, which is where ``write()`` and ``drain()`` already
+        look. Cancellation still propagates -- that is the group taking the
+        loop down rather than the loop failing.
+        """
         try:
             while True:
                 async with self._condition:
                     if not self._buffer:
-                        self._dispatch = None
+                        self._dispatching = False
                         # Nothing buffered and nothing in flight: the
                         # durability barrier is satisfied.
                         self._condition.notify_all()
@@ -335,16 +354,19 @@ class WorkflowStreamWriter:
 
                 try:
                     await self._send(group)
-                except asyncio.CancelledError:
-                    async with self._condition:
-                        self._put_back_group(group, octets)
-                        self._condition.notify_all()
-                    raise
                 except BaseException as error:
-                    async with self._condition:
-                        self._put_back_group(group, octets)
-                        self._sink_error = error
-                        self._condition.notify_all()
+                    cancelled = isinstance(error, anyio.get_cancelled_exc_class())
+                    # Shielded because acquiring the condition is a checkpoint:
+                    # in a cancelled task it would raise instead, leaving the
+                    # group booked as in flight forever.
+                    with anyio.CancelScope(shield=True):
+                        async with self._condition:
+                            self._put_back_group(group, octets)
+                            if not cancelled:
+                                self._sink_error = error
+                            self._condition.notify_all()
+                    if cancelled:
+                        raise
                     return
 
                 async with self._condition:
@@ -354,17 +376,20 @@ class WorkflowStreamWriter:
                     # bound. They re-check it and may block again.
                     self._condition.notify_all()
         except BaseException as error:
-            # Cancellation, or a bug in the loop itself. Either way no one is
-            # driving this buffer any more, so waiters have to be released --
-            # and for anything that is not cancellation the sink is poisoned
-            # too, because `drain()` would otherwise see an idle buffer, start
-            # a fresh loop, and hit the same bug forever.
-            async with self._condition:
-                self._dispatch = None
-                if not isinstance(error, asyncio.CancelledError):
-                    self._sink_error = error
-                self._condition.notify_all()
-            raise
+            # Cancellation outside `_send`, or a bug in the loop itself. Either
+            # way no one is driving this buffer any more, so waiters have to be
+            # released -- and for anything that is not cancellation the sink is
+            # poisoned too, because `drain()` would otherwise see an idle
+            # buffer, start a fresh loop, and hit the same bug forever.
+            cancelled = isinstance(error, anyio.get_cancelled_exc_class())
+            with anyio.CancelScope(shield=True):
+                async with self._condition:
+                    self._dispatching = False
+                    if not cancelled:
+                        self._sink_error = error
+                    self._condition.notify_all()
+            if cancelled:
+                raise
 
     async def _send(self, group: Sequence[bytes]) -> None:
         if len(group) == 1:
@@ -382,7 +407,7 @@ class WorkflowStreamWriter:
             while True:
                 if self._sink_error is not None:
                     raise self._sink_error
-                if not self._buffer and self._inflight_chunks == 0 and self._dispatch is None:
+                if not self._buffer and self._inflight_chunks == 0 and not self._dispatching:
                     return
                 self._start_dispatch()
                 await self._condition.wait()

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -88,12 +88,12 @@ def encode_frame(payload: bytes) -> bytes:
 
 
 def _reduce_uint8array(value: Any) -> Any:
-    """devalue reducer sending a chunk's ``bytes`` as a view. Falsy declines.
+    """devalue reducer framing a chunk's ``bytes`` as a ``Uint8Array``.
 
-    Only the emitted *form* differs: devalue writes a typed array as a view
-    onto its own buffer entry, ``["Uint8Array", <buffer>]``, where the payload
-    boundary writes the bare ``["ArrayBuffer", …]``. Both carry the same bytes
-    and both read back here as ``bytes``.
+    devalue writes a typed array as a view onto a separate buffer entry,
+    ``["Uint8Array", <buffer>]``, where the stringifier's own ``bytes`` branch
+    writes the bare ``["ArrayBuffer", …]``. Both carry the same bytes and both
+    read back here as ``bytes``; only the tag differs.
 
     It matters because of what reads a stream. The pattern the TypeScript docs
     lead with pipes a run's readable straight into a `Response`, and a body
@@ -101,12 +101,14 @@ def _reduce_uint8array(value: Any) -> Any:
     ``Received non-Uint8Array chunk``. So a step writing ``b"..."`` has to
     frame it as a view or every consumer doing that breaks.
 
-    Chunk-local on purpose. Python has one bytes type, so whichever form the
-    encoder picks the other becomes a one-way landing; the payload boundary
-    already chose ``ArrayBuffer`` and has tests pinning it. Nothing downstream
-    of a payload cares which form a ``bytes`` *field* took, so there is no
-    reason to move that.
+    Chunk-local for now. Teaching the stringifier that ``bytes`` means
+    ``Uint8Array`` (and ``bytearray`` means ``ArrayBuffer``) is the better fix
+    and would delete this, but it changes the payload wire format and what a JS
+    ``ArrayBuffer`` field lands as, so it wants its own change.
     """
+    # Exact type on purpose: `bytearray` and `memoryview` must fall through to
+    # the stringifier's `ArrayBuffer` branch, or this would re-enter on the
+    # view it returns below and recurse.
     if type(value) is not bytes:
         return False
     # A `memoryview` rather than the `bytes` itself, and not for speed: devalue
@@ -177,8 +179,7 @@ class FrameDecoder:
 # writer
 # ═══════════════════════════════════════════════════════════════════════════
 #
-# Ported from `@workflow/core`'s `WorkflowServerWritableStream`, whose shape is
-# not obvious and is worth restating.
+# Ported from `@workflow/core`'s `WorkflowServerWritableStream`.
 #
 # `write()` returns once the chunk is *buffered*, not once it is durable. That
 # early acknowledgement is what makes batching work at all: the producer keeps
@@ -209,13 +210,20 @@ MAX_BYTES_PER_BATCH = 1024 * 1024
 
 
 class WorkflowStreamWriter:
-    """A group-committing writer for one ``(run_id, name)`` stream.
+    """A stream that workflow steps can write to.
 
     Not safe to use from more than one event loop; within one loop, concurrent
     writers are fine and their chunks land in call order.
     """
 
-    def __init__(self, world: w.World, run_id: str, name: str) -> None:
+    def __init__(
+        self,
+        *,
+        world: w.World,
+        run_id: str,
+        name: str,
+        reentrant_ctx_on_err: bool = True,
+    ) -> None:
         if not name:
             raise ValueError(f'"name" is required, got {name!r}')
         self._world = world
@@ -236,6 +244,11 @@ class WorkflowStreamWriter:
         # that is the contract of an early-acknowledging sink.
         self._sink_error: BaseException | None = None
         self._closed = False
+        # Every critical section under this condition is await-free -- the only
+        # `await` taken while holding it is `wait()`, which releases it. The
+        # cancellation handler in `_dispatch_loop` depends on that: re-acquiring
+        # there must not suspend, or a second cancel could land mid-restore and
+        # drop the in-flight group.
         self._condition = asyncio.Condition()
 
         self._max_inflight_chunks = _env_int(
@@ -250,6 +263,8 @@ class WorkflowStreamWriter:
         self._max_bytes_per_batch = _env_int(
             "WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", MAX_BYTES_PER_BATCH
         )
+
+        self._reentrant_ctx_on_err = reentrant_ctx_on_err
 
     @property
     def name(self) -> str:
@@ -273,10 +288,8 @@ class WorkflowStreamWriter:
     async def write_from(self, source: AsyncIterable[Any]) -> None:
         """Append every item *source* yields, in order.
 
-        The counterpart of piping a stream into this one: a step forwarding an
-        upstream async iterator (LLM tokens, an HTTP body) wants this rather
-        than a hand-rolled loop, and it keeps the group-commit buffer fed
-        without the caller thinking about batching.
+        This is simply a shortcut for a manual loop + :meth:`write` for
+        forwarding an upstream async iterator (e.g. LLM tokens, HTTP body).
         """
         async for value in source:
             await self.write(value)
@@ -335,6 +348,13 @@ class WorkflowStreamWriter:
         self._buffered_bytes -= octets
         return group, octets
 
+    def _put_back_group(self, group: Sequence[bytes], octets: int) -> None:
+        self._buffer[:0] = group
+        self._buffered_bytes += octets
+        self._inflight_chunks = 0
+        self._inflight_bytes = 0
+        self._dispatch = None
+
     async def _dispatch_loop(self) -> None:
         try:
             while True:
@@ -351,27 +371,16 @@ class WorkflowStreamWriter:
 
                 try:
                     await self._send(group)
-                except BaseException as error:
-                    cancelled = isinstance(error, asyncio.CancelledError)
+                except asyncio.CancelledError:
                     async with self._condition:
-                        # The group did not land, so it goes back at the head
-                        # either way: the buffer holds everything not known to
-                        # be durable, and dropping it here would lose chunks
-                        # whose `write()` had already returned.
-                        self._buffer[:0] = group
-                        self._buffered_bytes += octets
-                        self._inflight_chunks = 0
-                        self._inflight_bytes = 0
-                        self._dispatch = None
-                        # Cancellation is this task being torn down, not the
-                        # stream failing. Recording it as the sink error would
-                        # make a later `write()` raise `CancelledError` inside
-                        # a caller that was never cancelled.
-                        if not cancelled:
-                            self._sink_error = error
+                        self._put_back_group(group, octets)
                         self._condition.notify_all()
-                    if cancelled:
-                        raise
+                    raise
+                except BaseException as error:
+                    async with self._condition:
+                        self._put_back_group(group, octets)
+                        self._sink_error = error
+                        self._condition.notify_all()
                     return
 
                 async with self._condition:
@@ -431,5 +440,5 @@ class WorkflowStreamWriter:
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-        if exc_type is None:
+        if exc_type is None or not self._reentrant_ctx_on_err:
             await self.close()

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -727,13 +727,13 @@ class StreamChunk(BaseModel):
     data: bytes
 
 
-class StreamChunksPage(BaseModel):
+class StreamChunksPage(PaginatedResult[StreamChunk]):
     """One page of already-written chunks -- a snapshot, not a live read."""
 
-    data: list[StreamChunk]
+    # Both are optional here, unlike the base: a page that ends the stream
+    # carries neither, and the endpoint omits them rather than sending nulls.
     cursor: str | None = None
     has_more: bool = pydantic.Field(default=False, alias="hasMore")
-    """Whether further pages of already-written chunks exist."""
 
     done: bool = False
     """Whether the stream is closed, so no more chunks will ever arrive."""

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from datetime import datetime
 from typing import (
     Annotated,
@@ -708,6 +708,37 @@ class PaginatedResult(BaseModel, Generic[T]):
     has_more: bool = pydantic.Field(alias="hasMore")
 
 
+class StreamInfo(BaseModel):
+    """Lightweight metadata about a stream, without reading its payloads."""
+
+    tail_index: int = pydantic.Field(alias="tailIndex")
+    """Index of the last known chunk, 0-based, or ``-1`` when none was written.
+
+    Anything deriving a start index from this has to handle ``-1`` rather than
+    treating it as a position.
+    """
+
+    done: bool
+    """Whether the stream has been closed."""
+
+
+class StreamChunk(BaseModel):
+    index: int
+    data: bytes
+
+
+class StreamChunksPage(BaseModel):
+    """One page of already-written chunks -- a snapshot, not a live read."""
+
+    data: list[StreamChunk]
+    cursor: str | None = None
+    has_more: bool = pydantic.Field(default=False, alias="hasMore")
+    """Whether further pages of already-written chunks exist."""
+
+    done: bool = False
+    """Whether the stream is closed, so no more chunks will ever arrive."""
+
+
 class EventResult(BaseModel):
     event: Event | None = None
     events: list[Event] | None = None
@@ -942,6 +973,71 @@ class World(metaclass=abc.ABCMeta):
         *,
         pagination: PaginationOptions | None = None,
     ) -> PaginatedResult[Event]: ...
+
+    # ── streams ────────────────────────────────────────────────────────────
+    #
+    # A stream is an append-only, indexed log of opaque chunks scoped to a run.
+    # Unlike the entities above it lives outside the event log: chunks are not
+    # events and are not replayed, which is what lets a workflow stream output
+    # without growing its own history.
+
+    @abc.abstractmethod
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        """Append one chunk to a stream, creating it if needed."""
+        ...
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        """Append several chunks in order, ideally in one round trip.
+
+        Concrete because a world that cannot batch is still correct without it:
+        chunk boundaries and indices come out the same either way, so the
+        default below only costs requests.
+        """
+        for chunk in chunks:
+            await self.streams_write(run_id, name, chunk)
+
+    @abc.abstractmethod
+    async def streams_close(self, run_id: str, name: str) -> None:
+        """Mark a stream complete, ending its readers.
+
+        Idempotent: closing a closed stream is not an error, which is what lets
+        a retried close be safe.
+        """
+        ...
+
+    @abc.abstractmethod
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncIterator[bytes]:
+        """Read a stream live, waiting for chunks that have not arrived yet.
+
+        The iterator ends when the stream is closed, not when it runs out of
+        currently-available chunks -- for a snapshot use
+        :meth:`streams_get_chunks` instead.
+
+        *start_index* skips that many chunks from the start. A negative value
+        counts back from the current end (``-3`` starts three chunks before it),
+        clamped at 0. Callers who abandon the iterator early should close it
+        (``contextlib.aclosing``) so the underlying request or poll stops.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def streams_list(self, run_id: str) -> list[str]:
+        """The names of every stream this run has written to."""
+        ...
+
+    @abc.abstractmethod
+    async def streams_get_chunks(
+        self, run_id: str, name: str, *, limit: int | None = None, cursor: str | None = None
+    ) -> StreamChunksPage:
+        """One page of currently-available chunks, oldest first."""
+        ...
+
+    @abc.abstractmethod
+    async def streams_get_info(self, run_id: str, name: str) -> StreamInfo:
+        """A stream's tail index and closed flag, without reading payloads."""
+        ...
 
 
 the_world: World | None = None

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import contextlib
 import hashlib
@@ -8,7 +9,7 @@ import pathlib
 import tempfile
 import threading
 import traceback
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from typing import Any, TypeVar, cast
@@ -40,6 +41,67 @@ def is_step_terminal(status: str) -> bool:
 # Marker the TypeScript `world-local` package uses to smuggle binary payloads
 # through JSON. See its `jsonReplacer` / `jsonReviver`.
 UINT8ARRAY_TYPE_TAG = "Uint8Array"
+
+# A chunk file is its EOF flag byte followed by the payload. The flag is what
+# marks the end of a stream: `close()` appends a chunk carrying it and nothing
+# else, so a reader can tell "closed" from "nothing written yet" without a
+# separate metadata file to keep in sync.
+_EOF_MARKER = 1
+
+# How often a live reader re-lists a stream's directory. The writer may be in
+# another process -- `vercel dev` serving a run while a test tails it -- so the
+# filesystem is the only channel that always works.
+_POLL_INTERVAL_SECONDS = 0.1
+
+
+class RunStreams(w.BaseModel):
+    streams: list[str]
+
+
+def _read_chunk(path: pathlib.Path) -> tuple[bool, bytes]:
+    """A chunk file's EOF flag and payload.
+
+    A missing file reads as an empty non-EOF chunk: a live reader lists the
+    directory and then opens what it found, and a concurrent writer's atomic
+    replace can retire a name in between.
+    """
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return False, b""
+    if not raw:
+        return False, b""
+    return raw[0] == _EOF_MARKER, raw[1:]
+
+
+def _read_eof_flag(path: pathlib.Path) -> bool:
+    """Just a chunk's EOF flag, without reading its payload."""
+    try:
+        with path.open("rb") as f:
+            return f.read(1) == bytes([_EOF_MARKER])
+    except FileNotFoundError:
+        return False
+
+
+def _encode_chunks_cursor(index: int) -> str:
+    return base64.b64encode(json.dumps({"i": index}).encode()).decode("ascii")
+
+
+def _decode_chunks_cursor(cursor: str | None) -> int:
+    """The data-chunk index a cursor points at, or 0 for anything unreadable.
+
+    Matching the TS reader, which treats a corrupt cursor as "start over"
+    rather than an error -- a cursor is an opaque token a client round-trips,
+    and failing the whole read over a mangled one helps nobody.
+    """
+    if not cursor:
+        return 0
+    try:
+        decoded = json.loads(base64.b64decode(cursor))
+        index = decoded["i"]
+    except Exception:
+        return 0
+    return index if isinstance(index, int) and index >= 0 else 0
 
 
 def to_js_iso(value: datetime) -> str:
@@ -168,6 +230,24 @@ def write_json(path: pathlib.Path, data: w.BaseModel | dict, *, overwrite: bool 
         raise w.EntityConflictError(f"File already exists: {path}") from None
 
 
+class UnsafeEntityIdError(ValueError):
+    """An id that would not stay put inside the data directory."""
+
+    def __init__(self, kind: str, value: str) -> None:
+        super().__init__(f"unsafe {kind}: {value!r}")
+
+
+def assert_safe_entity_id(kind: str, value: str) -> None:
+    """Reject an id that cannot be used as a path segment.
+
+    Mirrors the TS ``assertSafeEntityId``. Stream names in particular arrive
+    from a namespace the caller chose and become a *directory* name, so this is
+    the check that keeps ``../`` out of the data directory.
+    """
+    if not value or value.startswith(".") or set(value) & {"/", "\\", "\0", "."}:
+        raise UnsafeEntityIdError(kind, value)
+
+
 def write_exclusive(path: pathlib.Path, data: str) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -260,6 +340,9 @@ class LocalWorld(w.World):
         # We certainly *could* do more fine-grained locking but I
         # don't think it would really help.
         self._run_locks: dict[str, threading.Lock] = {}
+        # `${run_id}:${stream_name}` already written to the run's stream
+        # registry. See `_register_stream`.
+        self._registered_streams: set[str] = set()
 
     def _run_lock(self, run_id: str) -> threading.Lock:
         # dict.setdefault is atomic, so concurrent callers for the same run_id
@@ -845,6 +928,189 @@ class LocalWorld(w.World):
             run=run,
             step=step,
         )
+
+    # ── streams ────────────────────────────────────────────────────────────
+    #
+    # One file per chunk, under a directory per stream. The directory matters:
+    # a live reader re-lists it every 100ms, and a single flat directory would
+    # make each of those listings proportional to every chunk in the whole data
+    # directory rather than to this one stream (vercel/workflow#2797).
+    #
+    # Chunk order is file name order. Names are monotonic ULIDs minted *before*
+    # the first await in each method, so ordering follows the order calls were
+    # made and not the order their writes happen to complete.
+
+    def _chunk_dir(self, name: str) -> pathlib.Path:
+        assert_safe_entity_id("streamName", name)
+        return self.data_dir / "streams" / "chunks" / name
+
+    def _run_streams_path(self, run_id: str) -> pathlib.Path:
+        assert_safe_entity_id("runId", run_id)
+        return self.data_dir / "streams" / "runs" / f"{run_id}.json"
+
+    def _chunk_files(self, name: str) -> list[pathlib.Path]:
+        """Every chunk file of a stream, in chunk order."""
+        try:
+            entries = [p for p in self._chunk_dir(name).iterdir() if p.suffix == ".bin"]
+        except FileNotFoundError:
+            return []
+        return sorted(entries, key=lambda p: p.name)
+
+    def _register_stream(self, run_id: str, name: str) -> None:
+        """Record that *run_id* owns *name*, so ``streams_list`` finds it.
+
+        Remembered per process, because this runs on every chunk: without the
+        cache a stream of ten thousand chunks would read and re-parse the
+        registry ten thousand times. Another process registering the same
+        stream is unaffected -- each registers its own on first write, and the
+        file write is idempotent in content.
+        """
+        assert_safe_entity_id("streamName", name)
+        cache_key = f"{run_id}:{name}"
+        if cache_key in self._registered_streams:
+            return
+        path = self._run_streams_path(run_id)
+        with self._run_lock(f"streams:{run_id}"):
+            existing = read_json(path, RunStreams)
+            names = existing.streams if existing else []
+            if name not in names:
+                names.append(name)
+                write_json(path, RunStreams(streams=names), overwrite=True)
+        self._registered_streams.add(cache_key)
+
+    def _append_chunk(
+        self, run_id: str, name: str, chunk_id: str, payload: bytes, *, eof: bool
+    ) -> None:
+        self._register_stream(run_id, name)
+        path = self._chunk_dir(name) / f"{chunk_id}.bin"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(path, bytes([_EOF_MARKER if eof else 0]) + payload)
+
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        chunk_id = f"chnk_{self.monotonic_ulid(None)}"
+        self._append_chunk(run_id, name, chunk_id, chunk, eof=False)
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        if not chunks:
+            return
+        chunk_ids = [f"chnk_{self.monotonic_ulid(None)}" for _ in chunks]
+        for chunk_id, chunk in zip(chunk_ids, chunks, strict=True):
+            self._append_chunk(run_id, name, chunk_id, chunk, eof=False)
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        chunk_id = f"chnk_{self.monotonic_ulid(None)}"
+        self._append_chunk(run_id, name, chunk_id, b"", eof=True)
+
+    async def streams_list(self, run_id: str) -> list[str]:
+        data = read_json(self._run_streams_path(run_id), RunStreams)
+        return data.streams if data else []
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncIterator[bytes]:
+        return self._iter_stream(name, start_index)
+
+    async def _iter_stream(self, name: str, start_index: int | None) -> AsyncIterator[bytes]:
+        delivered: set[str] = set()
+        files = self._chunk_files(name)
+        start = self._resolve_start_index(files, start_index)
+
+        # Everything before the start position counts as delivered, so the poll
+        # below does not hand back what the caller asked to skip. An EOF marker
+        # in that skipped region means the stream ended before the caller's
+        # start index -- there is nothing left to wait for, and marking it
+        # delivered would leave the poll waiting for an end it had already
+        # passed. (`@workflow/world-local` marks it and hangs; a reader that
+        # overshoots a closed stream should come back empty, not never.)
+        for path in files[:start]:
+            if _read_eof_flag(path):
+                return
+            delivered.add(path.name)
+
+        for path in files[start:]:
+            delivered.add(path.name)
+            eof, payload = _read_chunk(path)
+            if eof:
+                return
+            if payload:
+                yield payload
+
+        while True:
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            for path in self._chunk_files(name):
+                if path.name in delivered:
+                    continue
+                delivered.add(path.name)
+                eof, payload = _read_chunk(path)
+                if eof:
+                    return
+                if payload:
+                    yield payload
+
+    def _resolve_start_index(self, files: Sequence[pathlib.Path], start_index: int | None) -> int:
+        """Turn *start_index* into a position in *files*.
+
+        A negative index counts back from the end, over data chunks only -- the
+        trailing EOF marker is not a chunk anyone asked for.
+        """
+        if start_index is None:
+            return 0
+        if start_index >= 0:
+            return start_index
+        data_count = len(files)
+        if files and _read_eof_flag(files[-1]):
+            data_count -= 1
+        return max(0, data_count + start_index)
+
+    async def streams_get_chunks(
+        self, run_id: str, name: str, *, limit: int | None = None, cursor: str | None = None
+    ) -> w.StreamChunksPage:
+        page_size = 100 if limit is None else limit
+        start = _decode_chunks_cursor(cursor)
+
+        chunks: list[w.StreamChunk] = []
+        done = False
+        index = 0  # running count of data (non-EOF) chunks seen
+        for path in self._chunk_files(name):
+            if index < start:
+                # Before the cursor only the flag matters, so skip the payload.
+                if _read_eof_flag(path):
+                    done = True
+                    break
+                index += 1
+                continue
+            if len(chunks) >= page_size:
+                # Peek one past the page to answer has_more/done without
+                # reading another payload.
+                if _read_eof_flag(path):
+                    done = True
+                else:
+                    index += 1
+                break
+            eof, payload = _read_chunk(path)
+            if eof:
+                done = True
+                break
+            chunks.append(w.StreamChunk(index=index, data=payload))
+            index += 1
+
+        has_more = not done and index > start + len(chunks)
+        return w.StreamChunksPage(
+            data=chunks,
+            cursor=_encode_chunks_cursor(start + len(chunks)) if has_more else None,
+            hasMore=has_more,
+            done=done,
+        )
+
+    async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
+        data_count = 0
+        done = False
+        for path in self._chunk_files(name):
+            if _read_eof_flag(path):
+                done = True
+                break
+            data_count += 1
+        return w.StreamInfo(tailIndex=data_count - 1, done=done)
 
     async def events_list(
         self,

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -83,7 +83,47 @@ def _read_eof_flag(path: pathlib.Path) -> bool:
         return False
 
 
+def _scan_chunks(
+    files: Sequence[pathlib.Path], start: int, limit: int | None = None
+) -> tuple[list[tuple[pathlib.Path, bytes]], int, bool]:
+    """Walk *files* from data-chunk *start*, at most *limit* chunks.
+
+    Returns the chunks found, the data-chunk index just past them, and whether
+    the walk reached the end of the stream. Before *start* only the one-byte
+    EOF flag is read, never a payload; an EOF marker there ends the walk too,
+    since a stream that closed before the caller's position has nothing left to
+    give it.
+    """
+    found: list[tuple[pathlib.Path, bytes]] = []
+    index = 0  # running count of data (non-EOF) chunks seen
+    for path in files:
+        if index < start:
+            if _read_eof_flag(path):
+                return found, index, True
+            index += 1
+            continue
+        if limit is not None and len(found) >= limit:
+            # Peek one past the limit: enough to tell "more to come" from "the
+            # end", without reading another payload.
+            if _read_eof_flag(path):
+                return found, index, True
+            return found, index + 1, False
+        eof, payload = _read_chunk(path)
+        if eof:
+            return found, index, True
+        found.append((path, payload))
+        index += 1
+    return found, index, False
+
+
 def _encode_chunks_cursor(index: int) -> str:
+    """An opaque token for the data-chunk index a page ended at.
+
+    `cursor` is the world-level pagination type, and against `VercelWorld` it
+    is a token the API issues and we forward verbatim -- so the local world
+    mints something that fits the same slot rather than exposing its int index.
+    The bytes are `@workflow/world-local`'s for want of a reason to differ.
+    """
     return base64.b64encode(json.dumps({"i": index}).encode()).decode("ascii")
 
 
@@ -243,6 +283,12 @@ def assert_safe_entity_id(kind: str, value: str) -> None:
     Mirrors the TS ``assertSafeEntityId``. Stream names in particular arrive
     from a namespace the caller chose and become a *directory* name, so this is
     the check that keeps ``../`` out of the data directory.
+
+    Callers that compose a name themselves have already made it safe --
+    ``workflow_run_stream_id`` base64url-encodes the namespace, so nothing from
+    ``get_writable()`` can reach here unencoded. The guard is for the world API,
+    which takes a bare name from tests, the CLI, or anything else holding one.
+    ``@workflow/world-local`` double-guards the same way.
     """
     if not value or value.startswith(".") or set(value) & {"/", "\\", "\0", "."}:
         raise UnsafeEntityIdError(kind, value)
@@ -348,6 +394,19 @@ class LocalWorld(w.World):
         # dict.setdefault is atomic, so concurrent callers for the same run_id
         # converge on one lock without a separate guard lock.
         return self._run_locks.setdefault(run_id, threading.Lock())
+
+    def _new_id(self, prefix: str) -> str:
+        """A monotonic, lexicographically ordered id.
+
+        Every caller mints one synchronously, *before* its first await, so a
+        listing sorted by name is in the order the calls were made rather than
+        the order their writes happened to finish. Chunk order in particular is
+        file-name order, which no integer counter could give us: one data
+        directory is shared by the dev server, the CLI and tests, so a counter
+        would need an allocator, and it would have to be zero-padded to a fixed
+        width to sort at all.
+        """
+        return f"{prefix}_{self.monotonic_ulid(None)}"
 
     def delete_all_hooks_for_run(self, run_id: str) -> None:
         hooks_dir = self.data_dir / "hooks"
@@ -524,11 +583,11 @@ class LocalWorld(w.World):
             return self._events_create_impl(run_id, data)
 
     def _events_create_impl(self, run_id: str | None, data: w.Event) -> w.EventResult:
-        event_id = f"evnt_{self.monotonic_ulid(None)}"
+        event_id = self._new_id("evnt")
         now = js_now()
 
         if data.event_type == "run_created" and not run_id:
-            effective_run_id = f"wrun_{self.monotonic_ulid(None)}"
+            effective_run_id = self._new_id("wrun")
         elif run_id is None:
             raise ValueError("runId is required for non-run_created events")
         else:
@@ -936,9 +995,8 @@ class LocalWorld(w.World):
     # make each of those listings proportional to every chunk in the whole data
     # directory rather than to this one stream (vercel/workflow#2797).
     #
-    # Chunk order is file name order. Names are monotonic ULIDs minted *before*
-    # the first await in each method, so ordering follows the order calls were
-    # made and not the order their writes happen to complete.
+    # Chunk order is file name order -- see `_new_id` for why the names are
+    # ULIDs.
 
     def _chunk_dir(self, name: str) -> pathlib.Path:
         assert_safe_entity_id("streamName", name)
@@ -987,18 +1045,18 @@ class LocalWorld(w.World):
         atomic_write(path, bytes([_EOF_MARKER if eof else 0]) + payload)
 
     async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
-        chunk_id = f"chnk_{self.monotonic_ulid(None)}"
+        chunk_id = self._new_id("chnk")
         self._append_chunk(run_id, name, chunk_id, chunk, eof=False)
 
     async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
         if not chunks:
             return
-        chunk_ids = [f"chnk_{self.monotonic_ulid(None)}" for _ in chunks]
+        chunk_ids = [self._new_id("chnk") for _ in chunks]
         for chunk_id, chunk in zip(chunk_ids, chunks, strict=True):
             self._append_chunk(run_id, name, chunk_id, chunk, eof=False)
 
     async def streams_close(self, run_id: str, name: str) -> None:
-        chunk_id = f"chnk_{self.monotonic_ulid(None)}"
+        chunk_id = self._new_id("chnk")
         self._append_chunk(run_id, name, chunk_id, b"", eof=True)
 
     async def streams_list(self, run_id: str) -> list[str]:
@@ -1011,32 +1069,31 @@ class LocalWorld(w.World):
         return self._iter_stream(name, start_index)
 
     async def _iter_stream(self, name: str, start_index: int | None) -> AsyncIterator[bytes]:
-        delivered: set[str] = set()
         files = self._chunk_files(name)
         start = self._resolve_start_index(files, start_index)
+        found, _, done = _scan_chunks(files, start)
 
-        # Everything before the start position counts as delivered, so the poll
-        # below does not hand back what the caller asked to skip. An EOF marker
-        # in that skipped region means the stream ended before the caller's
-        # start index -- there is nothing left to wait for, and marking it
-        # delivered would leave the poll waiting for an end it had already
-        # passed. (`@workflow/world-local` marks it and hangs; a reader that
-        # overshoots a closed stream should come back empty, not never.)
-        for path in files[:start]:
-            if _read_eof_flag(path):
-                return
+        # Everything the caller asked to skip counts as delivered, so the poll
+        # below does not hand it back. An EOF marker in that skipped region
+        # ends the read instead: the stream closed before the start index, so
+        # there is nothing left to wait for, and waiting would be waiting for
+        # an end already passed. (`@workflow/world-local` waits and hangs; a
+        # reader that overshoots a closed stream should come back empty, not
+        # never.)
+        delivered = {path.name for path in files[:start]}
+        for path, payload in found:
             delivered.add(path.name)
-
-        for path in files[start:]:
-            delivered.add(path.name)
-            eof, payload = _read_chunk(path)
-            if eof:
-                return
             if payload:
                 yield payload
+        if done:
+            return
 
         while True:
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            # By name rather than by index, because a chunk can still land
+            # behind the position already reached: ids are ULIDs, and another
+            # process's clock is its own. An index would re-yield the tail and
+            # lose the late arrival; a name set yields it late instead.
             for path in self._chunk_files(name):
                 if path.name in delivered:
                     continue
@@ -1065,51 +1122,30 @@ class LocalWorld(w.World):
     async def streams_get_chunks(
         self, run_id: str, name: str, *, limit: int | None = None, cursor: str | None = None
     ) -> w.StreamChunksPage:
-        page_size = 100 if limit is None else limit
         start = _decode_chunks_cursor(cursor)
+        found, index, done = _scan_chunks(
+            self._chunk_files(name), start, 100 if limit is None else limit
+        )
 
-        chunks: list[w.StreamChunk] = []
-        done = False
-        index = 0  # running count of data (non-EOF) chunks seen
-        for path in self._chunk_files(name):
-            if index < start:
-                # Before the cursor only the flag matters, so skip the payload.
-                if _read_eof_flag(path):
-                    done = True
-                    break
-                index += 1
-                continue
-            if len(chunks) >= page_size:
-                # Peek one past the page to answer has_more/done without
-                # reading another payload.
-                if _read_eof_flag(path):
-                    done = True
-                else:
-                    index += 1
-                break
-            eof, payload = _read_chunk(path)
-            if eof:
-                done = True
-                break
-            chunks.append(w.StreamChunk(index=index, data=payload))
-            index += 1
-
-        has_more = not done and index > start + len(chunks)
+        # The scan stopped past the page only if it peeked a chunk it did not
+        # return, which is exactly when there is more to read.
+        has_more = not done and index > start + len(found)
         return w.StreamChunksPage(
-            data=chunks,
-            cursor=_encode_chunks_cursor(start + len(chunks)) if has_more else None,
+            data=[
+                w.StreamChunk(index=start + offset, data=payload)
+                for offset, (_, payload) in enumerate(found)
+            ],
+            cursor=_encode_chunks_cursor(start + len(found)) if has_more else None,
             hasMore=has_more,
             done=done,
         )
 
     async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
-        data_count = 0
-        done = False
-        for path in self._chunk_files(name):
-            if _read_eof_flag(path):
-                done = True
-                break
-            data_count += 1
+        # Starting past the last file makes the scan read every EOF flag and no
+        # payload, and leaves the data-chunk count in its position -- which is
+        # the whole of this answer.
+        files = self._chunk_files(name)
+        _, data_count, done = _scan_chunks(files, len(files))
         return w.StreamInfo(tailIndex=data_count - 1, done=done)
 
     async def events_list(

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import json
 import math
@@ -5,8 +6,8 @@ import os
 import platform
 import traceback
 import urllib.parse
-from collections.abc import AsyncIterator, Mapping
-from typing import Any, TypeVar
+from collections.abc import AsyncIterator, Mapping, Sequence
+from typing import Any, TypeVar, overload
 
 import cbor2
 import httpx
@@ -24,6 +25,9 @@ MAX_DELAY_SECONDS = float(
 )  # 23 hours - leave 1h buffer before 24h retention limit
 
 T = TypeVar("T", bound=w.BaseModel)
+# A `TypeAdapter` can validate anything, not just a model -- the stream list
+# endpoint answers a bare array of names.
+U = TypeVar("U")
 
 
 def _cbor_tag_hook(tag: cbor2.CBORTag, shareable: bool = False) -> Any:
@@ -97,6 +101,84 @@ def _vercel_api_url() -> str:
 # Events whose result the runtime reads back resolved (run/step entity fields);
 # everything else is fetched lazily.
 _EVENTS_NEEDING_RESOLVE = frozenset({"run_created", "run_started", "step_started"})
+
+
+# ── stream transport ───────────────────────────────────────────────────────
+
+_MAX_CHUNKS_PER_REQUEST = 1000
+"""Chunks per multi-write request, matching the server's ``MAX_CHUNKS_PER_BATCH``."""
+
+_STREAM_MAX_ATTEMPTS = 3
+
+_WRITE_RETRY_STATUS = frozenset({429})
+"""Statuses a chunk append may be resent on.
+
+Deliberately excludes 5xx. An append is not idempotent, and a 5xx may mean the
+write *did* land -- resending it would duplicate a chunk and shift every index
+after it. 429 is safe because the request was rejected before being applied.
+"""
+
+_CLOSE_RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
+"""Statuses a close may be resent on -- closing twice is harmless."""
+
+
+def _quote(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def _encode_multi_chunks(chunks: Sequence[bytes]) -> bytes:
+    """Pack chunks for one multi-write request.
+
+    ``[4-byte big-endian length][chunk]…`` — the same length framing the stream
+    itself uses, for the same reason: the server has to recover the original
+    chunk boundaries so each becomes its own index, or ``start_index`` would
+    stop meaning anything to a reader.
+    """
+    parts = []
+    for chunk in chunks:
+        parts.append(len(chunk).to_bytes(4, "big"))
+        parts.append(chunk)
+    return b"".join(parts)
+
+
+async def _stream_retry_delay(attempt: int, retry_after: str | None) -> None:
+    """Wait before resending: the server's ``Retry-After``, else backoff."""
+    if retry_after is not None:
+        try:
+            await asyncio.sleep(max(0.0, float(retry_after)))
+            return
+        except ValueError:
+            pass
+    await asyncio.sleep(0.1 * 2**attempt)
+
+
+def _stream_http_error(
+    operation: str, endpoint: str, resp: httpx.Response, *, url: str
+) -> w.WorkflowWorldError:
+    """Turn a failed stream request into an error worth reading.
+
+    The ``x-vercel-*`` headers are what makes a report actionable when the
+    failure happened in the platform rather than the workflow server, so they
+    are carried into the message instead of being dropped.
+    """
+    diagnostics = [
+        f"{header}={resp.headers[header]}"
+        for header in ("x-vercel-id", "x-vercel-error", "x-vercel-mitigated")
+        if header in resp.headers
+    ]
+    context = "; ".join(
+        [f"PUT {endpoint}" if operation != "read" else f"GET {endpoint}"] + diagnostics
+    )
+    message = f"Stream {operation} failed: HTTP {resp.status_code} ({context})"
+    retry_after = resp.headers.get("retry-after")
+    if resp.status_code == 429:
+        return w.ThrottleError(
+            message,
+            status=resp.status_code,
+            url=url,
+            retry_after=int(retry_after) if retry_after and retry_after.isdigit() else None,
+        )
+    return w.WorkflowWorldError(message, status=resp.status_code, url=url)
 
 
 # Lazy wire schema for EventResult — mirrors the JS SDK's EventResultLazyWireSchema.
@@ -232,14 +314,24 @@ class VercelWorld(w.World):
                 headers["x-vercel-trusted-oidc-idp-token"] = oidc_token
         return headers
 
+    @overload
+    async def _cbor_request(
+        self, method: str, endpoint: str, *, schema: type[T], data: Any = None
+    ) -> T: ...
+
+    @overload
+    async def _cbor_request(
+        self, method: str, endpoint: str, *, schema: pydantic.TypeAdapter[U], data: Any = None
+    ) -> U: ...
+
     async def _cbor_request(
         self,
         method: str,
         endpoint: str,
         *,
-        schema: type[T] | pydantic.TypeAdapter[T],
+        schema: type[T] | pydantic.TypeAdapter[Any],
         data: Any = None,
-    ) -> T:
+    ) -> Any:
         # utils.ts, getHttpConfig, makeRequest
         headers = await self._auth_headers()
 
@@ -604,4 +696,157 @@ class VercelWorld(w.World):
             "GET",
             f"/v3/runs/{run_id}/events{query}",
             schema=w.PaginatedResult[w.Event],
+        )
+
+    # ── streams ────────────────────────────────────────────────────────────
+
+    def _stream_path(self, run_id: str, name: str) -> str:
+        return f"/v2/runs/{_quote(run_id)}/stream/{_quote(name)}"
+
+    async def _write_stream_request(
+        self,
+        endpoint: str,
+        *,
+        body: bytes | None,
+        extra_headers: Mapping[str, str],
+        retry_status: frozenset[int],
+        operation: str,
+    ) -> None:
+        """PUT to a stream endpoint, retrying only what is safe to retry.
+
+        A chunk append is not idempotent, so *retry_status* decides what may be
+        resent. See :data:`_WRITE_RETRY_STATUS`.
+        """
+        headers = await self._auth_headers()
+        headers.update(extra_headers)
+        if body is not None:
+            headers["Content-Type"] = "application/octet-stream"
+
+        last_error: Exception | None = None
+        for attempt in range(_STREAM_MAX_ATTEMPTS):
+            try:
+                async with httpx.AsyncClient(
+                    base_url=self._base_url, headers=headers, timeout=None
+                ) as client:
+                    resp = await client.request("PUT", endpoint, content=body)
+            except httpx.TransportError as error:
+                # The request never reached a server that could have applied
+                # it, so resending cannot duplicate a chunk.
+                last_error = error
+                await _stream_retry_delay(attempt, None)
+                continue
+
+            if resp.is_success:
+                return
+
+            if resp.status_code in retry_status and attempt < _STREAM_MAX_ATTEMPTS - 1:
+                await _stream_retry_delay(attempt, resp.headers.get("retry-after"))
+                continue
+
+            raise _stream_http_error(operation, endpoint, resp, url=self._base_url + endpoint)
+
+        assert last_error is not None
+        raise w.WorkflowWorldError(
+            f"Stream {operation} failed after {_STREAM_MAX_ATTEMPTS} attempts: {last_error}",
+            status=0,
+            url=self._base_url + endpoint,
+        ) from last_error
+
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        await self._write_stream_request(
+            self._stream_path(run_id, name),
+            body=chunk,
+            extra_headers={},
+            retry_status=_WRITE_RETRY_STATUS,
+            operation="write",
+        )
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        if not chunks:
+            return
+        # Page at the server's per-batch cap so an oversized flush is split
+        # rather than rejected whole. Atomicity relaxes across pages: an earlier
+        # page can land while a later one fails, and the caller retains its
+        # whole buffer, so a retry may duplicate. That beats refusing the write.
+        for start in range(0, len(chunks), _MAX_CHUNKS_PER_REQUEST):
+            batch = chunks[start : start + _MAX_CHUNKS_PER_REQUEST]
+            await self._write_stream_request(
+                self._stream_path(run_id, name),
+                body=_encode_multi_chunks(batch),
+                extra_headers={"X-Stream-Multi": "true"},
+                retry_status=_WRITE_RETRY_STATUS,
+                operation="write",
+            )
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        await self._write_stream_request(
+            self._stream_path(run_id, name),
+            body=None,
+            extra_headers={"X-Stream-Done": "true"},
+            # Close is idempotent, so a 5xx whose effect may or may not have
+            # applied is safe to resend -- and the server's close barrier relies
+            # on it, surfacing transient reconciliation as a retriable 503 with
+            # the stream left durably closing.
+            retry_status=_CLOSE_RETRY_STATUS,
+            operation="close",
+        )
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncIterator[bytes]:
+        return self._iter_stream(run_id, name, start_index)
+
+    async def _iter_stream(
+        self, run_id: str, name: str, start_index: int | None
+    ) -> AsyncIterator[bytes]:
+        # The live read is v3, not v2, and that is load-bearing: on its
+        # max-duration timeout (or a mid-stream drop) v3 *errors* the response
+        # body where v2 closes it cleanly. Only the error tells a resuming
+        # reader that a timeout is not the end of the stream, so reading from v2
+        # would silently truncate any stream outliving the server's limit.
+        endpoint = f"/v3/runs/{_quote(run_id)}/stream/{_quote(name)}"
+        params = {} if start_index is None else {"startIndex": str(start_index)}
+        headers = await self._auth_headers()
+        # No timeout at all: this request is meant to stay open, and a
+        # whole-request deadline would cut a healthy stream off mid-flight.
+        async with httpx.AsyncClient(
+            base_url=self._base_url, headers=headers, timeout=None
+        ) as client:
+            async with client.stream("GET", endpoint, params=params) as resp:
+                if not resp.is_success:
+                    await resp.aread()
+                    raise _stream_http_error("read", endpoint, resp, url=self._base_url + endpoint)
+                async for chunk in resp.aiter_bytes():
+                    # The server flushes a leading empty chunk to commit
+                    # response headers before any data exists.
+                    if chunk:
+                        yield chunk
+
+    async def streams_list(self, run_id: str) -> list[str]:
+        return await self._cbor_request(
+            "GET",
+            f"/v2/runs/{_quote(run_id)}/streams",
+            schema=pydantic.TypeAdapter(list[str]),
+        )
+
+    async def streams_get_chunks(
+        self, run_id: str, name: str, *, limit: int | None = None, cursor: str | None = None
+    ) -> w.StreamChunksPage:
+        params = {}
+        if limit is not None:
+            params["limit"] = str(limit)
+        if cursor:
+            params["cursor"] = cursor
+        query = f"?{urllib.parse.urlencode(params)}" if params else ""
+        return await self._cbor_request(
+            "GET",
+            f"/v2/runs/{_quote(run_id)}/streams/{_quote(name)}/chunks{query}",
+            schema=w.StreamChunksPage,
+        )
+
+    async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
+        return await self._cbor_request(
+            "GET",
+            f"/v2/runs/{_quote(run_id)}/streams/{_quote(name)}/info",
+            schema=w.StreamInfo,
         )

--- a/src/vercel/tests/integration/test_workflow_cli_interop.py
+++ b/src/vercel/tests/integration/test_workflow_cli_interop.py
@@ -42,6 +42,7 @@ from typing import Any
 import pytest
 
 from vercel._internal.workflow import core, runtime, serialization as ser, world as w
+from vercel._internal.workflow.streams import workflow_run_stream_id as stream_id
 from vercel._internal.workflow.worlds import local as local_mod
 from vercel.queue.testing import clear_subscriptions
 
@@ -165,8 +166,8 @@ def workflow_cli() -> Path:
     return entry
 
 
-def _inspect(cli: Path, data_dir: Path, *args: str) -> Any:
-    """Run ``workflow inspect … --json`` against ``data_dir`` and parse stdout.
+def _inspect_raw(cli: Path, data_dir: Path, *args: str) -> str:
+    """Run ``workflow inspect … --json`` against ``data_dir``, returning stdout.
 
     In JSON mode the CLI sends every log line to stderr, so stdout is pure
     JSON. The environment is scrubbed of the other ``WORKFLOW_*`` variables so
@@ -193,13 +194,30 @@ def _inspect(cli: Path, data_dir: Path, *args: str) -> Any:
             f"`workflow inspect {' '.join(args)}` exited {result.returncode}\n"
             f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
         )
+    return result.stdout
+
+
+def _inspect(cli: Path, data_dir: Path, *args: str) -> Any:
+    """Run ``workflow inspect … --json`` and parse stdout as one JSON value."""
+    raw = _inspect_raw(cli, data_dir, *args)
     try:
-        return json.loads(result.stdout)
+        return json.loads(raw)
     except json.JSONDecodeError as error:
         raise AssertionError(
             f"`workflow inspect {' '.join(args)}` did not print JSON: {error}\n"
-            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+            f"--- stdout ---\n{raw}"
         ) from None
+
+
+def _inspect_lines(cli: Path, data_dir: Path, *args: str) -> list[Any]:
+    """Like :func:`_inspect`, for a command that prints one JSON value per line.
+
+    ``inspect stream`` streams: it writes a line per chunk and returns when the
+    stream closes. The timeout inside `_inspect` is what keeps a stream the
+    workflow forgot to close from hanging the suite instead of failing it.
+    """
+    raw = _inspect_raw(cli, data_dir, *args)
+    return [json.loads(line) for line in raw.splitlines() if line.strip()]
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -217,19 +235,34 @@ registry = core.Workflows(as_vercel_job=False)
 @registry.step
 async def charge(*, amount: int) -> int:
     """A named parameter, so the call is recorded name-keyed: `[{"amount": 21}]`."""
+    # Streams the progress a client would render, then leaves the stream open:
+    # the run's stream spans steps, and `finish` is what ends it.
+    writable = runtime.get_writable()
+    await writable.write("charging")
+    await writable.write({"amount": amount})
     return amount * 2
 
 
 @registry.step
 async def notify(total: int, /) -> str:
     """Positional-only, so the call is recorded the way TS records `[42]`."""
+    await runtime.get_writable().write(f"notifying about {total}")
     return f"charged {total}"
+
+
+@registry.step
+async def finish() -> None:
+    # The CLI's stream reader blocks until EOF, which is exactly the behavior a
+    # browser client sees: nothing closes a run's stream implicitly.
+    await runtime.get_writable().close()
 
 
 @registry.workflow
 async def checkout(amount: int) -> str:
     total = await charge(amount=amount)
-    return await notify(total)
+    result = await notify(total)
+    await finish()
+    return result
 
 
 @pytest.fixture(autouse=True)
@@ -307,7 +340,7 @@ async def test_cli_lists_the_steps_python_wrote(workflow_cli, py_run) -> None:
 
     steps = _inspect(workflow_cli, data_dir, "steps", f"--runId={run_id}")
 
-    assert {step["stepName"] for step in steps} == {charge.name, notify.name}
+    assert {step["stepName"] for step in steps} == {charge.name, notify.name, finish.name}
     for step in steps:
         assert step["runId"] == run_id
         assert step["status"] == "completed"
@@ -327,16 +360,15 @@ async def test_cli_lists_the_event_log_python_wrote(workflow_cli, py_run) -> Non
     assert [event["eventType"] for event in reversed(events)] == [
         "run_created",
         "run_started",
-        "step_created",
-        "step_started",
-        "step_completed",
-        "step_created",
-        "step_started",
-        "step_completed",
+        *["step_created", "step_started", "step_completed"] * 3,
         "run_completed",
     ]
     created = [event for event in events if event["eventType"] == "step_created"]
-    assert {event["eventData"]["stepName"] for event in created} == {charge.name, notify.name}
+    assert {event["eventData"]["stepName"] for event in created} == {
+        charge.name,
+        notify.name,
+        finish.name,
+    }
 
 
 async def test_cli_shows_the_single_run_python_wrote(workflow_cli, py_run) -> None:
@@ -383,3 +415,31 @@ async def test_cli_hydrates_the_step_payloads_python_wrote(workflow_cli, py_run)
     assert by_name[charge.name]["output"] == 42
     assert by_name[notify.name]["input"] == {"args": [42]}
     assert by_name[notify.name]["output"] == "charged 42"
+
+
+async def test_cli_lists_the_stream_python_wrote(workflow_cli, py_run) -> None:
+    data_dir, run_id = py_run
+
+    streams = _inspect(workflow_cli, data_dir, "streams", f"--runId={run_id}")
+
+    # Reads `streams/runs/<runId>.json`, the registry py writes alongside the
+    # chunk files.
+    assert streams == [{"runId": run_id, "streamId": stream_id(run_id)}]
+
+
+async def test_cli_reads_the_stream_chunks_python_wrote(workflow_cli, py_run) -> None:
+    """The real consumer for a stream: `world.streams.get` piped through
+    `getDeserializeStream`.
+
+    This is the assertion that would catch a framing regression. Everything
+    else about a stream can look right -- the files exist, the CLI lists it --
+    while the frames inside are unreadable, and only a consumer that actually
+    decodes them notices. It also proves the ordering: the CLI emits chunks in
+    stored index order, so the sequence here is the order the steps wrote in,
+    across three separate step invocations.
+    """
+    data_dir, run_id = py_run
+
+    chunks = _inspect_lines(workflow_cli, data_dir, "stream", stream_id(run_id), f"--run={run_id}")
+
+    assert chunks == ["charging", {"amount": 21}, "notifying about 42"]

--- a/src/vercel/tests/unit/test_workflow_encryption.py
+++ b/src/vercel/tests/unit/test_workflow_encryption.py
@@ -35,6 +35,7 @@ from vercel._internal.workflow import (
 from vercel._internal.workflow.worlds import vercel as vercel_world
 from vercel._internal.workflow.worlds.vercel import VercelWorld
 from vercel.oidc import VercelOidcTokenError
+from vercel.tests.world_stubs import NoStreams
 
 DEPLOYMENT_KEY = bytes(range(32))
 PROJECT_ID = "prj_test"
@@ -508,7 +509,7 @@ def _run(**overrides) -> w.WorkflowRun:
     )
 
 
-class _CountingWorld(w.World):
+class _CountingWorld(NoStreams, w.World):
     """A world that records how often the runtime asked it for a key."""
 
     def __init__(self, key: bytes | None) -> None:

--- a/src/vercel/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel/tests/unit/test_workflow_get_writable.py
@@ -3,7 +3,8 @@
 A stream write returns as soon as it is buffered, so the guarantee that makes
 streaming usable is placed here rather than in the writer: by the time a step is
 recorded complete, everything it streamed is durable. These tests drive the real
-`step_handler` to pin that, plus the caching that keeps chunk order sane.
+step path of `workflow_handler` to pin that, plus the caching that keeps chunk
+order sane.
 """
 
 from __future__ import annotations
@@ -102,16 +103,15 @@ def registry() -> core.Workflows:
 
 
 async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
-    payload = w.StepInvokePayload(
-        workflowName=WORKFLOW_NAME,
-        workflowRunId=RUN_ID,
-        workflowStartedAt=0.0,
+    payload = w.WorkflowInvokePayload(
+        runId=RUN_ID,
         stepId=STEP_ID,
+        stepName=step_name,
     )
-    return await runtime.step_handler(
+    return await runtime.workflow_handler(
         payload.model_dump(by_alias=True),
         attempt=1,
-        queue_name=f"__wkf_step_{step_name}",
+        queue_name=f"__wkf_workflow_{WORKFLOW_NAME}",
         message_id="msg_1",
         registry=registry,
     )

--- a/src/vercel/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel/tests/unit/test_workflow_get_writable.py
@@ -1,0 +1,295 @@
+"""`get_writable()` inside a step, and what the step handler owes its chunks.
+
+A stream write returns as soon as it is buffered, so the guarantee that makes
+streaming usable is placed here rather than in the writer: by the time a step is
+recorded complete, everything it streamed is durable. These tests drive the real
+`step_handler` to pin that, plus the caching that keeps chunk order sane.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from vercel._internal.core.polyfills import UTC
+from vercel._internal.workflow import core, runtime, serialization as ser, streams, world as w
+from vercel.tests.world_stubs import NoStreams
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+RUN_ID = "wrun_test"
+STEP_ID = "step_test"
+WORKFLOW_NAME = "workflow//tests.wf"
+STREAM = "strm_test_user"
+
+
+class FakeWorld(NoStreams, w.World):
+    """Records the event log and the stream traffic in one ordered list.
+
+    One list, deliberately: the property under test is the *relative order* of
+    a chunk landing and the step being recorded complete.
+    """
+
+    def __init__(self, *, fail_writes: bool = False) -> None:
+        self.log: list[tuple[str, Any]] = []
+        self.fail_writes = fail_writes
+
+    async def get_deployment_id(self) -> str:
+        return ""
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        return "msg_fake"
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        raise NotImplementedError
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        if data.event_type == "step_started":
+            return w.EventResult(
+                step=w.NonFinalWorkflowStep(
+                    runId=RUN_ID,
+                    stepId=STEP_ID,
+                    stepName=data.correlation_id or "",
+                    status="running",
+                    attempt=1,
+                    createdAt=NOW,
+                    updatedAt=NOW,
+                    startedAt=NOW,
+                    input=ser.dehydrate(ser.step_arguments((), {})),
+                )
+            )
+        self.log.append((data.event_type, data))
+        return w.EventResult()
+
+    # -- streams --------------------------------------------------------
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        await self.streams_write_multi(run_id, name, [chunk])
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        if self.fail_writes:
+            raise w.WorkflowWorldError("stream unavailable", status=503)
+        self.log.append(("chunk", (name, list(chunks))))
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        self.log.append(("close", name))
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+@pytest.fixture
+def registry() -> core.Workflows:
+    return core.Workflows(as_vercel_job=False)
+
+
+async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
+    payload = w.StepInvokePayload(
+        workflowName=WORKFLOW_NAME,
+        workflowRunId=RUN_ID,
+        workflowStartedAt=0.0,
+        stepId=STEP_ID,
+    )
+    return await runtime.step_handler(
+        payload.model_dump(by_alias=True),
+        attempt=1,
+        queue_name=f"__wkf_step_{step_name}",
+        message_id="msg_1",
+        registry=registry,
+    )
+
+
+def _kinds(fake: FakeWorld) -> list[str]:
+    return [kind for kind, _ in fake.log]
+
+
+def _chunk_values(fake: FakeWorld) -> list[Any]:
+    decoder = streams.FrameDecoder()
+    out = []
+    for kind, entry in fake.log:
+        if kind != "chunk":
+            continue
+        for chunk in entry[1]:
+            for payload in decoder.feed(chunk):
+                out.append(ser.hydrate(payload, what="chunk"))
+    decoder.finish()
+    return out
+
+
+async def test_a_step_streams_and_the_chunks_land_before_it_completes(registry) -> None:
+    """The guarantee: "the step finished" implies "its chunks are readable".
+
+    Without the handler's drain, `step_completed` would be recorded while the
+    chunks were still sitting in the writer's buffer, and a reader could see the
+    run move on past output it never received.
+    """
+
+    @registry.step
+    async def emit() -> str:
+        writable = runtime.get_writable()
+        await writable.write("progress 1")
+        await writable.write("progress 2")
+        return "ok"
+
+    fake = FakeWorld()
+    w.set_world(fake)
+
+    await _invoke(registry, emit.name)
+
+    assert _kinds(fake) == ["chunk", "step_completed"]
+    assert _chunk_values(fake) == ["progress 1", "progress 2"]
+
+
+async def test_the_default_stream_is_named_after_the_run(registry) -> None:
+    @registry.step
+    async def emit() -> None:
+        await runtime.get_writable().write("x")
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, emit.name)
+
+    ((name, _),) = [entry for kind, entry in fake.log if kind == "chunk"]
+    assert name == STREAM
+
+
+async def test_two_calls_in_one_step_share_a_writer(registry) -> None:
+    """One writer per stream per step, so writes go through one serial sink.
+
+    A fresh writer per call would give each its own buffer over the same
+    stream, and two buffers flushing independently interleave by whichever
+    request wins -- scrambling the order the step wrote in.
+    """
+    seen: list[streams.WorkflowStreamWriter] = []
+
+    @registry.step
+    async def emit() -> None:
+        for i in range(3):
+            writable = runtime.get_writable()
+            seen.append(writable)
+            await writable.write(i)
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, emit.name)
+
+    assert seen[0] is seen[1] is seen[2]
+    assert _chunk_values(fake) == [0, 1, 2]
+
+
+async def test_a_namespace_gets_its_own_stream(registry) -> None:
+    @registry.step
+    async def emit() -> None:
+        await runtime.get_writable().write("default")
+        await runtime.get_writable(namespace="logs").write("logged")
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, emit.name)
+
+    names = {entry[0] for kind, entry in fake.log if kind == "chunk"}
+    assert names == {STREAM, streams.workflow_run_stream_id(RUN_ID, "logs")}
+
+
+async def test_closing_from_a_step_marks_the_stream_complete(registry) -> None:
+    @registry.step
+    async def finish() -> None:
+        writable = runtime.get_writable()
+        await writable.write("last")
+        await writable.close()
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, finish.name)
+
+    assert _kinds(fake) == ["chunk", "close", "step_completed"]
+
+
+async def test_a_stream_left_open_is_not_closed_by_the_step_ending(registry) -> None:
+    """Deliberate: the run's stream spans steps.
+
+    Closing at step end would end the stream after the first step that touched
+    it, and a closed stream cannot be reopened. The cost is that a workflow
+    which never closes leaves readers waiting until the run expires.
+    """
+
+    @registry.step
+    async def emit() -> None:
+        await runtime.get_writable().write("more to come")
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, emit.name)
+
+    assert "close" not in _kinds(fake)
+
+
+async def test_a_stream_write_failure_fails_the_step(registry) -> None:
+    # Surfacing at the drain is what turns a lost chunk into a retryable step
+    # rather than output that silently never arrives.
+    @registry.step
+    async def emit() -> str:
+        await runtime.get_writable().write("doomed")
+        return "unreachable"
+
+    fake = FakeWorld(fail_writes=True)
+    w.set_world(fake)
+
+    result = await _invoke(registry, emit.name)
+
+    assert _kinds(fake) == ["step_retrying"]
+    assert result == w.QueueContinuation(delay_seconds=1.0)
+    ((_, event),) = fake.log
+    assert "stream unavailable" in event.event_data.error
+
+
+async def test_a_failing_step_still_flushes_what_it_wrote(registry) -> None:
+    """A reader tailing the run should see the progress that led to the failure."""
+
+    @registry.step
+    async def emit() -> None:
+        await runtime.get_writable().write("got this far")
+        raise RuntimeError("boom")
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    await _invoke(registry, emit.name)
+
+    assert _kinds(fake) == ["chunk", "step_retrying"]
+    assert _chunk_values(fake) == ["got this far"]
+
+
+async def test_get_writable_outside_a_step_is_refused() -> None:
+    # Including inside a workflow body: it replays, and its sandbox has no
+    # network access.
+    with pytest.raises(RuntimeError, match="can only be called inside a step"):
+        runtime.get_writable()
+
+
+async def test_a_workflow_body_cannot_stream(registry) -> None:
+    @registry.workflow
+    async def wf() -> None:
+        runtime.get_writable()
+
+    fake = FakeWorld()
+    w.set_world(fake)
+    with pytest.raises(RuntimeError, match="a workflow body cannot write to a stream"):
+        await wf.func()

--- a/src/vercel/tests/unit/test_workflow_local_streamer.py
+++ b/src/vercel/tests/unit/test_workflow_local_streamer.py
@@ -1,0 +1,279 @@
+"""`LocalWorld`'s stream storage, and its live read.
+
+The on-disk shape is shared with the TypeScript `@workflow/world-local`, so the
+layout assertions here are about interoperability, not about our own
+preferences: one file per chunk under a per-stream directory, an EOF flag byte
+in front of each payload, and the run's stream list as TS-readable JSON.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_test"
+NAME = "strm_test_user"
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    return local_mod.LocalWorld()
+
+
+async def _drain(world: local_mod.LocalWorld, *, start_index: int | None = None) -> list[bytes]:
+    """Read a closed stream to its end."""
+    out = []
+    async for chunk in world.streams_get(RUN_ID, NAME, start_index):
+        out.append(chunk)
+    return out
+
+
+class TestLayout:
+    async def test_chunks_are_one_file_each_under_a_per_stream_directory(self, world) -> None:
+        # Per-stream rather than one flat directory: a live reader re-lists this
+        # every 100ms, and that cost has to scale with the stream, not the world.
+        await world.streams_write(RUN_ID, NAME, b"one")
+        await world.streams_write(RUN_ID, NAME, b"two")
+
+        chunk_dir = world.data_dir / "streams" / "chunks" / NAME
+        files = sorted(p.name for p in chunk_dir.iterdir())
+        assert len(files) == 2
+        assert all(name.startswith("chnk_") and name.endswith(".bin") for name in files)
+
+    async def test_a_chunk_file_is_its_eof_flag_then_the_payload(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"payload")
+        await world.streams_close(RUN_ID, NAME)
+
+        chunk_dir = world.data_dir / "streams" / "chunks" / NAME
+        data, eof = sorted(chunk_dir.iterdir(), key=lambda p: p.name)
+        assert data.read_bytes() == b"\x00payload"
+        assert eof.read_bytes() == b"\x01"
+
+    async def test_chunk_order_is_file_name_order(self, world) -> None:
+        # Names are monotonic ULIDs minted before the write, so lexicographic
+        # order is call order even when the writes complete out of order.
+        await world.streams_write_multi(RUN_ID, NAME, [str(i).encode() for i in range(20)])
+        await world.streams_close(RUN_ID, NAME)
+        assert await _drain(world) == [str(i).encode() for i in range(20)]
+
+    async def test_the_run_stream_list_is_ts_readable_json(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"x")
+        path = world.data_dir / "streams" / "runs" / f"{RUN_ID}.json"
+        # Real JSON, two-space indent -- the same `JSON.stringify(…, 2)` shape
+        # every other file in the data directory uses.
+        assert json.loads(path.read_text()) == {"streams": [NAME]}
+        assert path.read_text().startswith('{\n  "streams"')
+
+    async def test_streams_list_reports_every_stream_of_the_run(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"x")
+        await world.streams_write(RUN_ID, "strm_test_user_bG9ncw", b"y")
+        await world.streams_write(RUN_ID, NAME, b"z")  # already registered
+
+        assert await world.streams_list(RUN_ID) == [NAME, "strm_test_user_bG9ncw"]
+
+    async def test_the_registry_is_read_once_per_stream_not_once_per_chunk(
+        self, world, monkeypatch
+    ) -> None:
+        # Registration runs on every append, so without a cache a long stream
+        # would re-read and re-parse the registry for every chunk it writes.
+        reads = 0
+        real_read_json = local_mod.read_json
+
+        def counting_read_json(path, schema):
+            nonlocal reads
+            if path.parent.name == "runs":
+                reads += 1
+            return real_read_json(path, schema)
+
+        monkeypatch.setattr(local_mod, "read_json", counting_read_json)
+
+        await world.streams_write_multi(RUN_ID, NAME, [b"a", b"b", b"c"])
+        await world.streams_write(RUN_ID, NAME, b"d")
+        await world.streams_close(RUN_ID, NAME)
+
+        assert reads == 1
+        assert await world.streams_list(RUN_ID) == [NAME]
+
+    async def test_an_unknown_run_has_no_streams(self, world) -> None:
+        assert await world.streams_list("wrun_missing") == []
+
+    @pytest.mark.parametrize("name", ["../escape", "a/b", ".hidden", "", "with.dot"])
+    async def test_a_stream_name_that_could_escape_the_data_dir_is_refused(
+        self, world, name
+    ) -> None:
+        # The name becomes a directory, and a namespace is caller-chosen text.
+        with pytest.raises(local_mod.UnsafeEntityIdError):
+            await world.streams_write(RUN_ID, name, b"x")
+
+
+class TestLiveRead:
+    async def test_reads_what_was_already_written_then_ends_at_close(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"a")
+        await world.streams_write(RUN_ID, NAME, b"b")
+        await world.streams_close(RUN_ID, NAME)
+
+        assert await _drain(world) == [b"a", b"b"]
+
+    async def test_waits_for_chunks_that_have_not_been_written_yet(self, world) -> None:
+        """The defining property: a read tails, it does not stop at the tail."""
+        received: list[bytes] = []
+
+        async def reader() -> None:
+            async for chunk in world.streams_get(RUN_ID, NAME):
+                received.append(chunk)
+
+        task = asyncio.ensure_future(reader())
+        await asyncio.sleep(0.05)
+        assert received == [], "nothing written yet"
+
+        await world.streams_write(RUN_ID, NAME, b"late")
+        await asyncio.sleep(0.3)
+        assert received == [b"late"], "a chunk written after the read started"
+
+        await world.streams_close(RUN_ID, NAME)
+        await asyncio.wait_for(task, timeout=5)
+
+    async def test_an_open_stream_keeps_the_reader_waiting(self, world) -> None:
+        # Nothing closes a stream implicitly, which is exactly why a workflow
+        # that forgets to close leaves its readers hanging.
+        await world.streams_write(RUN_ID, NAME, b"a")
+        task = asyncio.ensure_future(_drain(world))
+        await asyncio.sleep(0.3)
+        assert not task.done()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def test_empty_payloads_are_not_delivered(self, world) -> None:
+        # An empty transport chunk carries nothing and would look like EOF to a
+        # naive consumer, so the read skips it -- while it still holds an index.
+        await world.streams_write(RUN_ID, NAME, b"")
+        await world.streams_write(RUN_ID, NAME, b"real")
+        await world.streams_close(RUN_ID, NAME)
+
+        assert await _drain(world) == [b"real"]
+
+    async def test_start_index_skips_from_the_beginning(self, world) -> None:
+        for i in range(5):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+        await world.streams_close(RUN_ID, NAME)
+
+        assert await _drain(world, start_index=2) == [b"2", b"3", b"4"]
+
+    async def test_a_negative_start_index_counts_back_from_the_end(self, world) -> None:
+        for i in range(5):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+        await world.streams_close(RUN_ID, NAME)
+
+        # -2 is the last two data chunks: the EOF marker is not one of them, so
+        # it must not shift the window.
+        assert await _drain(world, start_index=-2) == [b"3", b"4"]
+
+    async def test_a_negative_start_index_past_the_start_is_clamped(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"only")
+        await world.streams_close(RUN_ID, NAME)
+
+        assert await _drain(world, start_index=-10) == [b"only"]
+
+    async def test_a_start_index_past_the_end_yields_nothing_and_still_ends(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"a")
+        await world.streams_close(RUN_ID, NAME)
+
+        assert await _drain(world, start_index=50) == []
+
+    async def test_skipped_chunks_are_not_re_delivered_by_the_poll(self, world) -> None:
+        """A resumed read must not replay history once it starts polling.
+
+        The poll re-lists the whole directory, so anything the caller asked to
+        skip has to be remembered as already handled or it comes back.
+        """
+        for i in range(3):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+
+        received: list[bytes] = []
+
+        async def reader() -> None:
+            async for chunk in world.streams_get(RUN_ID, NAME, 2):
+                received.append(chunk)
+
+        task = asyncio.ensure_future(reader())
+        await asyncio.sleep(0.3)
+        await world.streams_write(RUN_ID, NAME, b"new")
+        await asyncio.sleep(0.3)
+        await world.streams_close(RUN_ID, NAME)
+        await asyncio.wait_for(task, timeout=5)
+
+        assert received == [b"2", b"new"]
+
+    async def test_abandoning_a_read_stops_its_poll(self, world) -> None:
+        await world.streams_write(RUN_ID, NAME, b"a")
+        stream = world.streams_get(RUN_ID, NAME)
+        async with contextlib.aclosing(stream):
+            assert await stream.__anext__() == b"a"
+        # Closing the generator is what releases the poll; an abandoned reader
+        # would otherwise keep listing the directory for the life of the process.
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+
+
+class TestSnapshot:
+    async def test_get_info_reports_the_tail_and_the_closed_flag(self, world) -> None:
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=-1, done=False)
+
+        await world.streams_write(RUN_ID, NAME, b"a")
+        await world.streams_write(RUN_ID, NAME, b"b")
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=1, done=False)
+
+        await world.streams_close(RUN_ID, NAME)
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=1, done=True)
+
+    async def test_get_chunks_returns_a_snapshot_not_a_live_read(self, world) -> None:
+        for i in range(3):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+
+        page = await world.streams_get_chunks(RUN_ID, NAME)
+        # Returns immediately on an open stream, unlike streams_get.
+        assert [(c.index, c.data) for c in page.data] == [(0, b"0"), (1, b"1"), (2, b"2")]
+        assert page.has_more is False
+        assert page.done is False
+        assert page.cursor is None
+
+    async def test_get_chunks_pages_through_with_a_cursor(self, world) -> None:
+        for i in range(5):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+        await world.streams_close(RUN_ID, NAME)
+
+        first = await world.streams_get_chunks(RUN_ID, NAME, limit=2)
+        assert [c.index for c in first.data] == [0, 1]
+        assert first.has_more is True
+        assert first.cursor is not None
+
+        second = await world.streams_get_chunks(RUN_ID, NAME, limit=2, cursor=first.cursor)
+        assert [c.index for c in second.data] == [2, 3]
+
+        third = await world.streams_get_chunks(RUN_ID, NAME, limit=2, cursor=second.cursor)
+        assert [c.index for c in third.data] == [4]
+        assert third.has_more is False
+        assert third.done is True, "the last page sees the EOF marker"
+
+    async def test_the_cursor_is_the_base64_json_shape_ts_writes(self, world) -> None:
+        for i in range(3):
+            await world.streams_write(RUN_ID, NAME, str(i).encode())
+
+        page = await world.streams_get_chunks(RUN_ID, NAME, limit=1)
+        assert page.cursor is not None
+        assert local_mod._decode_chunks_cursor(page.cursor) == 1
+
+    async def test_an_unreadable_cursor_restarts_rather_than_failing(self, world) -> None:
+        # A cursor is an opaque token a client round-trips; failing the whole
+        # read over a mangled one helps nobody.
+        await world.streams_write(RUN_ID, NAME, b"a")
+        page = await world.streams_get_chunks(RUN_ID, NAME, cursor="not-base64")
+        assert [c.data for c in page.data] == [b"a"]

--- a/src/vercel/tests/unit/test_workflow_queue_namespace.py
+++ b/src/vercel/tests/unit/test_workflow_queue_namespace.py
@@ -7,6 +7,7 @@ import pytest
 
 from vercel._internal.core.polyfills import UTC
 from vercel._internal.workflow import core, runtime, world as w
+from vercel.tests.world_stubs import NoStreams
 from vercel.workflow import Workflows
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
@@ -38,7 +39,7 @@ def _hook() -> w.Hook:
     )
 
 
-class FakeWorld(w.World):
+class FakeWorld(NoStreams, w.World):
     def __init__(
         self,
         *,

--- a/src/vercel/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel/tests/unit/test_workflow_step_handler.py
@@ -23,6 +23,7 @@ import respx
 
 from vercel._internal.core.polyfills import UTC
 from vercel._internal.workflow import core, runtime, serialization as ser, world as w
+from vercel.tests.world_stubs import NoStreams
 from vercel.workflow import FatalError
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
@@ -45,7 +46,7 @@ def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
     )
 
 
-class FakeWorld(w.World):
+class FakeWorld(NoStreams, w.World):
     """In-memory world driving the handler's step path.
 
     ``step`` is the persisted step ``steps_get`` returns (the pre-read snapshot).

--- a/src/vercel/tests/unit/test_workflow_stream_framing.py
+++ b/src/vercel/tests/unit/test_workflow_stream_framing.py
@@ -113,27 +113,20 @@ class TestStreamId:
 
 
 class TestBytesChunks:
-    """A `bytes` chunk goes out as a `Uint8Array`, unlike a `bytes` payload.
+    """A `bytes` chunk goes out as a `Uint8Array`.
 
-    Not a cosmetic difference. The TypeScript pattern for consuming a run's
-    stream pipes it straight into a `Response`, and a body stream takes
-    `Uint8Array` chunks only -- an `ArrayBuffer` raises `Received non-Uint8Array
-    chunk`. Nothing downstream of a *payload* cares, and the payload boundary
-    has its own pinned answer, so the two differ on purpose.
+    The TypeScript pattern for consuming a run's stream pipes it straight into a
+    `Response`, and a body stream takes `Uint8Array` chunks only -- an
+    `ArrayBuffer` raises `Received non-Uint8Array chunk`.
     """
 
     def _wire(self, frame: bytes) -> str:
         return frame[streams.FRAME_HEADER_SIZE + len(ser.DEVALUE_V1) :].decode()
 
     def test_a_chunk_is_a_view_onto_its_own_buffer(self) -> None:
-        # Byte for byte what `devalue.stringify(new Uint8Array([104, 105]))`
-        # emits in JS: the view references a separate buffer entry.
         assert (
             self._wire(streams.encode_value(b"hi")) == '[["Uint8Array",1],["ArrayBuffer","aGk="]]'
         )
-
-    def test_a_payload_still_writes_the_bare_buffer(self) -> None:
-        assert ser.dehydrate(b"hi")[len(ser.DEVALUE_V1) :].decode() == '[["ArrayBuffer","aGk="]]'
 
     def test_bytes_nested_in_a_chunk_are_views_too(self) -> None:
         # `run.readable` hands whole chunks to a consumer, so a `bytes` field
@@ -153,12 +146,6 @@ class TestBytesChunks:
         assert ser.hydrate(payload, what="chunk") == b""
 
     def test_a_repeated_buffer_is_still_written_once(self) -> None:
-        # devalue dedupes by identity, and the reducer must not defeat that.
         shared = b"xy"
         wire = self._wire(streams.encode_value([shared, shared]))
         assert wire.count("ArrayBuffer") == 1
-
-    def test_bytearray_is_left_on_the_buffer_form(self) -> None:
-        # Only `bytes` is what a producer streams; widening the reducer would
-        # start rewriting types the payload boundary deliberately leaves alone.
-        assert "Uint8Array" not in self._wire(streams.encode_value(bytearray(b"hi")))

--- a/src/vercel/tests/unit/test_workflow_stream_framing.py
+++ b/src/vercel/tests/unit/test_workflow_stream_framing.py
@@ -1,0 +1,112 @@
+"""Frame layout on a run's stream, and the naming of the stream itself.
+
+The framing is a wire format shared with `@workflow/core`, so these tests pin
+the bytes rather than a round trip through our own code: a round trip stays
+green while both ends drift together.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from vercel._internal.workflow import serialization as ser, streams
+
+
+def test_frame_is_a_four_byte_big_endian_length_then_the_payload() -> None:
+    assert streams.encode_frame(b"hello") == b"\x00\x00\x00\x05hello"
+    assert streams.encode_frame(b"") == b"\x00\x00\x00\x00"
+
+
+def test_value_frame_carries_a_devl_payload() -> None:
+    # The payload is exactly what the run/step payload boundary writes, which
+    # is what lets `getDeserializeStream` on the TS side read it.
+    frame = streams.encode_value({"hi": 1})
+    payload = ser.dehydrate({"hi": 1})
+    assert frame == len(payload).to_bytes(4, "big") + payload
+    assert payload.startswith(b"devl")
+
+
+def test_oversized_payload_is_refused_rather_than_framed() -> None:
+    with pytest.raises(ser.SerializationError, match="exceeds the maximum frame size"):
+        streams.encode_frame(b"x" * (streams.MAX_FRAME_SIZE + 1))
+
+
+class TestFrameDecoder:
+    """The transport picks its own read boundaries; the decoder absorbs that."""
+
+    def test_one_read_holding_several_frames(self) -> None:
+        decoder = streams.FrameDecoder()
+        wire = streams.encode_frame(b"a") + streams.encode_frame(b"bb")
+        assert list(decoder.feed(wire)) == [b"a", b"bb"]
+        decoder.finish()
+
+    def test_one_frame_split_across_reads(self) -> None:
+        decoder = streams.FrameDecoder()
+        wire = streams.encode_frame(b"payload")
+        # Split inside the header, then inside the payload.
+        assert list(decoder.feed(wire[:2])) == []
+        assert list(decoder.feed(wire[2:6])) == []
+        assert list(decoder.feed(wire[6:])) == [b"payload"]
+        decoder.finish()
+
+    def test_a_frame_straddling_a_read_boundary_is_delivered_whole(self) -> None:
+        decoder = streams.FrameDecoder()
+        wire = streams.encode_frame(b"one") + streams.encode_frame(b"two")
+        cut = 4 + 3 + 2  # first frame plus part of the second's header
+        assert list(decoder.feed(wire[:cut])) == [b"one"]
+        assert list(decoder.feed(wire[cut:])) == [b"two"]
+        decoder.finish()
+
+    def test_empty_frames_survive_the_round_trip(self) -> None:
+        # A zero-length frame is a real chunk and holds an index, so it cannot
+        # be skipped the way an empty transport read can.
+        decoder = streams.FrameDecoder()
+        wire = streams.encode_frame(b"") + streams.encode_frame(b"x")
+        assert list(decoder.feed(wire)) == [b"", b"x"]
+
+    def test_truncation_mid_frame_is_reported_not_dropped(self) -> None:
+        decoder = streams.FrameDecoder()
+        list(decoder.feed(streams.encode_frame(b"abcdef")[:-2]))
+        assert decoder.pending == 8
+        with pytest.raises(ser.SerializationError, match="truncated mid-frame"):
+            decoder.finish()
+
+    def test_an_absurd_length_header_is_refused_before_allocating(self) -> None:
+        # The likely cause is a raw stream being read as framed, not a 100MB+
+        # chunk, so this must not become a giant buffer.
+        decoder = streams.FrameDecoder()
+        with pytest.raises(ser.SerializationError, match="exceeds the maximum"):
+            list(decoder.feed(b"\xff\xff\xff\xff"))
+
+
+class TestStreamId:
+    def test_default_stream_replaces_the_run_prefix(self) -> None:
+        assert streams.workflow_run_stream_id("wrun_abc") == "strm_abc_user"
+
+    def test_only_the_first_prefix_occurrence_is_replaced(self) -> None:
+        # JS `String.replace` with a string pattern is first-match-only, and the
+        # name has to match byte for byte or the two SDKs address different keys.
+        assert streams.workflow_run_stream_id("wrun_wrun_x") == "strm_wrun_x_user"
+
+    def test_namespace_is_unpadded_base64url(self) -> None:
+        name = streams.workflow_run_stream_id("wrun_abc", "logs")
+        encoded = name.rsplit("_", 1)[-1]
+        assert name == f"strm_abc_user_{encoded}"
+        assert "=" not in encoded
+        assert base64.urlsafe_b64decode(encoded + "==") == b"logs"
+
+    def test_namespace_with_characters_a_key_could_not_hold(self) -> None:
+        # The point of encoding: a namespace reaches Redis keys on the Vercel
+        # world, so slashes and non-ASCII cannot go through raw.
+        name = streams.workflow_run_stream_id("wrun_abc", "a/b?ü")
+        encoded = name.rsplit("_", 1)[-1]
+        assert set(encoded) <= set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        )
+        assert base64.urlsafe_b64decode(encoded + "===")[: len("a/b")] == b"a/b"
+
+    def test_empty_namespace_is_the_default_stream(self) -> None:
+        assert streams.workflow_run_stream_id("wrun_abc", "") == "strm_abc_user"
+        assert streams.workflow_run_stream_id("wrun_abc", None) == "strm_abc_user"

--- a/src/vercel/tests/unit/test_workflow_stream_framing.py
+++ b/src/vercel/tests/unit/test_workflow_stream_framing.py
@@ -110,3 +110,55 @@ class TestStreamId:
     def test_empty_namespace_is_the_default_stream(self) -> None:
         assert streams.workflow_run_stream_id("wrun_abc", "") == "strm_abc_user"
         assert streams.workflow_run_stream_id("wrun_abc", None) == "strm_abc_user"
+
+
+class TestBytesChunks:
+    """A `bytes` chunk goes out as a `Uint8Array`, unlike a `bytes` payload.
+
+    Not a cosmetic difference. The TypeScript pattern for consuming a run's
+    stream pipes it straight into a `Response`, and a body stream takes
+    `Uint8Array` chunks only -- an `ArrayBuffer` raises `Received non-Uint8Array
+    chunk`. Nothing downstream of a *payload* cares, and the payload boundary
+    has its own pinned answer, so the two differ on purpose.
+    """
+
+    def _wire(self, frame: bytes) -> str:
+        return frame[streams.FRAME_HEADER_SIZE + len(ser.DEVALUE_V1) :].decode()
+
+    def test_a_chunk_is_a_view_onto_its_own_buffer(self) -> None:
+        # Byte for byte what `devalue.stringify(new Uint8Array([104, 105]))`
+        # emits in JS: the view references a separate buffer entry.
+        assert (
+            self._wire(streams.encode_value(b"hi")) == '[["Uint8Array",1],["ArrayBuffer","aGk="]]'
+        )
+
+    def test_a_payload_still_writes_the_bare_buffer(self) -> None:
+        assert ser.dehydrate(b"hi")[len(ser.DEVALUE_V1) :].decode() == '[["ArrayBuffer","aGk="]]'
+
+    def test_bytes_nested_in_a_chunk_are_views_too(self) -> None:
+        # `run.readable` hands whole chunks to a consumer, so a `bytes` field
+        # reaches the same `Response` the top-level one would.
+        assert self._wire(streams.encode_value({"blob": b"hi"})) == (
+            '[{"blob":1},["Uint8Array",2],["ArrayBuffer","aGk="]]'
+        )
+
+    def test_it_reads_back_as_bytes(self) -> None:
+        frame = streams.encode_value(b"round trip")
+        (payload,) = streams.FrameDecoder().feed(frame)
+        assert ser.hydrate(payload, what="chunk") == b"round trip"
+
+    def test_an_empty_chunk_survives(self) -> None:
+        frame = streams.encode_value(b"")
+        (payload,) = streams.FrameDecoder().feed(frame)
+        assert ser.hydrate(payload, what="chunk") == b""
+
+    def test_a_repeated_buffer_is_still_written_once(self) -> None:
+        # devalue dedupes by identity, and the reducer must not defeat that.
+        shared = b"xy"
+        wire = self._wire(streams.encode_value([shared, shared]))
+        assert wire.count("ArrayBuffer") == 1
+
+    def test_bytearray_is_left_on_the_buffer_form(self) -> None:
+        # Only `bytes` is what a producer streams; widening the reducer would
+        # start rewriting types the payload boundary deliberately leaves alone.
+        assert "Uint8Array" not in self._wire(streams.encode_value(bytearray(b"hi")))

--- a/src/vercel/tests/unit/test_workflow_stream_writer.py
+++ b/src/vercel/tests/unit/test_workflow_stream_writer.py
@@ -14,6 +14,7 @@ import contextlib
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
+import anyio
 import pytest
 
 from vercel._internal.workflow import serialization as ser, streams, world as w
@@ -81,8 +82,29 @@ class RecordingWorld(NoStreams, w.World):
         raise NotImplementedError
 
 
-def _writer(world: w.World) -> streams.WorkflowStreamWriter:
-    return streams.WorkflowStreamWriter(world=world, run_id=RUN_ID, name=NAME)
+@contextlib.asynccontextmanager
+async def _writing(world: w.World) -> AsyncIterator[streams.WorkflowStreamWriter]:
+    """A writer plus the task group its dispatch runs in.
+
+    Stands in for the step handler, which owns that group for the length of an
+    invocation. Leaving cancels rather than waits: a test that parks a request
+    on a gate it never opens should fail on its assertions, not hang here.
+    """
+    async with anyio.create_task_group() as task_group:
+        yield streams.WorkflowStreamWriter(
+            world=world, run_id=RUN_ID, name=NAME, task_group=task_group
+        )
+        task_group.cancel_scope.cancel()
+
+
+async def _settle() -> None:
+    """Let every runnable task reach its next blocking point.
+
+    The dispatch task starts at a checkpoint and takes several more to reach
+    the world, so a single `sleep(0)` does not mean "it got there".
+    """
+    for _ in range(10):
+        await asyncio.sleep(0)
 
 
 def _values(batches: list[list[bytes]]) -> list[Any]:
@@ -99,21 +121,19 @@ def _values(batches: list[list[bytes]]) -> list[Any]:
 
 async def test_writes_reach_the_world_in_order() -> None:
     world = RecordingWorld()
-    writer = _writer(world)
-
-    for i in range(5):
-        await writer.write(i)
-    await writer.drain()
+    async with _writing(world) as writer:
+        for i in range(5):
+            await writer.write(i)
+        await writer.drain()
 
     assert _values(world.batches) == [0, 1, 2, 3, 4]
 
 
 async def test_close_drains_then_marks_the_stream_complete() -> None:
     world = RecordingWorld()
-    writer = _writer(world)
-
-    await writer.write("last")
-    await writer.close()
+    async with _writing(world) as writer:
+        await writer.write("last")
+        await writer.close()
 
     assert _values(world.batches) == ["last"]
     assert world.closes == [NAME]
@@ -121,18 +141,18 @@ async def test_close_drains_then_marks_the_stream_complete() -> None:
 
 async def test_close_is_idempotent() -> None:
     world = RecordingWorld()
-    writer = _writer(world)
-    await writer.close()
-    await writer.close()
+    async with _writing(world) as writer:
+        await writer.close()
+        await writer.close()
     assert world.closes == [NAME]
 
 
 async def test_writing_after_close_is_refused() -> None:
     world = RecordingWorld()
-    writer = _writer(world)
-    await writer.close()
-    with pytest.raises(ser.SerializationError, match="is closed"):
-        await writer.write("late")
+    async with _writing(world) as writer:
+        await writer.close()
+        with pytest.raises(ser.SerializationError, match="is closed"):
+            await writer.write("late")
 
 
 async def test_chunks_arriving_during_a_request_leave_as_one_group() -> None:
@@ -144,16 +164,15 @@ async def test_chunks_arriving_during_a_request_leave_as_one_group() -> None:
     """
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
+    async with _writing(world) as writer:
+        await writer.write("first")
+        # The dispatch task has taken the first chunk and is blocked on the gate.
+        await _settle()
+        for i in range(4):
+            await writer.write(i)
 
-    await writer.write("first")
-    # The dispatch task has taken the first chunk and is blocked on the gate.
-    await asyncio.sleep(0)
-    for i in range(4):
-        await writer.write(i)
-
-    world.gate.set()
-    await writer.drain()
+        world.gate.set()
+        await writer.drain()
 
     assert [len(batch) for batch in world.batches] == [1, 4]
     assert _values(world.batches) == ["first", 0, 1, 2, 3]
@@ -163,12 +182,11 @@ async def test_a_group_is_capped_by_chunk_count(monkeypatch) -> None:
     monkeypatch.setenv("WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", "2")
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
-
-    for i in range(5):
-        await writer.write(i)
-    world.gate.set()
-    await writer.drain()
+    async with _writing(world) as writer:
+        for i in range(5):
+            await writer.write(i)
+        world.gate.set()
+        await writer.drain()
 
     assert [len(batch) for batch in world.batches] == [2, 2, 1]
     assert _values(world.batches) == [0, 1, 2, 3, 4]
@@ -179,12 +197,11 @@ async def test_a_group_is_capped_by_bytes(monkeypatch) -> None:
     monkeypatch.setenv("WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", "40")
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
-
-    for _ in range(3):
-        await writer.write("x" * 20)
-    world.gate.set()
-    await writer.drain()
+    async with _writing(world) as writer:
+        for _ in range(3):
+            await writer.write("x" * 20)
+        world.gate.set()
+        await writer.drain()
 
     assert [len(batch) for batch in world.batches] == [1, 1, 1]
 
@@ -192,10 +209,9 @@ async def test_a_group_is_capped_by_bytes(monkeypatch) -> None:
 async def test_a_chunk_larger_than_the_byte_cap_still_goes_out(monkeypatch) -> None:
     monkeypatch.setenv("WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", "10")
     world = RecordingWorld()
-    writer = _writer(world)
-
-    await writer.write("y" * 500)
-    await writer.drain()
+    async with _writing(world) as writer:
+        await writer.write("y" * 500)
+        await writer.drain()
 
     assert _values(world.batches) == ["y" * 500]
 
@@ -205,47 +221,45 @@ async def test_write_blocks_at_the_buffer_bound_and_resumes(monkeypatch) -> None
     monkeypatch.setenv("WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", "1")
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
+    async with _writing(world) as writer:
+        await writer.write(0)
+        await _settle()  # chunk 0 is in flight, blocked on the gate
+        await writer.write(1)
 
-    await writer.write(0)
-    await asyncio.sleep(0)  # chunk 0 is in flight, blocked on the gate
-    await writer.write(1)
+        blocked = asyncio.ensure_future(writer.write(2))
+        await _settle()
+        assert not blocked.done(), "write() should block once the bound is reached"
 
-    blocked = asyncio.ensure_future(writer.write(2))
-    await asyncio.sleep(0)
-    assert not blocked.done(), "write() should block once the bound is reached"
-
-    world.gate.set()
-    await blocked
-    await writer.drain()
+        world.gate.set()
+        await blocked
+        await writer.drain()
 
     assert _values(world.batches) == [0, 1, 2]
 
 
 async def test_a_failed_request_poisons_the_writer_with_its_own_error() -> None:
     world = RecordingWorld(fail_on=1)
-    writer = _writer(world)
+    async with _writing(world) as writer:
+        await writer.write("doomed")
 
-    await writer.write("doomed")
-
-    with pytest.raises(w.WorkflowWorldError, match="server said no") as first:
-        await writer.drain()
-    # Every later call reports the original failure, not a derived one: the
-    # chunk is still unsent, and a fresh error would hide why.
-    with pytest.raises(w.WorkflowWorldError, match="server said no") as second:
-        await writer.write("after")
-    with pytest.raises(w.WorkflowWorldError, match="server said no"):
-        await writer.close()
-    assert first.value is second.value
+        with pytest.raises(w.WorkflowWorldError, match="server said no") as first:
+            await writer.drain()
+        # Every later call reports the original failure, not a derived one: the
+        # chunk is still unsent, and a fresh error would hide why.
+        with pytest.raises(w.WorkflowWorldError, match="server said no") as second:
+            await writer.write("after")
+        with pytest.raises(w.WorkflowWorldError, match="server said no"):
+            await writer.close()
+        assert first.value is second.value
     assert world.closes == []
 
 
 async def test_a_failed_group_is_retained_not_dropped() -> None:
     world = RecordingWorld(fail_on=1)
-    writer = _writer(world)
-    await writer.write("kept")
-    with pytest.raises(w.WorkflowWorldError):
-        await writer.drain()
+    async with _writing(world) as writer:
+        await writer.write("kept")
+        with pytest.raises(w.WorkflowWorldError):
+            await writer.drain()
 
     # Nothing landed, and the chunk is still buffered rather than discarded --
     # so a caller that can recover has something to recover.
@@ -256,65 +270,64 @@ async def test_a_failure_reaches_a_writer_already_blocked_on_capacity(monkeypatc
     monkeypatch.setenv("WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", "1")
     world = RecordingWorld(fail_on=1)
     world.gate = asyncio.Event()
-    writer = _writer(world)
+    async with _writing(world) as writer:
+        await writer.write(0)
+        await _settle()
+        blocked = asyncio.ensure_future(writer.write(1))
+        await _settle()
+        assert not blocked.done()
 
-    await writer.write(0)
-    await asyncio.sleep(0)
-    blocked = asyncio.ensure_future(writer.write(1))
-    await asyncio.sleep(0)
-    assert not blocked.done()
-
-    world.gate.set()
-    with pytest.raises(w.WorkflowWorldError, match="server said no"):
-        await blocked
+        world.gate.set()
+        with pytest.raises(w.WorkflowWorldError, match="server said no"):
+            await blocked
 
 
 async def test_drain_waits_for_the_request_in_flight() -> None:
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
+    async with _writing(world) as writer:
+        await writer.write("pending")
+        await _settle()
+        draining = asyncio.ensure_future(writer.drain())
+        await _settle()
+        assert not draining.done(), "drain() must not resolve while a write is in flight"
 
-    await writer.write("pending")
-    await asyncio.sleep(0)
-    draining = asyncio.ensure_future(writer.drain())
-    await asyncio.sleep(0)
-    assert not draining.done(), "drain() must not resolve while a write is in flight"
-
-    world.gate.set()
-    await draining
+        world.gate.set()
+        await draining
     assert _values(world.batches) == ["pending"]
 
 
 async def test_cancelling_the_dispatch_does_not_poison_the_writer() -> None:
     """A torn-down dispatch task is not a stream failure.
 
-    `CancelledError` is a `BaseException`, so catching it alongside real send
-    failures would record it as the sink error -- and then a later `write()`
-    would raise `CancelledError` inside a caller that was never cancelled,
-    which reads as that caller being torn down.
+    `CancelledError` is a `BaseException`, so recording it alongside real send
+    failures would make a later `write()` raise it inside a caller that was
+    never cancelled -- which reads as that caller being torn down. The group
+    the dispatch was carrying goes back on the buffer instead, unsent rather
+    than lost.
     """
     world = RecordingWorld()
     world.gate = asyncio.Event()
-    writer = _writer(world)
 
-    await writer.write("first")
-    await asyncio.sleep(0)  # the dispatch task is now blocked on the gate
-    assert writer._dispatch is not None
-    writer._dispatch.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await writer._dispatch
+    async with anyio.create_task_group() as task_group:
+        writer = streams.WorkflowStreamWriter(
+            world=world, run_id=RUN_ID, name=NAME, task_group=task_group
+        )
+        await writer.write("first")
+        await _settle()  # the dispatch task is now blocked on the gate
+        assert writer._dispatching
+        task_group.cancel_scope.cancel()
 
-    # The writer is usable again, and the chunk was never lost.
-    world.gate.set()
-    await writer.write("second")
-    await writer.drain()
-
-    assert _values(world.batches) == ["first", "second"]
+    assert writer._sink_error is None
+    assert not writer._dispatching
+    assert world.batches == []
+    assert _values([writer._buffer]) == ["first"]
 
 
 async def test_drain_on_an_untouched_writer_is_a_no_op() -> None:
     world = RecordingWorld()
-    await _writer(world).drain()
+    async with _writing(world) as writer:
+        await writer.drain()
     assert world.batches == []
 
 
@@ -324,9 +337,9 @@ async def test_write_from_forwards_an_async_iterable_in_order() -> None:
             yield token
 
     world = RecordingWorld()
-    writer = _writer(world)
-    await writer.write_from(source())
-    await writer.drain()
+    async with _writing(world) as writer:
+        await writer.write_from(source())
+        await writer.drain()
 
     assert _values(world.batches) == ["a", "b", "c"]
 
@@ -334,14 +347,14 @@ async def test_write_from_forwards_an_async_iterable_in_order() -> None:
 async def test_concurrent_writers_do_not_interleave_a_single_chunk() -> None:
     """Chunks from concurrent producers stay whole and stay ordered per producer."""
     world = RecordingWorld()
-    writer = _writer(world)
+    async with _writing(world) as writer:
 
-    async def produce(tag: str) -> None:
-        for i in range(10):
-            await writer.write(f"{tag}{i}")
+        async def produce(tag: str) -> None:
+            for i in range(10):
+                await writer.write(f"{tag}{i}")
 
-    await asyncio.gather(produce("a"), produce("b"))
-    await writer.drain()
+        await asyncio.gather(produce("a"), produce("b"))
+        await writer.drain()
 
     sent = _values(world.batches)
     assert len(sent) == 20
@@ -351,21 +364,26 @@ async def test_concurrent_writers_do_not_interleave_a_single_chunk() -> None:
 
 async def test_context_manager_closes_on_success_only() -> None:
     world = RecordingWorld()
-    async with _writer(world) as writer:
-        await writer.write("done")
+    async with _writing(world) as writer:
+        async with writer:
+            await writer.write("done")
     assert world.closes == [NAME]
 
     # A stream a step failed midway through is left open on purpose: the run may
     # retry the step or write more from a later one, and a closed stream cannot
     # be reopened.
     world2 = RecordingWorld()
-    with pytest.raises(RuntimeError):
-        async with _writer(world2) as writer:
-            await writer.write("partial")
-            raise RuntimeError("boom")
+    async with _writing(world2) as writer:
+        with pytest.raises(RuntimeError):
+            async with writer:
+                await writer.write("partial")
+                raise RuntimeError("boom")
     assert world2.closes == []
 
 
 async def test_an_empty_stream_name_is_refused() -> None:
-    with pytest.raises(ValueError, match='"name" is required'):
-        streams.WorkflowStreamWriter(world=RecordingWorld(), run_id=RUN_ID, name="")
+    async with anyio.create_task_group() as task_group:
+        with pytest.raises(ValueError, match='"name" is required'):
+            streams.WorkflowStreamWriter(
+                world=RecordingWorld(), run_id=RUN_ID, name="", task_group=task_group
+            )

--- a/src/vercel/tests/unit/test_workflow_stream_writer.py
+++ b/src/vercel/tests/unit/test_workflow_stream_writer.py
@@ -82,7 +82,7 @@ class RecordingWorld(NoStreams, w.World):
 
 
 def _writer(world: w.World) -> streams.WorkflowStreamWriter:
-    return streams.WorkflowStreamWriter(world, RUN_ID, NAME)
+    return streams.WorkflowStreamWriter(world=world, run_id=RUN_ID, name=NAME)
 
 
 def _values(batches: list[list[bytes]]) -> list[Any]:
@@ -368,4 +368,4 @@ async def test_context_manager_closes_on_success_only() -> None:
 
 async def test_an_empty_stream_name_is_refused() -> None:
     with pytest.raises(ValueError, match='"name" is required'):
-        streams.WorkflowStreamWriter(RecordingWorld(), RUN_ID, "")
+        streams.WorkflowStreamWriter(world=RecordingWorld(), run_id=RUN_ID, name="")

--- a/src/vercel/tests/unit/test_workflow_stream_writer.py
+++ b/src/vercel/tests/unit/test_workflow_stream_writer.py
@@ -1,0 +1,371 @@
+"""`WorkflowStreamWriter`: group commit, its bounds, and its failure mode.
+
+The writer acknowledges a `write()` as soon as the chunk is buffered, which is
+what lets a producer keep filling while a request is in flight -- and is also
+what makes the failure behavior worth pinning: a chunk whose `write()` already
+returned can still fail, and it has to surface at the durability barrier rather
+than vanish.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+
+import pytest
+
+from vercel._internal.workflow import serialization as ser, streams, world as w
+from vercel.tests.world_stubs import NoStreams
+
+RUN_ID = "wrun_test"
+NAME = "strm_test_user"
+
+
+class RecordingWorld(NoStreams, w.World):
+    """Records stream traffic and can be told to stall or fail a request."""
+
+    def __init__(self, *, fail_on: int | None = None) -> None:
+        self.batches: list[list[bytes]] = []
+        self.closes: list[str] = []
+        self.fail_on = fail_on
+        self.calls = 0
+        # Set to block the next request until the test releases it, so a
+        # "while a request is in flight" state can be observed.
+        self.gate: asyncio.Event | None = None
+
+    # -- the streams surface under test ---------------------------------
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        await self._record(name, [chunk])
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        await self._record(name, list(chunks))
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        self.closes.append(name)
+
+    async def _record(self, name: str, chunks: list[bytes]) -> None:
+        self.calls += 1
+        if self.gate is not None:
+            await self.gate.wait()
+        if self.fail_on == self.calls:
+            raise w.WorkflowWorldError("server said no", status=500)
+        self.batches.append(chunks)
+
+    # -- unused World surface ------------------------------------------
+    async def get_deployment_id(self) -> str:
+        return ""
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        raise NotImplementedError
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        raise NotImplementedError
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+
+def _writer(world: w.World) -> streams.WorkflowStreamWriter:
+    return streams.WorkflowStreamWriter(world, RUN_ID, NAME)
+
+
+def _values(batches: list[list[bytes]]) -> list[Any]:
+    """Every chunk sent, decoded, flattened back into write order."""
+    decoder = streams.FrameDecoder()
+    out = []
+    for batch in batches:
+        for chunk in batch:
+            for payload in decoder.feed(chunk):
+                out.append(ser.hydrate(payload, what="chunk"))
+    decoder.finish()
+    return out
+
+
+async def test_writes_reach_the_world_in_order() -> None:
+    world = RecordingWorld()
+    writer = _writer(world)
+
+    for i in range(5):
+        await writer.write(i)
+    await writer.drain()
+
+    assert _values(world.batches) == [0, 1, 2, 3, 4]
+
+
+async def test_close_drains_then_marks_the_stream_complete() -> None:
+    world = RecordingWorld()
+    writer = _writer(world)
+
+    await writer.write("last")
+    await writer.close()
+
+    assert _values(world.batches) == ["last"]
+    assert world.closes == [NAME]
+
+
+async def test_close_is_idempotent() -> None:
+    world = RecordingWorld()
+    writer = _writer(world)
+    await writer.close()
+    await writer.close()
+    assert world.closes == [NAME]
+
+
+async def test_writing_after_close_is_refused() -> None:
+    world = RecordingWorld()
+    writer = _writer(world)
+    await writer.close()
+    with pytest.raises(ser.SerializationError, match="is closed"):
+        await writer.write("late")
+
+
+async def test_chunks_arriving_during_a_request_leave_as_one_group() -> None:
+    """The point of the early acknowledgement.
+
+    While the first chunk's request is in flight the producer keeps writing;
+    those chunks accumulate and go out together, so a producer writing in a
+    loop does not turn into one request per chunk.
+    """
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    await writer.write("first")
+    # The dispatch task has taken the first chunk and is blocked on the gate.
+    await asyncio.sleep(0)
+    for i in range(4):
+        await writer.write(i)
+
+    world.gate.set()
+    await writer.drain()
+
+    assert [len(batch) for batch in world.batches] == [1, 4]
+    assert _values(world.batches) == ["first", 0, 1, 2, 3]
+
+
+async def test_a_group_is_capped_by_chunk_count(monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", "2")
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    for i in range(5):
+        await writer.write(i)
+    world.gate.set()
+    await writer.drain()
+
+    assert [len(batch) for batch in world.batches] == [2, 2, 1]
+    assert _values(world.batches) == [0, 1, 2, 3, 4]
+
+
+async def test_a_group_is_capped_by_bytes(monkeypatch) -> None:
+    # Small enough that two frames cannot share a request.
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", "40")
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    for _ in range(3):
+        await writer.write("x" * 20)
+    world.gate.set()
+    await writer.drain()
+
+    assert [len(batch) for batch in world.batches] == [1, 1, 1]
+
+
+async def test_a_chunk_larger_than_the_byte_cap_still_goes_out(monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", "10")
+    world = RecordingWorld()
+    writer = _writer(world)
+
+    await writer.write("y" * 500)
+    await writer.drain()
+
+    assert _values(world.batches) == ["y" * 500]
+
+
+async def test_write_blocks_at_the_buffer_bound_and_resumes(monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", "2")
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", "1")
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    await writer.write(0)
+    await asyncio.sleep(0)  # chunk 0 is in flight, blocked on the gate
+    await writer.write(1)
+
+    blocked = asyncio.ensure_future(writer.write(2))
+    await asyncio.sleep(0)
+    assert not blocked.done(), "write() should block once the bound is reached"
+
+    world.gate.set()
+    await blocked
+    await writer.drain()
+
+    assert _values(world.batches) == [0, 1, 2]
+
+
+async def test_a_failed_request_poisons_the_writer_with_its_own_error() -> None:
+    world = RecordingWorld(fail_on=1)
+    writer = _writer(world)
+
+    await writer.write("doomed")
+
+    with pytest.raises(w.WorkflowWorldError, match="server said no") as first:
+        await writer.drain()
+    # Every later call reports the original failure, not a derived one: the
+    # chunk is still unsent, and a fresh error would hide why.
+    with pytest.raises(w.WorkflowWorldError, match="server said no") as second:
+        await writer.write("after")
+    with pytest.raises(w.WorkflowWorldError, match="server said no"):
+        await writer.close()
+    assert first.value is second.value
+    assert world.closes == []
+
+
+async def test_a_failed_group_is_retained_not_dropped() -> None:
+    world = RecordingWorld(fail_on=1)
+    writer = _writer(world)
+    await writer.write("kept")
+    with pytest.raises(w.WorkflowWorldError):
+        await writer.drain()
+
+    # Nothing landed, and the chunk is still buffered rather than discarded --
+    # so a caller that can recover has something to recover.
+    assert world.batches == []
+
+
+async def test_a_failure_reaches_a_writer_already_blocked_on_capacity(monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", "1")
+    world = RecordingWorld(fail_on=1)
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    await writer.write(0)
+    await asyncio.sleep(0)
+    blocked = asyncio.ensure_future(writer.write(1))
+    await asyncio.sleep(0)
+    assert not blocked.done()
+
+    world.gate.set()
+    with pytest.raises(w.WorkflowWorldError, match="server said no"):
+        await blocked
+
+
+async def test_drain_waits_for_the_request_in_flight() -> None:
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    await writer.write("pending")
+    await asyncio.sleep(0)
+    draining = asyncio.ensure_future(writer.drain())
+    await asyncio.sleep(0)
+    assert not draining.done(), "drain() must not resolve while a write is in flight"
+
+    world.gate.set()
+    await draining
+    assert _values(world.batches) == ["pending"]
+
+
+async def test_cancelling_the_dispatch_does_not_poison_the_writer() -> None:
+    """A torn-down dispatch task is not a stream failure.
+
+    `CancelledError` is a `BaseException`, so catching it alongside real send
+    failures would record it as the sink error -- and then a later `write()`
+    would raise `CancelledError` inside a caller that was never cancelled,
+    which reads as that caller being torn down.
+    """
+    world = RecordingWorld()
+    world.gate = asyncio.Event()
+    writer = _writer(world)
+
+    await writer.write("first")
+    await asyncio.sleep(0)  # the dispatch task is now blocked on the gate
+    assert writer._dispatch is not None
+    writer._dispatch.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await writer._dispatch
+
+    # The writer is usable again, and the chunk was never lost.
+    world.gate.set()
+    await writer.write("second")
+    await writer.drain()
+
+    assert _values(world.batches) == ["first", "second"]
+
+
+async def test_drain_on_an_untouched_writer_is_a_no_op() -> None:
+    world = RecordingWorld()
+    await _writer(world).drain()
+    assert world.batches == []
+
+
+async def test_write_from_forwards_an_async_iterable_in_order() -> None:
+    async def source() -> AsyncIterator[str]:
+        for token in ("a", "b", "c"):
+            yield token
+
+    world = RecordingWorld()
+    writer = _writer(world)
+    await writer.write_from(source())
+    await writer.drain()
+
+    assert _values(world.batches) == ["a", "b", "c"]
+
+
+async def test_concurrent_writers_do_not_interleave_a_single_chunk() -> None:
+    """Chunks from concurrent producers stay whole and stay ordered per producer."""
+    world = RecordingWorld()
+    writer = _writer(world)
+
+    async def produce(tag: str) -> None:
+        for i in range(10):
+            await writer.write(f"{tag}{i}")
+
+    await asyncio.gather(produce("a"), produce("b"))
+    await writer.drain()
+
+    sent = _values(world.batches)
+    assert len(sent) == 20
+    assert [v for v in sent if v.startswith("a")] == [f"a{i}" for i in range(10)]
+    assert [v for v in sent if v.startswith("b")] == [f"b{i}" for i in range(10)]
+
+
+async def test_context_manager_closes_on_success_only() -> None:
+    world = RecordingWorld()
+    async with _writer(world) as writer:
+        await writer.write("done")
+    assert world.closes == [NAME]
+
+    # A stream a step failed midway through is left open on purpose: the run may
+    # retry the step or write more from a later one, and a closed stream cannot
+    # be reopened.
+    world2 = RecordingWorld()
+    with pytest.raises(RuntimeError):
+        async with _writer(world2) as writer:
+            await writer.write("partial")
+            raise RuntimeError("boom")
+    assert world2.closes == []
+
+
+async def test_an_empty_stream_name_is_refused() -> None:
+    with pytest.raises(ValueError, match='"name" is required'):
+        streams.WorkflowStreamWriter(RecordingWorld(), RUN_ID, "")

--- a/src/vercel/tests/unit/test_workflow_vercel_streamer.py
+++ b/src/vercel/tests/unit/test_workflow_vercel_streamer.py
@@ -1,0 +1,291 @@
+"""`VercelWorld`'s stream transport: endpoints, headers, and what may be retried.
+
+The retry policy is the load-bearing part. A chunk append is not idempotent, so
+resending one that may already have landed duplicates it and shifts every index
+after it -- which silently breaks resume for every reader. Close is idempotent
+and must retry 5xx, because the server's close barrier surfaces transient
+reconciliation as a retriable 503.
+"""
+
+from __future__ import annotations
+
+import cbor2
+import httpx
+import pytest
+import respx
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds.vercel import VercelWorld
+
+RUN_ID = "wrun_test"
+NAME = "strm_test_user"
+BASE = "https://vercel-workflow.com/api"
+STREAM_URL = f"{BASE}/v2/runs/{RUN_ID}/stream/{NAME}"
+READ_URL = f"{BASE}/v3/runs/{RUN_ID}/stream/{NAME}"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_auth(monkeypatch) -> None:
+    # A token short-circuits the OIDC lookup, which would otherwise try the
+    # network from a unit test.
+    monkeypatch.delenv("VERCEL_OIDC_TOKEN", raising=False)
+
+
+@pytest.fixture
+def world() -> VercelWorld:
+    return VercelWorld(token="tok_test")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch) -> None:
+    """Collapse the retry backoff so the retry tests do not sleep for real."""
+    import asyncio
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+
+class TestWrite:
+    @respx.mock
+    async def test_a_single_chunk_is_put_to_the_v2_stream_endpoint(self, world) -> None:
+        route = respx.put(STREAM_URL).respond(200)
+
+        await world.streams_write(RUN_ID, NAME, b"hello")
+
+        assert route.called
+        request = route.calls.last.request
+        assert request.content == b"hello"
+        assert request.headers["Authorization"] == "Bearer tok_test"
+        assert "X-Stream-Multi" not in request.headers
+        assert "X-Stream-Done" not in request.headers
+
+    @respx.mock
+    async def test_a_batch_is_length_prefixed_and_flagged(self, world) -> None:
+        route = respx.put(STREAM_URL).respond(200)
+
+        await world.streams_write_multi(RUN_ID, NAME, [b"ab", b"c"])
+
+        request = route.calls.last.request
+        assert request.headers["X-Stream-Multi"] == "true"
+        # The server has to recover the original boundaries so each chunk keeps
+        # its own index -- hence the same framing the stream itself uses.
+        assert request.content == b"\x00\x00\x00\x02ab\x00\x00\x00\x01c"
+
+    @respx.mock
+    async def test_an_empty_batch_makes_no_request(self, world) -> None:
+        route = respx.put(STREAM_URL).respond(200)
+        await world.streams_write_multi(RUN_ID, NAME, [])
+        assert not route.called
+
+    @respx.mock
+    async def test_a_batch_over_the_server_cap_is_split_into_pages(self, world) -> None:
+        route = respx.put(STREAM_URL).respond(200)
+
+        await world.streams_write_multi(RUN_ID, NAME, [b"x"] * 1500)
+
+        assert len(route.calls) == 2
+        # 1000 then 500, each `[4-byte len][1 byte]`.
+        assert len(route.calls[0].request.content) == 1000 * 5
+        assert len(route.calls[1].request.content) == 500 * 5
+
+    @respx.mock
+    async def test_429_is_retried(self, world) -> None:
+        # The request was rejected before being applied, so resending cannot
+        # duplicate a chunk.
+        route = respx.put(STREAM_URL).mock(
+            side_effect=[httpx.Response(429, headers={"retry-after": "0"}), httpx.Response(200)]
+        )
+
+        await world.streams_write(RUN_ID, NAME, b"x")
+
+        assert len(route.calls) == 2
+
+    @respx.mock
+    async def test_500_is_not_retried_on_a_write(self, world) -> None:
+        """The whole point of the narrowed policy.
+
+        A 5xx may mean the append *did* land; resending it would store the chunk
+        twice and shift every later index.
+        """
+        route = respx.put(STREAM_URL).respond(500)
+
+        with pytest.raises(w.WorkflowWorldError, match="Stream write failed: HTTP 500"):
+            await world.streams_write(RUN_ID, NAME, b"x")
+
+        assert len(route.calls) == 1
+
+    @respx.mock
+    async def test_a_transport_error_is_retried(self, world) -> None:
+        # Never reached a server that could have applied it.
+        route = respx.put(STREAM_URL).mock(
+            side_effect=[httpx.ConnectError("reset"), httpx.Response(200)]
+        )
+
+        await world.streams_write(RUN_ID, NAME, b"x")
+
+        assert len(route.calls) == 2
+
+    @respx.mock
+    async def test_persistent_throttling_surfaces_as_throttle_error(self, world) -> None:
+        respx.put(STREAM_URL).respond(429, headers={"retry-after": "7"})
+
+        with pytest.raises(w.ThrottleError) as error:
+            await world.streams_write(RUN_ID, NAME, b"x")
+
+        assert error.value.retry_after == 7
+
+    @respx.mock
+    async def test_the_error_carries_the_vercel_request_id(self, world) -> None:
+        # Without it a failure inside the platform is unactionable.
+        respx.put(STREAM_URL).respond(
+            503, headers={"x-vercel-id": "iad1::abc", "x-vercel-error": "FUNCTION_THROTTLED"}
+        )
+
+        with pytest.raises(w.WorkflowWorldError, match="x-vercel-id=iad1::abc") as error:
+            await world.streams_write(RUN_ID, NAME, b"x")
+
+        assert "x-vercel-error=FUNCTION_THROTTLED" in str(error.value)
+
+
+class TestClose:
+    @respx.mock
+    async def test_close_flags_done_and_sends_no_body(self, world) -> None:
+        route = respx.put(STREAM_URL).respond(200)
+
+        await world.streams_close(RUN_ID, NAME)
+
+        request = route.calls.last.request
+        assert request.headers["X-Stream-Done"] == "true"
+        assert request.content == b""
+
+    @respx.mock
+    async def test_500_is_retried_on_close(self, world) -> None:
+        """Closing twice is harmless, and the server's close barrier expects it:
+        a transient reconciliation failure comes back as a retriable 503 with
+        the stream left durably closing."""
+        route = respx.put(STREAM_URL).mock(side_effect=[httpx.Response(503), httpx.Response(200)])
+
+        await world.streams_close(RUN_ID, NAME)
+
+        assert len(route.calls) == 2
+
+
+class TestRead:
+    @respx.mock
+    async def test_the_live_read_uses_v3(self, world) -> None:
+        """v3, not v2, and it matters.
+
+        v3 errors the response body when the server's max duration expires
+        where v2 closes it cleanly. Only the error distinguishes a timeout from
+        the end of the stream, so reading v2 would silently truncate any stream
+        that outlives the limit.
+        """
+        route = respx.get(READ_URL).respond(200, content=b"chunk")
+
+        chunks = [c async for c in world.streams_get(RUN_ID, NAME)]
+
+        assert chunks == [b"chunk"]
+        assert route.called
+        assert "/v3/" in str(route.calls.last.request.url)
+
+    @respx.mock
+    async def test_start_index_is_a_query_parameter(self, world) -> None:
+        route = respx.get(READ_URL).respond(200, content=b"")
+
+        [c async for c in world.streams_get(RUN_ID, NAME, 7)]
+
+        assert route.calls.last.request.url.params["startIndex"] == "7"
+
+    @respx.mock
+    async def test_a_negative_start_index_is_passed_through(self, world) -> None:
+        # Last-N is resolved by the server, which is the only side that knows
+        # the current tail.
+        route = respx.get(READ_URL).respond(200, content=b"")
+
+        [c async for c in world.streams_get(RUN_ID, NAME, -3)]
+
+        assert route.calls.last.request.url.params["startIndex"] == "-3"
+
+    @respx.mock
+    async def test_no_start_index_means_no_parameter(self, world) -> None:
+        route = respx.get(READ_URL).respond(200, content=b"")
+
+        [c async for c in world.streams_get(RUN_ID, NAME)]
+
+        assert "startIndex" not in route.calls.last.request.url.params
+
+    @respx.mock
+    async def test_the_leading_header_flush_chunk_is_skipped(self, world) -> None:
+        # The server writes an empty chunk to commit response headers before any
+        # data exists; it is not a chunk anyone wrote.
+        respx.get(READ_URL).respond(
+            200, stream=httpx.ByteStream(b""), content=b"".join([b"", b"real"])
+        )
+
+        chunks = [c async for c in world.streams_get(RUN_ID, NAME)]
+
+        assert b"" not in chunks
+
+    @respx.mock
+    async def test_a_failed_read_raises_before_yielding(self, world) -> None:
+        respx.get(READ_URL).respond(404)
+
+        with pytest.raises(w.WorkflowWorldError, match="Stream read failed: HTTP 404"):
+            [c async for c in world.streams_get(RUN_ID, NAME)]
+
+
+class TestSnapshot:
+    @respx.mock
+    async def test_get_info_reads_the_v2_info_endpoint(self, world) -> None:
+        respx.get(f"{BASE}/v2/runs/{RUN_ID}/streams/{NAME}/info").respond(
+            200, json={"tailIndex": 4, "done": True}
+        )
+
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=4, done=True)
+
+    @respx.mock
+    async def test_get_chunks_passes_paging_and_parses_the_page(self, world) -> None:
+        # CBOR, as the server really answers: chunk payloads arrive as native
+        # byte strings, so nothing base64-decodes them on the way in.
+        route = respx.get(f"{BASE}/v2/runs/{RUN_ID}/streams/{NAME}/chunks").respond(
+            200,
+            headers={"Content-Type": "application/cbor"},
+            content=cbor2.dumps(
+                {
+                    "data": [{"index": 0, "data": b"hi"}],
+                    "cursor": "next",
+                    "hasMore": True,
+                    "done": False,
+                }
+            ),
+        )
+
+        page = await world.streams_get_chunks(RUN_ID, NAME, limit=1, cursor="here")
+
+        params = route.calls.last.request.url.params
+        assert params["limit"] == "1"
+        assert params["cursor"] == "here"
+        assert page.has_more is True
+        assert page.cursor == "next"
+        assert [(c.index, c.data) for c in page.data] == [(0, b"hi")]
+
+    @respx.mock
+    async def test_list_returns_the_run_stream_names(self, world) -> None:
+        respx.get(f"{BASE}/v2/runs/{RUN_ID}/streams").respond(200, json=[NAME, "strm_other"])
+
+        assert await world.streams_list(RUN_ID) == [NAME, "strm_other"]
+
+
+class TestNaming:
+    @respx.mock
+    async def test_path_segments_are_percent_encoded(self, world) -> None:
+        # A namespace is base64url, so `-` and `_` show up in real names; the
+        # encoding is what keeps a surprising one from reshaping the URL.
+        weird = "strm_a b/c"
+        route = respx.put(f"{BASE}/v2/runs/{RUN_ID}/stream/strm_a%20b%2Fc").respond(200)
+
+        await world.streams_write(RUN_ID, weird, b"x")
+
+        assert route.called

--- a/src/vercel/tests/world_stubs.py
+++ b/src/vercel/tests/world_stubs.py
@@ -1,0 +1,47 @@
+"""Shared stubs for hand-written `World` doubles in the test suite.
+
+`World` declares the full contract a real world owes, streams included, so a
+double that only exercises the event-log paths still has to say something about
+them. Saying it once here keeps that from being six copied stub methods in
+every fake, and keeps "this double has no streams" legible at the class
+declaration instead of buried thirty lines down.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+
+from vercel._internal.workflow import world as w
+
+
+class NoStreams:
+    """Mix in to declare a `World` double that does not support streams.
+
+    Every method raises, so a test that unexpectedly reaches the stream path
+    fails loudly rather than reading back plausible empty results.
+    """
+
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        raise NotImplementedError
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        raise NotImplementedError
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        raise NotImplementedError
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncIterator[bytes]:
+        raise NotImplementedError
+
+    async def streams_list(self, run_id: str) -> list[str]:
+        raise NotImplementedError
+
+    async def streams_get_chunks(
+        self, run_id: str, name: str, *, limit: int | None = None, cursor: str | None = None
+    ) -> w.StreamChunksPage:
+        raise NotImplementedError
+
+    async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
+        raise NotImplementedError

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -99,7 +99,9 @@ workflow body take a handle and pass it into a step, here it cannot yet, so each
 step that streams calls `get_writable()` itself.
 
 Chunks are values, not just bytes: anything the payload format carries (see
-below) can be written, and a reader gets it back.
+below) can be written, and a reader gets it back. A `bytes` chunk arrives on the
+TypeScript side as a `Uint8Array`, so a consumer there can pipe the stream
+straight into a `Response`.
 
 Three things are worth knowing:
 

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -61,6 +61,70 @@ async def wait_for_approval() -> bool:
 
 `BaseHook` supports dataclasses and Pydantic models for external resume events.
 
+## Streaming
+
+Every run has a stream a step can write to while it runs, so a client sees
+progress without waiting for the run to finish:
+
+```python
+from vercel.workflow import Workflows, get_writable
+
+app = Workflows()
+
+
+@app.step
+async def summarize(*, document: str) -> str:
+    writable = get_writable()
+    summary = []
+    async for token in llm.stream(document):
+        await writable.write(token)
+        summary.append(token)
+    return "".join(summary)
+
+
+@app.step
+async def done() -> None:
+    await get_writable().close()
+
+
+@app.workflow
+async def analyze(*, document: str) -> str:
+    summary = await summarize(document=document)
+    await done()
+    return summary
+```
+
+`get_writable()` works inside a step only. Where the TypeScript SDK lets a
+workflow body take a handle and pass it into a step, here it cannot yet, so each
+step that streams calls `get_writable()` itself.
+
+Chunks are values, not just bytes: anything the payload format carries (see
+below) can be written, and a reader gets it back.
+
+Three things are worth knowing:
+
+- **Nothing closes a stream for you.** Not the end of a step, not the end of the
+  run — the stream spans steps, and a closed stream cannot be reopened. A reader
+  of a stream nobody closes waits until the run expires, so close it from the
+  last step that has something to say.
+- **A step is not complete until its chunks are.** `write()` returns once the
+  chunk is buffered, and the step handler flushes before recording the step, so
+  "the step finished" implies "everything it streamed is readable". Call
+  `await writable.drain()` if you need that guarantee earlier.
+- **Retries re-stream.** A step that fails halfway has already written what it
+  wrote, and the retry writes it again. Keep chunks idempotent, or stream from a
+  step you are willing to see repeated.
+
+`await writable.write_from(source)` forwards an async iterable in one call, and
+`get_writable(namespace="logs")` gives the run a second, independent stream.
+
+There is no public reader yet. A stream is consumed today by the TypeScript SDK
+(`run.readable`), the dashboard, or `workflow inspect stream <id> --run=<run-id>`.
+Python can read one through the world (`streams_get()` yields transport bytes,
+`FrameDecoder` turns them into payloads), but those live under
+`vercel._internal` and have no auto-reconnect, so a long read will not survive
+the server's stream timeout.
+
 ## Serializing your own types
 
 Workflow inputs, step results and hook payloads travel in the devalue format

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -120,6 +120,9 @@ Three things are worth knowing:
 `await writable.write_from(source)` forwards an async iterable in one call, and
 `get_writable(namespace="logs")` gives the run a second, independent stream.
 
+`async with get_writable() as writable:` closes the stream on the way out — on
+the clean path only, so a step that raises leaves the stream open for its retry.
+
 There is no public reader yet. A stream is consumed today by the TypeScript SDK
 (`run.readable`), the dashboard, or `workflow inspect stream <id> --run=<run-id>`.
 Python can read one through the world (`streams_get()` yields transport bytes,

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -7,8 +7,15 @@ from vercel._internal.workflow.core import (
     sleep,
     time_ns,
 )
-from vercel._internal.workflow.runtime import Run, StepInfo, get_step_metadata, start
+from vercel._internal.workflow.runtime import (
+    Run,
+    StepInfo,
+    get_step_metadata,
+    get_writable,
+    start,
+)
 from vercel._internal.workflow.serde import register_serializable, serializable
+from vercel._internal.workflow.streams import WorkflowStreamWriter
 
 from . import sandbox
 from .errors import (
@@ -34,6 +41,8 @@ __all__ = [
     "BaseHook",
     "HookEvent",
     "get_step_metadata",
+    "get_writable",
+    "WorkflowStreamWriter",
     "StepInfo",
     "serializable",
     "register_serializable",


### PR DESCRIPTION
The write side of workflow streaming. A step pushes chunks to the run's stream while it runs, and a client reads them without waiting for the run to finish.

```python
@app.step
async def summarize(*, doc: str) -> str:
    writable = get_writable()
    async for token in llm.stream(doc):
        await writable.write(token)
    ...

@app.step
async def done() -> None:
    await get_writable().close()
```

Chunks are readable immediately from the TypeScript SDK (`run.readable`), the dashboard, and `workflow inspect stream`.

## What's here

- `get_writable()` inside a step, with `write()` / `write_from()` / `drain()` / `close()`.
- Length-prefixed frames around the same `devl` payload the event log uses. One write, one frame, one chunk index — that is what makes `start_index + frames_consumed` a correct resume position.
- `World.streams_*`, over HTTP for the Vercel world and one file per chunk for the local one.
- The writer group-commits: `write()` returns once the chunk is buffered, so a producer keeps filling while a request is in flight and the group leaves as one request.
- A `bytes` chunk goes out as a `Uint8Array`, so a TypeScript consumer can pipe the stream straight into a `Response` — that body only accepts `Uint8Array` chunks, and the `ArrayBuffer` a payload would use raises there.

## Behaviour worth knowing

- **Nothing closes a stream implicitly.** It spans steps, and a closed stream cannot be reopened. A run that never closes leaves readers waiting until it expires.
- **A step is not recorded complete until its chunks are durable**, so a write failure fails the step instead of surfacing to a reader that never sees the chunk.
- **Retries re-stream.** A step that fails halfway already wrote what it wrote. Keep chunks idempotent.

## Not here — follows in 2/2

- Reading from Python: `Run.readable()` and the reconnecting reader.
- Passing a stream into a step as an argument.
- Encryption (`encr` / `encp`) and compression.

## Deliberate divergences from `@workflow/core`

- **Stricter step completion.** TS gives the flush 500 ms and finishes the step either way. Here it always waits, which is safe because `drain()` waits only on chunks already handed to it, so it cannot hang.
- **A read starting past the end of a *closed* stream returns empty.** On an open stream both SDKs wait, which is right — the chunk may still be written. Once the stream is closed it never will be, but `@workflow/world-local` marks every skipped file delivered, EOF marker included, so its poll never sees the end and waits forever.
- **An unknown format prefix raises**, naming the prefix, where TS silently drops the chunk.

## Verified

- 96 unit tests: framing, the writer's bounds and failure modes, both worlds' transports.
- The real `workflow` CLI reads the chunks a Python run wrote — added to the existing interop suite.
- Ran against a deployed project: streaming across a durable sleep, batched writes, close, and resume at both a positive and a negative `startIndex`.

Three commits, one per layer, each reviewable on its own.
