### PR TITLE
workflow: read encrypted `encr` payloads

### DIFF
--- a/changes/vercel/workflow-encr-payloads.feature.md
+++ b/changes/vercel/workflow-encr-payloads.feature.md
@@ -1,0 +1,1 @@
+Add support to read the encrypted (`encr`) workflow payloads (AES-GCM) under the new `encryption` extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "uvicorn>=0.30.0,<1",
     "hypothesis>=6.0.0,<7",
     "respx>=0.21.0,<1",
+    "cryptography>=48.0.1",
     "uvloop<1",
     "mypy>=1.20.2,<2",
     "build<2",

--- a/src/vercel/_internal/workflow/encryption.py
+++ b/src/vercel/_internal/workflow/encryption.py
@@ -1,0 +1,136 @@
+"""The `encr` payload format, as `@workflow/world-vercel` writes it.
+
+Decryption only, for now: writing `encr` is not implemented, so the payloads
+this SDK produces are plain `devl`.
+
+The envelope is two nested layers::
+
+    encr payload:  [ 'e' 'n' 'c' 'r' ][ nonce (12) ][ ciphertext + tag (16) ]
+    plaintext:     [ 'd' 'e' 'v' 'l' ][ devalue.stringify output, UTF-8 ]
+
+`encp`, the X25519 sealed-box format, is a different construction and is not
+read here.
+
+AES-GCM comes from `cryptography`, which is a large native wheel and so ships
+in the ``encryption`` extra rather than in the default install.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+from collections.abc import Callable
+
+KEY_LENGTH = 32
+"""AES-256."""
+
+NONCE_LENGTH = 12
+TAG_LENGTH = 16
+
+
+class DecryptionError(Exception):
+    """An encrypted payload could not be opened."""
+
+
+def _load_aes_gcm_decrypt() -> Callable[[bytes, bytes, bytes], bytes | None] | None:
+    """Bind `cryptography`'s AES-GCM, or ``None`` without the extra installed.
+
+    At import time, not per call: a run input is hydrated inside the workflow
+    sandbox. Binding here means the sandbox only ever calls the host function.
+    """
+    try:
+        from cryptography.exceptions import InvalidTag
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    except ImportError:
+        return None
+
+    def decrypt(key: bytes, nonce: bytes, sealed: bytes) -> bytes | None:
+        """Open *sealed* — ciphertext then its 16-byte tag. ``None`` if it fails."""
+        try:
+            return AESGCM(key).decrypt(nonce, sealed, None)
+        except InvalidTag:
+            return None
+
+    return decrypt
+
+
+_AES_GCM_DECRYPT = _load_aes_gcm_decrypt()
+
+
+def hkdf_sha256(*, ikm: bytes, salt: bytes, info: bytes, length: int) -> bytes:
+    """HKDF-SHA256 (RFC 5869): extract *ikm* under *salt*, expand over *info*."""
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    okm = bytearray()
+    block = b""
+    counter = 1
+    while len(okm) < length:
+        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha256).digest()
+        okm += block
+        counter += 1
+    return bytes(okm[:length])
+
+
+def derive_run_key(deployment_key: bytes, *, project_id: str, run_id: str) -> bytes:
+    """The AES-256 key for one run, from the deployment's 32-byte secret.
+
+    ``info`` is ``f"{project_id}|{run_id}"``: the project first, a literal
+    ``|``, no spaces. Getting any of it wrong yields a key that decrypts
+    nothing and says only that the tag failed to authenticate.
+    """
+    if len(deployment_key) != KEY_LENGTH:
+        raise ValueError(f"A deployment key is {KEY_LENGTH} bytes, got {len(deployment_key)}")
+    if not project_id:
+        raise ValueError("Cannot derive a run key without a project id")
+    return hkdf_sha256(
+        ikm=deployment_key,
+        # 32 zero bytes, spelled the way `world-vercel` spells it. HMAC pads a
+        # key shorter than its 64-byte block, so this extracts identically to
+        # `b""` and to the absent salt of RFC 5869 §3.1 -- the length carries no
+        # meaning of its own, and matching the source is all it is for.
+        salt=bytes(32),
+        info=f"{project_id}|{run_id}".encode(),
+        length=KEY_LENGTH,
+    )
+
+
+def decode_key(encoded: str, *, what: str) -> bytes:
+    """Decode a base64 32-byte key."""
+    normalized = encoded.strip().replace("-", "+").replace("_", "/")
+    try:
+        key = base64.b64decode(normalized, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise ValueError(f"{what} is not valid base64: {error}") from error
+    if len(key) != KEY_LENGTH:
+        raise ValueError(f"{what} decodes to {len(key)} bytes, expected {KEY_LENGTH}")
+    return key
+
+
+def open_envelope(key: bytes, payload: bytes) -> bytes:
+    """Open the nonce-prefixed AES-GCM envelope an `encr` payload carries.
+
+    *payload* is everything after the 4-byte format prefix. A wrong key and a
+    modified payload are the same failure — a tag that does not authenticate —
+    so :class:`DecryptionError` names both.
+    """
+    if _AES_GCM_DECRYPT is None:
+        raise DecryptionError(
+            "Reading encrypted workflow payloads requires the 'encryption' extra: "
+            'pip install "vercel[encryption]"'
+        )
+    if len(key) != KEY_LENGTH:
+        raise ValueError(f"A run key is {KEY_LENGTH} bytes, got {len(key)}")
+    if len(payload) < NONCE_LENGTH + TAG_LENGTH:
+        raise DecryptionError(
+            f"An encrypted payload is at least {NONCE_LENGTH + TAG_LENGTH} bytes, "
+            f"got {len(payload)}"
+        )
+
+    nonce, sealed = payload[:NONCE_LENGTH], payload[NONCE_LENGTH:]
+    plaintext = _AES_GCM_DECRYPT(key, nonce, sealed)
+    if plaintext is None:
+        raise DecryptionError(
+            "authentication failed: the payload was modified, or the run key is wrong"
+        )
+    return plaintext

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -232,9 +232,18 @@ class WorkflowOrchestratorContext:
     _ctx: contextvars.ContextVar[Self] = contextvars.ContextVar("WorkflowContext")
 
     def __init__(
-        self, events: list[w.Event], *, seed: str, started_at: int, registry: core.Workflows
+        self,
+        events: list[w.Event],
+        *,
+        seed: str,
+        started_at: int,
+        registry: core.Workflows,
+        run_key: bytes | None = None,
     ):
         self.events = events
+        # The key is per-run, so it is resolved once and reused for every
+        # payload in the replay.
+        self.run_key = run_key
         # List of Out-of-order HookReceivedEvent: such events may arrive at any time unexpectedly,
         # so we stash them separately for delayed consumption
         self.ooo_hook_received_events: deque[w.HookReceivedEvent] = deque()
@@ -267,7 +276,9 @@ class WorkflowOrchestratorContext:
                 obj = getattr(obj, attr)
 
             what = f"the input of run {workflow_run.run_id}"
-            args, kwargs = ser.call_arguments(ser.hydrate(workflow_run.input, what=what), what=what)
+            args, kwargs = ser.call_arguments(
+                ser.hydrate(workflow_run.input, what=what, key=self.run_key), what=what
+            )
 
             token = self._ctx.set(self)
             try:
@@ -468,7 +479,11 @@ class WorkflowOrchestratorContext:
                 case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
                     sus = self.suspensions.pop(event.correlation_id)
                     assert isinstance(sus, Suspension)
-                    result = ser.hydrate(data, what=f"the result of step {event.correlation_id}")
+                    result = ser.hydrate(
+                        data,
+                        what=f"the result of step {event.correlation_id}",
+                        key=self.run_key,
+                    )
                     if not sus.future.cancelled():
                         sus.future.set_result(result)
 
@@ -500,7 +515,11 @@ class WorkflowOrchestratorContext:
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]
                     assert isinstance(hook, Hook)
-                    result = ser.hydrate(data, what=f"the payload of hook {event.correlation_id}")
+                    result = ser.hydrate(
+                        data,
+                        what=f"the payload of hook {event.correlation_id}",
+                        key=self.run_key,
+                    )
                     hook.set_result(result)
                     if not hook.futures:
                         self.suspensions.pop(event.correlation_id)
@@ -518,6 +537,18 @@ class WorkflowOrchestratorContext:
         # Suspend.
         else:
             raise _SuspendException()
+
+
+async def _resolve_run_key(
+    world: w.World, run: w.WorkflowRun, events: list[w.Event]
+) -> bytes | None:
+    """The key this run's payloads need, or ``None`` when none of them is encrypted."""
+    encrypted = ser.is_encrypted(run.input) or any(
+        ser.is_encrypted(payload) for event in events for payload in event.payloads()
+    )
+    if not encrypted:
+        return None
+    return await world.run_key(run.run_id, deployment_id=run.deployment_id)
 
 
 async def workflow_handler(
@@ -624,7 +655,11 @@ async def workflow_handler(
             return None
 
     context = WorkflowOrchestratorContext(
-        events, seed=run_id, started_at=workflow_started_at, registry=registry
+        events,
+        seed=run_id,
+        started_at=workflow_started_at,
+        registry=registry,
+        run_key=await _resolve_run_key(world, workflow_run, events),
     )
     try:
         output = context.run_workflow(workflow_run)
@@ -851,7 +886,12 @@ async def _execute_step(
         if not step_run.input:
             raise RuntimeError(f"Step '{req.step_id}' has no input")
         what = f"the input of step {req.step_id}"
-        args, kwargs = ser.step_call_arguments(ser.hydrate(step_run.input, what=what), what=what)
+        # No deployment id: the queue message routed this step to the deployment
+        # that owns the run, so the key resolves against the current one.
+        run_key = await world.run_key(req.run_id) if ser.is_encrypted(step_run.input) else None
+        args, kwargs = ser.step_call_arguments(
+            ser.hydrate(step_run.input, what=what, key=run_key), what=what
+        )
 
         logger.debug(
             "[Workflows] '%s' - invoking step '%s' (step_id=%s, attempt=%d)",
@@ -1077,7 +1117,10 @@ class Run:
             if run.status == "completed":
                 if not run.output:
                     raise RuntimeError(f"Completed workflow {run.run_id} has no output")
-                return ser.hydrate(run.output, what=f"the output of run {run.run_id}")
+                key = None
+                if ser.is_encrypted(run.output):
+                    key = await self._world.run_key(run.run_id, deployment_id=run.deployment_id)
+                return ser.hydrate(run.output, what=f"the output of run {run.run_id}", key=key)
 
             elif run.status == "cancelled":
                 raise RuntimeError("workflow cancelled")

--- a/src/vercel/_internal/workflow/serialization.py
+++ b/src/vercel/_internal/workflow/serialization.py
@@ -6,10 +6,12 @@ payload. The only format this SDK writes is ``devl`` — UTF-8
 `devalue.stringify` output — so a payload written here parses with
 `devalue.parse` in JavaScript and vice versa.
 
+``encr`` — an encrypted payload — is read too.
+
 The remaining tags are recognized so that an envelope written by the
-TypeScript SDK is reported as unsupported by name instead of as corrupt
-data. None of them are implemented: `encr`/`encp` need the run's key
-material, and `gzip`/`zstd` wrap another prefixed payload.
+TypeScript SDK is reported as unsupported by name instead of as corrupt data:
+`encp` is a different (X25519) construction, and `gzip`/`zstd` wrap another
+prefixed payload.
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ from typing import Any
 
 from vercel._internal import devalue
 
-from . import serde
+from . import encryption, serde
 
 FORMAT_PREFIX_LENGTH = 4
 
@@ -57,7 +59,19 @@ def dehydrate(value: Any) -> bytes:
         raise SerializationError(f"Cannot serialize value: {error}") from error
 
 
-def hydrate(data: Any, *, what: str) -> Any:
+def is_encrypted(data: Any) -> bool:
+    """Whether reading *data* would need the run's key.
+
+    Lets a caller skip resolving a key it does not need, which can cost an API
+    call. Takes ``Any`` for the same reason :func:`hydrate` does, and answers
+    ``False`` for anything that is not a payload at all.
+    """
+    if not isinstance(data, bytes | bytearray | memoryview):
+        return False
+    return bytes(data[:FORMAT_PREFIX_LENGTH]) == ENCRYPTED
+
+
+def hydrate(data: Any, *, what: str, key: bytes | None = None) -> Any:
     """Decode a format-prefixed payload written by either SDK.
 
     Takes ``Any`` because it is the boundary that checks: a payload field can
@@ -67,6 +81,9 @@ def hydrate(data: Any, *, what: str) -> Any:
 
     *what* names the payload in the error message — it is the only context
     the caller has that would help someone reading the traceback.
+
+    *key* is the run's 32-byte key, needed only for an ``encr`` payload;
+    :func:`is_encrypted` says in advance whether one will be asked for.
     """
     if not isinstance(data, bytes | bytearray | memoryview):
         raise SerializationError(f"{what} is not serialized data: {type(data).__name__}")
@@ -80,6 +97,17 @@ def hydrate(data: Any, *, what: str) -> Any:
             return devalue.parse(payload.decode(), serde.REVIVERS)
         except (devalue.DevalueError, ValueError, TypeError) as error:
             raise SerializationError(f"Cannot deserialize {what}: {error}") from error
+    if prefix == ENCRYPTED:
+        if key is None:
+            raise SerializationError(
+                f"{what} is encrypted, and no key was resolved for the run that wrote it"
+            )
+        try:
+            plaintext = encryption.open_envelope(key, payload)
+        except (encryption.DecryptionError, ValueError) as error:
+            raise SerializationError(f"Cannot decrypt {what}: {error}") from error
+        # The plaintext carries its own prefix, normally `devl`.
+        return hydrate(plaintext, what=what, key=key)
     if prefix in KNOWN_FORMATS:
         raise SerializationError(
             f"{what} uses the {prefix.decode()!r} format, which this SDK cannot read"

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -315,6 +315,13 @@ class BaseEvent(BaseModel):
     )
     server_props: ServerProps | None = pydantic.Field(default=None, exclude=True)
 
+    def payloads(self) -> tuple[Any, ...]:
+        """The serialized payloads this event carries, if any.
+
+        One per entry in JS's ``EVENT_DATA_PAYLOAD_FIELD_BY_EVENT_TYPE``.
+        """
+        return ()
+
     @pydantic.model_validator(mode="before")
     @classmethod
     def fold_server_props(cls, data: Any) -> Any:
@@ -350,6 +357,9 @@ class RunCreatedEvent(BaseEvent):
     event_type: Literal["run_created"] = pydantic.Field(default="run_created", alias="eventType")
     event_data: RunCreatedEventData = pydantic.Field(alias="eventData")
 
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.input,)
+
 
 class RunStartedEvent(BaseEvent):
     """
@@ -382,6 +392,9 @@ class RunCompletedEvent(BaseEvent):
     )
     event_data: RunCompletedEventData = pydantic.Field(alias="eventData")
 
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.output,)
+
 
 class RunFailedEventData(BaseModel):
     error: Any
@@ -402,6 +415,9 @@ class RunFailedEvent(BaseEvent):
         alias="eventType",
     )
     event_data: RunFailedEventData = pydantic.Field(alias="eventData")
+
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.error,)
 
 
 class StepCreatedEventData(BaseModel):
@@ -424,6 +440,9 @@ class StepCreatedEvent(BaseEvent):
     )
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: StepCreatedEventData = pydantic.Field(alias="eventData")
+
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.input,)
 
 
 class StepStartedEventData(BaseModel):
@@ -469,6 +488,9 @@ class StepRetryingEvent(BaseEvent):
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: StepRetryingEventData = pydantic.Field(alias="eventData")
 
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.error,)
+
 
 class StepCompletedEventData(BaseModel):
     result: bytes | Any = None
@@ -484,6 +506,9 @@ class StepCompletedEvent(BaseEvent):
     )
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: StepCompletedEventData = pydantic.Field(alias="eventData")
+
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.result,)
 
 
 class StepFailedEventData(BaseModel):
@@ -501,6 +526,9 @@ class StepFailedEvent(BaseEvent):
     )
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: StepFailedEventData = pydantic.Field(alias="eventData")
+
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.error,)
 
 
 class Hook(BaseModel):
@@ -538,6 +566,9 @@ class HookCreatedEvent(BaseEvent):
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: HookCreatedEventData = pydantic.Field(alias="eventData")
 
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.metadata,)
+
 
 class HookReceivedEventData(BaseModel):
     payload: bytes
@@ -553,6 +584,9 @@ class HookReceivedEvent(BaseEvent):
     )
     correlation_id: str = pydantic.Field(alias="correlationId")
     event_data: HookReceivedEventData = pydantic.Field(alias="eventData")
+
+    def payloads(self) -> tuple[Any, ...]:
+        return (self.event_data.payload,)
 
 
 class HookDisposedEvent(BaseEvent):
@@ -847,6 +881,13 @@ class World(metaclass=abc.ABCMeta):
             An HTTP handler that processes incoming queue requests.
         """
         ...
+
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        """The encryption key that opens the payloads of *run_id*.
+
+        ``None`` means the run's payloads are plaintext.
+        """
+        return None
 
     @abc.abstractmethod
     async def runs_get(self, run_id: str) -> WorkflowRun: ...

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -14,9 +14,10 @@ import pydantic
 
 import vercel.queue as vqs
 from vercel._internal.core.polyfills import UTC
+from vercel.oidc import VercelOidcTokenError
 from vercel.oidc.aio import get_vercel_oidc_token
 
-from .. import world as w
+from .. import encryption, world as w
 
 MAX_DELAY_SECONDS = float(
     os.getenv("VERCEL_QUEUE_MAX_DELAY_SECONDS", "82800")
@@ -73,6 +74,10 @@ class _QueueTransport:
 _QUEUE_TRANSPORT = _QueueTransport()
 
 
+def _vercel_api_url() -> str:
+    return os.getenv("WORKFLOW_VERCEL_BACKEND_URL") or "https://api.vercel.com/v1/workflow"
+
+
 # Events whose result the runtime reads back resolved (run/step entity fields);
 # everything else is fetched lazily.
 _EVENTS_NEEDING_RESOLVE = frozenset({"run_created", "run_started", "step_started"})
@@ -87,6 +92,10 @@ class _LazyWorkflowRun(w.BaseWorkflowRun):
     error: Any = None
     input: Any = None
     output: Any = None
+
+
+class _RunKeyResponse(w.BaseModel):
+    key: str | None
 
 
 class _LazyEventResult(w.EventResult):
@@ -110,6 +119,8 @@ class VercelWorld(w.World):
         team_id: str | None = None,
     ) -> None:
         self._token = token
+        self._project_id = project_id
+        self._team_id = team_id
         self._queue_callbacks: list[Any] = []
         # Points the world at a workflow-server other than production, e.g. a
         # branch deployment. world-vercel also has an inline constant that
@@ -126,9 +137,7 @@ class VercelWorld(w.World):
         if self._using_proxy:
             # WORKFLOW_VERCEL_BACKEND_URL swaps the proxy itself, independently
             # of the workflow-server override above.
-            self._base_url = (
-                os.getenv("WORKFLOW_VERCEL_BACKEND_URL") or "https://api.vercel.com/v1/workflow"
-            )
+            self._base_url = _vercel_api_url()
         else:
             default_host = server_url_override or "https://vercel-workflow.com"
             self._base_url = f"{default_host}/api"
@@ -263,6 +272,100 @@ class VercelWorld(w.World):
         if not deployment_id:
             raise ValueError("VERCEL_DEPLOYMENT_ID environment variable is not set.")
         return deployment_id
+
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        """Resolve the key that opens *run_id*'s ``encr`` payloads.
+
+        Two paths, mirroring `@workflow/world-vercel`. A run of the deployment
+        we are running in derives its key in-process from the deployment secret
+        the platform injects; anything else — external tooling, or a run of a
+        different deployment — asks the API for the derived per-run key.
+        """
+        # `VERCEL_PROJECT_ID` backs the constructor argument here and nowhere
+        # else, which is where JS puts it too. Widening it to `__init__` would
+        # change how `_using_proxy` is decided, which is, by default, whether
+        # WORKFLOW_VERCEL_PROJECT and WORKFLOW_VERCEL_TEAM are both set.
+        project_id = self._project_id or os.getenv("VERCEL_PROJECT_ID")
+        if not project_id:
+            raise RuntimeError(
+                f"Cannot resolve the encryption key for run {run_id}: no project id. "
+                "Set VERCEL_PROJECT_ID, or pass one to the world."
+            )
+
+        current_deployment = os.getenv("VERCEL_DEPLOYMENT_ID")
+        own_deployment = deployment_id is None or deployment_id == current_deployment
+        # `VERCEL=1` only inside a serverless function. Outside one -- the CLI,
+        # the e2e driver -- the deployment secret is not there to derive from,
+        # so even a run of the current deployment goes to the API.
+        if os.getenv("VERCEL") == "1" and own_deployment:
+            deployment_key = os.getenv("VERCEL_DEPLOYMENT_KEY")
+            # No secret here means the run is not encrypted, the same as JS does.
+            if not deployment_key:
+                return None
+            return encryption.derive_run_key(
+                encryption.decode_key(deployment_key, what="VERCEL_DEPLOYMENT_KEY"),
+                project_id=project_id,
+                run_id=run_id,
+            )
+
+        return await self._fetch_run_key(
+            deployment_id or current_deployment, project_id=project_id, run_id=run_id
+        )
+
+    async def _fetch_run_key(
+        self, deployment_id: str | None, *, project_id: str, run_id: str
+    ) -> bytes | None:
+        """Ask the API for a run's key. ``None`` means the run is not encrypted."""
+        if not deployment_id:
+            raise RuntimeError(
+                f"Cannot resolve the encryption key for run {run_id}: no deployment id. "
+                "Set VERCEL_DEPLOYMENT_ID."
+            )
+        # `resolveVercelApiToken`'s order. `VERCEL_TOKEN` is the rung for
+        # tooling with no OIDC token to fetch -- the CLI, the e2e driver.
+        token = self._token or os.getenv("VERCEL_TOKEN")
+        if not token:
+            try:
+                token = await get_vercel_oidc_token()
+            except VercelOidcTokenError as e:
+                raise RuntimeError(
+                    f"Cannot resolve the encryption key for run {run_id}: "
+                    "no OIDC token or VERCEL_TOKEN available"
+                ) from e
+        params = {"projectId": project_id, "runId": run_id}
+        # No environment fallback for the team, matching the JS impl.
+        # VERCEL_PROJECT_ID was gated earlier anyways.
+        if self._team_id:
+            params["teamId"] = self._team_id
+
+        url = f"{_vercel_api_url()}/run-key/{deployment_id}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                url, params=params, headers={"Authorization": f"Bearer {token}"}
+            )
+        if not resp.is_success:
+            body = resp.text[:500]
+            raise w.WorkflowWorldError(
+                f"Cannot resolve the encryption key for run {run_id}: "
+                f"HTTP {resp.status_code}: {resp.reason_phrase}{f' — {body}' if body else ''}",
+                status=resp.status_code,
+                url=url,
+            )
+
+        try:
+            parsed = _RunKeyResponse.model_validate(resp.json())
+        except ValueError as error:
+            raise w.WorkflowWorldError(
+                f'Invalid response from the Vercel API: expected {{"key": string | null}}, '
+                f"got {resp.text[:200]!r}",
+                status=resp.status_code,
+                url=url,
+            ) from error
+
+        if parsed.key is None:
+            # Encryption is disabled for this run; its payloads are plaintext.
+            return None
+        return encryption.decode_key(parsed.key, what=f"the key for run {run_id}")
 
     async def queue(
         self,

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -11,6 +11,11 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE", "LICENSE.*"]
 
+[project.optional-dependencies]
+encryption = [
+    "cryptography>=48.0.1",
+]
+
 [tool.hatch.metadata.hooks.custom]
 path = "hatch_build.py"
 

--- a/src/vercel/tests/unit/test_workflow_encryption.py
+++ b/src/vercel/tests/unit/test_workflow_encryption.py
@@ -1,0 +1,637 @@
+"""Reading the `encr` payloads `@workflow/world-vercel` writes.
+
+Every input the format fixes is checkable without a deployment: the HKDF
+parameters that derive the key, the AES-GCM envelope around the payload, and
+what a missing or wrong key is reported as.
+
+Sealing is done with `cryptography`'s own AES-GCM and HKDF, so what is under
+test is this SDK's reading of the format rather than a round trip through one
+implementation.
+"""
+
+from __future__ import annotations
+
+import base64
+import builtins
+import os
+import sys
+import typing
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from vercel._internal.workflow import (
+    encryption,
+    py_sandbox,
+    runtime,
+    serialization as ser,
+    world as w,
+)
+from vercel._internal.workflow.worlds import vercel as vercel_world
+from vercel._internal.workflow.worlds.vercel import VercelWorld
+from vercel.oidc import VercelOidcTokenError
+
+DEPLOYMENT_KEY = bytes(range(32))
+PROJECT_ID = "prj_test"
+RUN_ID = "wrun_test"
+
+
+def _oidc_token(token: str | None):
+    """A stand-in for ``get_vercel_oidc_token``; ``None`` makes it fail.
+
+    Patched rather than left to the environment: the real one reads a process
+    cache and can try to refresh against a local `.vercel`, so what it answers
+    would otherwise depend on the machine the tests run on.
+    """
+
+    async def get_vercel_oidc_token() -> str:
+        if token is None:
+            raise VercelOidcTokenError("no OIDC request header and no local project context")
+        return token
+
+    return get_vercel_oidc_token
+
+
+def _no_cryptography(monkeypatch):
+    """An ``__import__`` that refuses `cryptography`, and a cleared cache for it."""
+    real_import = builtins.__import__
+    for module in [name for name in sys.modules if name.startswith("cryptography")]:
+        monkeypatch.delitem(sys.modules, module)
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("cryptography"):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    return blocked
+
+
+def seal(key: bytes, plaintext: bytes, nonce: bytes = bytes(12)) -> bytes:
+    """An `encr` payload, built the way the TypeScript side builds one."""
+    return ser.ENCRYPTED + nonce + AESGCM(key).encrypt(nonce, plaintext, None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the key
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_hkdf_matches_rfc_5869() -> None:
+    # RFC 5869 appendix A.1, the SHA-256 basic case.
+    okm = encryption.hkdf_sha256(
+        ikm=bytes.fromhex("0b" * 22),
+        salt=bytes.fromhex("000102030405060708090a0b0c"),
+        info=bytes.fromhex("f0f1f2f3f4f5f6f7f8f9"),
+        length=42,
+    )
+    assert okm.hex() == (
+        "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    )
+
+
+@pytest.mark.parametrize("length", [16, 32, 64])
+def test_hkdf_matches_an_independent_implementation(length: int) -> None:
+    # More than one output block, so the expand loop's chaining is covered too.
+    expected = HKDF(algorithm=SHA256(), length=length, salt=bytes(32), info=b"info").derive(
+        DEPLOYMENT_KEY
+    )
+
+    assert (
+        encryption.hkdf_sha256(ikm=DEPLOYMENT_KEY, salt=bytes(32), info=b"info", length=length)
+        == expected
+    )
+
+
+def test_the_run_key_is_hkdf_over_project_then_run() -> None:
+    # The `info` string is `<projectId>|<runId>`: project first, a literal pipe,
+    # no spaces. Every way of getting it wrong produces a well-formed key that
+    # simply decrypts nothing.
+    assert encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID) == HKDF(
+        algorithm=SHA256(), length=32, salt=bytes(32), info=f"{PROJECT_ID}|{RUN_ID}".encode()
+    ).derive(DEPLOYMENT_KEY)
+
+
+def test_the_salt_length_does_not_change_the_key() -> None:
+    # `world-vercel` writes 32 zero bytes and cites RFC 5869 §3.1, which reads
+    # as though the exact spelling matters. It does not: HMAC pads any key
+    # shorter than its 64-byte block, so every zero salt up to that length -- and
+    # the absent one -- extracts the same PRK. Recorded so that nobody spends a
+    # debugging session on the salt, the way this file's first version did.
+    keys = {
+        encryption.hkdf_sha256(ikm=DEPLOYMENT_KEY, salt=salt, info=b"i", length=32)
+        for salt in (b"", bytes(32), bytes(64))
+    }
+
+    over_a_block = encryption.hkdf_sha256(ikm=DEPLOYMENT_KEY, salt=bytes(65), info=b"i", length=32)
+
+    assert len(keys) == 1
+    assert over_a_block not in keys
+
+
+def test_a_run_key_is_bound_to_its_run_and_project() -> None:
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    other_run = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id="wrun_2")
+    other_project = encryption.derive_run_key(DEPLOYMENT_KEY, project_id="prj_2", run_id=RUN_ID)
+    # `p|r` and `pr` would collide if the separator were dropped, and `a|b`
+    # would equal `ab|` if the two halves were concatenated the other way.
+    swapped = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=RUN_ID, run_id=PROJECT_ID)
+
+    assert len({key, other_run, other_project, swapped}) == 4
+
+
+def test_a_deployment_key_must_be_thirty_two_bytes() -> None:
+    with pytest.raises(ValueError, match="32 bytes, got 16"):
+        encryption.derive_run_key(bytes(16), project_id=PROJECT_ID, run_id=RUN_ID)
+
+
+def test_a_base64_key_is_checked_before_it_is_used() -> None:
+    assert encryption.decode_key(base64.b64encode(DEPLOYMENT_KEY).decode(), what="k") == (
+        DEPLOYMENT_KEY
+    )
+    # A trailing newline in an environment variable, and the URL-safe alphabet
+    # `Buffer.from(key, 'base64')` also accepts, are not what a decode error
+    # should be spent on.
+    urlsafe = base64.urlsafe_b64encode(bytes([251, 255]) + DEPLOYMENT_KEY[2:]).decode()
+    assert encryption.decode_key(f" {urlsafe}\n", what="k")[:2] == b"\xfb\xff"
+    with pytest.raises(ValueError, match="k is not valid base64"):
+        encryption.decode_key("not base64!", what="k")
+    with pytest.raises(ValueError, match="k decodes to 3 bytes"):
+        encryption.decode_key(base64.b64encode(b"abc").decode(), what="k")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the envelope
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("size", [0, 1, 15, 16, 17, 1000])
+def test_the_envelope_opens_what_webcrypto_sealed(size: int) -> None:
+    # Block-boundary sizes: GCM's counter mode and its GHASH both special-case
+    # a partial trailing block, in different ways.
+    key = AESGCM.generate_key(bit_length=256)
+    nonce, plaintext = os.urandom(12), os.urandom(size)
+    sealed = AESGCM(key).encrypt(nonce, plaintext, None)
+
+    assert encryption.open_envelope(key, nonce + sealed) == plaintext
+
+
+def test_the_envelope_carries_no_additional_data() -> None:
+    # `world-vercel` calls `aesGcmEncrypt(aesKey, data)` with `aad` omitted --
+    # the AAD machinery in that module is for `encp`.
+    key = AESGCM.generate_key(bit_length=256)
+    nonce = os.urandom(12)
+    with_aad = AESGCM(key).encrypt(nonce, b"payload", b"aad")
+
+    with pytest.raises(encryption.DecryptionError, match="authentication failed"):
+        encryption.open_envelope(key, nonce + with_aad)
+
+
+def test_a_tampered_payload_says_authentication_failed() -> None:
+    # The alternative -- returning what the counter mode produced anyway --
+    # surfaces later as a devalue parse error over binary garbage.
+    key = AESGCM.generate_key(bit_length=256)
+    nonce = os.urandom(12)
+    sealed = bytearray(AESGCM(key).encrypt(nonce, b"devl[42]", None))
+    sealed[-1] ^= 0x01
+
+    with pytest.raises(encryption.DecryptionError, match="authentication failed"):
+        encryption.open_envelope(key, nonce + bytes(sealed))
+
+
+def test_a_wrong_key_is_the_same_failure() -> None:
+    nonce = os.urandom(12)
+    sealed = AESGCM(AESGCM.generate_key(bit_length=256)).encrypt(nonce, b"devl[42]", None)
+
+    with pytest.raises(encryption.DecryptionError, match="the run key is wrong"):
+        encryption.open_envelope(AESGCM.generate_key(bit_length=256), nonce + sealed)
+
+
+def test_a_truncated_envelope_is_rejected_before_the_cipher() -> None:
+    key = AESGCM.generate_key(bit_length=256)
+    with pytest.raises(encryption.DecryptionError, match="at least 28 bytes"):
+        encryption.open_envelope(key, os.urandom(27))
+
+
+def test_without_the_extra_the_failure_names_the_remedy(monkeypatch) -> None:
+    # `cryptography` is not in the default install, and a run on a deployment is
+    # always encrypted -- so this is a plausible first encounter with the
+    # feature, and "No module named 'cryptography'" would not say what to do.
+    monkeypatch.setattr(encryption, "_AES_GCM_DECRYPT", None)
+
+    with pytest.raises(encryption.DecryptionError, match=r'pip install "vercel\[encryption\]"'):
+        encryption.open_envelope(bytes(32), os.urandom(28))
+
+
+def test_the_extra_is_probed_once_at_import(monkeypatch) -> None:
+    # Not per call, because a run input is hydrated inside the sandbox, whose
+    # context has a private `sys.modules` -- an import reached from there would
+    # build a second copy of a native extension. Blocking the import and
+    # decrypting anyway is what pins that the binding already happened.
+    monkeypatch.setattr(builtins, "__import__", _no_cryptography(monkeypatch))
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+
+    assert encryption.open_envelope(key, seal(key, b"devl[42]")[4:]) == b"devl[42]"
+
+
+def test_decryption_works_inside_the_workflow_sandbox() -> None:
+    # A run input is hydrated inside the sandbox, so this is the path that
+    # `test_the_extra_is_probed_once_at_import` protects, driven end to end.
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    payload = seal(key, ser.dehydrate([{"amount": 21}]))
+
+    with py_sandbox.workflow_sandbox():
+        assert ser.hydrate(payload, what="the input of run wrun_1", key=key) == [{"amount": 21}]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# the payload
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_an_encrypted_payload_hydrates_through_its_inner_prefix() -> None:
+    # The plaintext's own prefix is dispatched like any other payload, which is
+    # what would make a future `gzip`-inside-`encr` work without touching this.
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    payload = seal(key, ser.dehydrate([{"amount": 21}]))
+
+    assert ser.hydrate(payload, what="the input of run wrun_1", key=key) == [{"amount": 21}]
+
+
+def test_a_decrypted_payload_that_is_not_a_payload_is_reported() -> None:
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    payload = seal(key, b"json{}")
+
+    with pytest.raises(ser.SerializationError, match="unknown serialization format"):
+        ser.hydrate(payload, what="the input of run wrun_1", key=key)
+
+
+def test_an_encrypted_payload_without_a_key_names_the_problem() -> None:
+    with pytest.raises(ser.SerializationError, match="the input of run wrun_1 is encrypted"):
+        ser.hydrate(ser.ENCRYPTED + bytes(28), what="the input of run wrun_1")
+
+
+def test_a_payload_that_does_not_authenticate_names_the_payload() -> None:
+    key = encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    payload = seal(key, ser.dehydrate(42))
+
+    with pytest.raises(ser.SerializationError, match="Cannot decrypt the input of run wrun_1"):
+        ser.hydrate(payload, what="the input of run wrun_1", key=bytes(32))
+
+
+def test_only_an_encrypted_payload_asks_for_a_key() -> None:
+    # What keeps a plaintext run off the resolution path, and with it the API
+    # request that resolving can cost.
+    assert ser.is_encrypted(ser.ENCRYPTED + bytes(28))
+    assert not ser.is_encrypted(ser.dehydrate(42))
+    assert not ser.is_encrypted(ser.SEALED + bytes(28))
+    # A run's `input` is `bytes | str`: `run_created` echoes back '[Circular]'.
+    assert not ser.is_encrypted("[Circular]")
+    assert not ser.is_encrypted(None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# resolving the key on the Vercel world
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _deployed(monkeypatch, **overrides: str | None) -> None:
+    """The environment of a function running on a Vercel deployment."""
+    env = {
+        "VERCEL": "1",
+        "VERCEL_DEPLOYMENT_ID": "dpl_current",
+        "VERCEL_PROJECT_ID": PROJECT_ID,
+        "VERCEL_DEPLOYMENT_KEY": base64.b64encode(DEPLOYMENT_KEY).decode(),
+        **overrides,
+    }
+    for name, value in env.items():
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+
+async def test_a_run_of_this_deployment_derives_its_key_in_process(monkeypatch) -> None:
+    # No network: HKDF over the deployment secret is the whole resolution.
+    _deployed(monkeypatch)
+    world = VercelWorld()
+
+    key = await world.run_key(RUN_ID)
+
+    assert key == encryption.derive_run_key(DEPLOYMENT_KEY, project_id=PROJECT_ID, run_id=RUN_ID)
+    assert await world.run_key(RUN_ID, deployment_id="dpl_current") == key
+
+
+async def test_local_derivation_needs_a_project_id(monkeypatch) -> None:
+    # Getting it wrong yields a GCM failure rather than anything that names it.
+    _deployed(monkeypatch, VERCEL_PROJECT_ID=None)
+    world = VercelWorld()
+
+    with pytest.raises(RuntimeError, match="no project id"):
+        await world.run_key(RUN_ID)
+
+
+@respx.mock
+async def test_a_run_of_another_deployment_asks_the_api(monkeypatch) -> None:
+    # The secret in this process derives keys for this deployment's runs only.
+    _deployed(monkeypatch)
+    expected = os.urandom(32)
+    route = respx.get(
+        "https://api.vercel.com/v1/workflow/run-key/dpl_other",
+    ).mock(return_value=httpx.Response(200, json={"key": base64.b64encode(expected).decode()}))
+    world = VercelWorld(token="test-token")
+
+    assert await world.run_key(RUN_ID, deployment_id="dpl_other") == expected
+
+    request = route.calls.last.request
+    assert dict(request.url.params) == {"projectId": PROJECT_ID, "runId": RUN_ID}
+    assert request.headers["Authorization"] == "Bearer test-token"
+    # `fetchRunKey` sends `Authorization` and nothing else. The world's own
+    # headers steer the workflow-server proxy and have no meaning here.
+    assert "x-vercel-project-id" not in request.headers
+    assert "x-vercel-workflow-api-url" not in request.headers
+
+
+@respx.mock
+async def test_the_api_token_is_config_then_env_then_oidc(monkeypatch) -> None:
+    # `resolveVercelApiToken`'s order. `VERCEL_TOKEN` is the rung for tooling
+    # with no OIDC token to fetch -- the CLI, and the e2e driver that creates
+    # these runs -- so it has to win over OIDC, not merely exist.
+    _deployed(monkeypatch)
+    monkeypatch.setattr(vercel_world, "get_vercel_oidc_token", _oidc_token("oidc_tok"))
+    route = respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_other").mock(
+        return_value=httpx.Response(200, json={"key": None})
+    )
+
+    async def authorization(world: VercelWorld) -> str:
+        await world.run_key(RUN_ID, deployment_id="dpl_other")
+        return route.calls.last.request.headers["Authorization"]
+
+    assert await authorization(VercelWorld()) == "Bearer oidc_tok"
+    monkeypatch.setenv("VERCEL_TOKEN", "vt_from_env")
+    assert await authorization(VercelWorld()) == "Bearer vt_from_env"
+    assert await authorization(VercelWorld(token="cfg_tok")) == "Bearer cfg_tok"
+
+
+@respx.mock
+async def test_no_token_at_all_is_reported_before_the_request(monkeypatch) -> None:
+    # Sending an unauthenticated request instead would come back as a 403 that
+    # reads like a permissions problem.
+    _deployed(monkeypatch, VERCEL_TOKEN=None)
+    monkeypatch.setattr(vercel_world, "get_vercel_oidc_token", _oidc_token(None))
+    route = respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_other")
+
+    with pytest.raises(RuntimeError, match="no OIDC token or VERCEL_TOKEN"):
+        await VercelWorld().run_key(RUN_ID, deployment_id="dpl_other")
+    assert not route.called
+
+
+@respx.mock
+async def test_an_unexpected_oidc_failure_is_not_reported_as_a_missing_token(
+    monkeypatch,
+) -> None:
+    # Only `VercelOidcTokenError` means "there is no token here". A broken
+    # socket, or a bug in the token code, would otherwise be reported as an
+    # unset environment variable and send the reader after the wrong thing.
+    _deployed(monkeypatch, VERCEL_TOKEN=None)
+
+    async def broken() -> str:
+        raise httpx.ConnectError("the OIDC endpoint is unreachable")
+
+    monkeypatch.setattr(vercel_world, "get_vercel_oidc_token", broken)
+
+    with pytest.raises(httpx.ConnectError):
+        await VercelWorld().run_key(RUN_ID, deployment_id="dpl_other")
+
+
+@respx.mock
+async def test_a_response_without_a_key_field_is_not_read_as_plaintext(monkeypatch) -> None:
+    # `.get("key")` would turn a changed or truncated body into "this run is
+    # not encrypted", and the `encr` payload would fail several frames later.
+    _deployed(monkeypatch)
+    respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_other").mock(
+        return_value=httpx.Response(200, json={"unexpected": True})
+    )
+
+    with pytest.raises(w.WorkflowWorldError, match="Invalid response from the Vercel API"):
+        await VercelWorld(token="t").run_key(RUN_ID, deployment_id="dpl_other")
+
+
+@respx.mock
+async def test_the_team_comes_from_the_world_not_the_environment(monkeypatch) -> None:
+    # `world-vercel` passes `config.projectConfig.teamId` through with no
+    # environment fallback -- unlike the project, which has one for the runtime.
+    _deployed(monkeypatch)
+    monkeypatch.setenv("VERCEL_TEAM_ID", "team_from_env")
+    route = respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_other").mock(
+        return_value=httpx.Response(200, json={"key": None})
+    )
+
+    await VercelWorld(token="t").run_key(RUN_ID, deployment_id="dpl_other")
+    assert "teamId" not in route.calls.last.request.url.params
+
+    await VercelWorld(token="t", project_id="prj_cfg", team_id="team_cfg").run_key(
+        RUN_ID, deployment_id="dpl_other"
+    )
+    params = dict(route.calls.last.request.url.params)
+    # The configured project wins over the environment on the same path.
+    assert params == {"projectId": "prj_cfg", "runId": RUN_ID, "teamId": "team_cfg"}
+
+
+@respx.mock
+async def test_a_deployment_without_a_secret_reports_no_key(monkeypatch) -> None:
+    # What `world-vercel` answers, rather than reaching for the API: a run of
+    # this deployment is derived from the secret or not encrypted at all. If
+    # the platform turns out not to inject one into a Python function, the
+    # `encr` payload that follows says so instead of being papered over here.
+    _deployed(monkeypatch, VERCEL_DEPLOYMENT_KEY=None)
+    route = respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_current")
+
+    assert await VercelWorld(token="test-token").run_key(RUN_ID) is None
+    assert not route.called
+
+
+@respx.mock
+async def test_a_null_key_means_the_run_is_not_encrypted(monkeypatch) -> None:
+    # Not an error: encryption is disabled for the run, and its payloads are
+    # plaintext.
+    _deployed(monkeypatch)
+    respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_other").mock(
+        return_value=httpx.Response(200, json={"key": None})
+    )
+    world = VercelWorld(token="test-token")
+
+    assert await world.run_key(RUN_ID, deployment_id="dpl_other") is None
+
+
+@respx.mock
+async def test_a_failed_key_fetch_says_which_run(monkeypatch) -> None:
+    # Outside a serverless function, where even a run of the deployment named
+    # in the environment has to be fetched.
+    _deployed(monkeypatch, VERCEL=None)
+    respx.get("https://api.vercel.com/v1/workflow/run-key/dpl_current").mock(
+        return_value=httpx.Response(403)
+    )
+    world = VercelWorld(token="test-token")
+
+    with pytest.raises(w.WorkflowWorldError, match=f"key for run {RUN_ID}"):
+        await world.run_key(RUN_ID)
+
+
+async def test_a_world_that_does_not_encrypt_resolves_no_key() -> None:
+    from vercel._internal.workflow.worlds.local import LocalWorld
+
+    assert await LocalWorld().run_key(RUN_ID) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# what the runtime asks for
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _run(**overrides) -> w.WorkflowRun:
+    return w.WorkflowRunAdaptor.validate_python(
+        {
+            "runId": RUN_ID,
+            "status": "running",
+            "deploymentId": "dpl_current",
+            "workflowName": "wf",
+            "createdAt": "2026-07-30T00:00:00.000Z",
+            "updatedAt": "2026-07-30T00:00:00.000Z",
+            "startedAt": "2026-07-30T00:00:00.000Z",
+            **overrides,
+        }
+    )
+
+
+class _CountingWorld(w.World):
+    """A world that records how often the runtime asked it for a key."""
+
+    def __init__(self, key: bytes | None) -> None:
+        self._key = key
+        self.asks = 0
+
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        self.asks += 1
+        return self._key
+
+    async def get_deployment_id(self) -> str:
+        raise NotImplementedError
+
+    async def queue(self, queue_name, message, **kwargs) -> str:
+        raise NotImplementedError
+
+    def create_queue_handler(self, queue_name_prefix, handler):
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str):
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str):
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str):
+        raise NotImplementedError
+
+    async def events_create(self, run_id, data):
+        raise NotImplementedError
+
+    async def events_list(self, run_id, *, pagination=None):
+        raise NotImplementedError
+
+
+def test_every_serialized_event_field_is_reported_by_payloads() -> None:
+    """``Event.payloads()`` must not miss a field that can hold a payload.
+
+    One that it misses reads as "this run is not encrypted", and the run then
+    fails on the payload it could not get a key for -- so the check is against
+    the field annotations rather than against a list kept by hand here.
+    """
+    events = typing.get_args(typing.get_args(w.Event)[0])
+    checked = 0
+
+    for event_cls in events:
+        data_field = event_cls.model_fields.get("event_data")
+        if data_field is None:
+            assert event_cls.model_construct().payloads() == ()
+            continue
+        # `bytes` for a payload field, `Any` for the error ones the TypeScript
+        # side also encrypts. A plain `str`/`datetime`/`int` field is neither.
+        data_cls = next(
+            arg
+            for arg in (typing.get_args(data_field.annotation) or (data_field.annotation,))
+            if arg is not type(None)
+        )
+        payload_fields = {
+            name
+            for name, field in data_cls.model_fields.items()
+            if field.annotation is Any or "bytes" in str(field.annotation)
+        }
+        if not payload_fields:
+            continue
+        sentinels = {name: f"payload of {name}".encode() for name in payload_fields}
+        event = event_cls.model_construct(event_data=data_cls.model_construct(**sentinels))
+        reported = event.payloads()
+
+        omitted = sorted(name for name, value in sentinels.items() if value not in reported)
+        assert not omitted, f"{event_cls.__name__}.payloads() omits {omitted}"
+        checked += 1
+
+    assert checked, "no event carried a payload field -- the reflection above broke"
+
+
+async def test_a_plaintext_run_never_resolves_a_key() -> None:
+    # No HKDF and no API request for a run that has nothing to decrypt -- and
+    # so none of the ways resolving a key can fail, either.
+    world = _CountingWorld(bytes(32))
+    run = _run(input=ser.dehydrate([]))
+    events: list[w.Event] = [
+        w.StepCreatedEventData(
+            stepName="pay", input=ser.dehydrate(ser.step_arguments((), {}))
+        ).into_event("step_0"),
+        w.StepCompletedEventData(result=ser.dehydrate(42)).into_event("step_0"),
+        w.StepStartedEvent(correlationId="step_0"),
+        w.RunStartedEvent(),
+    ]
+
+    assert await runtime._resolve_run_key(world, run, events) is None
+    assert world.asks == 0
+
+
+@pytest.mark.parametrize(
+    "where", ["input", "step result", "hook payload", "step input", "hook metadata"]
+)
+async def test_one_encrypted_payload_anywhere_resolves_the_key_once(where: str) -> None:
+    # Any one of them may be the encrypted one on its own, and the scan covers
+    # every payload field rather than the narrower set a replay hydrates: a
+    # `step input` or `hook metadata` that needed a key and did not get one
+    # would stand the run, and only ever an encrypted one.
+    key = bytes(range(32))
+    world = _CountingWorld(key)
+    sealed = seal(key, ser.dehydrate(42))
+
+    def payload(field: str, plain: Any) -> Any:
+        return sealed if where == field else plain
+
+    run = _run(input=payload("input", ser.dehydrate([])))
+    events: list[w.Event] = [
+        w.StepCreatedEventData(
+            stepName="pay", input=payload("step input", ser.dehydrate({"args": []}))
+        ).into_event("step_0"),
+        w.StepCompletedEventData(result=payload("step result", ser.dehydrate(42))).into_event(
+            "step_0"
+        ),
+        w.HookCreatedEventData(
+            token="tok", metadata=payload("hook metadata", ser.dehydrate({}))
+        ).into_event("hook_0"),
+        w.HookReceivedEventData(payload=payload("hook payload", ser.dehydrate({}))).into_event(
+            "hook_0"
+        ),
+    ]
+
+    assert await runtime._resolve_run_key(world, run, events) == key
+    assert world.asks == 1

