### PR TITLE
workflow: accept spec version 6

### DIFF
--- a/changes/vercel/workflow-spec-version-6.bugfix.md
+++ b/changes/vercel/workflow-spec-version-6.bugfix.md
@@ -1,0 +1,1 @@
+Allow workflow events with `specVersion` 6.

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -101,8 +101,12 @@ def get_physical_topic(queue_name: str) -> SanitizedName:
 #   3  CBOR queue transport
 #   4  native attributes (`attr_set`)
 #   5  payloads may be zstd- or gzip-compressed
+#   6  slot-numbered event ids
 #
+# `CURRENT` is what we stamp on rows we create; `MAX_SUPPORTED` is the highest
+# version we accept when reading, mirroring the same split in TS.
 SPEC_VERSION_CURRENT: Literal[2] = 2
+SPEC_VERSION_MAX_SUPPORTED = 6
 
 
 class BaseModel(pydantic.BaseModel):
@@ -310,8 +314,11 @@ class BaseEvent(BaseModel):
     correlation_id: str | None = pydantic.Field(
         default=None, alias="correlationId", exclude_if=lambda e: e is None
     )
-    spec_version: Literal[1, 2, 3, 4, 5] = pydantic.Field(
-        default=SPEC_VERSION_CURRENT, alias="specVersion"
+    spec_version: int = pydantic.Field(
+        default=SPEC_VERSION_CURRENT,
+        alias="specVersion",
+        ge=1,
+        le=SPEC_VERSION_MAX_SUPPORTED,
     )
     server_props: ServerProps | None = pydantic.Field(default=None, exclude=True)
 

--- a/src/vercel/tests/unit/test_workflow_local_world_format.py
+++ b/src/vercel/tests/unit/test_workflow_local_world_format.py
@@ -18,6 +18,9 @@ import base64
 import json
 from datetime import datetime, timedelta, timezone
 
+import pydantic
+import pytest
+
 from vercel._internal.workflow import serialization as ser, world as w
 from vercel._internal.workflow.worlds import local as local_mod
 
@@ -221,9 +224,10 @@ async def test_hook_token_claim_matches_the_ts_sidecar(tmp_path, monkeypatch) ->
 async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch) -> None:
     # The shape of a `vercel/workflow` e2e run against a Python app: the log is
     # opened by the TypeScript driver, whose `start()` writes `run_created` at
-    # its own SPEC_VERSION_CURRENT -- 5 today -- and the Python app under test
-    # replays it. Nothing here decodes by version (the payload prefix says the
-    # format), and the row inherits the version of the event.
+    # the version its World declares -- 6 on the Vercel adapter -- and the
+    # Python app under test replays it. Nothing here decodes by version (the
+    # payload prefix says the format), and the row inherits the version of the
+    # event.
     world = _world(tmp_path, monkeypatch)
     result = await world.events_create(
         None,
@@ -233,15 +237,20 @@ async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch
                 workflowName="workflow//./src/wf//main",
                 input=ser.dehydrate([]),
             ),
-            specVersion=5,
+            specVersion=6,
         ),
     )
     assert result.run is not None
     run_id = result.run.run_id
-    assert result.run.spec_version == 5
-    assert json.loads((world.data_dir / "runs" / f"{run_id}.json").read_text())["specVersion"] == 5
-    assert [event.spec_version for event in (await world.events_list(run_id)).data] == [5]
+    assert result.run.spec_version == 6
+    assert json.loads((world.data_dir / "runs" / f"{run_id}.json").read_text())["specVersion"] == 6
+    assert [event.spec_version for event in (await world.events_list(run_id)).data] == [6]
 
     # Our own writes into the run leave its version alone.
     await world.events_create(run_id, w.RunStartedEvent())
-    assert (await world.runs_get(run_id)).spec_version == 5
+    assert (await world.runs_get(run_id)).spec_version == 6
+
+
+def test_rejects_a_spec_version_above_the_supported_ceiling() -> None:
+    with pytest.raises(pydantic.ValidationError, match="less than or equal to 6"):
+        w.RunStartedEvent(specVersion=w.SPEC_VERSION_MAX_SUPPORTED + 1)


### PR DESCRIPTION
vercel/workflow#3389 (*World-side incrementing event ID, specVersion 6*) makes the Vercel World stamp every run it creates with `specVersion: 6`. We bump our upper cap for now to accept 6 for e2e test. Actual spec impl follows soon.