### PR TITLE
devalue: encode bytes as Uint8Array

### DIFF
--- a/changes/vercel/devalue-uint8array.breaking.md
+++ b/changes/vercel/devalue-uint8array.breaking.md
@@ -1,0 +1,2 @@
+`bytes` now crosses the wire as a `Uint8Array` instead of an `ArrayBuffer`, and
+a JavaScript `ArrayBuffer` decodes to `bytearray` instead of `bytes`.

--- a/src/vercel/_internal/devalue/parse.py
+++ b/src/vercel/_internal/devalue/parse.py
@@ -220,7 +220,8 @@ def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
             b64 = value[1]
             if not isinstance(b64, str):
                 raise ValueError("Invalid ArrayBuffer encoding")
-            hydrated[index] = base64.b64decode(b64)
+            # A bare buffer, `bytearray`; a view over one is `bytes` below.
+            hydrated[index] = bytearray(base64.b64decode(b64))
 
         elif type_name in _TYPED_ARRAY_TYPES:
             ref_idx = value[1]
@@ -230,16 +231,18 @@ def unflatten(parsed: Any, revivers: dict[str, Callable] | None = None) -> Any:
             if not (isinstance(ref_val, list) and len(ref_val) > 0 and ref_val[0] == "ArrayBuffer"):
                 raise ValueError("Invalid data")
             buf = hydrate(value[1])
+            # Always a copy, so that writing through the `bytearray` the buffer
+            # parsed to cannot reach a view over it.
             if len(value) > 2:
                 byte_offset = value[2]
                 elem_count = value[3]
                 if type_name == "DataView":
-                    hydrated[index] = buf[byte_offset : byte_offset + elem_count]
+                    hydrated[index] = bytes(buf[byte_offset : byte_offset + elem_count])
                 else:
                     bpe = _BYTES_PER_ELEMENT.get(type_name, 1)
-                    hydrated[index] = buf[byte_offset : byte_offset + elem_count * bpe]
+                    hydrated[index] = bytes(buf[byte_offset : byte_offset + elem_count * bpe])
             else:
-                hydrated[index] = buf
+                hydrated[index] = bytes(buf)
 
         elif type_name == "URL":
             hydrated[index] = value[1]

--- a/src/vercel/_internal/devalue/stringify.py
+++ b/src/vercel/_internal/devalue/stringify.py
@@ -35,7 +35,8 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
 
     Supports: ``None``, ``bool``, ``int``, ``float`` (including NaN / ±Inf /
     −0), ``str``, ``list``, ``tuple``, ``dict`` (string keys only), ``set``,
-    ``frozenset``, ``datetime``, ``re.Pattern``, ``bytes``, ``bytearray``,
+    ``frozenset``, ``datetime``, ``re.Pattern``, ``bytes`` (as a
+    ``Uint8Array``), ``bytearray`` and ``memoryview`` (as an ``ArrayBuffer``),
     and the ``Undefined`` sentinel.
 
     Cyclic and repeated references are handled automatically.  Integers
@@ -209,11 +210,26 @@ def stringify(value: Any, reducers: dict[str, Callable] | None = None) -> str:
                 stringified[index] = f'["RegExp",{stringify_string(source)}]'
             return index
 
-        # --- bytes / bytearray → ArrayBuffer ---
-        if isinstance(thing, (bytes, bytearray, memoryview)):
-            raw = bytes(thing)
-            b64 = base64.b64encode(raw).decode("ascii")
+        # --- bytearray / memoryview → ArrayBuffer ---
+        if isinstance(thing, (bytearray, memoryview)):
+            b64 = base64.b64encode(bytes(thing)).decode("ascii")
             stringified[index] = f'["ArrayBuffer","{b64}"]'
+            return index
+
+        # --- bytes → Uint8Array over its own ArrayBuffer ---
+        # `bytes` gets the view rather than the bare buffer because that is what
+        # the far side wants: a `Uint8Array` can be piped straight into a
+        # `Response`, an `ArrayBuffer` cannot.
+        if isinstance(thing, bytes):
+            b64 = base64.b64encode(thing).decode("ascii")
+            # Allocated here rather than through `flatten`, which would need a
+            # temporary object to key on and would offer it to the reducers.
+            buffer_index = p
+            p += 1
+            stringified[buffer_index] = f'["ArrayBuffer","{b64}"]'
+            # No offset or length: upstream emits those only for a view narrower
+            # than its buffer, and this one never is.
+            stringified[index] = f'["Uint8Array",{buffer_index}]'
             return index
 
         raise DevalueError("Cannot stringify arbitrary non-POJOs", keys, thing, value)

