### PR TITLE
workflow: send the Trusted Sources bypass header

### DIFF
--- a/changes/vercel/workflow-trusted-oidc-header.bugfix.md
+++ b/changes/vercel/workflow-trusted-oidc-header.bugfix.md
@@ -1,0 +1,2 @@
+Send the Trusted Sources bypass header on direct workflow-server requests, and
+derive a non-2xx error from the HTTP status before parsing the body.

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -35,6 +35,22 @@ def _cbor_filter_undefined(value: Mapping[Any, Any], shareable: bool = False) ->
     return {k: None if v is cbor2.undefined else v for k, v in value.items()}
 
 
+def _parse_response_body(resp: httpx.Response) -> Any:
+    """utils.ts, parseResponseBody."""
+    if "application/cbor" in resp.headers.get("Content-Type", ""):
+        return cbor2.loads(
+            resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
+        )
+    try:
+        return resp.json()
+    except Exception:
+        # Server may return CBOR without the correct Content-Type header
+        # (e.g. through a proxy). Try CBOR decoding as fallback.
+        return cbor2.loads(
+            resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
+        )
+
+
 class _QueueTransport:
     """CBOR queue transport with a JSON fallback on receive.
 
@@ -173,6 +189,40 @@ class VercelWorld(w.World):
     async def aclose(self) -> None:
         self._queue_clients.clear()
 
+    async def _auth_headers(self) -> dict[str, str]:
+        """utils.ts, getHttpConfig."""
+        headers = self._headers.copy()
+        if self._using_proxy:
+            # The api-workflow proxy authenticates the caller with a regular
+            # Vercel auth token; it does not accept OIDC. Fail loudly instead
+            # of letting an opaque 401 bubble up at request time.
+            if not self._token:
+                raise ValueError(
+                    f"VercelWorld: api-workflow proxy requested ({self._base_url}) but no "
+                    "Vercel auth token was provided. Pass one as `token` (the SDK reads it "
+                    "from `WORKFLOW_VERCEL_AUTH_TOKEN`)."
+                )
+            headers["Authorization"] = f"Bearer {self._token}"
+        else:
+            # Direct workflow-server path. The bearer prefers an explicitly
+            # configured token (CLI / GitHub Actions runner / local dev) and
+            # falls back to the per-request Vercel OIDC token. The
+            # trusted-sources bypass header always uses the OIDC token.
+            oidc_token: str | None = None
+            try:
+                oidc_token = await get_vercel_oidc_token()
+            except Exception:
+                # No OIDC available outside a Vercel function context.
+                pass
+            auth_token = self._token or oidc_token
+            if auth_token:
+                headers["Authorization"] = f"Bearer {auth_token}"
+            if oidc_token:
+                # Deployment protection's Trusted Sources bypass reads this
+                # header, not Authorization.
+                headers["x-vercel-trusted-oidc-idp-token"] = oidc_token
+        return headers
+
     async def _cbor_request(
         self,
         method: str,
@@ -182,13 +232,7 @@ class VercelWorld(w.World):
         data: Any = None,
     ) -> T:
         # utils.ts, getHttpConfig, makeRequest
-        if self._token is None:
-            token = await get_vercel_oidc_token()
-        else:
-            token = self._token
-        headers = self._headers.copy()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        headers = await self._auth_headers()
 
         headers["Accept"] = "application/cbor"
         # NOTE: Add a unique header to bypass RSC request memoization.
@@ -208,55 +252,65 @@ class VercelWorld(w.World):
                 content=body,
             )
 
-        # utils.ts, parseResponseBody
-        content_type = resp.headers.get("Content-Type", "")
-        if "application/cbor" in content_type:
-            result = cbor2.loads(
-                resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
-            )
-        else:
-            try:
-                result = resp.json()
-            except Exception:
-                # Server may return CBOR without the correct Content-Type header
-                # (e.g. through a proxy). Try CBOR decoding as fallback.
-                result = cbor2.loads(
-                    resp.content, tag_hook=_cbor_tag_hook, object_hook=_cbor_filter_undefined
-                )
+        # utils.ts, makeRequest: the status decides, not the body. A body only
+        # has to parse when the server said the call succeeded — otherwise an
+        # HTML login page from a protected deployment surfaces as a CBOR
+        # framing error instead of the redirect it is.
+        if not resp.is_success:
+            raise self._error_for_response(method, endpoint, resp)
 
-        if resp.is_success:
-            if isinstance(schema, pydantic.TypeAdapter):
-                return schema.validate_python(result)
-            else:
-                return schema.model_validate(result)
+        result = _parse_response_body(resp)
+        if isinstance(schema, pydantic.TypeAdapter):
+            return schema.validate_python(result)
         else:
-            if not isinstance(result, dict):
-                result = {}
-            message = (
-                result.get("message")
-                or f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}"
+            return schema.model_validate(result)
+
+    def _error_for_response(self, method: str, endpoint: str, resp: httpx.Response) -> Exception:
+        """utils.ts, makeRequest — map a non-2xx response to a typed error."""
+        try:
+            result = _parse_response_body(resp)
+        except Exception:
+            # An error body is whatever the server felt like sending: an HTML
+            # error page, an empty body, a gateway's own framing. The status
+            # still has to reach the caller.
+            result = None
+        if not isinstance(result, dict):
+            result = {}
+        message = result.get("message") or self._status_message(method, endpoint, resp)
+        url = f"{self._base_url}{endpoint}"
+        code = result.get("code")
+        if resp.status_code == 409:
+            return w.EntityConflictError(message)
+        if resp.status_code == 410:
+            return w.RunExpiredError(message, status=resp.status_code, code=code, url=url)
+        # retryAfter (seconds) is carried in the Retry-After header.
+        retry_after_header = resp.headers.get("retry-after")
+        retry_after: int | None = None
+        if retry_after_header is not None:
+            try:
+                retry_after = int(retry_after_header)
+            except ValueError:
+                retry_after = None
+        if resp.status_code == 425:
+            return w.TooEarlyError(message, retry_after=retry_after)
+        if resp.status_code == 429:
+            return w.ThrottleError(
+                message, status=resp.status_code, code=code, url=url, retry_after=retry_after
             )
-            url = f"{self._base_url}{endpoint}"
-            code = result.get("code")
-            if resp.status_code == 409:
-                raise w.EntityConflictError(message)
-            if resp.status_code == 410:
-                raise w.RunExpiredError(message, status=resp.status_code, code=code, url=url)
-            # retryAfter (seconds) is carried in the Retry-After header.
-            retry_after_header = resp.headers.get("retry-after")
-            retry_after: int | None = None
-            if retry_after_header is not None:
-                try:
-                    retry_after = int(retry_after_header)
-                except ValueError:
-                    retry_after = None
-            if resp.status_code == 425:
-                raise w.TooEarlyError(message, retry_after=retry_after)
-            if resp.status_code == 429:
-                raise w.ThrottleError(
-                    message, status=resp.status_code, code=code, url=url, retry_after=retry_after
-                )
-            raise w.WorkflowWorldError(message, status=resp.status_code, code=code, url=url)
+        return w.WorkflowWorldError(message, status=resp.status_code, code=code, url=url)
+
+    @staticmethod
+    def _status_message(method: str, endpoint: str, resp: httpx.Response) -> str:
+        message = f"{method} {endpoint} -> HTTP {resp.status_code}: {resp.reason_phrase}"
+        if resp.has_redirect_location:
+            # httpx does not follow redirects, so the 302 arrives intact. A
+            # workflow-server that redirects is a workflow-server behind
+            # deployment protection that did not recognise this caller.
+            message += (
+                f" (redirect to {resp.headers['location']}) — deployment protection rejected "
+                "this request; the Trusted Sources bypass needs a Vercel OIDC token"
+            )
+        return message
 
     async def get_deployment_id(self) -> str:
         deployment_id = os.getenv("VERCEL_DEPLOYMENT_ID")

--- a/src/vercel/tests/unit/test_project_routes_client.py
+++ b/src/vercel/tests/unit/test_project_routes_client.py
@@ -6,10 +6,10 @@ from vercel.client import AsyncVercel, Vercel
 from vercel.project_routes import (
     AsyncProjectRoutesClient,
     ProjectRoute,
-    RouteDefinition,
     ProjectRoutesClient,
     RedirectRoute,
     RewriteRoute,
+    RouteDefinition,
     SetStatusRoute,
     add_route,
     delete_routes,

--- a/src/vercel/tests/unit/test_workflow_trusted_oidc_header.py
+++ b/src/vercel/tests/unit/test_workflow_trusted_oidc_header.py
@@ -1,0 +1,254 @@
+"""Tests for how VercelWorld authenticates an HTTP call, mirroring
+``getHttpConfig`` and ``makeRequest`` in world-vercel's ``utils.ts``.
+
+A workflow-server that is a preview deployment has deployment protection on,
+and callers get past it through Trusted Sources — which reads
+``x-vercel-trusted-oidc-idp-token``, not ``Authorization``. Without that header
+the request comes back as a 302 to the SSO login page, and because the body used
+to be decoded before the status was looked at, the failure surfaced as a CBOR
+framing error from an HTML page rather than as the redirect it was.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import cbor2
+import httpx
+import pytest
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds import vercel as vercel_mod
+from vercel.oidc import VercelOidcTokenError
+
+BYPASS_HEADER = "x-vercel-trusted-oidc-idp-token"
+
+
+class _Ping(w.BaseModel):
+    ok: bool
+
+
+def _cbor_ok(request: httpx.Request) -> httpx.Response:
+    del request
+    return httpx.Response(
+        200,
+        content=cbor2.dumps({"ok": True}),
+        headers={"Content-Type": "application/cbor"},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_server_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VERCEL_WORKFLOW_SERVER_URL", raising=False)
+    monkeypatch.delenv("WORKFLOW_VERCEL_BACKEND_URL", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_oidc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No test may reach the real token resolver: it reads the environment and
+    the on-disk CLI credentials, so an unstubbed call is a silent dependency on
+    whoever is running the suite."""
+
+    async def _fail() -> str:
+        raise AssertionError("get_vercel_oidc_token() was not stubbed")
+
+    monkeypatch.setattr(vercel_mod, "get_vercel_oidc_token", _fail)
+
+
+def _stub_oidc(monkeypatch: pytest.MonkeyPatch, token: str | None) -> None:
+    """Stub the OIDC resolver; ``None`` means "not in a Vercel function"."""
+
+    async def _get() -> str:
+        if token is None:
+            raise VercelOidcTokenError("The 'x-vercel-oidc-token' header is missing")
+        return token
+
+    monkeypatch.setattr(vercel_mod, "get_vercel_oidc_token", _get)
+
+
+def _capture_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response] = _cbor_ok,
+) -> list[httpx.Request]:
+    """Answer every outbound request from ``_cbor_request`` locally, and hand
+    back the requests as httpx assembled them (client headers merged in)."""
+    sent: list[httpx.Request] = []
+    real_client = httpx.AsyncClient
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        sent.append(request)
+        return handler(request)
+
+    def _factory(**kwargs: Any) -> httpx.AsyncClient:
+        return real_client(transport=httpx.MockTransport(_record), **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    return sent
+
+
+async def _get_ping(world: vercel_mod.VercelWorld) -> _Ping:
+    return await world._cbor_request("GET", "/v2/runs/wrun_1", schema=_Ping)
+
+
+async def test_direct_call_carries_the_bypass_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The two headers can hold different values: the bearer prefers the
+    configured token, the bypass header is always the OIDC token."""
+    _stub_oidc(monkeypatch, "oidc-token")
+    sent = _capture_requests(monkeypatch)
+
+    await _get_ping(vercel_mod.VercelWorld(token="configured-token"))
+
+    assert sent[0].headers["Authorization"] == "Bearer configured-token"
+    assert sent[0].headers[BYPASS_HEADER] == "oidc-token"
+
+
+async def test_bearer_falls_back_to_the_oidc_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_oidc(monkeypatch, "oidc-token")
+    sent = _capture_requests(monkeypatch)
+
+    await _get_ping(vercel_mod.VercelWorld())
+
+    assert sent[0].headers["Authorization"] == "Bearer oidc-token"
+    assert sent[0].headers[BYPASS_HEADER] == "oidc-token"
+
+
+async def test_missing_oidc_does_not_fail_the_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Outside a Vercel function there is no OIDC token; the call still goes
+    out with whatever bearer it has, as in the TypeScript SDK."""
+    _stub_oidc(monkeypatch, None)
+    sent = _capture_requests(monkeypatch)
+
+    await _get_ping(vercel_mod.VercelWorld(token="configured-token"))
+
+    assert sent[0].headers["Authorization"] == "Bearer configured-token"
+    assert BYPASS_HEADER not in sent[0].headers
+
+
+async def test_no_token_at_all_still_sends_the_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_oidc(monkeypatch, None)
+    sent = _capture_requests(monkeypatch)
+
+    await _get_ping(vercel_mod.VercelWorld())
+
+    assert "Authorization" not in sent[0].headers
+    assert BYPASS_HEADER not in sent[0].headers
+
+
+async def test_proxy_call_omits_the_bypass_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Through api.vercel.com the caller authenticates with a real Vercel auth
+    token, and the bypass header is neither needed nor correct. The OIDC
+    resolver is not consulted — the autouse fixture asserts it."""
+    sent = _capture_requests(monkeypatch)
+
+    world = vercel_mod.VercelWorld(token="vercel-auth-token", project_id="prj_1", team_id="team_1")
+    await _get_ping(world)
+
+    assert sent[0].headers["Authorization"] == "Bearer vercel-auth-token"
+    assert BYPASS_HEADER not in sent[0].headers
+
+
+async def test_proxy_without_a_token_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The proxy does not accept OIDC, so a missing auth token is a
+    configuration error, not an opaque 401 at request time."""
+    sent = _capture_requests(monkeypatch)
+
+    world = vercel_mod.VercelWorld(project_id="prj_1", team_id="team_1")
+    with pytest.raises(ValueError, match="WORKFLOW_VERCEL_AUTH_TOKEN"):
+        await _get_ping(world)
+
+    assert sent == []
+
+
+async def test_a_redirect_names_deployment_protection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A protected deployment answers with a 302 to an HTML login page. The
+    error must say so rather than blaming the CBOR parser."""
+    _stub_oidc(monkeypatch, None)
+
+    def _sso_redirect(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            302,
+            content=b"<html>login</html>",
+            headers={
+                "Content-Type": "text/html; charset=utf-8",
+                "Location": "https://vercel.com/sso-api?url=...",
+            },
+        )
+
+    _capture_requests(monkeypatch, _sso_redirect)
+
+    with pytest.raises(w.WorkflowWorldError) as excinfo:
+        await _get_ping(vercel_mod.VercelWorld(token="configured-token"))
+
+    assert excinfo.value.status == 302
+    message = str(excinfo.value)
+    assert "302" in message
+    assert "deployment protection" in message
+    assert "https://vercel.com/sso-api?url=..." in message
+
+
+async def test_an_unparseable_error_body_still_reports_the_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gateway's HTML 502 used to surface as CBORDecodeEOF."""
+    _stub_oidc(monkeypatch, "oidc-token")
+    _capture_requests(
+        monkeypatch,
+        lambda request: httpx.Response(502, content=b"<html>bad gateway</html>"),
+    )
+
+    with pytest.raises(w.WorkflowWorldError) as excinfo:
+        await _get_ping(vercel_mod.VercelWorld())
+
+    assert excinfo.value.status == 502
+    assert "502" in str(excinfo.value)
+
+
+async def test_error_bodies_still_drive_the_typed_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checking the status first must not cost the server's own message."""
+    _stub_oidc(monkeypatch, "oidc-token")
+    _capture_requests(
+        monkeypatch,
+        lambda request: httpx.Response(
+            410,
+            content=json.dumps({"message": "run expired", "code": "RUN_EXPIRED"}).encode(),
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+
+    with pytest.raises(w.RunExpiredError) as excinfo:
+        await _get_ping(vercel_mod.VercelWorld())
+
+    assert str(excinfo.value) == "run expired"
+    assert excinfo.value.code == "RUN_EXPIRED"
+
+
+async def test_throttling_still_reads_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_oidc(monkeypatch, "oidc-token")
+    _capture_requests(
+        monkeypatch,
+        lambda request: httpx.Response(
+            429,
+            content=cbor2.dumps({"message": "slow down"}),
+            headers={"Content-Type": "application/cbor", "Retry-After": "7"},
+        ),
+    )
+
+    with pytest.raises(w.ThrottleError) as excinfo:
+        await _get_ping(vercel_mod.VercelWorld())
+
+    assert excinfo.value.retry_after == 7
+    assert str(excinfo.value) == "slow down"
+
+
+async def test_success_still_decodes_unlabelled_cbor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A proxy may drop the Content-Type; the JSON-then-CBOR fallback stays."""
+    _stub_oidc(monkeypatch, "oidc-token")
+    _capture_requests(
+        monkeypatch,
+        lambda request: httpx.Response(200, content=cbor2.dumps({"ok": True})),
+    )
+
+    assert (await _get_ping(vercel_mod.VercelWorld())).ok is True


### PR DESCRIPTION
Mirrors [vercel/workflow#1882](https://github.com/vercel/workflow/pull/1882).

Send OIDC token as `x-vercel-trusted-oidc-idp-token` if present, in addition to `Authorization`.

Also, non-2xx responses now raises before parsing the body.

The first commit is an unrelated import sort that fails `ruff check` on `main`.