### PR TITLE
workflow: streaming (2/2)

### DIFF
--- a/changes/vercel/20260803160000.feature.md
+++ b/changes/vercel/20260803160000.feature.md
@@ -1,2 +1,3 @@
-A step can now stream output while it runs with `get_writable()`, readable
-from the TypeScript SDK, the dashboard and `workflow inspect stream`.
+A step can now stream output while it runs with `get_writable()`, and
+`run.readable()` reads it back. The same stream is readable from the
+TypeScript SDK, the dashboard and `workflow inspect stream`.

--- a/changes/vercel/20260803160000.feature.md
+++ b/changes/vercel/20260803160000.feature.md
@@ -1,3 +1,4 @@
 A step can now stream output while it runs with `get_writable()`, and
-`run.readable()` reads it back. The same stream is readable from the
-TypeScript SDK, the dashboard and `workflow inspect stream`.
+`run.readable()` reads it back. A workflow body can take the stream and pass it
+to its steps. The same stream is readable from the TypeScript SDK, the
+dashboard and `workflow inspect stream`.

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -151,7 +151,9 @@ class _StepStreams:
     """
 
     run_id: str
-    writers: dict[str, streams.WorkflowStreamWriter] = dataclasses.field(default_factory=dict)
+    writers: dict[tuple[str, str], streams.WorkflowStreamWriter] = dataclasses.field(
+        default_factory=dict
+    )
     _task_group: anyio.abc.TaskGroup | None = None
 
     @contextlib.asynccontextmanager
@@ -162,6 +164,10 @@ class _StepStreams:
         need a group whose lifetime covers every write *and* the flush that
         follows. Leaving the block waits for them, so nothing is still in
         flight once it returns.
+
+        It has to open before the step's input is hydrated, not just around the
+        body: a stream the workflow passed in becomes a writer while the input
+        is being read, and a writer with no group behind it cannot send.
 
         If the block raises, the chunks the step did manage to stream are
         flushed first: those are as real as any other, and a reader tailing the
@@ -195,28 +201,40 @@ class _StepStreams:
     def writer(
         self, namespace: str | None, *, reentrant_ctx_on_err: bool = True
     ) -> streams.WorkflowStreamWriter:
-        """The writer for this run's *namespace* stream, created on first use.
+        """The writer for this run's *namespace* stream."""
+        return self.writer_for(
+            self.run_id,
+            streams.workflow_run_stream_id(self.run_id, namespace),
+            reentrant_ctx_on_err=reentrant_ctx_on_err,
+        )
+
+    def writer_for(
+        self, run_id: str, name: str, *, reentrant_ctx_on_err: bool = True
+    ) -> streams.WorkflowStreamWriter:
+        """The writer for one stream, created on first use.
 
         One writer per stream per step, deliberately. Handing out a fresh writer
         each call would give each its own buffer over the same stream, and two
         buffers flushing independently interleave their chunks by whichever
         request happens to win -- so `get_writable()` twice in a loop would
         scramble the order the caller wrote in. Sharing one serial sink makes
-        that pattern correct instead of subtly wrong.
+        that pattern correct instead of subtly wrong, and it is why a handle the
+        workflow passed in resolves to the same writer the step would have got
+        by asking for the stream itself.
         """
         if self._task_group is None:
             raise RuntimeError("stream writers are only available while a step is running")
-        name = streams.workflow_run_stream_id(self.run_id, namespace)
-        writer = self.writers.get(name)
+        key = (run_id, name)
+        writer = self.writers.get(key)
         if writer is None:
             writer = streams.WorkflowStreamWriter(
                 world=w.get_world(),
-                run_id=self.run_id,
+                run_id=run_id,
                 name=name,
                 task_group=self._task_group,
                 reentrant_ctx_on_err=reentrant_ctx_on_err,
             )
-            self.writers[name] = writer
+            self.writers[key] = writer
         return writer
 
     async def drain(self) -> None:
@@ -256,23 +274,23 @@ def get_writable(
     *,
     namespace: str | None = None,
     reentrant_ctx_on_err: bool = True,
-) -> streams.WorkflowStreamWriter:
-    """The run's writable stream, for streaming output as the step runs.
+) -> streams.WorkflowWritable:
+    """The run's writable stream, for streaming output while the run works.
 
-    Chunks become readable immediately -- through ``run.readable`` on the
-    TypeScript side, the dashboard, or ``workflow inspect stream`` -- without
-    waiting for the step or the run to finish. This SDK has no reader of its own
-    yet; :meth:`vercel._internal.workflow.world.World.streams_get` is the
-    unstable way in.
+    Chunks are readable straight away, through :meth:`Run.readable`, the
+    TypeScript SDK, the dashboard or ``workflow inspect stream`` -- no waiting
+    for the step or the run to finish.
+
+    In a step this is a :class:`~.streams.WorkflowStreamWriter`, ready to write.
+    In a workflow body it is a :class:`~.streams.WorkflowStreamHandle`, which
+    names the stream but cannot write to it: that body re-executes on every
+    replay and its sandbox has no network. Pass the handle to a step and it
+    arrives as the writer -- the same one the step would get by asking for the
+    stream itself, so ordering holds however the step obtained it.
 
     Pass *namespace* to write to a second, independent stream on the same run.
 
-    Must be called from within a step body; raises ``RuntimeError`` otherwise.
-    A workflow body cannot stream: unlike the TypeScript SDK it cannot even take
-    a handle to pass into a step, which is why a streaming step calls this
-    itself.
-
-    Nothing closes the stream implicitly. Call :meth:`close` on the writer when
+    Nothing closes the stream implicitly. Call ``close()`` on the writer when
     the run has nothing more to say, or readers will wait until the run expires.
 
     When used as an asynchronous context in ``async with`` statements, the stream
@@ -282,11 +300,41 @@ def get_writable(
     try:
         state = _step_streams_ctx.get()
     except LookupError:
+        pass
+    else:
+        return state.writer(namespace, reentrant_ctx_on_err=reentrant_ctx_on_err)
+
+    try:
+        ctx = WorkflowOrchestratorContext.current()
+    except LookupError:
         raise RuntimeError(
-            "get_writable() can only be called inside a step; a workflow body "
-            "cannot write to a stream directly"
+            "get_writable() can only be called inside a workflow or a step"
         ) from None
-    return state.writer(namespace, reentrant_ctx_on_err=reentrant_ctx_on_err)
+    return ctx.stream_handle(namespace)
+
+
+def open_writable(run_id: str | None, name: str) -> streams.WorkflowWritable:
+    """Turn a serialized stream reference back into something writable.
+
+    The reviving half of the ``WritableStream`` tag, so a handle a workflow put
+    in a step's arguments arrives as something the step can write to. Inside a
+    step it is a writer registered with that step, which is what gets it
+    drained before the step is recorded complete.
+
+    Outside one -- a client hydrating a payload that happens to carry a stream
+    -- it stays a handle. A writer sends from a task in the step handler's
+    group, and there is no such group here, so there would be nothing to own
+    the sends or to guarantee they finished.
+    """
+    try:
+        state = _step_streams_ctx.get()
+    except LookupError:
+        if run_id is None:
+            raise ser.SerializationError(
+                f"stream {name!r} arrived without a run id and there is no step to take it from"
+            ) from None
+        return streams.WorkflowStreamHandle(run_id, name)
+    return state.writer_for(run_id or state.run_id, name)
 
 
 if sys.version_info >= (3, 11):
@@ -372,11 +420,13 @@ class WorkflowOrchestratorContext:
         self,
         events: list[w.Event],
         *,
+        run_id: str,
         seed: str,
         started_at: int,
         registry: core.Workflows,
         run_key: bytes | None = None,
     ):