--- a/src/vercel/_internal/workflow/serde.py
+++ b/src/vercel/_internal/workflow/serde.py
@@ -297,7 +297,7 @@ REVIVERS: dict[str, Callable[[Any], Any]] = {"Instance": revive_instance}
 #
 # Standard-library types that devalue rejects outright and that turn up in
 # ordinary payloads. Types it already carries are left alone -- `datetime` is
-# a `Date`, `bytes` an `ArrayBuffer`, `set` a `Set` -- as are the ones it
+# a `Date`, `bytes` a `Uint8Array`, `set` a `Set` -- as are the ones it
 # narrows rather than rejects (`tuple` to a list, `frozenset` to a set,
 # `OrderedDict` to an object): those already cross the wire, and wrapping them
 # would take a plain JavaScript array or Set away from a JavaScript reader for

--- a/src/vercel/tests/integration/test_devalue.py
+++ b/src/vercel/tests/integration/test_devalue.py
@@ -53,7 +53,8 @@ from vercel._internal.devalue.constants import (
 )
 from vercel._internal.devalue.parse import _BYTES_PER_ELEMENT
 
-# Every tag devalue uses for an array view; all of them land as plain bytes.
+# Every tag devalue uses for an array view; all of them land as plain bytes,
+# which is faithful only for `Uint8Array`.
 _TYPED_ARRAY_TAGS = frozenset(_BYTES_PER_ELEMENT)
 
 # Pins the npm fallback used when VERCEL_DEVALUE_JS is not set. It has no
