### PR TITLE
Add vercel.functions.metric()

### DIFF
--- a/changes/vercel-cache/20260810000000.internal.md
+++ b/changes/vercel-cache/20260810000000.internal.md
@@ -1,0 +1,1 @@
+Add the runtime callback context used by `vercel.functions.metric()`.

--- a/changes/vercel/20260810000000.feature.md
+++ b/changes/vercel/20260810000000.feature.md
@@ -1,0 +1,1 @@
+Add `vercel.functions.metric()` for reporting custom metrics from Vercel Functions.

--- a/src/vercel-cache/tests/test_cache_context.py
+++ b/src/vercel-cache/tests/test_cache_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 
 import pytest
 
@@ -11,12 +11,14 @@ from vercel.headers import set_headers as set_shared_headers
 @pytest.fixture
 def isolated_context() -> Generator[None, None, None]:
     ctx._cv_wait_until.set(None)
+    ctx._cv_metric.set(None)
     ctx._cv_cache.set(None)
     ctx._cv_async_cache.set(None)
     ctx._cv_purge.set(None)
     set_shared_headers(None)
     yield
     ctx._cv_wait_until.set(None)
+    ctx._cv_metric.set(None)
     ctx._cv_cache.set(None)
     ctx._cv_async_cache.set(None)
     ctx._cv_purge.set(None)
@@ -27,6 +29,17 @@ class FakeCacheObject: ...
 
 
 class TestSetContextSetsValues:
+    def test_metric_callback_is_assigned(self, isolated_context: None) -> None:
+        def metric(
+            name: str,
+            value: int | float,
+            tags: Mapping[str, str] | None,
+        ) -> None:
+            return
+
+        ctx.set_context(metric=metric)
+        assert ctx.get_context().metric is metric
+
     def test_cache_is_assigned(self, isolated_context: None) -> None:
         instance = FakeCacheObject()
         ctx.set_context(cache=instance)

--- a/src/vercel-cache/vercel/cache/context.py
+++ b/src/vercel-cache/vercel/cache/context.py
@@ -8,9 +8,15 @@ from vercel.headers import get_headers as _get_headers, set_headers as _set_head
 
 from .types import PurgeAPI
 
+_MetricCallback = Callable[
+    [str, int | float, Mapping[str, str] | None],
+    None,
+]
+
 _cv_wait_until: ContextVar[Callable[[Awaitable[object]], None] | None] = ContextVar(
     "vercel_wait_until", default=None
 )
+_cv_metric: ContextVar[_MetricCallback | None] = ContextVar("vercel_metric", default=None)
 _cv_cache: ContextVar[object | None] = ContextVar("vercel_cache", default=None)
 _cv_async_cache: ContextVar[object | None] = ContextVar("vercel_async_cache", default=None)
 _cv_purge: ContextVar[PurgeAPI | None] = ContextVar("vercel_purge", default=None)
@@ -25,6 +31,7 @@ UNSET = _Unset()
 @dataclass
 class _ContextSnapshot:
     wait_until: Callable[[Awaitable[object]], None] | None
+    metric: _MetricCallback | None
     cache: object | None
     async_cache: object | None
     purge: PurgeAPI | None
