### PR TITLE
sandbox: Add fork_sandbox support

### DIFF
--- a/changes/vercel-sandbox/202.feature.md
+++ b/changes/vercel-sandbox/202.feature.md
@@ -1,0 +1,2 @@
+Add sync and async `fork_sandbox(...)` support for creating a sandbox from an
+existing named sandbox with optional configuration overrides.

--- a/src/vercel-sandbox/README.md
+++ b/src/vercel-sandbox/README.md
@@ -72,6 +72,48 @@ console commands. Both are aliases that delegate all arguments to `npx sandbox`;
 they require Node.js with npm and `npx` installed. Node.js is not required when
 using the Python API directly.
 
+## Creating, forking, and restoring
+
+Create a sandbox from a runtime, Git repository, tarball, or snapshot with
+`create_sandbox(...)`. A snapshot source restores that snapshot's filesystem
+into a new sandbox:
+
+```python
+from vercel import sandbox
+from vercel.sandbox import SnapshotSource
+
+restored = await sandbox.create_sandbox(
+    name="restored-workspace",
+    source=SnapshotSource(snapshot_id="snap_123"),
+)
+```
+
+Use `fork_sandbox(...)` when the source is an existing named sandbox. The
+server restores the fork from the source's current snapshot, or from its
+runtime or image when no snapshot exists. It also copies the source's ports,
+execution time limit, resources, image, persistence, network policy,
+environment variables, tags, snapshot expiration, and snapshot retention.
+Only pass values that should override the inherited configuration:
+
+```python
+forked = await sandbox.fork_sandbox(
+    source_sandbox="production-agent",
+    name="debug-agent",
+    resources=sandbox.SandboxResources(vcpus=4, memory=8192),
+    tags={"purpose": "debug"},
+)
+```
+
+Both creation and fork operations can be used as async context managers for
+automatic stop and destroy. The synchronous mirror uses the same arguments:
+
+```python
+from vercel.sandbox import sync as sandbox
+
+with sandbox.fork_sandbox(source_sandbox="production-agent") as forked:
+    result = forked.run_process("python", ["script.py"], capture_output=True)
+```
+
 ## Session lifecycles
 
 Sandbox-level process and filesystem operations resume a stopped sandbox