--- a/src/vercel/tests/unit/test_workflow_serialization.py
+++ b/src/vercel/tests/unit/test_workflow_serialization.py
@@ -53,10 +53,11 @@ def test_shared_references_survive() -> None:
 
 
 def test_envelope_formats_are_reported_by_name() -> None:
-    # Written by the TS SDK when a run has encryption or compression enabled.
-    # Unsupported here, but the payload is not corrupt and should not read as if
-    # it were.
-    for prefix in (ser.ENCRYPTED, ser.SEALED, ser.GZIP, ser.ZSTD):
+    # Written by the TS SDK when a run has compression enabled, or seals a
+    # payload to another run. Unsupported here, but the payload is not corrupt
+    # and should not read as if it were. `encr` is the one that is read --
+    # ``test_workflow_encryption.py`` covers it.
+    for prefix in (ser.SEALED, ser.GZIP, ser.ZSTD):
         with pytest.raises(ser.SerializationError, match=f"{prefix.decode()}.*cannot read"):
             ser.hydrate(prefix + b"...", what="a payload")
 

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,7 @@ members = [
 [manifest.dependency-groups]
 dev = [
     { name = "build", specifier = "<2" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
     { name = "ggt", marker = "python_full_version >= '3.11'", specifier = ">=1.5.2" },
     { name = "hatchling", specifier = ">=1.27.0,<2" },
@@ -612,7 +613,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -793,7 +794,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2460,12 +2461,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.11'" },
-    { name = "jsonschema", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "rich", marker = "python_full_version < '3.11'" },
-    { name = "toml", marker = "python_full_version < '3.11'" },
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "toml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/bd/b92bbd4a5e6fb52c05af4fdef86726e05c38e5a36313716cf37e38183c65/vendoring-1.2.0.tar.gz", hash = "sha256:6340a84bf542222c96f22ebc3cb87e4d86932dc04bc8d446e38285594702c00e", size = 21475, upload-time = "2021-10-14T06:18:33.641Z" }
 wheels = [
@@ -2482,13 +2483,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.11'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pip", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "rich", marker = "python_full_version >= '3.11'" },
-    { name = "tomli", marker = "python_full_version >= '3.11'" },
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "packaging" },
+    { name = "pip" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/a6/2ad9ec99117eccf78ba6e69e7c904a3dc08ca2fba50e8869a3f02c1bc518/vendoring-1.4.0.tar.gz", hash = "sha256:48113adfb29db5e5051da823c083219567b9b3405859682cc04400a7743279d9", size = 24761, upload-time = "2026-05-19T14:39:50.773Z" }
 wheels = [
@@ -2515,10 +2516,16 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+encryption = [
+    { name = "cryptography" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5" },
     { name = "cbor2", specifier = ">=6.0,<7" },
+    { name = "cryptography", marker = "extra == 'encryption'", specifier = ">=48.0.1" },
     { name = "httpx", specifier = ">=0.27.0,<1" },
     { name = "pydantic", specifier = ">=2.7.0,<3" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2" },
@@ -2532,6 +2539,7 @@ requires-dist = [
     { name = "vercel-sandbox", editable = "src/vercel-sandbox" },
     { name = "websockets", specifier = ">=12.0,<17" },
 ]
+provides-extras = ["encryption"]
 
 [[package]]
 name = "vercel-apscheduler"


### PR DESCRIPTION
This PR adds read support for encrypted workflow payloads with `encr` as the format tag. Writing `encr` is left for later; the payloads this SDK produces stay plain `devl`.

- `serialization.hydrate(..., key=)` now handles `encr`.
- `encryption.py`: HKDF-SHA256 over the deployment secret (32 zero-byte salt, `info = "<projectId>|<runId>"`) and the AES-GCM envelope.
- AES-GCM comes from `cryptography`, in a new `vercel[encryption]` extra. Without the extra, it still works for plaintext payloads and an encrypted one raises an error naming the extra.

`encp` (X25519) is still reported as unsupported.

Fixes #115 