### PR TITLE
workflow: carry run creation data on the queue

### DIFF
--- a/changes/vercel/workflow-resilient-start.bugfix.md
+++ b/changes/vercel/workflow-resilient-start.bugfix.md
@@ -1,0 +1,1 @@
+Carry run creation data through the workflow queue for resilient start.

--- a/src/vercel/_internal/workflow/runtime.py
+++ b/src/vercel/_internal/workflow/runtime.py
@@ -700,14 +700,11 @@ class WorkflowOrchestratorContext:
                     hook = self.suspensions.pop(event.correlation_id, None)
                     if hook is not None:
                         assert isinstance(hook, Hook)
+                        conflict = f'Hook token "{token}" is already in use by another workflow'
                         while hook.futures:
                             future = hook.futures.popleft()
                             if not future.cancelled():
-                                future.set_exception(
-                                    RuntimeError(
-                                        f'Hook token "{token}" is already in use by another workflow'
-                                    )
-                                )
+                                future.set_exception(RuntimeError(conflict))
 
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -113,6 +113,24 @@ class BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(serialize_by_alias=True)
 
 
+class RunInput(BaseModel):
+    input: Any
+    deployment_id: str = pydantic.Field(alias="deploymentId")
+    workflow_name: str = pydantic.Field(alias="workflowName")
+    spec_version: int = pydantic.Field(alias="specVersion")
+    execution_context: dict[str, Any] | None = pydantic.Field(
+        default=None, alias="executionContext", exclude_if=lambda e: e is None
+    )
+    attributes: dict[str, str] | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
+    allow_reserved_attributes: Literal[True] | None = pydantic.Field(
+        default=None, alias="allowReservedAttributes", exclude_if=lambda e: e is None
+    )
+    encryption_public_key: str | None = pydantic.Field(
+        default=None, alias="encryptionPublicKey", exclude_if=lambda e: e is None
+    )
+    environment: str | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
+
+
 class WorkflowInvokePayload(BaseModel):
     """Payload for invoking a workflow.
 
@@ -122,6 +140,10 @@ class WorkflowInvokePayload(BaseModel):
     """
 
     run_id: str = pydantic.Field(alias="runId")