--- a/src/vercel-sandbox/examples/sandbox_07_fork.py
+++ b/src/vercel-sandbox/examples/sandbox_07_fork.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fork a configured Sandbox and work on its filesystem in isolation."""
+
+import asyncio
+from datetime import timedelta
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from vercel import sandbox
+
+load_dotenv()
+
+
+async def main() -> None:
+    suffix = uuid4().hex[:12]
+    source_name = f"vercel-py-fork-source-{suffix}"
+    fork_name = f"vercel-py-fork-child-{suffix}"
+    snapshot = None
+
+    try:
+        async with sandbox.create_sandbox(
+            name=source_name,
+            execution_time_limit=timedelta(minutes=2),
+            env={"INHERITED_MESSAGE": "hello from the source"},
+            tags={"example": "fork-source"},
+        ) as source:
+            await source.fs.write_text("workspace/message.txt", "source version\n")
+
+            # A fork starts from the source's current snapshot when it has one.
+            # Creating one here makes the filesystem state copied by this demo
+            # explicit and lets us clean it up when the example finishes.
+            snapshot = await source.snapshot()
+
+            # Omitted settings, including the environment, are inherited from
+            # the source. Values passed here override the inherited setting.
+            async with sandbox.fork_sandbox(
+                source_sandbox=source.name,
+                name=fork_name,
+                tags={"example": "fork-child"},
+            ) as forked:
+                assert await forked.fs.read_text("workspace/message.txt") == "source version\n"
+
+                result = await forked.run_process(
+                    "python",
+                    ["-c", "import os; print(os.environ['INHERITED_MESSAGE'])"],
+                    capture_output=True,
+                    check=True,
+                )
+                assert result.stdout == "hello from the source\n"
+
+                await forked.fs.write_text("workspace/message.txt", "fork version\n")
+                assert await source.fs.read_text("workspace/message.txt") == "source version\n"
+                print(f"forked {source.name} as {forked.name} from {snapshot.id}")
+    finally:
+        if snapshot is not None:
+            await snapshot.delete()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/vercel-sandbox/tests/test_sandbox_api_client.py
+++ b/src/vercel-sandbox/tests/test_sandbox_api_client.py
@@ -6,6 +6,7 @@ from httpx._types import HeaderTypes, QueryParamTypes
 
 from vercel._internal.core.http import (
     BaseTransport,
+    JSONBody,
     ReadResponsePolicy,
     RequestBody,
     StreamingRequest,
@@ -62,6 +63,40 @@ class JsonTransport(BaseTransport):
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
     ) -> httpx.Response:
         return httpx.Response(200, json=self.data, request=httpx.Request(method, path))
+
+
+class RecordingJsonTransport(JsonTransport):
+    def __init__(self, data: object) -> None:
+        super().__init__(data)
+        self.request: tuple[str, str, str | None, QueryParamTypes | None, RequestBody] | None = None
+
+    async def send(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        params: QueryParamTypes | None = None,
+        body: RequestBody = None,
+        headers: HeaderTypes | None = None,
+        timeout: timedelta | None = None,
+        follow_redirects: bool | None = None,
+        stream: bool = False,
+        read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
+    ) -> httpx.Response:
+        self.request = (method, path, token, params, body)
+        return await super().send(
+            method,
+            path,
+            token=token,
+            params=params,
+            body=body,
+            headers=headers,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            stream=stream,
+            read_response=read_response,
+        )
 
 
 class _CompletedResponse(StreamingResponse):
@@ -144,6 +179,55 @@ def test_format_url_path_quotes_placeholder_values() -> None:
         name="name/with spaces",
         command_id="cmd?x=1",
     ) == ("v2/sandboxes/name%2Fwith%20spaces/cmd%3Fx%3D1")
+
+
+async def test_fork_sandbox_encodes_source_query_and_overrides() -> None:
+    transport = RecordingJsonTransport(
+        {
+            "sandbox": {
+                "name": "forked",
+                "currentSessionId": "sbx_fork",
+                "status": "running",
+            },
+            "session": {
+                "id": "sbx_fork",
+                "sourceSandboxName": "forked",
+                "projectId": "prj_other",
+                "status": "running",
+            },
+        }
+    )
+    client = _sandbox_client(transport)
+
+    result = await client.fork_sandbox(
+        source_sandbox="source/with spaces",
+        project_id="prj_other",
+        name="forked",
+        ports=[],
+        execution_time_limit=timedelta(seconds=12.5),
+        image="team/project/image:v1",
+        persistent=False,
+        env={},
+        tags={},
+    )
+
+    assert result.name == "forked"
+    assert transport.request is not None
+    method, path, token, params, body = transport.request
+    assert method == "POST"
+    assert path == "https://sandbox.test/v2/sandboxes/source%2Fwith%20spaces/fork"
+    assert token == "token"
+    assert params == {"teamId": "team_123", "projectId": "prj_other"}
+    assert isinstance(body, JSONBody)
+    assert body.data == {
+        "name": "forked",
+        "ports": [],
+        "timeout": 12500,
+        "image": "team/project/image:v1",
+        "persistent": False,
+        "env": {},
+        "tags": {},
+    }
 
 
 async def test_stop_runtime_session_retains_sparse_sandbox_metadata() -> None:

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -451,6 +451,101 @@ async def test_public_create_sandbox_encodes_protocol_and_observed_state(
 
 
 @respx.mock
+async def test_public_fork_sandbox_encodes_overrides_polls_and_cleans_up(
+    mock_env_clear: None,
+) -> None:
+    pending = _sandbox_response(name="forked", session_id="sbx_fork", status="pending")
+    fork_route = respx.post("https://sandbox.test/v2/sandboxes/source/fork").mock(
+        return_value=httpx.Response(200, json=pending)
+    )
+    get_route = respx.get("https://sandbox.test/v2/sandboxes/forked").mock(
+        return_value=httpx.Response(
+            200, json=_sandbox_response(name="forked", session_id="sbx_fork")
+        )
+    )
+    stop_route = respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_fork/stop").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session": _sandbox_response(
+                    name="forked",
+                    session_id="sbx_fork",
+                    status="stopped",
+                    session_status="stopped",
+                )["session"]
+            },
+        )
+    )
+
+    async with session(service_options=_session_options()):
+        async with sandbox.fork_sandbox(
+            source_sandbox="source",
+            project_id="prj_other",
+            name="forked",
+            ports=[],
+            execution_time_limit=12.5,
+            resources=SandboxResources(vcpus=2, memory=4096),
+            image="team/project/image:v1",
+            persistent=False,
+            network_policy=NetworkPolicy.deny_all(),
+            env={},
+            tags={},
+            snapshot_expiration=0,
+            snapshot_retention=SnapshotRetention(
+                count=2,
+                expiration=timedelta(days=1),
+                delete_evicted=False,
+            ),
+            destroy=False,
+        ) as forked:
+            assert forked.name == "forked"
+
+    request = fork_route.calls.last.request
+    assert dict(request.url.params) == {"teamId": "team_123", "projectId": "prj_other"}
+    assert json.loads(request.content) == {
+        "name": "forked",
+        "ports": [],
+        "timeout": 12500,
+        "resources": {"vcpus": 2, "memory": 4096},
+        "image": "team/project/image:v1",
+        "persistent": False,
+        "networkPolicy": {"mode": "deny-all"},
+        "env": {},
+        "tags": {},
+        "snapshotExpiration": 0,
+        "keepLastSnapshots": {
+            "count": 2,
+            "expiration": 86400000,
+            "deleteEvicted": False,
+        },
+    }
+    assert dict(get_route.calls.last.request.url.params) == {
+        "teamId": "team_123",
+        "projectId": "prj_other",
+        "resume": "false",
+    }
+    assert stop_route.called
+
+
+@respx.mock
+def test_sync_fork_sandbox_uses_inherited_defaults(mock_env_clear: None) -> None:
+    fork_route = respx.post("https://sandbox.test/v2/sandboxes/source/fork").mock(
+        return_value=httpx.Response(
+            200, json=_sandbox_response(name="forked", session_id="sbx_fork")
+        )
+    )
+
+    with session(service_options=_session_options()):
+        forked = sandbox_sync.fork_sandbox(source_sandbox="source")
+
+    assert isinstance(forked, sandbox_sync.SyncSandbox)
+    assert forked.name == "forked"
+    request = fork_route.calls.last.request
+    assert dict(request.url.params) == {"teamId": "team_123", "projectId": "prj_123"}
+    assert json.loads(request.content) == {}
+
+
+@respx.mock
 async def test_network_policy_async_public_flow(mock_env_clear: None) -> None:
     create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -11,6 +11,7 @@ from vercel.sandbox._internal.async_filesystem_handle import (
 )
 from vercel.sandbox._internal.async_runtime import (
     CreateSandboxOperation,
+    ForkSandboxOperation,
     Process,
     ResumeSandboxOperation,
     Sandbox,
@@ -20,6 +21,7 @@ from vercel.sandbox._internal.async_runtime import (
     SandboxSessionOperation,
     Snapshot,
     create_sandbox_operation as _create_sandbox_operation,
+    fork_sandbox_operation as _fork_sandbox_operation,
     get_or_create_sandbox as _get_or_create_sandbox,
     get_sandbox as _get_sandbox,
     get_snapshot as _get_snapshot,
@@ -149,6 +151,77 @@ def create_sandbox(
         ports=ports,
         execution_time_limit=execution_time_limit,
         resources=resources,
+        persistent=persistent,
+        network_policy=network_policy,
+        env=env,
+        tags=tags,
+        snapshot_expiration=snapshot_expiration,
+        snapshot_retention=snapshot_retention,
+        destroy=destroy,
+    )
+
+
+def fork_sandbox(
+    *,
+    source_sandbox: str,
+    project_id: str | None = None,
+    name: str | None = None,
+    ports: list[int] | None = None,
+    execution_time_limit: DurationInput = None,
+    resources: SandboxResources | None = None,
+    image: str | None = None,
+    persistent: bool | None = None,
+    network_policy: NetworkPolicy | None = None,
+    env: Mapping[str, str] | None = None,
+    tags: Mapping[str, str] | None = None,
+    snapshot_expiration: SnapshotExpirationInput = None,
+    snapshot_retention: SnapshotRetention | None = None,
+    destroy: bool = True,
+) -> ForkSandboxOperation:
+    """Prepare an asynchronous sandbox fork operation.
+
+    The server initializes the fork from the source sandbox's current snapshot,
+    or from its runtime or image when it has no snapshot. Configuration is
+    inherited from the source; values supplied here replace the corresponding
+    inherited values.
+
+    Awaiting the returned operation performs no automatic cleanup. Using it as
+    an async context manager stops the fork on exit and destroys it by default.
+
+    Args:
+        source_sandbox: Name of the sandbox to fork.
+        project_id: Project that owns both the source and fork. Uses the active
+            credentials when omitted.
+        name: Requested name for the fork. The service generates one when
+            omitted.
+        ports: Ports to expose instead of the source sandbox's ports.
+        execution_time_limit: Maximum session runtime override.
+        resources: CPU and memory resource override.
+        image: Vercel Container Registry image override.
+        persistent: Persistence override.
+        network_policy: Network access policy override.
+        env: Environment variable override.
+        tags: Metadata tag override.
+        snapshot_expiration: Default snapshot lifetime override.
+        snapshot_retention: Automatic snapshot retention override.
+        destroy: Whether context-manager exit destroys the fork after stopping
+            it. Awaiting the operation never triggers cleanup.
+
+    Returns:
+        A single-use awaitable and async context manager for the fork.
+
+    Raises:
+        SandboxTerminalStateError: If the fork reaches a terminal failure state.
+    """
+    return _fork_sandbox_operation(
+        _service(),
+        source_sandbox=source_sandbox,
+        project_id=project_id,
+        name=name,
+        ports=ports,
+        execution_time_limit=execution_time_limit,
+        resources=resources,
+        image=image,
         persistent=persistent,
         network_policy=network_policy,
         env=env,
@@ -403,6 +476,7 @@ __all__ = [
     "SandboxTextWriter",
     "Sandbox",
     "CreateSandboxOperation",
+    "ForkSandboxOperation",
     "SandboxApiError",
     "SandboxCleanupError",
     "ProcessStatus",
@@ -454,6 +528,7 @@ __all__ = [
     "TarballSource",
     "TextReader",
     "create_sandbox",
+    "fork_sandbox",
     "get_or_create_sandbox",
     "get_sandbox",
     "get_snapshot",

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -130,11 +130,8 @@ class _ApiRequestModel(_ApiModel):
         return cast(JSONObject, self.model_dump(by_alias=True, exclude_none=True))
 
 
-class _CreateSandboxRequest(_ApiRequestModel):
-    project_id: str = Field(serialization_alias="projectId")
+class _SandboxCreationOverridesRequest(_ApiRequestModel):
     name: str | None = None
-    image: str | None = None
-    source: SandboxSource | None = None
     ports: list[int] | None = None
     timeout: timedelta | None = None
     resources: SandboxResources | None = None
@@ -171,6 +168,16 @@ class _CreateSandboxRequest(_ApiRequestModel):
         if value is None or isinstance(value, NetworkPolicy):
             return value
         raise TypeError("network_policy must be a NetworkPolicy")
+
+
+class _CreateSandboxRequest(_SandboxCreationOverridesRequest):
+    project_id: str = Field(serialization_alias="projectId")
+    image: str | None = None
+    source: SandboxSource | None = None
+
+
+class _ForkSandboxRequest(_SandboxCreationOverridesRequest):
+    image: str | None = None
 
 
 class _UpdateSandboxRequest(_ApiRequestModel):
@@ -934,6 +941,46 @@ class SandboxApiClient:
         )
         data = await self._request_json(
             "POST", "v3/sandboxes", credentials=credentials, body=request.to_api_dict()
+        )
+        return _validate_response(_SandboxResponse, data).to_sandbox()
+
+    async def fork_sandbox(
+        self,
+        *,
+        source_sandbox: str,
+        project_id: str | None = None,
+        name: str | None = None,
+        ports: list[int] | None = None,
+        execution_time_limit: timedelta | None = None,
+        resources: SandboxResources | None = None,
+        image: str | None = None,
+        persistent: bool | None = None,
+        network_policy: NetworkPolicy | None = None,
+        env: Mapping[str, str] | None = None,
+        tags: Mapping[str, str] | None = None,
+        snapshot_expiration: SnapshotExpiration | None = None,
+        snapshot_retention: SnapshotRetention | None = None,
+    ) -> SandboxState:
+        credentials = await self._credentials_factory()
+        request = _ForkSandboxRequest(
+            name=name,
+            ports=ports,
+            timeout=execution_time_limit,
+            resources=resources,
+            image=image,
+            persistent=persistent,
+            network_policy=network_policy,
+            env=dict(env) if env is not None else None,
+            tags=dict(tags) if tags is not None else None,
+            snapshot_expiration=snapshot_expiration,
+            keep_last_snapshots=snapshot_retention,
+        )
+        data = await self._request_json(
+            "POST",
+            format_url_path("v2/sandboxes/{source_sandbox}/fork", source_sandbox=source_sandbox),
+            credentials=credentials,
+            params={"projectId": project_id or credentials.project_id},
+            body=request.to_api_dict(),
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -1497,6 +1497,97 @@ class CreateSandboxOperation:
 
 
 @dataclass(frozen=True, slots=True)
+class _ForkSandboxParams:
+    source_sandbox: str
+    project_id: str | None = None
+    name: str | None = None
+    ports: list[int] | None = None
+    execution_time_limit: timedelta | None = None
+    resources: SandboxResources | None = None
+    image: str | None = None
+    persistent: bool | None = None
+    network_policy: NetworkPolicy | None = None
+    env: Mapping[str, str] | None = None
+    tags: Mapping[str, str] | None = None
+    snapshot_expiration: SnapshotExpiration | None = None
+    snapshot_retention: SnapshotRetention | None = None
+
+
+class ForkSandboxOperation:
+    """Manage one asynchronous sandbox fork request.
+
+    Await the operation to fork a sandbox that remains alive, or use it as an
+    async context manager to stop the fork and optionally destroy it on exit.
+    An operation can be consumed only once.
+    """
+
+    def __init__(
+        self,
+        *,
+        service: SandboxService,
+        params: _ForkSandboxParams,
+        destroy: bool,
+    ) -> None:
+        self._service = service
+        self._params = params
+        self._destroy = destroy
+        self._consumed = False
+        self._handle: Sandbox | None = None
+
+    def _mark_consumed(self) -> None:
+        if self._consumed:
+            raise RuntimeError("sandbox.fork_sandbox(...) operations can only be used once")
+        self._consumed = True
+
+    async def _run_once(self) -> Sandbox:
+        self._mark_consumed()
+        return await _fork_sandbox(
+            self._service,
+            source_sandbox=self._params.source_sandbox,
+            project_id=self._params.project_id,
+            name=self._params.name,
+            ports=self._params.ports,
+            execution_time_limit=self._params.execution_time_limit,
+            resources=self._params.resources,
+            image=self._params.image,
+            persistent=self._params.persistent,
+            network_policy=self._params.network_policy,
+            env=self._params.env,
+            tags=self._params.tags,
+            snapshot_expiration=self._params.snapshot_expiration,
+            snapshot_retention=self._params.snapshot_retention,
+        )
+
+    def __await__(self) -> Generator[Any, None, Sandbox]:
+        return self._run_once().__await__()
+
+    async def __aenter__(self) -> Sandbox:
+        handle = await self._run_once()
+        self._handle = handle
+        return handle
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._handle is None:
+            return None
+        await _cleanup_managed_sandbox(self._handle, destroy=self._destroy)
+        return None
+
+    def __del__(self) -> None:
+        if self._consumed:
+            return
+        warnings.warn(
+            "sandbox.fork_sandbox(...) operation was never awaited or entered",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class _ResumeSandboxParams:
     name: str
     project_id: str | None = None
@@ -1591,6 +1682,13 @@ async def _create_sandbox(service: SandboxService, **kwargs: Any) -> Sandbox:
         raise _terminal_error(error, Sandbox(payload=error.sandbox, service=service)) from error
 
 
+async def _fork_sandbox(service: SandboxService, **kwargs: Any) -> Sandbox:
+    try:
+        return Sandbox(payload=await service.fork_sandbox(**kwargs), service=service)
+    except _SandboxTerminalState as error:
+        raise _terminal_error(error, Sandbox(payload=error.sandbox, service=service)) from error
+
+
 def create_sandbox_operation(
     service: SandboxService,
     *,
@@ -1619,6 +1717,45 @@ def create_sandbox_operation(
             ports=ports,
             execution_time_limit=parse_duration_seconds(execution_time_limit),
             resources=resources,
+            persistent=persistent,
+            network_policy=network_policy,
+            env=env,
+            tags=tags,
+            snapshot_expiration=_parse_snapshot_expiration(snapshot_expiration),
+            snapshot_retention=snapshot_retention,
+        ),
+        destroy=destroy,
+    )
+
+
+def fork_sandbox_operation(
+    service: SandboxService,
+    *,
+    source_sandbox: str,
+    project_id: str | None = None,
+    name: str | None = None,
+    ports: list[int] | None = None,
+    execution_time_limit: DurationInput = None,
+    resources: SandboxResources | None = None,
+    image: str | None = None,
+    persistent: bool | None = None,
+    network_policy: NetworkPolicy | None = None,
+    env: Mapping[str, str] | None = None,
+    tags: Mapping[str, str] | None = None,
+    snapshot_expiration: SnapshotExpirationInput = None,
+    snapshot_retention: SnapshotRetention | None = None,
+    destroy: bool = True,
+) -> ForkSandboxOperation:
+    return ForkSandboxOperation(
+        service=service,
+        params=_ForkSandboxParams(
+            source_sandbox=source_sandbox,
+            project_id=project_id,
+            name=name,
+            ports=ports,
+            execution_time_limit=parse_duration_seconds(execution_time_limit),
+            resources=resources,
+            image=image,
             persistent=persistent,
             network_policy=network_policy,
             env=env,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -283,6 +283,41 @@ class SandboxService:
         )
         return await self._wait_for_ready_sandbox(sandbox, project_id=project_id)
 
+    async def fork_sandbox(
+        self,
+        *,
+        source_sandbox: str,
+        project_id: str | None = None,
+        name: str | None = None,
+        ports: list[int] | None = None,
+        execution_time_limit: timedelta | None = None,
+        resources: SandboxResources | None = None,
+        image: str | None = None,
+        persistent: bool | None = None,
+        network_policy: NetworkPolicy | None = None,
+        env: Mapping[str, str] | None = None,
+        tags: Mapping[str, str] | None = None,
+        snapshot_expiration: SnapshotExpiration | None = None,
+        snapshot_retention: SnapshotRetention | None = None,
+    ) -> SandboxState:
+        self._ensure_open()
+        sandbox = await self._api_client.fork_sandbox(
+            source_sandbox=source_sandbox,
+            project_id=project_id,
+            name=name,
+            ports=ports,
+            execution_time_limit=execution_time_limit,
+            resources=resources,
+            image=image,
+            persistent=persistent,
+            network_policy=network_policy,
+            env=env,
+            tags=tags,
+            snapshot_expiration=snapshot_expiration,
+            snapshot_retention=snapshot_retention,
+        )
+        return await self._wait_for_ready_sandbox(sandbox, project_id=project_id)
+
     async def get_sandbox(
         self,
         *,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -1536,6 +1536,51 @@ def create_sandbox(
         raise _terminal_error(error, SyncSandbox(payload=error.sandbox, service=service)) from error
 
 
+def fork_sandbox(
+    service: SandboxService,
+    *,
+    source_sandbox: str,
+    project_id: str | None = None,
+    name: str | None = None,
+    ports: list[int] | None = None,
+    execution_time_limit: DurationInput = None,
+    resources: SandboxResources | None = None,
+    image: str | None = None,
+    persistent: bool | None = None,
+    network_policy: NetworkPolicy | None = None,
+    env: Mapping[str, str] | None = None,
+    tags: Mapping[str, str] | None = None,
+    snapshot_expiration: SnapshotExpirationInput = None,
+    snapshot_retention: SnapshotRetention | None = None,
+    destroy: bool = True,
+) -> _ManagedSyncSandbox:
+    try:
+        state = iter_coroutine(
+            service.fork_sandbox(
+                source_sandbox=source_sandbox,
+                project_id=project_id,
+                name=name,
+                ports=ports,
+                execution_time_limit=parse_duration_seconds(execution_time_limit),
+                resources=resources,
+                image=image,
+                persistent=persistent,
+                network_policy=network_policy,
+                env=env,
+                tags=tags,
+                snapshot_expiration=_parse_snapshot_expiration(snapshot_expiration),
+                snapshot_retention=snapshot_retention,
+            )
+        )
+        return _ManagedSyncSandbox(
+            payload=state,
+            service=service,
+            destroy_on_exit=destroy,
+        )
+    except _SandboxTerminalState as error:
+        raise _terminal_error(error, SyncSandbox(payload=error.sandbox, service=service)) from error
+
+
 def get_sandbox(
     service: SandboxService,
     *,

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -70,6 +70,7 @@ from vercel.sandbox._internal.sync_runtime import (
     SyncSnapshot,
     _ManagedSyncSandbox,
     create_sandbox as _create_sandbox,
+    fork_sandbox as _fork_sandbox,
     get_or_create_sandbox as _get_or_create_sandbox,
     get_sandbox as _get_sandbox,
     get_snapshot as _get_snapshot,
@@ -144,6 +145,78 @@ def create_sandbox(
         ports=ports,
         execution_time_limit=execution_time_limit,
         resources=resources,
+        persistent=persistent,
+        network_policy=network_policy,
+        env=env,
+        tags=tags,
+        snapshot_expiration=snapshot_expiration,
+        snapshot_retention=snapshot_retention,
+        destroy=destroy,
+    )
+
+
+def fork_sandbox(
+    *,
+    source_sandbox: str,
+    project_id: str | None = None,
+    name: str | None = None,
+    ports: list[int] | None = None,
+    execution_time_limit: DurationInput = None,
+    resources: SandboxResources | None = None,
+    image: str | None = None,
+    persistent: bool | None = None,
+    network_policy: NetworkPolicy | None = None,
+    env: Mapping[str, str] | None = None,
+    tags: Mapping[str, str] | None = None,
+    snapshot_expiration: SnapshotExpirationInput = None,
+    snapshot_retention: SnapshotRetention | None = None,
+    destroy: bool = True,
+) -> _ManagedSyncSandbox:
+    """Fork a sandbox and wait until the fork is ready.
+
+    The server initializes the fork from the source sandbox's current snapshot,
+    or from its runtime or image when it has no snapshot. Configuration is
+    inherited from the source; values supplied here replace the corresponding
+    inherited values.
+
+    The returned handle is also a context manager that stops the fork on exit
+    and destroys it by default. Calling this function without entering the
+    handle performs no automatic cleanup.
+
+    Args:
+        source_sandbox: Name of the sandbox to fork.
+        project_id: Project that owns both the source and fork. Uses the active
+            credentials when omitted.
+        name: Requested name for the fork. The service generates one when
+            omitted.
+        ports: Ports to expose instead of the source sandbox's ports.
+        execution_time_limit: Maximum session runtime override.
+        resources: CPU and memory resource override.
+        image: Vercel Container Registry image override.
+        persistent: Persistence override.
+        network_policy: Network access policy override.
+        env: Environment variable override.
+        tags: Metadata tag override.
+        snapshot_expiration: Default snapshot lifetime override.
+        snapshot_retention: Automatic snapshot retention override.
+        destroy: Whether context-manager exit destroys the fork after stopping
+            it.
+
+    Returns:
+        A managed handle for the fork.
+
+    Raises:
+        SandboxTerminalStateError: If the fork reaches a terminal failure state.
+    """
+    return _fork_sandbox(
+        _service(),
+        source_sandbox=source_sandbox,
+        project_id=project_id,
+        name=name,
+        ports=ports,
+        execution_time_limit=execution_time_limit,
+        resources=resources,
+        image=image,
         persistent=persistent,
         network_policy=network_policy,
         env=env,
@@ -446,6 +519,7 @@ __all__ = [
     "TarballSource",
     "SyncTextReader",
     "create_sandbox",
+    "fork_sandbox",
     "get_or_create_sandbox",
     "get_sandbox",
     "get_snapshot",


### PR DESCRIPTION
Adds `fork_sandbox` method for creating a new sandbox from another named sandbox.

`fork_sandbox` acts like `create_sandbox` such that it can be used as a context-manager, which will delete the sandbox after exit, or you can await `fork_sandbox` to keep the new sandbox around.

Closes #202