@@ -34,6 +41,7 @@ class _ContextSnapshot:
 def get_context() -> _ContextSnapshot:
     return _ContextSnapshot(
         wait_until=_cv_wait_until.get(),
+        metric=_cv_metric.get(),
         cache=_cv_cache.get(),
         async_cache=_cv_async_cache.get(),
         purge=_cv_purge.get(),
@@ -44,6 +52,7 @@ def get_context() -> _ContextSnapshot:
 def set_context(
     *,
     wait_until: Callable[[Awaitable[object]], None] | None | _Unset = UNSET,
+    metric: _MetricCallback | None | _Unset = UNSET,
     cache: object | None | _Unset = UNSET,
     async_cache: object | None | _Unset = UNSET,
     purge: PurgeAPI | None | _Unset = UNSET,
@@ -51,6 +60,8 @@ def set_context(
 ) -> None:
     if not isinstance(wait_until, _Unset):
         _cv_wait_until.set(wait_until)
+    if not isinstance(metric, _Unset):
+        _cv_metric.set(metric)
     if not isinstance(cache, _Unset):
         _cv_cache.set(cache)
     if not isinstance(async_cache, _Unset):

--- a/src/vercel/functions/__init__.py
+++ b/src/vercel/functions/__init__.py
@@ -1,6 +1,7 @@
 from ..cache import AsyncRuntimeCache, RuntimeCache, get_cache
 from ..env import Env, get_env
 from ..headers import Geo, geolocation, get_headers, ip_address, set_headers
+from .metric import metric
 from .wait_until import wait_until
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "get_cache",
     "RuntimeCache",
     "AsyncRuntimeCache",
+    "metric",
     "wait_until",
 ]

--- a/src/vercel/functions/metric.py
+++ b/src/vercel/functions/metric.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from vercel.cache.context import get_context
+
+
+def metric(
+    name: str,
+    value: int | float,
+    tags: Mapping[str, str] | None = None,
+) -> None:
+    """Report a custom metric for the current Vercel Function invocation."""
+    callback = get_context().metric
+    if callback is not None:
+        callback(name, value, tags)

--- a/src/vercel/tests/unit/test_functions_metric.py
+++ b/src/vercel/tests/unit/test_functions_metric.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+
+import pytest
+
+from vercel.cache.context import set_context
+from vercel.functions import metric
+
+
+@pytest.fixture(autouse=True)
+def clear_metric_context() -> Generator[None, None, None]:
+    set_context(metric=None)
+    yield
+    set_context(metric=None)
+
+
+def test_metric_reports_through_runtime_context() -> None:
+    reported: list[tuple[str, int | float, Mapping[str, str] | None]] = []
+
+    def report(
+        name: str,
+        value: int | float,
+        tags: Mapping[str, str] | None,
+    ) -> None:
+        reported.append((name, value, tags))
+
+    set_context(metric=report)
+    metric("tinybird.query_ms", 100, {"query": "getUser"})
+
+    assert reported == [
+        ("tinybird.query_ms", 100, {"query": "getUser"}),
+    ]
+
+
+def test_metric_supports_calls_without_tags() -> None:
+    reported: list[tuple[str, int | float, Mapping[str, str] | None]] = []
+
+    def report(
+        name: str,
+        value: int | float,
+        tags: Mapping[str, str] | None,
+    ) -> None:
+        reported.append((name, value, tags))
+
+    set_context(metric=report)
+    metric("tinybird.query_ms", 100)
+
+    assert reported == [("tinybird.query_ms", 100, None)]
+
+
+def test_metric_is_a_noop_without_runtime_context() -> None:
+    metric("tinybird.query_ms", 100)


### PR DESCRIPTION
## Summary

- add `vercel.functions.metric(name, value, tags=None)`
- add the invocation-context callback used by the Vercel Python runtime
- safely no-op when no compatible runtime invocation is active

## Why

This gives Python Functions the same custom metric helper as `@vercel/functions`, while keeping transport details owned by the runtime. Documentation is intentionally omitted during the soft launch.

This PR pairs with the Python runtime IPC change in https://github.com/vercel/vercel-internal/pull/178.

## Validation

- `uv run --no-sync poe test vercel vercel-cache` (1062 passed, 27 credential-gated tests skipped)
- `uv run --no-sync poe lint vercel vercel-cache`
- `uv run poe typecheck vercel vercel-cache`
- focused metric/context tests (13 passed)

The required `vercel` feature and `vercel-cache` internal news fragments are included. The local `check-news-fragments` command could not run because uv 0.11.2 removed the `workspace metadata --locked` option still used by the repository script.
