### PR TITLE
Move typeutils into vercel-internal-core

### DIFF
--- a/changes/vercel-internal-core/typeutils-shared.internal.md
+++ b/changes/vercel-internal-core/typeutils-shared.internal.md
@@ -1,0 +1,3 @@
+Absorb `typeutils` from `vercel-queue`: the annotation predicates and runtime
+forward-reference resolution now live in `vercel._internal.core.typeutils`,
+where more than one package can reach them.

--- a/changes/vercel-queue/typeutils-shared.internal.md
+++ b/changes/vercel-queue/typeutils-shared.internal.md
@@ -1,0 +1,2 @@
+Take `typeutils` from `vercel._internal.core` rather than carrying a private
+copy. Adds a dependency on `vercel-internal-core`.

--- a/src/vercel-internal-core/tests/test_typeutils.py
+++ b/src/vercel-internal-core/tests/test_typeutils.py
@@ -1,26 +1,9 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, ClassVar, Final, ForwardRef, TypeVar, Union
-
-import importlib.util
-import sys
 from collections.abc import Iterable
-from pathlib import Path
+from typing import Annotated, ClassVar, Final, ForwardRef, TypeVar, Union
 
-
-def _load_typeutils() -> Any:
-    root = Path(__file__).parents[2]
-    path = root / "vercel" / "queue" / "_internal" / "typeutils.py"
-    spec = importlib.util.spec_from_file_location("queue_typeutils_for_tests", path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-typeutils = _load_typeutils()
+from vercel._internal.core import typeutils
 
 
 def test_generic_alias_detection() -> None:
@@ -76,12 +59,3 @@ def test_resolve_annotation_handles_forward_refs_inside_generics() -> None:
         )
         == dict[str, list[Payload]]
     )
-
-
-if __name__ == "__main__":
-    test_generic_alias_detection()
-    test_annotated_detection_and_stripping()
-    test_special_form_detection()
-    test_union_detection_supports_typing_and_pep604()
-    test_origin_and_args_helpers()
-    test_resolve_annotation_handles_forward_refs_inside_generics()

--- a/src/vercel-internal-core/vercel/_internal/core/typeutils.py
+++ b/src/vercel-internal-core/vercel/_internal/core/typeutils.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import inspect
+import types
+from dataclasses import dataclass
+from types import FrameType
 from typing import (
     Annotated,
     Any,
@@ -13,11 +17,6 @@ from typing import (
     get_origin,
     get_type_hints,
 )
-
-import inspect
-import types
-from dataclasses import dataclass
-from types import FrameType
 
 _T = TypeVar("_T")
 _TYPE_VAR_TYPE = type(_T)

--- a/src/vercel-queue/pyproject.toml
+++ b/src/vercel-queue/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-multipart>=0.0.20",
     "typing_extensions>=4.0.0",
     "vercel-headers>=0.6.0",
+    "vercel-internal-core>=0.1.0,<0.2.0",
     "vercel-oidc>=0.6.0",
 ]
 
@@ -32,6 +33,7 @@ trio = ["anyio[trio]>=4.0.0"]
 [tool.uv.sources]
 vercel-oidc = { workspace = true }
 vercel-headers = { workspace = true }
+vercel-internal-core = { workspace = true }
 
 [tool.hatch.version]
 path = "vercel/queue/version.py"
@@ -63,6 +65,10 @@ exclude = [
 extend = "../../pyproject.toml"
 cache-dir = "../../.ruff_cache"
 preview = true
+# `vercel` is a PEP 420 namespace package split across workspace members, so
+# `vercel._internal.core` is this package's own shared internals rather than
+# another project's privates. import-private-name needs telling.
+namespace-packages = ["vercel"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/src/vercel-queue/vercel/queue/_internal/subscribers.py
+++ b/src/vercel-queue/vercel/queue/_internal/subscribers.py
@@ -12,6 +12,15 @@ from importlib import import_module
 from itertools import count
 from types import MappingProxyType
 
+from vercel._internal.core.typeutils import (
+    ResolvedAnnotation,
+    TypeAnnotationResolutionError,
+    args,
+    origin_is,
+    resolve_annotation_with_namespace_from_call_stack,
+    strip_annotated,
+)
+
 from .errors import (
     DuplicateSubscriptionError,
     PayloadValidationError,
@@ -43,14 +52,6 @@ from .types import (
     Topic,
     Transport,
     duration_to_seconds,
-)
-from .typeutils import (
-    ResolvedAnnotation,
-    TypeAnnotationResolutionError,
-    args,
-    origin_is,
-    resolve_annotation_with_namespace_from_call_stack,
-    strip_annotated,
 )
 
 _Subscriber: TypeAlias = Callable[..., Any | Awaitable[Any]]

--- a/src/vercel-queue/vercel/queue/_internal/transports.py
+++ b/src/vercel-queue/vercel/queue/_internal/transports.py
@@ -7,6 +7,17 @@ import json
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
 from importlib import import_module
 
+from vercel._internal.core.typeutils import (
+    annotation_needs_resolution,
+    args,
+    is_classvar,
+    is_final,
+    is_type_var,
+    is_union_type,
+    origin_is,
+    strip_annotated,
+)
+
 from .constants import CONTENT_TYPE_JSON, CONTENT_TYPE_OCTET_STREAM, CONTENT_TYPE_TEXT
 from .errors import SubscriptionError
 from .streams import (
@@ -19,16 +30,6 @@ from .types import (
     RequestContent,
     Topic,
     Transport,
-)
-from .typeutils import (
-    annotation_needs_resolution,
-    args,
-    is_classvar,
-    is_final,
-    is_type_var,
-    is_union_type,
-    origin_is,
-    strip_annotated,
 )
 
 T = TypeVar("T")

--- a/uv.lock
+++ b/uv.lock
@@ -2668,6 +2668,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "typing-extensions" },
     { name = "vercel-headers" },
+    { name = "vercel-internal-core" },
     { name = "vercel-oidc" },
 ]
 
@@ -2692,6 +2693,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", marker = "extra == 'devserver'" },
     { name = "vercel-headers", editable = "src/vercel-headers" },
+    { name = "vercel-internal-core", editable = "src/vercel-internal-core" },
     { name = "vercel-oidc", editable = "src/vercel-oidc" },
 ]
 provides-extras = ["devserver", "trio", "typed"]


### PR DESCRIPTION
The annotation predicates and forward-reference resolution were private to
vercel-queue, but they are not queue-specific, and the workflow codec wants
the same reading of a signature.

vercel-queue gains a dependency on vercel-internal-core, and ruff needs
namespace-packages set to see that vercel._internal.core is shared
internals rather than another project's privates.
