### PR TITLE
queue: let accept_and_handle pick the transport

### DIFF
--- a/changes/vercel-queue/accept-and-handle-transport.feature.md
+++ b/changes/vercel-queue/accept-and-handle-transport.feature.md
@@ -1,0 +1,4 @@
+`accept_and_handle()` now takes a `transport`, so a caller that knows the wire
+format of a delivery can supply it instead of relying on the codec inferred
+from the subscriber's payload annotation — which cannot express formats such as
+CBOR. The `Transport` protocol is exported to go with it.

--- a/src/vercel-queue/benchmarks/async_load.py
+++ b/src/vercel-queue/benchmarks/async_load.py
@@ -246,6 +246,7 @@ class _BenchmarkPushClient(QueueClient):
         raw_body: Any,
         headers: Any = None,
         *,
+        transport: Any | None = None,
         lease_duration: Any | None = None,
     ) -> None:
         started = time.perf_counter()
@@ -253,6 +254,7 @@ class _BenchmarkPushClient(QueueClient):
             await super().accept_and_handle(
                 raw_body,
                 headers,
+                transport=transport,
                 lease_duration=lease_duration,
             )
         except Exception:

--- a/src/vercel-queue/tests/unit/test_queue_accept_handle.py
+++ b/src/vercel-queue/tests/unit/test_queue_accept_handle.py
@@ -1132,6 +1132,107 @@ def test_sync_accept_and_handle_infers_text_buffer_transport(
     assert eqs.state.by_id[delivery.message_id].acknowledged
 
 
+class _HalfJsonTransport:
+    """Stands in for a non-JSON codec: same object, different bytes.
+
+    Nothing about the payload or the subscriber signature can imply it, so a
+    delivery only decodes when the transport was named explicitly.
+    """
+
+    content_type = "application/x-half-json"
+
+    def serialize(self, value: Any) -> bytes:
+        return b"half:" + json.dumps(value).encode()
+
+    async def deserialize(
+        self,
+        payload: AsyncIterator[bytes],
+        *,
+        content_type: str,
+    ) -> Any:
+        del content_type
+        body = b"".join([chunk async for chunk in payload])
+        return json.loads(body.removeprefix(b"half:"))
+
+
+def test_sync_accept_and_handle_uses_the_given_transport(
+    eqs: EmbeddedQueueDevServer,
+    isolated_subscriptions: None,
+) -> None:
+    """An untyped subscriber infers JSON, which cannot read these bytes."""
+    calls: list[object] = []
+
+    @callback_subscribe(topic="emails")
+    def handle(payload: object) -> None:
+        calls.append(payload)
+
+    delivery = sync_delivery(eqs, {"ok": True}, transport=_HalfJsonTransport())
+    assert delivery.body == b'half:{"ok": true}'
+
+    assert isinstance(delivery.client, SyncQueueClient)
+    delivery.client.accept_and_handle(
+        delivery.body,
+        delivery.headers,
+        transport=_HalfJsonTransport(),
+        lease_duration=30,
+    )
+
+    assert calls == [{"ok": True}]
+    assert eqs.state.by_id[delivery.message_id].acknowledged
+
+
+@pytest.mark.anyio
+async def test_async_accept_and_handle_uses_the_given_transport(
+    eqs: EmbeddedQueueDevServer,
+    isolated_subscriptions: None,
+) -> None:
+    calls: list[object] = []
+
+    @callback_subscribe(topic="emails")
+    async def handle(payload: object) -> None:
+        calls.append(payload)
+
+    delivery = await async_delivery(eqs, {"ok": True}, transport=_HalfJsonTransport())
+
+    assert isinstance(delivery.client, QueueClient)
+    await delivery.client.accept_and_handle(
+        delivery.body,
+        delivery.headers,
+        transport=_HalfJsonTransport(),
+        lease_duration=30,
+    )
+
+    assert calls == [{"ok": True}]
+
+
+def test_accept_and_handle_transport_wins_over_a_typed_subscriber(
+    eqs: EmbeddedQueueDevServer,
+    isolated_subscriptions: None,
+) -> None:
+    """The codec is replaced; the annotation still validates the result."""
+
+    class Payload(BaseModel):
+        count: int
+
+    calls: list[Payload] = []
+
+    @callback_subscribe(topic="emails")
+    def handle(payload: Payload) -> None:
+        calls.append(payload)
+
+    delivery = sync_delivery(eqs, {"count": 3}, transport=_HalfJsonTransport())
+
+    assert isinstance(delivery.client, SyncQueueClient)
+    delivery.client.accept_and_handle(
+        delivery.body,
+        delivery.headers,
+        transport=_HalfJsonTransport(),
+        lease_duration=30,
+    )
+
+    assert calls == [Payload(count=3)]
+
+
 def test_accept_and_handle_infers_json_transport_for_union_with_buffer_types(
     eqs: EmbeddedQueueDevServer,
     isolated_subscriptions: None,

--- a/src/vercel-queue/vercel/queue/_internal/api_async.py
+++ b/src/vercel-queue/vercel/queue/_internal/api_async.py
@@ -21,6 +21,7 @@ from .types import (
     RawHeaders,
     StrContainer,
     Topic,
+    Transport,
 )
 
 T = TypeVar("T")
@@ -71,6 +72,7 @@ async def accept_and_handle(
     raw_body: AsyncPushDeliveryBody,
     headers: RawHeaders,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None: ...
 
@@ -80,6 +82,7 @@ async def accept_and_handle(
     raw_body: AsyncHttpMessage,
     headers: None = None,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None: ...
 
@@ -88,6 +91,7 @@ async def accept_and_handle(
     raw_body: AsyncPushDeliveryBody | AsyncHttpMessage,
     headers: RawHeaders | None = None,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None:
     """Accept a push callback and dispatch async subscribers.
@@ -95,6 +99,8 @@ async def accept_and_handle(
     Args:
         raw_body: Callback body bytes, byte iterable, or response object.
         headers: Callback request headers, unless ``raw_body`` is a response.
+        transport: Wire codec for this delivery. Overrides the codec
+            inferred from the matching subscriber's signature.
         lease_duration: Processing timeout used while handlers run.
 
     Raises:
@@ -106,6 +112,7 @@ async def accept_and_handle(
     await client._accept_and_handle(  # noqa: SLF001
         raw_body,
         headers,
+        transport=transport,
         lease_duration=lease_duration,
     )
 

--- a/src/vercel-queue/vercel/queue/_internal/api_common.py
+++ b/src/vercel-queue/vercel/queue/_internal/api_common.py
@@ -35,6 +35,7 @@ StrContainer = _types.StrContainer
 TextBufferTransport = _transports.TextBufferTransport
 TextStreamTransport = _transports.TextStreamTransport
 Topic = _types.Topic
+Transport = _types.Transport
 TypedJsonTransport = _transports.TypedJsonTransport
 __version__ = _version.__version__
 asgi_app = _asgi.asgi_app
@@ -93,6 +94,7 @@ __all__ = (
     "ThrottledError",
     "TokenResolutionError",
     "Topic",
+    "Transport",
     "TypedJsonTransport",
     "UnauthorizedError",
     "UnhandledMessageError",

--- a/src/vercel-queue/vercel/queue/_internal/api_sync.py
+++ b/src/vercel-queue/vercel/queue/_internal/api_sync.py
@@ -14,6 +14,7 @@ from .types import (
     MessageID,
     RawHeaders,
     Topic,
+    Transport,
 )
 
 T = TypeVar("T")
@@ -47,6 +48,7 @@ def accept_and_handle(
     raw_body: PushDeliveryBody,
     headers: RawHeaders,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None: ...
 
@@ -56,6 +58,7 @@ def accept_and_handle(
     raw_body: HttpResponse,
     headers: None = None,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None: ...
 
@@ -64,6 +67,7 @@ def accept_and_handle(
     raw_body: PushDeliveryBody | HttpResponse,
     headers: RawHeaders | None = None,
     *,
+    transport: Transport[Any] | None = None,
     lease_duration: Duration | None = None,
 ) -> None:
     """Accept a push callback and dispatch sync subscribers."""
@@ -71,6 +75,7 @@ def accept_and_handle(
     client._accept_and_handle(  # noqa: SLF001
         raw_body,
         headers,
+        transport=transport,
         lease_duration=lease_duration,
     )
 

--- a/src/vercel-queue/vercel/queue/_internal/client.py
+++ b/src/vercel-queue/vercel/queue/_internal/client.py
@@ -741,6 +741,7 @@ class QueueClient(BaseQueueClient):
         raw_body: AsyncPushDeliveryBody,
         headers: RawHeaders,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None: ...
 
@@ -750,6 +751,7 @@ class QueueClient(BaseQueueClient):
         raw_body: AsyncHttpMessage,
         headers: None = None,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None: ...
 
@@ -758,6 +760,7 @@ class QueueClient(BaseQueueClient):
         raw_body: AsyncPushDeliveryInput,
         headers: RawHeaders | None = None,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None:
         """Accept a push callback and dispatch matching subscribers.
@@ -765,6 +768,8 @@ class QueueClient(BaseQueueClient):
         Args:
             raw_body: Callback body bytes, byte iterable, or response object.
             headers: Callback request headers, unless ``raw_body`` is a response.
+            transport: Wire codec for this delivery. Overrides the codec
+                inferred from the matching subscriber's signature.
             lease_duration: Processing timeout used while handlers run.
 
         Raises:
@@ -775,6 +780,7 @@ class QueueClient(BaseQueueClient):
         await self._accept_and_handle(
             raw_body,
             headers,
+            transport=transport,
             lease_duration=lease_duration,
         )
 

--- a/src/vercel-queue/vercel/queue/_internal/client_sync.py
+++ b/src/vercel-queue/vercel/queue/_internal/client_sync.py
@@ -141,6 +141,7 @@ class QueueClient(BaseQueueClient):
         raw_body: PushDeliveryBody,
         headers: RawHeaders,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None: ...
 
@@ -150,6 +151,7 @@ class QueueClient(BaseQueueClient):
         raw_body: HttpResponse,
         headers: None = None,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None: ...
 
@@ -158,12 +160,18 @@ class QueueClient(BaseQueueClient):
         raw_body: PushDeliveryBody | HttpResponse,
         headers: RawHeaders | None = None,
         *,
+        transport: Transport[Any] | None = None,
         lease_duration: Duration | None = None,
     ) -> None:
-        """Accept a push callback and dispatch matching subscribers."""
+        """Accept a push callback and dispatch matching subscribers.
+
+        ``transport`` overrides the codec inferred from the matching
+        subscriber's signature.
+        """
         self._accept_and_handle(
             raw_body,
             headers,
+            transport=transport,
             lease_duration=lease_duration,
         )
 

--- a/src/vercel-queue/vercel/queue/_internal/types.py
+++ b/src/vercel-queue/vercel/queue/_internal/types.py
@@ -297,4 +297,5 @@ __all__: tuple[str, ...] = (
     "RetryAfter",
     "StrContainer",
     "Topic",
+    "Transport",
 )


### PR DESCRIPTION
The receive codec is inferred from the subscriber's payload annotation, which
has no way to name a format such as CBOR — `payload_transport_kind()` maps
every structured annotation onto `RawJsonTransport`, and an untyped handler
gets it unconditionally. A caller that already knows the wire format of a
delivery had nowhere to say so: the `transport` argument existed on the private
`_accept_and_handle`, but not on the public entry points.

Adds `transport` to `accept_and_handle` on the async client, the sync client,
and both module-level functions, and exports the `Transport` protocol the
parameter is typed with.

The codec is all it replaces — payload validation is separate
(`InvocationPlan.payload_adapter` runs `validate_python` on whatever the
transport returned), so a typed subscriber is still validated. There is a test
for that.

No behaviour change when the argument is omitted.

First of three:

1. **this PR** — `accept_and_handle(transport=...)`
2. `subscribe(transport=...)`, so a delivery dispatched by a client the SDK did
   not construct also decodes correctly
3. the Vercel workflow world's CBOR transport, which is what needs both