+    # Run creation data for the resilient-start path, on first deliveries only.
+    run_input: RunInput | None = pydantic.Field(
+        default=None, alias="runInput", exclude_if=lambda e: e is None
+    )
     # Step ID for step execution on the combined handler. When present, the
     # receiver executes that step instead of replaying the run.
     step_id: str | None = pydantic.Field(
@@ -368,6 +390,44 @@ class RunCreatedEvent(BaseEvent):
         return (self.event_data.input,)
 
 
+class RunStartedEventData(BaseModel):
+    input: Any = None
+    deployment_id: str | None = pydantic.Field(
+        default=None, alias="deploymentId", exclude_if=lambda e: e is None
+    )
+    workflow_name: str | None = pydantic.Field(
+        default=None, alias="workflowName", exclude_if=lambda e: e is None
+    )
+    execution_context: dict[str, Any] | None = pydantic.Field(
+        default=None, alias="executionContext", exclude_if=lambda e: e is None
+    )
+    attributes: dict[str, str] | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
+    allow_reserved_attributes: Literal[True] | None = pydantic.Field(
+        default=None, alias="allowReservedAttributes", exclude_if=lambda e: e is None
+    )
+    # Mirrors `run_created.eventData.encryptionPublicKey`. This is the path that
+    # recreates a run from the queued message, which is exactly when the key
+    # would otherwise be lost for the rest of the run's life.
+    encryption_public_key: str | None = pydantic.Field(
+        default=None, alias="encryptionPublicKey", exclude_if=lambda e: e is None
+    )
+
+    @classmethod
+    def from_run_input(cls, run_input: RunInput) -> "RunStartedEventData":
+        return cls(
+            input=run_input.input,
+            deploymentId=run_input.deployment_id,
+            workflowName=run_input.workflow_name,
+            executionContext=run_input.execution_context,
+            attributes=run_input.attributes,
+            allowReservedAttributes=run_input.allow_reserved_attributes,
+            encryptionPublicKey=run_input.encryption_public_key,
+        )
+
+    def into_event(self, *, spec_version: int = SPEC_VERSION_CURRENT) -> "RunStartedEvent":
+        return RunStartedEvent(eventData=self, specVersion=spec_version)
+
+
 class RunStartedEvent(BaseEvent):
     """
     Event created when a workflow run starts executing.
@@ -378,6 +438,14 @@ class RunStartedEvent(BaseEvent):
         default="run_started",
         alias="eventType",
     )
+    event_data: RunStartedEventData | None = pydantic.Field(
+        default=None, alias="eventData", exclude_if=lambda e: e is None
+    )
+
+    def payloads(self) -> tuple[Any, ...]:
+        if self.event_data is None or self.event_data.input is None:
+            return ()
+        return (self.event_data.input,)
 
 
 class RunCompletedEventData(BaseModel):
@@ -879,6 +947,10 @@ class HTTPHandler(Protocol):
 class World(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def get_deployment_id(self) -> str: ...
+
+    def get_environment(self) -> str | None:
+        """The environment this World's writes are attributed to."""
+        return None
 
     @abc.abstractmethod
     async def queue(

--- a/src/vercel/_internal/workflow/worlds/vercel.py
+++ b/src/vercel/_internal/workflow/worlds/vercel.py
@@ -419,6 +419,13 @@ class VercelWorld(w.World):
             raise ValueError("VERCEL_DEPLOYMENT_ID environment variable is not set.")
         return deployment_id
 
+    def get_environment(self) -> str | None:
+        """utils.ts, resolveClientEnvironment."""
+        header = self._headers.get("x-vercel-environment")
+        if header:
+            return header
+        return os.getenv("VERCEL_TARGET_ENV") or os.getenv("VERCEL_ENV") or None
+
     async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
         """Resolve the key that opens *run_id*'s ``encr`` payloads.
 

--- a/src/vercel/tests/unit/test_workflow_resilient_start_models.py
+++ b/src/vercel/tests/unit/test_workflow_resilient_start_models.py
@@ -1,0 +1,217 @@
+"""Tests for the models that carry run creation data through the queue.
+
+``start()`` writes ``run_created`` and pushes the queue message without ordering
+them, so a consumer can be handed a run id whose row does not exist yet. The
+recovery data rides the message as ``runInput`` and is echoed into the
+``run_started`` event; these tests pin the wire shape both directions, because
+the producer is the TypeScript SDK and a dropped field is silent.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vercel._internal.workflow import world as w
+from vercel._internal.workflow.worlds import vercel as vercel_mod
+from vercel.tests.world_stubs import NoStreams
+
+# What `@workflow/core`'s start() puts on the queue at specVersion 6, keyed the
+# way it appears on the wire.
+RUN_INPUT_WIRE = {
+    "input": b"devl\x00payload",
+    "deploymentId": "dpl_1",
+    "workflowName": "greet",
+    "specVersion": 6,
+    "executionContext": {"queueNamespace": "alpha"},
+    "attributes": {"$rootRunId": "wrun_root", "tier": "pro"},
+    "allowReservedAttributes": True,
+    "encryptionPublicKey": "cHVibGljLWtleQ==",
+    "environment": "production",
+}
+
+
+def test_run_input_round_trips_every_field() -> None:
+    """A field we drop here is a field the recreated run loses permanently."""
+    payload = w.WorkflowInvokePayload.model_validate(
+        {"runId": "wrun_1", "runInput": RUN_INPUT_WIRE}
+    )
+
+    assert payload.run_input is not None
+    assert payload.run_input.model_dump() == RUN_INPUT_WIRE
+
+
+def test_run_input_absent_on_re_enqueues() -> None:
+    """Re-enqueues and pre-v3 producers send no `runInput`, and that is normal."""
+    payload = w.WorkflowInvokePayload.model_validate({"runId": "wrun_1"})
+
+    assert payload.run_input is None
+    # Omitted rather than serialized as null: the TS reader types it `undefined`.
+    assert "runInput" not in payload.model_dump()
+
+
+def test_run_input_optional_fields_may_all_be_absent() -> None:
+    """Only the four creation essentials are required of a producer."""
+    run_input = w.RunInput.model_validate(
+        {
+            "input": b"devl\x00payload",
+            "deploymentId": "dpl_1",
+            "workflowName": "greet",
+            "specVersion": 3,
+        }
+    )
+
+    assert run_input.execution_context is None
+    assert run_input.attributes is None
+    assert run_input.allow_reserved_attributes is None
+    assert run_input.encryption_public_key is None
+    assert run_input.environment is None
+
+
+def test_run_started_event_data_forwards_the_whole_run_input() -> None:
+    """The echo into `run_started` is where a dropped field would be lost."""
+    run_input = w.RunInput.model_validate(RUN_INPUT_WIRE)
+
+    data = w.RunStartedEventData.from_run_input(run_input)
+
+    assert data.model_dump() == {
+        "input": RUN_INPUT_WIRE["input"],
+        "deploymentId": "dpl_1",
+        "workflowName": "greet",
+        "executionContext": {"queueNamespace": "alpha"},
+        "attributes": {"$rootRunId": "wrun_root", "tier": "pro"},
+        "allowReservedAttributes": True,
+        "encryptionPublicKey": "cHVibGljLWtleQ==",
+    }
+    # `environment` and `specVersion` are deliberately not among them:
+    # the former is for the consumer's own guard, the latter rides the event.
+    assert "environment" not in data.model_dump()
+    assert "specVersion" not in data.model_dump()
+
+
+def test_run_started_carries_the_creating_client_spec_version() -> None:
+    """A run recreated at our own CURRENT would be mislabelled: the row inherits
+    the event's version, and the creator wrote 6, not 2."""
+    run_input = w.RunInput.model_validate(RUN_INPUT_WIRE)
+
+    event = w.RunStartedEventData.from_run_input(run_input).into_event(
+        spec_version=run_input.spec_version
+    )
+
+    assert event.spec_version == 6
+    assert event.model_dump()["specVersion"] == 6
+
+
+def test_bare_run_started_serializes_without_event_data() -> None:
+    """No `runInput` on the message means no `eventData` on the event at all —
+    not an empty object, which the world would try to create a run from."""
+    event = w.RunStartedEvent()
+
+    assert event.event_data is None
+    assert "eventData" not in event.model_dump()
+
+
+def test_run_started_payloads_expose_the_carried_input() -> None:
+    """`payloads()` is what decides whether the run needs a decryption key, so
+    a resilient start's input has to be visible to it."""
+    run_input = w.RunInput.model_validate(RUN_INPUT_WIRE)
+
+    with_data = w.RunStartedEventData.from_run_input(run_input).into_event()
+
+    assert with_data.payloads() == (RUN_INPUT_WIRE["input"],)
+    assert w.RunStartedEvent().payloads() == ()
+
+
+def test_run_started_accepts_a_server_echo_of_event_data() -> None:
+    """The world strips `eventData` from the stored row, but a reader must not
+    choke if one comes back."""
+    event = w.EventAdaptor.validate_python(
+        {
+            "eventType": "run_started",
+            "runId": "wrun_1",
+            "eventId": "evnt_1",
+            "createdAt": "2026-08-11T00:00:00.000Z",
+            "specVersion": 6,
+            "eventData": {"deploymentId": "dpl_1", "workflowName": "greet"},
+        }
+    )
+
+    assert isinstance(event, w.RunStartedEvent)
+    assert event.event_data is not None
+    assert event.event_data.deployment_id == "dpl_1"
+    assert event.event_data.input is None
+
+
+class TestGetEnvironment:
+    """`get_environment()` feeds the cross-environment guard, so it has to report
+    what the backend will actually attribute our writes to."""
+
+    def test_default_world_has_no_environment_dimension(self) -> None:
+        class _World(NoStreams, w.World):
+            get_deployment_id = None  # type: ignore[assignment]
+            queue = None  # type: ignore[assignment]
+            create_queue_handler = None  # type: ignore[assignment]
+            runs_get = None  # type: ignore[assignment]
+            steps_get = None  # type: ignore[assignment]
+            hooks_get_by_token = None  # type: ignore[assignment]
+            events_create = None  # type: ignore[assignment]
+            events_list = None  # type: ignore[assignment]
+
+        assert _World().get_environment() is None
+
+    def test_proxy_path_reports_the_header_it_sends(self) -> None:
+        """Read back from the header so the two can never drift."""
+        world = vercel_mod.VercelWorld(
+            token="tok", environment="preview", project_id="prj_1", team_id="team_1"
+        )
+
+        assert world.get_environment() == "preview"
+        assert world._headers["x-vercel-environment"] == "preview"
+
+    def test_proxy_path_defaults_to_production(self) -> None:
+        """`|| 'production'` is part of the contract, not an incidental default."""
+        world = vercel_mod.VercelWorld(token="tok", project_id="prj_1", team_id="team_1")
+
+        assert world.get_environment() == "production"
+
+    def test_oidc_path_prefers_target_env(self, monkeypatch) -> None:
+        """`VERCEL_ENV` says `preview` inside a custom environment while the OIDC
+        claim carries the slug, which would fabricate a mismatch."""
+        monkeypatch.setenv("VERCEL_TARGET_ENV", "staging")
+        monkeypatch.setenv("VERCEL_ENV", "preview")
+
+        assert vercel_mod.VercelWorld().get_environment() == "staging"
+
+    def test_oidc_path_falls_back_to_vercel_env(self, monkeypatch) -> None:
+        monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
+        monkeypatch.setenv("VERCEL_ENV", "preview")
+
+        assert vercel_mod.VercelWorld().get_environment() == "preview"
+
+    def test_unknown_outside_vercel(self, monkeypatch) -> None:
+        """Guessing here would refuse a legitimate preview delivery."""
+        for name in ("VERCEL_TARGET_ENV", "VERCEL_ENV"):
+            monkeypatch.delenv(name, raising=False)
+
+        assert vercel_mod.VercelWorld().get_environment() is None
+
+    def test_empty_env_var_is_unknown_not_empty_string(self, monkeypatch) -> None:
+        monkeypatch.setenv("VERCEL_TARGET_ENV", "")
+        monkeypatch.setenv("VERCEL_ENV", "")
+
+        assert vercel_mod.VercelWorld().get_environment() is None
+
+
+def test_vercel_world_environment_is_not_read_from_the_process_on_proxy_path() -> None:
+    """The header wins: on the proxy path the backend ignores our env vars."""
+    previous = os.environ.get("VERCEL_ENV")
+    os.environ["VERCEL_ENV"] = "development"
+    try:
+        world = vercel_mod.VercelWorld(
+            token="tok", environment="production", project_id="prj_1", team_id="team_1"
+        )
+        assert world.get_environment() == "production"
+    finally:
+        if previous is None:
+            os.environ.pop("VERCEL_ENV", None)
+        else:
+            os.environ["VERCEL_ENV"] = previous


### PR DESCRIPTION
First of three. Groundwork only — no behaviour changes yet.

`start()` writes `run_created` and pushes the queue message with no ordering between them. The TS client issues the two [concurrently on purpose](https://github.com/vercel/workflow/blob/main/packages/core/src/runtime/start.ts) (`Promise.allSettled`, "If events.create fails with 429/5xx, the run was still accepted via the queue"), so a consumer can be handed a run id whose row does not exist yet. The data needed to recover from that rides the message as `runInput` — and we were dropping it: pydantic ignores unknown fields, so it never survived `model_validate`.

## What's here

- **`RunInput` on `WorkflowInvokePayload`** — keeps what a first delivery brings. Re-enqueues omit it, as do producers below spec version 3.
- **`RunStartedEventData`** — `run_started` can now carry that data back as `eventData`, which is how a world creates the run from the message instead of from the missing row. Every field optional, mirroring `RunStartedEventSchema` upstream.
- **`World.get_environment()`** — reports the environment a world's writes are attributed to. Nothing consults it yet.

Attributes and `encryptionPublicKey` are pass-through: this SDK reads neither, but a run recreated without them would lose both permanently, so they are carried verbatim rather than dropped.

`get_environment()` on the Vercel world reads back the `x-vercel-environment` header we already send, falling back to `VERCEL_TARGET_ENV || VERCEL_ENV`. Reading the header back is deliberate — it is what keeps the reported value and the sent one from drifting, the same reason upstream shares one helper between `getHeaders` and `getEnvironment`. `VERCEL_TARGET_ENV` is preferred over `VERCEL_ENV` because the latter reports `preview` inside a Vercel custom environment while the OIDC claim carries the custom environment's slug.

## Also

One pre-existing over-length line in `runtime.py` that fails `ruff` on `main`, wrapped so CI can go green.

## Test plan

16 new tests pinning the wire shape both directions — the producer is the TypeScript SDK, so a dropped field is silent. `uv run poe qa` green.