### PR TITLE
queue: support transport payload validation

### DIFF
--- a/changes/vercel-queue/transport-payload-validation.feature.md
+++ b/changes/vercel-queue/transport-payload-validation.feature.md
@@ -1,0 +1,2 @@
+Allow custom queue transports to validate decoded subscriber payloads without
+requiring annotation-based Pydantic validation.

--- a/src/vercel-queue/tests/unit/test_queue_subscriptions.py
+++ b/src/vercel-queue/tests/unit/test_queue_subscriptions.py
@@ -25,6 +25,7 @@ from vercel.queue import (
     PayloadValidationError,
     QueueError,
     QueueSubscriber,
+    RawJsonTransport,
     RetryAfter,
     SanitizedName,
     StrContainer,
@@ -106,6 +107,42 @@ def _typecheck_str_container_examples() -> None:
 
     string_topics: StrContainer = "events-one"  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     del string_topics
+
+
+def test_transport_payload_validator_replaces_annotation_validation(
+    isolated_subscriptions: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, int]] = []
+
+    class ValidatingTransport(RawJsonTransport[dict[str, int]]):
+        def validate_payload(self, payload: Any) -> dict[str, int]:
+            assert payload == {"count": "3"}
+            return {"count": 3}
+
+    transport = ValidatingTransport()
+    monkeypatch.setattr(
+        queue_subscribers,
+        "import_module",
+        lambda name: pytest.fail(f"unexpected import: {name}"),
+    )
+
+    @subscribe(topic=Topic[dict[str, int]]("explicit", transport=transport))
+    def handle(payload: dict[str, int]) -> None:
+        calls.append(payload)
+
+    subscription = get_subscriptions()[0]
+    call_subscribers_sync(
+        Message(
+            payload={"count": "3"},
+            metadata=make_metadata(
+                topic=subscription.topic,
+                consumer_group=subscription.consumer_group,
+            ),
+        )
+    )
+
+    assert calls == [{"count": 3}]
 
 
 def _queue_debug_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:

--- a/src/vercel-queue/vercel/queue/_internal/subscribers.py
+++ b/src/vercel-queue/vercel/queue/_internal/subscribers.py
@@ -71,6 +71,14 @@ class PayloadAdapter(Protocol):
     def validate_python(self, value: Any, /) -> Any: ...
 
 
+class _TransportPayloadAdapter:
+    def __init__(self, validate_payload: Callable[[Any], Any]) -> None:
+        self._validate_payload = validate_payload
+
+    def validate_python(self, value: Any, /) -> Any:
+        return self._validate_payload(value)
+
+
 class EmbeddedDispatcher(Protocol):
     def register_subscription(
         self,
@@ -383,7 +391,11 @@ def _payload_adapter(
     annotation: Any,
     *,
     localns: dict[str, Any] | None = None,
+    transport: Transport[Any] | None = None,
 ) -> PayloadAdapter | None:
+    validate_payload = getattr(transport, "validate_payload", None)
+    if callable(validate_payload):
+        return _TransportPayloadAdapter(validate_payload)
     annotation = strip_annotated(annotation)
     if is_untyped_payload_annotation(annotation):
         return None
@@ -474,6 +486,7 @@ def _build_invocation_plan(
         payload_adapter=_payload_adapter(
             payload_annotation,
             localns=resolved_annotation.localns,
+            transport=transport,
         ),
         mode=mode,
         transport_kind=_transport_kind(payload_annotation),


### PR DESCRIPTION
Let explicit transports validate decoded subscriber payloads before
handler invocation. This allows integrations to own validation without
loading the optional Pydantic adapter, while ordinary codecs continue to
use annotation-based validation.