+        self.run_id = run_id
         self.events = events
         # The key is per-run, so it is resolved once and reused for every
         # payload in the replay.
@@ -459,6 +509,16 @@ class WorkflowOrchestratorContext:
 
     def random(self) -> random.Random:
         return self._user_random
+
+    def stream_handle(self, namespace: str | None) -> streams.WorkflowStreamHandle:
+        """A reference to one of this run's streams, for a step to write to.
+
+        Deterministic, so a replay of the body produces the same handle rather
+        than pointing a later attempt at a different stream.
+        """
+        return streams.WorkflowStreamHandle(
+            self.run_id, streams.workflow_run_stream_id(self.run_id, namespace)
+        )
 
     def create_hook(self, token: str | None, hook_cls: type[T]) -> core.HookEvent[T]:
         hook = Hook(
@@ -793,6 +853,7 @@ async def workflow_handler(
 
     context = WorkflowOrchestratorContext(
         events,
+        run_id=run_id,
         seed=run_id,
         started_at=workflow_started_at,
         registry=registry,
@@ -1019,44 +1080,47 @@ async def _execute_step(
     # managed to write before it raised.
     step_streams = _StepStreams(run_id=req.run_id)
 
+    # Installed around the whole invocation, not just the body: a stream the
+    # workflow passed in is revived while the input is hydrated, and it has to
+    # register with this step or nothing would ever drain it.
+    streams_token = _step_streams_ctx.set(step_streams)
+
     try:
-        if not step_run.started_at:
-            raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
-
-        # Deserialize step input
-        if not step_run.input:
-            raise RuntimeError(f"Step '{req.step_id}' has no input")
-        what = f"the input of step {req.step_id}"
-        # No deployment id: the queue message routed this step to the deployment
-        # that owns the run, so the key resolves against the current one.
-        run_key = await world.run_key(req.run_id) if ser.is_encrypted(step_run.input) else None
-        args, kwargs = ser.step_call_arguments(
-            ser.hydrate(step_run.input, what=what, key=run_key), what=what
-        )
-
-        logger.debug(
-            "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
-            req.run_id,
-            step.name,
-            req.step_id,
-            current_attempt,
-        )
-        token = _step_ctx.set(
-            StepInfo(
-                run_id=req.run_id,
-                step_id=req.step_id,
-                step_name=step.name,
-                attempt=current_attempt,
-            )
-        )
-        streams_token = _step_streams_ctx.set(step_streams)
         async with step_streams.dispatching():
+            if not step_run.started_at:
+                raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
+
+            # Deserialize step input
+            if not step_run.input:
+                raise RuntimeError(f"Step '{req.step_id}' has no input")
+            what = f"the input of step {req.step_id}"
+            # No deployment id: the queue message routed this step to the deployment
+            # that owns the run, so the key resolves against the current one.
+            run_key = await world.run_key(req.run_id) if ser.is_encrypted(step_run.input) else None
+            args, kwargs = ser.step_call_arguments(
+                ser.hydrate(step_run.input, what=what, key=run_key), what=what
+            )
+
+            logger.debug(
+                "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
+                req.run_id,
+                step.name,
+                req.step_id,
+                current_attempt,
+            )
+            token = _step_ctx.set(
+                StepInfo(
+                    run_id=req.run_id,
+                    step_id=req.step_id,
+                    step_name=step.name,
+                    attempt=current_attempt,
+                )
+            )
             # Execute the step function
             try:
                 result = await step.func(*args, **kwargs)
             finally:
                 _step_ctx.reset(token)
-                _step_streams_ctx.reset(streams_token)
 
             # A stream write returns as soon as it is buffered, so the chunks
             # this step wrote are not durable yet. Force them out before
@@ -1151,6 +1215,9 @@ async def _execute_step(
 
             # Return timeout to keep message visible for retry
             return w.QueueContinuation(delay_seconds=1.0)
+
+    finally:
+        _step_streams_ctx.reset(streams_token)
 
     # Re-invoke the workflow to continue execution
     await world.queue(

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -11,7 +11,7 @@ import re
 import sys
 import traceback
 from collections import deque
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
 from datetime import datetime, timedelta
 from typing import Any, Generic, Literal, ParamSpec, TypeVar
 
@@ -1291,6 +1291,95 @@ class Run:
 
             else:
                 await asyncio.sleep(1)
+
+    def readable(
+        self, *, namespace: str | None = None, start_index: int | None = None
+    ) -> AsyncGenerator[Any, None]:
+        """Read what the run's steps stream, as they stream it.
+
+        Yields one value per :meth:`~vercel.workflow.WorkflowStreamWriter.write`,
+        in write order, and ends when a step closes the stream. A run that never
+        closes its stream leaves this waiting until the run expires.
+
+        *start_index* skips that many chunks; a negative value reads that many
+        back from the end. Positive values resume exactly, which is what makes
+        this usable behind a reconnecting client -- hand back the index you last
+        saw and pass it in next time. A negative one cannot: it resolves against
+        wherever the tail was at connect time, so the read is single-shot and
+        will not survive a dropped connection.
+
+        A method rather than a property, because each call opens its own read:
+        iterating a property twice would quietly start a second one.
+        """
+
+        async def values() -> AsyncGenerator[Any, None]:
+            name = streams.workflow_run_stream_id(self._run_id, namespace)
+            frames = streams.reconnecting_frames(self._world, self._run_id, name, start_index)
+            async with contextlib.aclosing(frames):
+                index = start_index or 0
+                async for payload in frames:
+                    yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
+                    index += 1
+
+        return values()
+
+    def readable_bytes(
+        self, *, namespace: str | None = None, start_index: int | None = None
+    ) -> AsyncGenerator[bytes, None]:
+        """:meth:`readable`, for a stream of nothing but ``bytes``.
+
+        The shape an HTTP body wants, so a route can hand this straight to a
+        streaming response. A chunk that is not ``bytes`` is an error here
+        rather than something for the response layer to trip over.
+        """
+
+        async def data() -> AsyncGenerator[bytes, None]:
+            source = self.readable(namespace=namespace, start_index=start_index)
+            async with contextlib.aclosing(source):
+                async for value in source:
+                    if not isinstance(value, bytes | bytearray):
+                        raise ser.SerializationError(
+                            f"Stream chunk is {type(value).__name__}, not bytes; use "
+                            f"readable() for a stream of values"
+                        )
+                    yield bytes(value)
+
+        return data()
+
+    async def stream_info(self, *, namespace: str | None = None) -> w.StreamInfo:
+        """The stream's last chunk index and whether it has been closed.
+
+        ``tail_index`` is ``-1`` when nothing has been written yet, so a caller
+        deriving a start index from it has to handle that rather than treat it
+        as a position.
+        """
+        name = streams.workflow_run_stream_id(self._run_id, namespace)
+        return await self._world.streams_get_info(self._run_id, name)
+
+    async def list_streams(self) -> list[str]:
+        """Every stream this run has written to, namespaced ones included."""
+        return await self._world.streams_list(self._run_id)
+
+
+def read_stream(
+    run_id: str, name: str, *, start_index: int | None = None
+) -> AsyncGenerator[Any, None]:
+    """Read any stream of a run by name, for a stream :class:`Run` cannot name.
+
+    :meth:`Run.readable` covers the run's own streams; this is the way in when
+    the name came from :meth:`Run.list_streams` or from another SDK.
+    """
+
+    async def values() -> AsyncGenerator[Any, None]:
+        world = w.get_world()
+        frames = streams.reconnecting_frames(world, run_id, name, start_index)
+        async with contextlib.aclosing(frames):
+            index = start_index or 0
+            async for payload in frames:
+                yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
+                index += 1
+
+    return values()
 
 
 async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> Run:

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -283,7 +283,7 @@ def get_writable(
 
     In a step this is a :class:`~.streams.WorkflowStreamWriter`, ready to write.
     In a workflow body it is a :class:`~.streams.WorkflowStreamHandle`, which
-    names the stream but cannot write to it: that body re-executes on every
+    refers to the stream but cannot write to it: that body re-executes on every
     replay and its sandbox has no network. Pass the handle to a step and it
     arrives as the writer -- the same one the step would get by asking for the
     stream itself, so ordering holds however the step obtained it.
@@ -1431,10 +1431,12 @@ class Run:
 def read_stream(
     run_id: str, name: str, *, start_index: int | None = None
 ) -> AsyncGenerator[Any, None]:
-    """Read any stream of a run by name, for a stream :class:`Run` cannot name.
+    """Read one of a run's streams by its full name.
 
-    :meth:`Run.readable` covers the run's own streams; this is the way in when
-    the name came from :meth:`Run.list_streams` or from another SDK.
+    :meth:`Run.readable` derives the name from the run id and a namespace, so
+    it only reaches streams that follow that scheme. This takes the name
+    verbatim, which is what :meth:`Run.list_streams` returns and what another
+    SDK may have used.
     """
 
     async def values() -> AsyncGenerator[Any, None]:

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -44,10 +44,42 @@ class SerializationError(RuntimeError):
     """A payload could not be encoded, or arrived in a format we cannot read."""
 
 
+def _reduce_writable_stream(value: Any) -> Any:
+    """devalue reducer for a run's stream. Falsy declines the value.
+
+    Rides `@workflow/core`'s own ``WritableStream`` tag rather than the
+    ``Instance`` rail :mod:`.serde` uses for new types, because a stream is not
+    a new type: the TypeScript SDK already defines this tag and revives it into
+    a real `WritableStream` against the same ``(runId, name)``. A Python
+    workflow can therefore hand one of its streams to a JavaScript peer.
+    """
+    from . import streams
+
+    if isinstance(value, streams.WorkflowStreamHandle | streams.WorkflowStreamWriter):
+        return {"name": value.name, "runId": value.run_id}
+    return False
+
+
+def _revive_writable_stream(value: Any) -> Any:
+    """devalue reviver for the ``WritableStream`` tag."""
+    from . import runtime
+
+    if not isinstance(value, dict) or not isinstance(value.get("name"), str):
+        raise ValueError(f"malformed WritableStream payload: {value!r}")
+    run_id = value.get("runId")
+    return runtime.open_writable(run_id if isinstance(run_id, str) else None, value["name"])
+
+
+# `serde` owns the custom-type rail; streams sit alongside it on a tag
+# `@workflow/core` composes itself.
+REDUCERS: dict[str, Any] = {**serde.REDUCERS, "WritableStream": _reduce_writable_stream}
+REVIVERS: dict[str, Any] = {**serde.REVIVERS, "WritableStream": _revive_writable_stream}
+
+
 def dehydrate(value: Any) -> bytes:
     """Encode *value* as a ``devl``-prefixed devalue payload."""
     try:
-        return DEVALUE_V1 + devalue.stringify(value, serde.REDUCERS).encode()
+        return DEVALUE_V1 + devalue.stringify(value, REDUCERS).encode()
     except devalue.DevalueError as error:
         at = f" at {error.path}" if error.path else ""
         raise SerializationError(
@@ -94,7 +126,7 @@ def hydrate(data: Any, *, what: str, key: bytes | None = None) -> Any:
     prefix, payload = data[:FORMAT_PREFIX_LENGTH], data[FORMAT_PREFIX_LENGTH:]
     if prefix == DEVALUE_V1:
         try:
-            return devalue.parse(payload.decode(), serde.REVIVERS)
+            return devalue.parse(payload.decode(), REVIVERS)
         except (devalue.DevalueError, ValueError, TypeError) as error:
             raise SerializationError(f"Cannot deserialize {what}: {error}") from error
     if prefix == ENCRYPTED:

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -57,6 +57,12 @@ def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
     Mirrors `@workflow/world`'s ``envNumber``: an unset, non-numeric or
     out-of-range value is ignored rather than fatal, since these are
     operational overrides and a typo should not take a deployment down.
+
+    Every caller reads the knob where it uses it, rather than into a module
+    global once at import, so an override still applies when the environment
+    is populated after this module loads -- which is how the tests set these,
+    and how the JS side reads its own (``envNumber`` behind a getter, called
+    per use).
     """
     raw = os.getenv(name)
     if raw is None:
@@ -150,20 +156,21 @@ class FrameDecoder:
 # ═══════════════════════════════════════════════════════════════════════════
 
 MAX_RECONNECTS = 50
-"""Consecutive reconnects allowed before a read gives up.
+"""How many reconnects in a row may deliver nothing before the read gives up.
 
-Reset by any reconnect that delivers a frame, so this bounds *consecutive*
-failures rather than the lifetime total: a long-lived stream may reconnect far
-more than this and stay healthy, as long as it keeps making progress.
+Any reconnect that delivers a frame resets this to zero, so it measures being
+stuck, not how often the connection dropped -- a read that runs for hours may
+reconnect far more than 50 times and never come close. Same value as
+`@workflow/core`'s ``FRAMED_STREAM_MAX_RECONNECTS``.
 """
 
 MAX_TOTAL_RECONNECTS = 1000
-"""Absolute backstop, independent of progress.
+"""How many reconnects in total. Never resets.
 
-The consecutive cap resets on forward progress, which is correct against a
-backend that honours ``start_index``. One that ignored it would re-deliver
-earlier frames, look like progress every time, and never trip that cap -- so
-this guarantees the loop terminates regardless.
+The cap above resets whenever a frame arrives, which works as long as a new
+frame really means the read moved forward. A backend that ignored
+``start_index`` would re-send the same old frames after every break, so it
+would reset forever and the read would never end. This one cannot reset.
 """
 
 
@@ -267,10 +274,10 @@ MAX_BYTES_PER_BATCH = 1024 * 1024
 class WorkflowWritable(abc.ABC):
     """One of a run's streams, as :func:`vercel.workflow.get_writable` hands it out.
 
-    Two things wear this interface. In a step it is a
-    :class:`WorkflowStreamWriter` and every method works. In a workflow body it
-    is a :class:`WorkflowStreamHandle`, which knows which stream it is but
-    refuses to write to it.
+    Two classes implement it. In a step it is a :class:`WorkflowStreamWriter`
+    and every method works. In a workflow body it is a
+    :class:`WorkflowStreamHandle`, which refers to the stream but refuses to
+    write to it.
 
     One interface rather than two so that a workflow can take a writable and
     pass it to a step without the type changing on the way, which is also how
@@ -307,18 +314,18 @@ class WorkflowWritable(abc.ABC):
 
 @dataclasses.dataclass(frozen=True)
 class WorkflowStreamHandle(WorkflowWritable):
-    """A stream that can be named here but only written to from a step.
+    """A reference to a stream, writable only once it reaches a step.
 
     A workflow body re-executes on every replay and its sandbox has no network,
-    so writing from there is not on offer -- but naming the stream is, and that
-    is what a step needs. Pass the handle into a step and it arrives as a
-    :class:`WorkflowStreamWriter`. Hydrating a payload outside a step yields a
-    handle for the same reason: a writer sends from a task the step handler
-    owns, and there is no such owner out there.
+    so writing from there is not on offer -- but referring to the stream is,
+    and that is what a step needs. Pass the handle into a step and it arrives
+    as a :class:`WorkflowStreamWriter`. Hydrating a payload outside a step
+    yields a handle for the same reason: a writer sends from a task the step
+    handler owns, and there is no such owner out there.
 
-    Deterministic by construction: the name comes from the run id and the
-    namespace, so a replay produces the same handle rather than pointing a
-    later attempt at a different stream.
+    Deterministic by construction: the stream name is derived from the run id
+    and the namespace, so a replay produces the same handle rather than
+    pointing a later attempt at a different stream.
     """
 
     # Underscored because the interface declares `run_id` and `name` as

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -22,8 +22,10 @@ frame boundaries without understanding the payload format at all.
 
 from __future__ import annotations
 
+import abc
 import base64
 import contextlib
+import dataclasses
 import os
 from collections.abc import AsyncGenerator, AsyncIterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
@@ -262,7 +264,99 @@ MAX_BYTES_PER_BATCH = 1024 * 1024
 """Cumulative bytes in one write request, under platform body limits."""
 
 
-class WorkflowStreamWriter:
+class WorkflowWritable(abc.ABC):
+    """One of a run's streams, as :func:`vercel.workflow.get_writable` hands it out.
+
+    Two things wear this interface. In a step it is a
+    :class:`WorkflowStreamWriter` and every method works. In a workflow body it
+    is a :class:`WorkflowStreamHandle`, which knows which stream it is but
+    refuses to write to it.
+
+    One interface rather than two so that a workflow can take a writable and
+    pass it to a step without the type changing on the way, which is also how
+    `@workflow/core` does it -- its workflow-side `getWritable()` returns
+    something with `WritableStream`'s prototype whose methods throw.
+    """
+
+    @property
+    @abc.abstractmethod
+    def run_id(self) -> str:
+        """The run that owns the stream."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """The stream this writes to."""
+
+    @abc.abstractmethod
+    async def write(self, value: Any) -> None:
+        """Append *value* as one chunk."""
+
+    @abc.abstractmethod
+    async def write_from(self, source: AsyncIterable[Any]) -> None:
+        """Append every item *source* yields, in order."""
+
+    @abc.abstractmethod
+    async def drain(self) -> None:
+        """Wait until every accepted chunk is durably written."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Mark the stream complete, ending its readers."""
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkflowStreamHandle(WorkflowWritable):
+    """A stream that can be named here but only written to from a step.
+
+    A workflow body re-executes on every replay and its sandbox has no network,
+    so writing from there is not on offer -- but naming the stream is, and that
+    is what a step needs. Pass the handle into a step and it arrives as a
+    :class:`WorkflowStreamWriter`. Hydrating a payload outside a step yields a
+    handle for the same reason: a writer sends from a task the step handler
+    owns, and there is no such owner out there.
+
+    Deterministic by construction: the name comes from the run id and the
+    namespace, so a replay produces the same handle rather than pointing a
+    later attempt at a different stream.
+    """
+
+    # Underscored because the interface declares `run_id` and `name` as
+    # properties, and a dataclass field only annotates -- it puts nothing in the
+    # class body for `abc` to see as the implementation. Constructed
+    # positionally, so the names stay out of the way.
+    _run_id: str
+    _name: str
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def _refuse(self) -> RuntimeError:
+        return RuntimeError(
+            f"cannot write to stream {self._name!r} from here: a workflow body re-runs "
+            f"on every replay and cannot reach the network, and outside a run there is "
+            f"nothing to carry the sends. Pass this to a step and write to it there."
+        )
+
+    async def write(self, value: Any) -> None:
+        raise self._refuse()
+
+    async def write_from(self, source: AsyncIterable[Any]) -> None:
+        raise self._refuse()
+
+    async def drain(self) -> None:
+        raise self._refuse()
+
+    async def close(self) -> None:
+        raise self._refuse()
+
+
+class WorkflowStreamWriter(WorkflowWritable):
     """A stream that workflow steps can write to.
 
     Sending happens in a task of *task_group*, not in ``write()``, which is

--- a/src/vercel/_internal/workflow/streams.py
+++ b/src/vercel/_internal/workflow/streams.py
@@ -23,8 +23,9 @@ frame boundaries without understanding the payload format at all.
 from __future__ import annotations
 
 import base64
+import contextlib
 import os
-from collections.abc import AsyncIterable, Iterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -140,6 +141,91 @@ class FrameDecoder:
                 f"Stream ended with {len(self._buffer)} bytes of incomplete frame data; "
                 f"it was truncated mid-frame"
             )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# reader
+# ═══════════════════════════════════════════════════════════════════════════
+
+MAX_RECONNECTS = 50
+"""Consecutive reconnects allowed before a read gives up.
+
+Reset by any reconnect that delivers a frame, so this bounds *consecutive*
+failures rather than the lifetime total: a long-lived stream may reconnect far
+more than this and stay healthy, as long as it keeps making progress.
+"""
+
+MAX_TOTAL_RECONNECTS = 1000
+"""Absolute backstop, independent of progress.
+
+The consecutive cap resets on forward progress, which is correct against a
+backend that honours ``start_index``. One that ignored it would re-deliver
+earlier frames, look like progress every time, and never trip that cap -- so
+this guarantees the loop terminates regardless.
+"""
+
+
+async def reconnecting_frames(
+    world: w.World, run_id: str, name: str, start_index: int | None = None
+) -> AsyncGenerator[bytes, None]:
+    """Read a stream's frames, reopening the connection when it breaks.
+
+    A live read is long-lived and the transport under it is not: the Vercel
+    world's read endpoint errors the response body when the server's max
+    duration expires, which is what tells this loop apart from the end of the
+    stream. A clean end of iteration means the stream is closed and the read is
+    done; an error means reopen at the next unread frame and carry on.
+
+    Resuming is exact because one frame is one stored chunk, so the position is
+    ``start_index`` plus the frames already handed to the caller. Bytes of a
+    frame that had not fully arrived are dropped -- the reopened connection
+    re-sends that chunk whole.
+
+    A negative *start_index* (last-N) cannot be resumed: its meaning depends on
+    where the tail was at connect time, and re-resolving it after a break would
+    silently move the window. Such a read is single-shot.
+    """
+    resumable = start_index is None or start_index >= 0
+    position = start_index or 0
+    consumed = 0
+    consecutive = 0
+    total = 0
+    max_reconnects = _env_int("WORKFLOW_FRAMED_STREAM_MAX_RECONNECTS", MAX_RECONNECTS)
+    max_total = _env_int("WORKFLOW_FRAMED_STREAM_MAX_TOTAL_RECONNECTS", MAX_TOTAL_RECONNECTS)
+
+    while True:
+        # A fresh decoder per connection: whatever partial frame the broken
+        # connection left behind is not continued, it is re-sent.
+        decoder = FrameDecoder()
+        effective = position + consumed if resumable else start_index
+        try:
+            source = world.streams_get(run_id, name, effective)
+            async with contextlib.aclosing(source):
+                async for data in source:
+                    for payload in decoder.feed(data):
+                        consumed += 1
+                        consecutive = 0
+                        yield payload
+        except Exception as error:
+            if not resumable:
+                raise
+            consecutive += 1
+            total += 1
+            if consecutive > max_reconnects:
+                raise ser.SerializationError(
+                    f"Stream {name!r} exceeded {max_reconnects} consecutive reconnection attempts"
+                ) from error
+            if total > max_total:
+                raise ser.SerializationError(
+                    f"Stream {name!r} exceeded {max_total} total reconnection attempts"
+                ) from error
+            position += consumed
+            consumed = 0
+            continue
+
+        # Iteration ended without error: the stream is closed and complete.
+        decoder.finish()
+        return
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import sys
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from datetime import datetime
 from typing import (
     Annotated,
@@ -1008,7 +1008,7 @@ class World(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def streams_get(
         self, run_id: str, name: str, start_index: int | None = None
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         """Read a stream live, waiting for chunks that have not arrived yet.
 
         The iterator ends when the stream is closed, not when it runs out of

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -9,7 +9,7 @@ import pathlib
 import tempfile
 import threading
 import traceback
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from typing import Any, TypeVar, cast
@@ -1065,10 +1065,10 @@ class LocalWorld(w.World):
 
     def streams_get(
         self, run_id: str, name: str, start_index: int | None = None
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         return self._iter_stream(name, start_index)
 
-    async def _iter_stream(self, name: str, start_index: int | None) -> AsyncIterator[bytes]:
+    async def _iter_stream(self, name: str, start_index: int | None) -> AsyncGenerator[bytes, None]:
         files = self._chunk_files(name)
         start = self._resolve_start_index(files, start_index)
         found, _, done = _scan_chunks(files, start)

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -6,7 +6,7 @@ import os
 import platform
 import traceback
 import urllib.parse
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from typing import Any, TypeVar, overload
 
 import cbor2
@@ -793,12 +793,12 @@ class VercelWorld(w.World):
 
     def streams_get(
         self, run_id: str, name: str, start_index: int | None = None
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         return self._iter_stream(run_id, name, start_index)
 
     async def _iter_stream(
         self, run_id: str, name: str, start_index: int | None
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         # The live read is v3, not v2, and that is load-bearing: on its
         # max-duration timeout (or a mid-stream drop) v3 *errors* the response
         # body where v2 closes it cleanly. Only the error tells a resuming

--- a/src/vercel/tests/unit/test_workflow_determinism.py
+++ b/src/vercel/tests/unit/test_workflow_determinism.py
@@ -29,6 +29,7 @@ def _context(
 ) -> runtime.WorkflowOrchestratorContext:
     ctx = runtime.WorkflowOrchestratorContext(
         events,
+        run_id=seed,
         seed=seed,
         started_at=0,
         registry=core.Workflows(as_vercel_job=False),

--- a/src/vercel/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel/tests/unit/test_workflow_get_writable.py
@@ -280,13 +280,13 @@ async def test_a_failing_step_still_flushes_what_it_wrote(registry) -> None:
 
 
 async def test_get_writable_outside_a_run_is_refused() -> None:
-    # There is no stream to name without a run, so this cannot answer.
+    # Without a run there is no stream to refer to, so this cannot answer.
     with pytest.raises(RuntimeError, match="inside a workflow or a step"):
         runtime.get_writable()
 
 
 class TestHandOff:
-    """A workflow body naming a stream and a step writing to it.
+    """A workflow body picking out a stream and a step writing to it.
 
     The workflow cannot write -- it replays, and its sandbox has no network --
     but it can say *which* stream, which is what lets one workflow fan the same
@@ -335,7 +335,7 @@ class TestHandOff:
 
         The handle is dehydrated into the step's arguments as `@workflow/core`'s
         `WritableStream` tag and revived on the other side as a live writer, so
-        the step writes to the stream the workflow named.
+        the step writes to the stream the workflow chose.
         """
         handle = streams.WorkflowStreamHandle(RUN_ID, STREAM)
         payload = ser.dehydrate(ser.step_arguments((), {"out": handle}))

--- a/src/vercel/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel/tests/unit/test_workflow_get_writable.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
+import anyio
 import pytest
 
 from vercel._internal.core.polyfills import UTC
@@ -33,9 +34,10 @@ class FakeWorld(NoStreams, w.World):
     a chunk landing and the step being recorded complete.
     """
 
-    def __init__(self, *, fail_writes: bool = False) -> None:
+    def __init__(self, *, fail_writes: bool = False, step_input: bytes | None = None) -> None:
         self.log: list[tuple[str, Any]] = []
         self.fail_writes = fail_writes
+        self.step_input = step_input or ser.dehydrate(ser.step_arguments((), {}))
 
     async def get_deployment_id(self) -> str:
         return ""
@@ -72,7 +74,7 @@ class FakeWorld(NoStreams, w.World):
                     createdAt=NOW,
                     updatedAt=NOW,
                     startedAt=NOW,
-                    input=ser.dehydrate(ser.step_arguments((), {})),
+                    input=self.step_input,
                 )
             )
         self.log.append((data.event_type, data))
@@ -178,7 +180,7 @@ async def test_two_calls_in_one_step_share_a_writer(registry) -> None:
     stream, and two buffers flushing independently interleave by whichever
     request wins -- scrambling the order the step wrote in.
     """
-    seen: list[streams.WorkflowStreamWriter] = []
+    seen: list[streams.WorkflowWritable] = []
 
     @registry.step
     async def emit() -> None:
@@ -277,19 +279,142 @@ async def test_a_failing_step_still_flushes_what_it_wrote(registry) -> None:
     assert _chunk_values(fake) == ["got this far"]
 
 
-async def test_get_writable_outside_a_step_is_refused() -> None:
-    # Including inside a workflow body: it replays, and its sandbox has no
-    # network access.
-    with pytest.raises(RuntimeError, match="can only be called inside a step"):
+async def test_get_writable_outside_a_run_is_refused() -> None:
+    # There is no stream to name without a run, so this cannot answer.
+    with pytest.raises(RuntimeError, match="inside a workflow or a step"):
         runtime.get_writable()
 
 
-async def test_a_workflow_body_cannot_stream(registry) -> None:
-    @registry.workflow
-    async def wf() -> None:
-        runtime.get_writable()
+class TestHandOff:
+    """A workflow body naming a stream and a step writing to it.
 
-    fake = FakeWorld()
-    w.set_world(fake)
-    with pytest.raises(RuntimeError, match="a workflow body cannot write to a stream"):
-        await wf.func()
+    The workflow cannot write -- it replays, and its sandbox has no network --
+    but it can say *which* stream, which is what lets one workflow fan the same
+    stream out to several steps.
+    """
+
+    async def test_a_workflow_body_gets_a_handle_it_cannot_write_to(self, registry) -> None:
+        writable: list[Any] = []
+
+        @registry.workflow
+        async def wf() -> None:
+            writable.append(runtime.get_writable())
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        ctx = runtime.WorkflowOrchestratorContext(
+            [], run_id=RUN_ID, seed=RUN_ID, started_at=0, registry=registry
+        )
+        token = ctx._ctx.set(ctx)
+        try:
+            await wf.func()
+        finally:
+            ctx._ctx.reset(token)
+
+        (handle,) = writable
+        assert isinstance(handle, streams.WorkflowStreamHandle)
+        assert handle.name == STREAM
+        assert handle.run_id == RUN_ID
+        with pytest.raises(RuntimeError, match="Pass this to a step"):
+            await handle.write("nope")
+
+    async def test_the_handle_is_the_same_on_every_replay(self, registry) -> None:
+        # Derived from the run id, not minted, so a replay cannot point a later
+        # attempt at a different stream.
+        ctx = runtime.WorkflowOrchestratorContext(
+            [], run_id=RUN_ID, seed=RUN_ID, started_at=0, registry=registry
+        )
+        again = runtime.WorkflowOrchestratorContext(
+            [], run_id=RUN_ID, seed=RUN_ID, started_at=0, registry=registry
+        )
+        assert ctx.stream_handle(None) == again.stream_handle(None)
+        assert ctx.stream_handle("logs") != ctx.stream_handle(None)
+
+    async def test_a_handle_survives_the_trip_into_a_step(self, registry) -> None:
+        """The round trip that makes the feature work.
+
+        The handle is dehydrated into the step's arguments as `@workflow/core`'s
+        `WritableStream` tag and revived on the other side as a live writer, so
+        the step writes to the stream the workflow named.
+        """
+        handle = streams.WorkflowStreamHandle(RUN_ID, STREAM)
+        payload = ser.dehydrate(ser.step_arguments((), {"out": handle}))
+
+        # The tag is the one a TypeScript peer already understands.
+        assert b'"WritableStream"' in payload
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        state = runtime._StepStreams(run_id=RUN_ID)
+        token = runtime._step_streams_ctx.set(state)
+        try:
+            # Inside `dispatching()`, as the real step path is: reviving the tag
+            # makes a writer, and a writer needs the group its sends run in.
+            async with state.dispatching():
+                _, kwargs = ser.step_call_arguments(
+                    ser.hydrate(payload, what="input"), what="input"
+                )
+        finally:
+            runtime._step_streams_ctx.reset(token)
+
+        revived = kwargs["out"]
+        assert isinstance(revived, streams.WorkflowStreamWriter)
+        assert (revived.run_id, revived.name) == (RUN_ID, STREAM)
+
+    async def test_a_handle_hydrated_outside_a_step_stays_a_handle(self) -> None:
+        """Nothing out here can carry the sends.
+
+        A writer dispatches from a task in the group the step handler owns, so
+        a client reading a payload that happens to name a stream gets the
+        handle back rather than a writer with nowhere to send from.
+        """
+        payload = ser.dehydrate(
+            ser.step_arguments((), {"out": streams.WorkflowStreamHandle(RUN_ID, STREAM)})
+        )
+
+        _, kwargs = ser.step_call_arguments(ser.hydrate(payload, what="input"), what="input")
+
+        revived = kwargs["out"]
+        assert isinstance(revived, streams.WorkflowStreamHandle)
+        assert (revived.run_id, revived.name) == (RUN_ID, STREAM)
+        with pytest.raises(RuntimeError, match="Pass this to a step"):
+            await revived.write("nope")
+
+    async def test_a_revived_handle_is_the_step_own_writer(self, registry) -> None:
+        """Not a second writer over the same stream.
+
+        Two writers would each buffer independently and interleave by whichever
+        request wins, so a step that both received a handle and called
+        `get_writable()` would scramble its own chunk order.
+        """
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit(*, out: Any) -> None:
+            seen.append(out)
+            seen.append(runtime.get_writable())
+            await out.write("via handle")
+            await seen[1].write("via get_writable")
+
+        fake = FakeWorld(
+            step_input=ser.dehydrate(
+                ser.step_arguments((), {"out": streams.WorkflowStreamHandle(RUN_ID, STREAM)})
+            )
+        )
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        assert seen[0] is seen[1], "the revived handle has to be the step's own writer"
+        assert _chunk_values(fake) == ["via handle", "via get_writable"]
+        assert _kinds(fake)[-1] == "step_completed"
+
+    async def test_a_writer_reduces_back_to_the_same_reference(self) -> None:
+        # A step forwarding its own writable onward has to produce the same
+        # descriptor the workflow would have.
+        world = FakeWorld()
+        async with anyio.create_task_group() as task_group:
+            writer = streams.WorkflowStreamWriter(
+                world=world, run_id=RUN_ID, name=STREAM, task_group=task_group
+            )
+            handle = streams.WorkflowStreamHandle(RUN_ID, STREAM)
+            assert ser.dehydrate(writer) == ser.dehydrate(handle)

--- a/src/vercel/tests/unit/test_workflow_stream_reader.py
+++ b/src/vercel/tests/unit/test_workflow_stream_reader.py
@@ -1,0 +1,296 @@
+"""Reading a stream back, and surviving the connection breaking underneath.
+
+A live read outlives its transport: the Vercel world's read endpoint errors the
+response body when the server's max duration expires. Telling that apart from
+the end of the stream, and resuming at exactly the right chunk, is the whole
+job of the reader -- so most of this file is about the break.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator, Sequence
+from typing import Any
+
+import pytest
+
+from vercel._internal.workflow import runtime, serialization as ser, streams, world as w
+from vercel.tests.world_stubs import NoStreams
+
+RUN_ID = "wrun_test"
+NAME = "strm_test_user"
+
+
+class ReplayWorld(NoStreams, w.World):
+    """Serves a fixed list of frames, optionally breaking part-way through.
+
+    ``breaks`` is how many times a read should fail before one is allowed to
+    run to the end, and ``deliver_before_break`` how many frames each of those
+    reads hands over first. ``reads`` records the ``start_index`` of every
+    connection, which is what the resume assertions are about.
+    """
+
+    def __init__(
+        self,
+        values: Sequence[Any],
+        *,
+        breaks: int = 0,
+        deliver_before_break: int = 1,
+        split_at: int | None = None,
+    ) -> None:
+        self.frames = [streams.encode_value(value) for value in values]
+        self.breaks = breaks
+        self.deliver_before_break = deliver_before_break
+        # Byte offset to cut the transport read at, so a frame is delivered in
+        # two pieces -- and, on a breaking read, cut mid-frame.
+        self.split_at = split_at
+        self.reads: list[int | None] = []
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncGenerator[bytes, None]:
+        self.reads.append(start_index)
+        breaking = self.breaks > 0
+        if breaking:
+            self.breaks -= 1
+        return self._serve(start_index or 0, breaking)
+
+    async def _serve(self, start: int, breaking: bool) -> AsyncGenerator[bytes, None]:
+        wire = b"".join(self.frames[start:])
+        if breaking:
+            # Hand over whole frames, then a partial one, then die.
+            whole = b"".join(self.frames[start : start + self.deliver_before_break])
+            trailing = self.frames[start + self.deliver_before_break :]
+            yield whole + (trailing[0][:3] if trailing else b"")
+            raise w.WorkflowWorldError("connection reset", status=500)
+        if self.split_at is not None:
+            yield wire[: self.split_at]
+            yield wire[self.split_at :]
+        else:
+            yield wire
+
+    async def get_deployment_id(self) -> str:
+        return ""
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        raise NotImplementedError
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        raise NotImplementedError
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+
+async def _read(world: w.World, start_index: int | None = None) -> list[Any]:
+    out = []
+    frames = streams.reconnecting_frames(world, RUN_ID, NAME, start_index)
+    async with contextlib.aclosing(frames):
+        async for payload in frames:
+            out.append(ser.hydrate(payload, what="chunk"))
+    return out
+
+
+class TestReading:
+    async def test_reads_every_frame_in_order(self) -> None:
+        world = ReplayWorld(["a", {"b": 1}, 2])
+        assert await _read(world) == ["a", {"b": 1}, 2]
+        # An absent start index resolves to 0 on the way out, as it does in
+        # `createReconnectingFramedStream`, so resume arithmetic has a base.
+        assert world.reads == [0]
+
+    async def test_a_clean_end_does_not_reconnect(self) -> None:
+        # EOF is the stream being closed, not a failure -- reconnecting here
+        # would reopen a finished stream forever.
+        world = ReplayWorld(["only"])
+        await _read(world)
+        assert len(world.reads) == 1
+
+    async def test_frames_split_across_transport_reads_are_reassembled(self) -> None:
+        world = ReplayWorld(["first", "second"], split_at=7)
+        assert await _read(world) == ["first", "second"]
+
+    async def test_start_index_is_passed_through(self) -> None:
+        world = ReplayWorld(["a", "b", "c"])
+        assert await _read(world, 1) == ["b", "c"]
+        assert world.reads == [1]
+
+    async def test_an_empty_stream_yields_nothing(self) -> None:
+        assert await _read(ReplayWorld([])) == []
+
+
+class TestReconnect:
+    async def test_resumes_at_the_frame_after_the_last_one_delivered(self) -> None:
+        world = ReplayWorld(["a", "b", "c", "d"], breaks=1, deliver_before_break=2)
+
+        assert await _read(world) == ["a", "b", "c", "d"]
+        # Two frames arrived before the break, so the reopen asks for the third.
+        assert world.reads == [0, 2]
+
+    async def test_a_frame_cut_in_half_by_the_break_arrives_whole(self) -> None:
+        """The partial frame is dropped, not stitched onto the new connection.
+
+        The reopened read starts at a frame boundary and re-sends that chunk in
+        full, so keeping the fragment would corrupt it.
+        """
+        world = ReplayWorld(["a", "bbbbbbbb", "c"], breaks=1, deliver_before_break=1)
+
+        assert await _read(world) == ["a", "bbbbbbbb", "c"]
+        assert world.reads == [0, 1]
+
+    async def test_resume_is_relative_to_the_caller_start_index(self) -> None:
+        world = ReplayWorld(["a", "b", "c", "d"], breaks=1, deliver_before_break=1)
+
+        assert await _read(world, 1) == ["b", "c", "d"]
+        # Started at 1, delivered one frame, so the reopen is at 2 -- not at 1.
+        assert world.reads == [1, 2]
+
+    async def test_repeated_breaks_keep_making_progress(self) -> None:
+        world = ReplayWorld(list("abcde"), breaks=3, deliver_before_break=1)
+
+        assert await _read(world) == list("abcde")
+        assert world.reads == [0, 1, 2, 3]
+
+    async def test_a_negative_start_index_is_never_resumed(self) -> None:
+        """Last-N resolves against the tail at connect time.
+
+        Reopening would re-resolve it against a tail that has since moved, so
+        the window would shift under the reader; single-shot is the honest
+        behaviour.
+        """
+        world = ReplayWorld(["a", "b"], breaks=1)
+
+        with pytest.raises(w.WorkflowWorldError, match="connection reset"):
+            await _read(world, -2)
+        assert len(world.reads) == 1
+
+    async def test_giving_up_after_too_many_consecutive_failures(self, monkeypatch) -> None:
+        monkeypatch.setenv("WORKFLOW_FRAMED_STREAM_MAX_RECONNECTS", "3")
+        # Never delivers anything, so no reconnect ever counts as progress.
+        world = ReplayWorld(["a"], breaks=100, deliver_before_break=0)
+
+        with pytest.raises(ser.SerializationError, match="3 consecutive reconnection"):
+            await _read(world)
+        assert len(world.reads) == 4
+
+    async def test_progress_resets_the_consecutive_budget(self, monkeypatch) -> None:
+        # Two failures, each delivering a frame, under a budget of two: the
+        # budget must not accumulate across a reconnect that made progress.
+        monkeypatch.setenv("WORKFLOW_FRAMED_STREAM_MAX_RECONNECTS", "2")
+        world = ReplayWorld(list("abcd"), breaks=2, deliver_before_break=1)
+
+        assert await _read(world) == list("abcd")
+
+    async def test_the_absolute_backstop_stops_a_backend_that_ignores_resume(
+        self, monkeypatch
+    ) -> None:
+        """A world that re-sends from the start looks like progress forever.
+
+        The consecutive cap resets every time, so only the total cap can end
+        this -- without it the loop would never terminate.
+        """
+        monkeypatch.setenv("WORKFLOW_FRAMED_STREAM_MAX_TOTAL_RECONNECTS", "5")
+
+        class IgnoresStartIndex(ReplayWorld):
+            def streams_get(self, run_id, name, start_index=None):
+                self.reads.append(start_index)
+                return self._serve(0, True)  # always from 0, always breaks
+
+        world = IgnoresStartIndex(["a", "b"], deliver_before_break=1)
+
+        with pytest.raises(ser.SerializationError, match="5 total reconnection"):
+            await _read(world)
+
+
+class TestRunApi:
+    @pytest.fixture(autouse=True)
+    def _reset_world(self):
+        yield
+        w.set_world(None)
+
+    async def test_readable_hydrates_the_run_default_stream(self) -> None:
+        world = ReplayWorld(["hello", {"n": 1}])
+        w.set_world(world)
+
+        assert [chunk async for chunk in runtime.Run(RUN_ID).readable()] == ["hello", {"n": 1}]
+
+    async def test_readable_bytes_yields_only_bytes(self) -> None:
+        world = ReplayWorld([b"one", b"two"])
+        w.set_world(world)
+
+        assert [b async for b in runtime.Run(RUN_ID).readable_bytes()] == [b"one", b"two"]
+
+    async def test_readable_bytes_refuses_a_stream_of_values(self) -> None:
+        # An HTTP body cannot carry a dict, and failing here names the problem
+        # better than whatever the response layer would say.
+        world = ReplayWorld([{"not": "bytes"}])
+        w.set_world(world)
+
+        with pytest.raises(ser.SerializationError, match="not bytes"):
+            [b async for b in runtime.Run(RUN_ID).readable_bytes()]
+
+    async def test_a_namespace_reads_its_own_stream(self) -> None:
+        world = ReplayWorld(["logged"])
+        w.set_world(world)
+
+        run = runtime.Run(RUN_ID)
+        async with contextlib.aclosing(run.readable(namespace="logs")) as chunks:
+            assert [c async for c in chunks] == ["logged"]
+
+    async def test_abandoning_a_read_closes_the_underlying_one(self) -> None:
+        closed = False
+
+        class Watcher(ReplayWorld):
+            def streams_get(self, run_id, name, start_index=None):
+                self.reads.append(start_index)
+                return self._watched()
+
+            async def _watched(self):
+                nonlocal closed
+                try:
+                    for frame in self.frames:
+                        yield frame
+                finally:
+                    closed = True
+
+        w.set_world(Watcher(["a", "b", "c"]))
+
+        chunks = runtime.Run(RUN_ID).readable()
+        async with contextlib.aclosing(chunks):
+            assert await chunks.__anext__() == "a"
+
+        assert closed, "closing the reader has to release the transport read"
+
+    async def test_stream_info_and_list_reach_the_world(self) -> None:
+        class Meta(ReplayWorld):
+            async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
+                return w.StreamInfo(tailIndex=4, done=True)
+
+            async def streams_list(self, run_id: str) -> list[str]:
+                return [NAME]
+
+        w.set_world(Meta([]))
+        run = runtime.Run(RUN_ID)
+
+        assert await run.stream_info() == w.StreamInfo(tailIndex=4, done=True)
+        assert await run.list_streams() == [NAME]
+
+    async def test_read_stream_takes_a_name_run_cannot_derive(self) -> None:
+        world = ReplayWorld(["x"])
+        w.set_world(world)
+
+        assert [c async for c in runtime.read_stream(RUN_ID, "strm_someone_else")] == ["x"]

--- a/src/vercel/tests/world_stubs.py
+++ b/src/vercel/tests/world_stubs.py
@@ -9,7 +9,7 @@ declaration instead of buried thirty lines down.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 
 from vercel._internal.workflow import world as w
 
@@ -32,7 +32,7 @@ class NoStreams:
 
     def streams_get(
         self, run_id: str, name: str, start_index: int | None = None
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         raise NotImplementedError
 
     async def streams_list(self, run_id: str) -> list[str]:

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -94,9 +94,23 @@ async def analyze(*, document: str) -> str:
     return summary
 ```
 
-`get_writable()` works inside a step only. Where the TypeScript SDK lets a
-workflow body take a handle and pass it into a step, here it cannot yet, so each
-step that streams calls `get_writable()` itself.
+A workflow body can call `get_writable()` too and pass the result to its steps,
+which take it as a `WorkflowWritable` and write to it:
+
+```python
+@app.step
+async def summarize(*, document: str, out: WorkflowWritable) -> str:
+    await out.write("starting")
+    ...
+
+
+@app.workflow
+async def analyze(*, document: str) -> str:
+    out = get_writable()
+    return await summarize(document=document, out=out)
+```
+
+Only a step can write. Calling `write()` on what the workflow body holds raises.
 
 Chunks are values, not just bytes: anything the payload format carries (see
 below) can be written, and a reader gets it back. A `bytes` chunk arrives on the

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -167,7 +167,7 @@ server ends a long read at its own time limit. Resuming is exact, so nothing is
 duplicated or skipped.
 
 `run.stream_info()` gives the last chunk index and whether the stream is closed
-(`tail_index` is `-1` before anything is written), `run.list_streams()` names
+(`tail_index` is `-1` before anything is written), `run.list_streams()` lists
 every stream the run has, and `read_stream(run_id, name)` reads one by name.
 
 The same stream is readable from the TypeScript SDK (`run.readable`), the

--- a/src/vercel/workflow/README.md
+++ b/src/vercel/workflow/README.md
@@ -123,12 +123,41 @@ Three things are worth knowing:
 `async with get_writable() as writable:` closes the stream on the way out — on
 the clean path only, so a step that raises leaves the stream open for its retry.
 
-There is no public reader yet. A stream is consumed today by the TypeScript SDK
-(`run.readable`), the dashboard, or `workflow inspect stream <id> --run=<run-id>`.
-Python can read one through the world (`streams_get()` yields transport bytes,
-`FrameDecoder` turns them into payloads), but those live under
-`vercel._internal` and have no auto-reconnect, so a long read will not survive
-the server's stream timeout.
+### Reading it back
+
+`run.readable()` yields the values as they are written, and ends when a step
+closes the stream:
+
+```python
+run = await start(analyze, document=text)
+
+async for chunk in run.readable():
+    print(chunk)
+```
+
+`run.readable_bytes()` is the same thing narrowed to `bytes`, which is what an
+HTTP body wants — hand it to a streaming response as-is.
+
+Pass `start_index` to resume: a positive index picks up exactly where a client
+left off, a negative one reads that many chunks back from the end. Only the
+positive form survives a dropped connection, because a negative index resolves
+against wherever the tail happened to be when it connected.
+
+```python
+async for chunk in run.readable(start_index=last_seen + 1):
+    ...
+```
+
+A read reconnects on its own when the transport drops, which it will: the
+server ends a long read at its own time limit. Resuming is exact, so nothing is
+duplicated or skipped.
+
+`run.stream_info()` gives the last chunk index and whether the stream is closed
+(`tail_index` is `-1` before anything is written), `run.list_streams()` names
+every stream the run has, and `read_stream(run_id, name)` reads one by name.
+
+The same stream is readable from the TypeScript SDK (`run.readable`), the
+dashboard, and `workflow inspect stream <id> --run=<run-id>`.
 
 ## Serializing your own types
 

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -16,7 +16,11 @@ from vercel._internal.workflow.runtime import (
     start,
 )
 from vercel._internal.workflow.serde import register_serializable, serializable
-from vercel._internal.workflow.streams import WorkflowStreamWriter
+from vercel._internal.workflow.streams import (
+    WorkflowStreamHandle,
+    WorkflowStreamWriter,
+    WorkflowWritable,
+)
 
 from . import sandbox
 from .errors import (
@@ -44,7 +48,9 @@ __all__ = [
     "get_step_metadata",
     "get_writable",
     "read_stream",
+    "WorkflowWritable",
     "WorkflowStreamWriter",
+    "WorkflowStreamHandle",
     "StepInfo",
     "serializable",
     "register_serializable",

--- a/src/vercel/workflow/__init__.py
+++ b/src/vercel/workflow/__init__.py
@@ -12,6 +12,7 @@ from vercel._internal.workflow.runtime import (
     StepInfo,
     get_step_metadata,
     get_writable,
+    read_stream,
     start,
 )
 from vercel._internal.workflow.serde import register_serializable, serializable
@@ -42,6 +43,7 @@ __all__ = [
     "HookEvent",
     "get_step_metadata",
     "get_writable",
+    "read_stream",
     "WorkflowStreamWriter",
     "StepInfo",
     "serializable",


### PR DESCRIPTION
Stacks on #256 — review that first; this branch adds two commits on top.

The read side, plus letting a workflow hand its stream to the steps that write.

```python
run = await start(analyze, document=text)

async for chunk in run.readable():
    print(chunk)
```

## What's here

- `run.readable()` yields the values a run's steps stream, in write order, ending when a step closes the stream. `readable_bytes()` narrows that to `bytes` for an HTTP body.
- `run.stream_info()` reports the tail index and whether the stream is closed; `run.list_streams()` names every stream the run has; `read_stream(run_id, name)` reads one by name.
- `get_writable()` now answers in a workflow body too, so one workflow can name a stream and pass it to every step that writes to it:

```python
@app.step
async def summarize(*, document: str, out: WorkflowWritable) -> str:
    await out.write("starting")
    ...

@app.workflow
async def analyze(*, document: str) -> str:
    out = get_writable()
    return await summarize(document=document, out=out)
```

## Resuming

`start_index` picks where to start. A positive index resumes exactly — hand back the index you last saw and pass it in next time. A negative one reads that many chunks back from the end, and is single-shot: it resolves against wherever the tail was at connect time, so reopening would shift the window rather than resume it.

A read reconnects on its own when the transport drops, which it will — the server ends a long read at its own time limit. One frame is one stored chunk, so the resume position is exact and nothing is duplicated or skipped.

## Deliberate divergences from `@workflow/core`

- **`run.readable()` is a method, not a property.** Each call opens its own read. A property would make iterating it twice quietly start a second one; TS gets away with it because a `ReadableStream` can be handed out repeatedly, where a Python async generator is single-use.
- **The workflow body's writable raises instead of failing obscurely.** TS returns an object carrying `WritableStream`'s prototype, so writing to it throws a brand-check error. Here both contexts share a `WorkflowWritable` interface and the workflow-side one raises with what to do instead.

## Notes for review

- `get_writable()` now returns `WorkflowWritable` rather than `WorkflowStreamWriter`. Source-compatible — the writer implements it.
- Reviving a stream passed into a step registers it with that step, so it drains before the step is recorded complete. That required installing the step context before the input is hydrated, not just around the body.
- No new changelog fragment: this updates #256's, since the two do not release separately.

## Verified

- 24 new unit tests, mostly on the reconnect: the resume index after a break, a frame cut in half by one arriving whole, a clean EOF not reconnecting, and both caps — including a world that ignores `start_index`, which resets the consecutive cap forever and can only be stopped by the absolute one.
- The existing CLI interop suite still passes, so the JS reader agrees with what Python writes.