### PR TITLE
vercel-sandbox: Stabilize sandbox tests across async backends

### DIFF
--- a/src/vercel-sandbox/tests/sandbox_fixtures.py
+++ b/src/vercel-sandbox/tests/sandbox_fixtures.py
@@ -1,6 +1,6 @@
 """Shared helpers for Sandbox tests."""
 
-import asyncio
+import sniffio
 
 from vercel._internal.core.options import ServiceOptions
 from vercel.sandbox import SandboxCredentials, SandboxServiceOptions, sync as sandbox_sync
@@ -19,8 +19,8 @@ def sandbox_service_options(
 
     if sync is None:
         try:
-            asyncio.get_running_loop()
-        except RuntimeError:
+            sniffio.current_async_library()
+        except sniffio.AsyncLibraryNotFoundError:
             sync = True
         else:
             sync = False

--- a/src/vercel-sandbox/tests/test_sandbox_filesystem.py
+++ b/src/vercel-sandbox/tests/test_sandbox_filesystem.py
@@ -1183,7 +1183,7 @@ class _TrackedSyncStream(httpx.SyncByteStream):
     ),
     chunk_size=st.integers(min_value=1, max_value=8),
 )
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(deadline=1000, suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_text_reader_preserves_crlf_split_across_chunks(
     mock_env_clear: None,
     prefix: str,


### PR DESCRIPTION
Detect async execution through sniffio so Trio-backed tests select the
async sandbox client correctly. Also relax the CRLF property-test
deadline to tolerate parallel suite load without reducing generated
coverage.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>