@@ -347,9 +348,15 @@ ROUND_TRIP_CASES: list[Case] = [
     Case("regex_js_only_flags", "/a+/gu", JsRegExp("a+", "gu")),
     Case("regex_named_group", r"/(?<y>\d{4})/", JsRegExp(r"(?<y>\d{4})", "")),
     Case("regex_unicode_property", r"/\p{Letter}/u", JsRegExp(r"\p{Letter}", "u")),
-    Case("bytes", "new Uint8Array([0,1,255]).buffer", b"\x00\x01\xff"),
-    Case("bytes_empty", "new Uint8Array([]).buffer", b""),
-    Case("bytearray", "new Uint8Array([1,2]).buffer", bytearray(b"\x01\x02"), expected=b"\x01\x02"),
+    Case("bytes", "new Uint8Array([0,1,255])", b"\x00\x01\xff"),
+    Case("bytes_empty", "new Uint8Array([])", b""),
+    Case("bytearray", "new Uint8Array([1,2]).buffer", bytearray(b"\x01\x02")),
+    Case(
+        "memoryview",
+        "new Uint8Array([1,2]).buffer",
+        memoryview(b"\x01\x02"),
+        expected=bytearray(b"\x01\x02"),
+    ),
     # ── integers across the JS safe boundary ───────────────────────────────
     Case("safe_int_max", "9007199254740991", 2**53 - 1),
     Case("safe_int_min", "-9007199254740991", -(2**53) + 1),
@@ -422,7 +429,7 @@ JS_ORIGIN_CASES: list[Case] = [
     ),
     Case("js_uint8array", "new Uint8Array([1,2,3])", expected=b"\x01\x02\x03"),
     Case("js_uint16array", "new Uint16Array([1,2])", expected=b"\x01\x00\x02\x00"),
-    Case("js_arraybuffer", "new Uint8Array([9,8]).buffer", expected=b"\x09\x08"),
+    Case("js_arraybuffer", "new Uint8Array([9,8]).buffer", expected=bytearray(b"\x09\x08")),
     # Boxed primitives are unboxed.
     Case("js_boxed_number", "Object(42)", expected=42),
     Case("js_boxed_string", 'Object("woo!!!")', expected="woo!!!"),
@@ -686,7 +693,8 @@ _KNOWN_LOSSY: dict[str, str] = {
     '["Date",""': "an invalid Date becomes None",
     '["DataView"': "DataView becomes bytes",
     '["Temporal.': "Temporal values become str",
-    **{f'["{tag}"': f"{tag} becomes bytes" for tag in _TYPED_ARRAY_TAGS},
+    # `Uint8Array` is absent: `bytes` is exactly it, so it round-trips.
+    **{f'["{tag}"': f"{tag} becomes bytes" for tag in _TYPED_ARRAY_TAGS - {"Uint8Array"}},
 }
 
 # Needs revivers we deliberately do not supply, or a Python container that

--- a/src/vercel/tests/unit/test_devalue.py
+++ b/src/vercel/tests/unit/test_devalue.py
@@ -123,10 +123,14 @@ class TestStringifyBasics:
         assert parsed == {1, 2, 3}
 
     def test_bytes(self):
-        assert stringify(b"\x01\x02\x03") == '[["ArrayBuffer","AQID"]]'
+        # Byte-identical to `devalue.stringify(new Uint8Array([1, 2, 3]))`.
+        assert stringify(b"\x01\x02\x03") == '[["Uint8Array",1],["ArrayBuffer","AQID"]]'
 
     def test_bytearray(self):
         assert stringify(bytearray(b"\x01\x02\x03")) == '[["ArrayBuffer","AQID"]]'
+
+    def test_memoryview(self):
+        assert stringify(memoryview(b"\x01\x02\x03")) == '[["ArrayBuffer","AQID"]]'
 
     def test_tuple_as_array(self):
         assert stringify(("a", "b")) == '[[1,2],"a","b"]'
@@ -256,9 +260,10 @@ class TestStringifyRepetition:
         assert result == '[[1,1],["Date","2001-09-09T01:46:40.000Z"]]'
 
     def test_bytes_repetition(self):
+        # One view and one buffer, however many times the value appears.
         buf = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"
         result = stringify([buf, buf])
-        assert result == '[[1,1],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+        assert result == '[[1,1],["Uint8Array",2],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -470,10 +475,17 @@ class TestParseBasics:
     def test_arraybuffer(self):
         result = parse('[["ArrayBuffer","AQID"]]')
         assert result == b"\x01\x02\x03"
+        assert type(result) is bytearray
 
     def test_typed_array(self):
         result = parse('[["Uint8Array",1],["ArrayBuffer","AQID"]]')
         assert result == b"\x01\x02\x03"
+        assert type(result) is bytes
+
+    def test_typed_array_does_not_alias_its_buffer(self):
+        view, buffer = parse('[[1,2],["Uint8Array",2],["ArrayBuffer","AQID"]]')
+        buffer[0] = 0xFF
+        assert view == b"\x01\x02\x03"
 
     def test_url_as_string(self):
         result = parse('[["URL","https://example.com/path"]]')
@@ -826,7 +838,15 @@ class TestRoundTrip:
 
     def test_bytes(self):
         data = b"\x00\x01\x02\xff"
-        assert parse(stringify(data)) == data
+        result = parse(stringify(data))
+        assert result == data
+        assert type(result) is bytes
+
+    def test_bytearray(self):
+        data = bytearray(b"\x00\x01\x02\xff")
+        result = parse(stringify(data))
+        assert result == data
+        assert type(result) is bytearray
 
     def test_nested(self):
         val = {


### PR DESCRIPTION
devalue keeps a typed-array view and its buffer as two entries; our port
collapsed both onto Python `bytes` in each direction. A `bytes` value a Python
step returned therefore arrived in TypeScript as an `ArrayBuffer`, which cannot
be piped into a `Response`.

- `bytes` → `["Uint8Array", <ref>]` over a separate `ArrayBuffer` entry,
  byte-identical to upstream. `bytearray` and `memoryview` keep the bare
  `ArrayBuffer`.
- An `ArrayBuffer` parses to `bytearray`; every view parses to `bytes`, always
  as a copy so it cannot alias the buffer.
- `["Uint8Array"` leaves the conformance corpus' `_KNOWN_LOSSY` list. The wider
  views (`Uint16Array` and up, `DataView`, `Uint8ClampedArray`) still lose their
  element type and stay on it.

**Breaking:** a JS `ArrayBuffer` field now decodes to `bytearray` rather than
`bytes`, so it is no longer hashable — a `Map` keyed by one raises on parse. A
JS `Uint8Array` still decodes to `bytes`.

This is the change #256's `_reduce_uint8array` docstring said it wanted; that
reducer becomes dead once #256 rebases on this.