### PR TITLE
Run APScheduler coroutine jobs on a portal loop

### DIFF
--- a/changes/vercel-apscheduler/async-jobs-portal-loop.bugfix.md
+++ b/changes/vercel-apscheduler/async-jobs-portal-loop.bugfix.md
@@ -1,0 +1,3 @@
+Run coroutine jobs on a persistent portal event loop so they execute from
+the queue worker instead of being rejected, and so loop-bound resources
+(async clients, locks) stay valid across runs.

--- a/integrations/vercel-apscheduler/pyproject.toml
+++ b/integrations/vercel-apscheduler/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE", "LICENSE.*"]
 dependencies = [
+    "anyio>=4,<5",
     "APScheduler>=3.10.4,<4",
     "redis>=5,<7",
     "vercel-cache>=0.7.1",

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_executor.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_executor.py
@@ -1,0 +1,91 @@
+"""Coroutine job execution through the inline executor's portal loop."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import anyio
+from anyio.lowlevel import current_token
+
+from vercel.integrations.apscheduler._executor import (
+    _run_awaitable,
+    _run_job_at_reference_time,
+)
+from vercel.integrations.apscheduler._imports import (
+    EVENT_JOB_ERROR,
+    EVENT_JOB_EXECUTED,
+)
+
+UTC = timezone.utc
+
+
+async def _loop_token() -> object:
+    return current_token()
+
+
+def test_runs_coroutine_without_a_running_loop() -> None:
+    assert _run_awaitable(_loop_token()) is not None
+
+
+def test_runs_coroutine_from_a_running_event_loop() -> None:
+    """The queue worker delivers on its own event loop thread; a coroutine
+    job must still execute instead of being rejected."""
+
+    async def deliver() -> object:
+        # Simulates a sync wakeup handler running on the worker's loop.
+        return _run_awaitable(_loop_token())
+
+    assert anyio.run(deliver) is not None
+
+
+def test_coroutine_jobs_share_one_persistent_loop() -> None:
+    """Loop-bound resources (async clients, locks) created by one run must
+    stay valid for the next, matching a stock AsyncIOScheduler."""
+    first = _run_awaitable(_loop_token())
+
+    async def deliver() -> object:
+        return _run_awaitable(_loop_token())
+
+    second = anyio.run(deliver)
+    assert first == second
+
+
+def test_job_loop_is_not_the_callers_loop() -> None:
+    async def deliver() -> tuple[object, object]:
+        return current_token(), _run_awaitable(_loop_token())
+
+    caller_token, job_token = anyio.run(deliver)
+    assert caller_token != job_token
+
+
+def _make_job(func: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        func=func,
+        args=(),
+        kwargs={},
+        id="job-1",
+        misfire_grace_time=None,
+        _jobstore_alias="default",
+    )
+
+
+def test_async_job_success_event_carries_the_return_value() -> None:
+    async def job() -> str:
+        return "ran"
+
+    now = datetime.now(UTC)
+    events = _run_job_at_reference_time(_make_job(job), "default", [now], "test", now)
+    assert [event.code for event in events] == [EVENT_JOB_EXECUTED]
+    assert events[0].retval == "ran"
+
+
+def test_async_job_failure_becomes_a_job_error_event() -> None:
+    async def job() -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    now = datetime.now(UTC)
+    events = _run_job_at_reference_time(_make_job(job), "default", [now], "test", now)
+    assert [event.code for event in events] == [EVENT_JOB_ERROR]
+    assert isinstance(events[0].exception, RuntimeError)

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_executor.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_executor.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-import asyncio
+import atexit
 import logging
 import sys
+import threading
 from collections.abc import Awaitable
+from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
 from traceback import format_tb
+
+from anyio.from_thread import BlockingPortal, start_blocking_portal
 
 from ._imports import (
     EVENT_JOB_ERROR,
@@ -25,20 +29,40 @@ UTC = timezone.utc
 __all__ = ["VercelInlineExecutor"]
 
 
+class _JobPortal:
+    """The process's dedicated event loop thread for coroutine jobs.
+
+    Every coroutine job runs on this one loop regardless of where the
+    scheduler was woken from: the queue worker delivers on its own event
+    loop thread, where a job cannot be awaited inline, and a fresh loop
+    per run would invalidate loop-bound resources (async clients, locks)
+    between runs. A single persistent loop preserves the contract a stock
+    AsyncIOScheduler gives jobs by running them all on its loop.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._portal: BlockingPortal | None = None
+
+    def get(self) -> BlockingPortal:
+        """Return the portal, starting its loop thread on first use."""
+        with self._lock:
+            if self._portal is None:
+                stack = ExitStack()
+                self._portal = stack.enter_context(start_blocking_portal())
+                atexit.register(stack.close)
+            return self._portal
+
+
+_JOB_PORTAL = _JobPortal()
+
+
 async def _await_result(value: Awaitable[object]) -> object:
     return await value
 
 
 def _run_awaitable(value: Awaitable[object]) -> object:
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(_await_result(value))
-
-    raise RuntimeError(
-        "cannot run APScheduler async jobs from a running event loop; "
-        "call this scheduler from a synchronous queue worker context instead"
-    )
+    return _JOB_PORTAL.get().call(_await_result, value)
 
 
 def _run_job_at_reference_time(

--- a/uv.lock
+++ b/uv.lock
@@ -2522,6 +2522,7 @@ requires-dist = [
 name = "vercel-apscheduler"
 source = { editable = "integrations/vercel-apscheduler" }
 dependencies = [
+    { name = "anyio" },
     { name = "apscheduler" },
     { name = "redis" },
     { name = "vercel-cache" },
@@ -2530,6 +2531,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4,<5" },
     { name = "apscheduler", specifier = ">=3.10.4,<4" },
     { name = "redis", specifier = ">=5,<7" },
     { name = "vercel-cache", editable = "src/vercel-cache" },


### PR DESCRIPTION
Fixes coroutine jobs never executing on Vercel: the inline executor rejected them whenever an event loop was already running, and every queue worker delivery runs on one (vercel-queue invokes sync subscription handlers on its event loop thread).

Coroutine jobs now run on a process-lifetime AnyIO blocking portal. One persistent loop rather than a loop per run also means loop-bound resources a job creates (async Redis clients, locks) stay valid across runs, which is the same contract a stock AsyncIOScheduler gives jobs by running them all on its loop.

The sync-context path changes accordingly: previously each run got a fresh `asyncio.run` loop, which invalidated those same resources between runs.

Found by a stock FastAPI + AsyncIOScheduler demo whose `async def` job failed on every delivery with "cannot run APScheduler async jobs from a running event loop".