### PR TITLE
workflow: resilient start in the local world

### DIFF
--- a/changes/vercel/workflow-resilient-start.bugfix.md
+++ b/changes/vercel/workflow-resilient-start.bugfix.md
@@ -1,1 +1,2 @@
-Carry run creation data through the workflow queue for resilient start.
+Carry run creation data through the workflow queue and rebuild from it a run
+whose `run_created` never landed.

--- a/src/vercel/_internal/workflow/world.py
+++ b/src/vercel/_internal/workflow/world.py
@@ -223,6 +223,7 @@ class BaseWorkflowRun(BaseModel):
     # Plaintext string-string metadata. Always materialized (as `{}` when
     # unset) so a run row carries the same field set the TS SDK writes.
     attributes: dict[str, str] = pydantic.Field(default_factory=dict)
+    encryption_public_key: str | None = pydantic.Field(default=None, alias="encryptionPublicKey")
     expired_at: datetime | None = pydantic.Field(default=None, alias="expiredAt")
     started_at: datetime | None = pydantic.Field(default=None, alias="startedAt")
     completed_at: datetime | None = pydantic.Field(default=None, alias="completedAt")

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -454,7 +454,9 @@ class LocalWorld(w.World):
         **kwargs,
     ) -> str:
         payload = {
-            "payload": message.model_dump(),
+            # Same JSON dialect the file store uses: the transport is plain
+            # JSON, which has nowhere to put `bytes`.
+            "payload": _encode_js(message.model_dump()),
             "queueName": queue_name,
             "deploymentId": "<local>",
         }
@@ -480,7 +482,10 @@ class LocalWorld(w.World):
                 if "queueName" not in body:
                     raise ValueError("Invalid message body: missing 'queueName' field")
                 queue_name = body["queueName"]
-                payload = body["payload"]
+                # `jsonReviver`'s counterpart: restore the `bytes` the envelope
+                # stands in for before anything validates the payload, which is
+                # what lets `RunInput.input` stay as loose as TS's `z.unknown()`.
+                payload = _decode_js(body["payload"])
                 result = await handler(
                     payload,
                     queue_name=queue_name,

--- a/src/vercel/_internal/workflow/worlds/local.py
+++ b/src/vercel/_internal/workflow/worlds/local.py
@@ -582,8 +582,65 @@ class LocalWorld(w.World):
         with self._run_lock(run_id):
             return self._events_create_impl(run_id, data)
 
+    def _resilient_create_run(
+        self, run_id: str, data: w.Event, now: datetime
+    ) -> w.WorkflowRun | None:
+        """events-storage.ts, the resilient start branch.
+
+        Returns the run to continue with — the one we created, or the one a
+        concurrent ``run_created`` won the race with — or ``None`` when there is
+        nothing to recover from, which is every ordinary call.
+        """
+        if data.event_type != "run_started":
+            return None
+        assert isinstance(data, w.RunStartedEvent)
+        run_data = data.event_data
+        if run_data is None or not run_data.deployment_id or not run_data.workflow_name:
+            return None
+        if run_data.input is None:
+            return None
+
+        created = w.NonFinalWorkflowRun(
+            runId=run_id,
+            deploymentId=run_data.deployment_id,
+            status="pending",
+            workflowName=run_data.workflow_name,
+            specVersion=data.spec_version,
+            executionContext=run_data.execution_context,
+            input=run_data.input,
+            attributes=run_data.attributes or {},
+            encryptionPublicKey=run_data.encryption_public_key,
+            createdAt=now,
+            updatedAt=now,
+        )
+        run_path = self.data_dir / "runs" / f"{run_id}.json"
+        # Exclusive so a concurrent `run_created` cannot be overwritten — it may
+        # already have moved the run to 'running'.
+        if not write_exclusive(run_path, dumps_js(created.model_dump(exclude_none=True)).decode()):
+            return read_json(run_path, w.WorkflowRunAdaptor)
+
+        # The log needs the `run_created` it never got, in an earlier slot than
+        # the caller's event so replay reads it first.
+        run_created = w.RunCreatedEvent(
+            eventData=w.RunCreatedEventData(
+                deploymentId=run_data.deployment_id,
+                workflowName=run_data.workflow_name,
+                input=run_data.input,
+                executionContext=run_data.execution_context,
+            ),
+            specVersion=data.spec_version,
+        )
+        run_created_id = self._new_id("evnt")
+        event = w.EventAdaptor.validate_python(
+            run_created.model_dump()
+            | {"runId": run_id, "eventId": run_created_id, "createdAt": now}
+        )
+        write_json(
+            self.data_dir / "events" / f"{run_id}-{run_created_id}.json", event_record(event)
+        )
+        return created
+
     def _events_create_impl(self, run_id: str | None, data: w.Event) -> w.EventResult:
-        event_id = self._new_id("evnt")
         now = js_now()
 
         if data.event_type == "run_created" and not run_id:
@@ -598,6 +655,18 @@ class LocalWorld(w.World):
         if data.event_type != "run_created" and data.event_type not in skip_run_validation_events:
             run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
             current_run = read_json(run_path, w.WorkflowRunAdaptor)
+
+        if current_run is None:
+            current_run = self._resilient_create_run(effective_run_id, data, now)
+
+        # Match the Vercel world's 404 rather than persist an event for a run
+        # that was never created.
+        if current_run is None and data.event_type in ("run_started", "run_failed"):
+            raise RuntimeError(f"Run {effective_run_id} not found")
+
+        # Minted after the resilient path, whose synthetic `run_created` takes
+        # the earlier slot.
+        event_id = self._new_id("evnt")
 
         if current_run and is_run_terminal(current_run.status):
             run_terminal_events = ["run_started", "run_completed", "run_failed"]
@@ -655,8 +724,18 @@ class LocalWorld(w.World):
                 # Already disposed (or never created). Mirrors the backend's 404.
                 raise w.HookNotFoundError(hook_id=data.correlation_id)
 
+        # Idempotent for a run already running: the runtime issues `run_started`
+        # on every delivery, so appending one per replay would be unbounded.
+        if data.event_type == "run_started" and current_run and current_run.status == "running":
+            return w.EventResult(run=current_run)
+
+        stored = data.model_dump()
+        # `eventData` is transport for the resilient path above; it belongs to
+        # the `run_created` that path wrote, not on the row here.
+        if data.event_type == "run_started":
+            stored.pop("eventData", None)
         event = w.EventAdaptor.validate_python(
-            data.model_dump()
+            stored
             | {
                 "runId": effective_run_id,
                 "eventId": event_id,
@@ -697,6 +776,7 @@ class LocalWorld(w.World):
                     executionContext=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
+                    encryptionPublicKey=current_run.encryption_public_key,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     status="running",
@@ -717,6 +797,7 @@ class LocalWorld(w.World):
                     executionContext=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
+                    encryptionPublicKey=current_run.encryption_public_key,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,
@@ -754,6 +835,7 @@ class LocalWorld(w.World):
                     executionContext=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
+                    encryptionPublicKey=current_run.encryption_public_key,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,
@@ -780,6 +862,7 @@ class LocalWorld(w.World):
                     executionContext=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
+                    encryptionPublicKey=current_run.encryption_public_key,
                     createdAt=current_run.created_at,
                     expiredAt=current_run.expired_at,
                     startedAt=current_run.started_at,

--- a/src/vercel/tests/unit/test_workflow_local_queue_codec.py
+++ b/src/vercel/tests/unit/test_workflow_local_queue_codec.py
@@ -1,0 +1,148 @@
+"""Bytes crossing the local world's queue.
+
+The transport is plain JSON, which has nowhere to put `bytes`, so
+`@workflow/world-local` smuggles them through as a `{__type: "Uint8Array"}`
+envelope via its `jsonReplacer` / `jsonReviver` pair. The file store already
+speaks that dialect (`dumps_js` / `read_json`); the queue has to as well, or a
+payload carrying a run's input either fails to serialize on the way out or
+arrives as an envelope nothing unwraps.
+
+The pair has to stay a pair. Decoding on receive without encoding on send breaks
+the re-enqueue path, which re-sends the payload it was handed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from vercel._internal.workflow import serialization as ser, world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_codec"
+WORKFLOW = "add_ten"
+# What `dehydrate` produces, and what a TS producer base64s into the envelope.
+INPUT = ser.dehydrate([[1], 123])
+
+
+def _payload() -> w.WorkflowInvokePayload:
+    return w.WorkflowInvokePayload(
+        runId=RUN_ID,
+        runInput=w.RunInput.model_validate(
+            {
+                "input": INPUT,
+                "deploymentId": "dpl_local",
+                "workflowName": WORKFLOW,
+                "specVersion": 6,
+            }
+        ),
+    )
+
+
+def _on_the_wire(payload: w.WorkflowInvokePayload) -> dict:
+    """What `queue()` hands the transport, proven JSON-serializable."""
+    encoded = local_mod._encode_js(payload.model_dump())
+    return json.loads(json.dumps(encoded))
+
+
+def _parse(wire: dict) -> w.WorkflowInvokePayload:
+    """Decode a wire dict the way the receive handler does."""
+    parsed = w.QueuePayloadAdaptor.validate_python(local_mod._decode_js(wire))
+    assert isinstance(parsed, w.WorkflowInvokePayload)
+    assert parsed.run_input is not None
+    return parsed
+
+
+def test_send_encodes_bytes_as_the_uint8array_envelope() -> None:
+    """Raw `bytes` would not survive `json.dumps` at all."""
+    wire = _on_the_wire(_payload())
+
+    assert wire["runInput"]["input"] == {
+        "__type": "Uint8Array",
+        "data": "ZGV2bFtbMSwzXSxbMl0sMSwxMjNd",
+    }
+
+
+def test_receive_restores_the_bytes() -> None:
+    parsed = _parse(_on_the_wire(_payload()))
+
+    assert parsed.run_input is not None and parsed.run_input.input == INPUT
+
+
+def test_a_ts_written_envelope_is_accepted() -> None:
+    """The producer is `@workflow/world-local`, so this is the real input shape —
+    and the run entity it builds wants `bytes`, not the envelope."""
+    ts_wire = {
+        "runId": RUN_ID,
+        "runInput": {
+            "input": {"__type": "Uint8Array", "data": "ZGV2bFtbMSwzXSxbMl0sMSwxMjNd"},
+            "deploymentId": "dpl_local",
+            "workflowName": WORKFLOW,
+            "specVersion": 6,
+        },
+    }
+
+    parsed = _parse(ts_wire)
+
+    assert parsed.run_input is not None and parsed.run_input.input == INPUT
+    # The whole point: this is what `_resilient_create_run` feeds the run row.
+    run = w.NonFinalWorkflowRun(
+        runId=RUN_ID,
+        deploymentId="dpl_local",
+        status="pending",
+        workflowName=WORKFLOW,
+        specVersion=6,
+        input=parsed.run_input.input,
+        createdAt=local_mod.js_now(),
+        updatedAt=local_mod.js_now(),
+    )
+    assert run.input == INPUT
+
+
+def test_re_enqueue_round_trips() -> None:
+    """The receive handler re-sends the payload it was handed, so a decoded
+    `bytes` has to be re-encodable. Decoding without encoding breaks here."""
+    parsed = _parse(_on_the_wire(_payload()))
+
+    again = _parse(_on_the_wire(parsed))
+
+    assert again.run_input is not None and again.run_input.input == INPUT
+
+
+def test_a_payload_without_bytes_is_unchanged() -> None:
+    """A re-enqueue carries no `runInput`, and must not grow anything."""
+    bare = w.WorkflowInvokePayload(runId=RUN_ID)
+
+    wire = _on_the_wire(bare)
+
+    assert wire == {"runId": RUN_ID}
+
+
+async def test_bytes_survive_a_real_local_queue_delivery(tmp_path, monkeypatch) -> None:
+    """End to end through the embedded queue, which is where the two halves of
+    the codec actually have to meet."""
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = local_mod.LocalWorld()
+    delivered: list[dict] = []
+
+    async def handler(
+        message: Any, *, attempt: int, queue_name: str, message_id: str
+    ) -> w.QueueContinuation | None:
+        delivered.append(message)
+        return None
+
+    world.create_queue_handler(w.get_queue_topic_prefix(), handler)
+    try:
+        await world.queue(w.get_queue_name(WORKFLOW), _payload())
+        for _ in range(100):
+            if delivered:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await world.aclose()
+
+    assert delivered, "the message was never delivered"
+    parsed = w.QueuePayloadAdaptor.validate_python(delivered[0])
+    assert isinstance(parsed, w.WorkflowInvokePayload)
+    assert parsed.run_input is not None and parsed.run_input.input == INPUT

--- a/src/vercel/tests/unit/test_workflow_local_resilient_start.py
+++ b/src/vercel/tests/unit/test_workflow_local_resilient_start.py
@@ -1,0 +1,331 @@
+"""LocalWorld creating a run from a ``run_started`` whose row never landed.
+
+Mirrors ``@workflow/world-local``'s ``events-storage.ts`` resilient-start branch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vercel._internal.workflow import serialization as ser, world as w
+from vercel._internal.workflow.worlds import local as local_mod
+
+RUN_ID = "wrun_resilient"
+
+
+def _world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    return local_mod.LocalWorld()
+
+
+def _run_input(**overrides) -> w.RunInput:
+    return w.RunInput.model_validate(
+        {
+            "input": ser.dehydrate([7]),
+            "deploymentId": "dpl_1",
+            "workflowName": "add_ten",
+            "specVersion": 6,
+            "executionContext": {"workflowCoreVersion": "5.0.0"},
+        }
+        | overrides
+    )
+
+
+def _resilient_event(run_input: w.RunInput | None = None) -> w.RunStartedEvent:
+    run_input = run_input or _run_input()
+    return w.RunStartedEventData.from_run_input(run_input).into_event(
+        spec_version=run_input.spec_version
+    )
+
+
+async def test_run_started_creates_the_missing_run(tmp_path, monkeypatch) -> None:
+    """The whole point: no row, and the run still starts."""
+    world = _world(tmp_path, monkeypatch)
+
+    result = await world.events_create(RUN_ID, _resilient_event())
+
+    assert result.run is not None
+    assert result.run.run_id == RUN_ID
+    # It went through pending and out the other side in the one call.
+    assert result.run.status == "running"
+    assert result.run.started_at is not None
+    assert (await world.runs_get(RUN_ID)).status == "running"
+
+
+async def test_recreated_run_carries_the_creating_client_data(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_input = _run_input(attributes={"tier": "pro"}, encryptionPublicKey="cHVibGljLWtleQ==")
+
+    await world.events_create(RUN_ID, _resilient_event(run_input))
+
+    run = await world.runs_get(RUN_ID)
+    assert run.deployment_id == "dpl_1"
+    assert run.workflow_name == "add_ten"
+    assert run.input == run_input.input
+    assert run.execution_context == {"workflowCoreVersion": "5.0.0"}
+    assert run.attributes == {"tier": "pro"}
+    # Neither is readable through this SDK, but a run that lost them could never
+    # get them back.
+    assert run.encryption_public_key == "cHVibGljLWtleQ=="
+
+
+async def test_recreated_run_keeps_the_creators_spec_version(tmp_path, monkeypatch) -> None:
+    """Relabelling to our own CURRENT (2) would misreport the run's capabilities."""
+    world = _world(tmp_path, monkeypatch)
+
+    await world.events_create(RUN_ID, _resilient_event(_run_input(specVersion=6)))
+
+    assert (await world.runs_get(RUN_ID)).spec_version == 6
+
+
+async def test_synthetic_run_created_replays_first(tmp_path, monkeypatch) -> None:
+    """Replay reads the log in order, so the `run_created` we invent has to sort
+    below the `run_started` that caused it."""
+    world = _world(tmp_path, monkeypatch)
+
+    await world.events_create(RUN_ID, _resilient_event())
+
+    events = (await world.events_list(RUN_ID)).data
+    assert [e.event_type for e in events] == ["run_created", "run_started"]
+    assert events[0].server_props is not None and events[1].server_props is not None
+    assert events[0].server_props.event_id < events[1].server_props.event_id
+
+
+async def test_synthetic_run_created_carries_the_input(tmp_path, monkeypatch) -> None:
+    """It is the event replay reads the arguments from."""
+    world = _world(tmp_path, monkeypatch)
+    run_input = _run_input()
+
+    await world.events_create(RUN_ID, _resilient_event(run_input))
+
+    run_created = (await world.events_list(RUN_ID)).data[0]
+    assert isinstance(run_created, w.RunCreatedEvent)
+    assert run_created.event_data.input == run_input.input
+    assert run_created.event_data.deployment_id == "dpl_1"
+    assert run_created.event_data.workflow_name == "add_ten"
+    assert run_created.spec_version == 6
+
+
+async def test_stored_run_started_has_no_event_data(tmp_path, monkeypatch) -> None:
+    """`eventData` is queue transport, not part of the event. Leaving it on the
+    row would put the run's input in the log twice."""
+    world = _world(tmp_path, monkeypatch)
+
+    await world.events_create(RUN_ID, _resilient_event())
+
+    rows = [json.loads(p.read_text()) for p in sorted((tmp_path / "events").glob("*.json"))]
+    run_started = next(r for r in rows if r["eventType"] == "run_started")
+    assert "eventData" not in run_started
+
+
+async def test_existing_run_is_untouched_by_event_data(tmp_path, monkeypatch) -> None:
+    """When the row is there, the carried data is ignored entirely — it must not
+    overwrite what `run_created` actually recorded."""
+    world = _world(tmp_path, monkeypatch)
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_real",
+            workflowName="add_ten",
+            input=ser.dehydrate([1]),
+        ).into_event(),
+    )
+    assert created.run is not None
+    run_id = created.run.run_id
+
+    await world.events_create(
+        run_id, _resilient_event(_run_input(deploymentId="dpl_bogus", input=ser.dehydrate([999])))
+    )
+
+    run = await world.runs_get(run_id)
+    assert run.status == "running"
+    assert run.deployment_id == "dpl_real"
+    assert run.input == ser.dehydrate([1])
+    # No second run_created invented on top of the real one.
+    events = (await world.events_list(run_id)).data
+    assert [e.event_type for e in events] == ["run_created", "run_started"]
+
+
+async def test_concurrent_run_created_wins_the_row(tmp_path, monkeypatch) -> None:
+    """`start()`'s own write may land between our read and our create, so the
+    exclusive write has to leave it alone.
+
+    Simulated by having the racing writer land *inside* our attempt: absent when
+    we look, present when we write, which is the whole window.
+    """
+    world = _world(tmp_path, monkeypatch)
+    real_input = ser.dehydrate([1])
+    real_row = local_mod.dumps_js(
+        w.NonFinalWorkflowRun(
+            runId=RUN_ID,
+            deploymentId="dpl_real",
+            status="pending",
+            workflowName="add_ten",
+            specVersion=6,
+            input=real_input,
+            createdAt=local_mod.js_now(),
+            updatedAt=local_mod.js_now(),
+        ).model_dump(exclude_none=True)
+    ).decode()
+    real = local_mod.write_exclusive
+    raced = False
+
+    def racing_write_exclusive(path, data):
+        nonlocal raced
+        if path.name == f"{RUN_ID}.json" and not raced:
+            raced = True
+            # The other writer gets there first, so ours loses the file.
+            assert real(path, real_row)
+            return real(path, data)
+        return real(path, data)
+
+    monkeypatch.setattr(local_mod, "write_exclusive", racing_write_exclusive)
+
+    result = await world.events_create(
+        RUN_ID, _resilient_event(_run_input(deploymentId="dpl_bogus"))
+    )
+
+    assert raced, "the race path was never taken"
+    assert result.run is not None
+    assert result.run.status == "running"
+    # Theirs, not the one our queue message described.
+    assert result.run.deployment_id == "dpl_real"
+    assert result.run.input == real_input
+    # We lost, so we wrote no synthetic run_created either.
+    assert [e.event_type for e in (await world.events_list(RUN_ID)).data] == ["run_started"]
+
+
+async def test_bare_run_started_on_a_missing_run_still_fails(tmp_path, monkeypatch) -> None:
+    """A re-enqueue carries no `runInput`, so there is nothing to recover from
+    and the missing row stays an error, as the Vercel world's 404 does."""
+    world = _world(tmp_path, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="not found"):
+        await world.events_create(RUN_ID, w.RunStartedEvent())
+
+    # No row and no event invented out of nothing.
+    with pytest.raises(RuntimeError, match="not found"):
+        await world.runs_get(RUN_ID)
+    assert not list((tmp_path / "events").glob("*.json"))
+
+
+@pytest.mark.parametrize("field", ["deploymentId", "workflowName", "input"])
+@pytest.mark.parametrize("how", ["missing", "empty"])
+async def test_incomplete_event_data_creates_nothing(tmp_path, monkeypatch, field, how) -> None:
+    """All three are needed to open a row; a partial one would be worse than none.
+
+    Empty counts as absent for the two names, matching the truthiness guard in
+    `events-storage.ts` — a run row with an empty `deploymentId` is garbage.
+    """
+    world = _world(tmp_path, monkeypatch)
+    data = {
+        "deploymentId": "dpl_1",
+        "workflowName": "add_ten",
+        "input": ser.dehydrate([7]),
+    }
+    if how == "missing":
+        del data[field]
+    else:
+        data[field] = b"" if field == "input" else ""
+        if field == "input":
+            pytest.skip("empty bytes is a legal payload, unlike an empty name")
+
+    with pytest.raises(RuntimeError, match="not found"):
+        await world.events_create(
+            RUN_ID, w.RunStartedEvent(eventData=w.RunStartedEventData.model_validate(data))
+        )
+
+    with pytest.raises(RuntimeError, match="not found"):
+        await world.runs_get(RUN_ID)
+
+
+async def test_terminal_run_still_conflicts(tmp_path, monkeypatch) -> None:
+    """Resilient start must not resurrect a run that already finished."""
+    world = _world(tmp_path, monkeypatch)
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1", workflowName="add_ten", input=ser.dehydrate([1])
+        ).into_event(),
+    )
+    assert created.run is not None
+    run_id = created.run.run_id
+    await world.events_create(run_id, w.RunStartedEvent())
+    await world.events_create(
+        run_id, w.RunCompletedEventData(output=ser.dehydrate(11)).into_event()
+    )
+
+    with pytest.raises(w.EntityConflictError):
+        await world.events_create(run_id, _resilient_event())
+
+
+async def test_run_started_on_a_running_run_appends_no_event(tmp_path, monkeypatch) -> None:
+    """The runtime issues `run_started` on *every* delivery, so a log that grew
+    an entry per replay would be unbounded."""
+    world = _world(tmp_path, monkeypatch)
+    first = await world.events_create(RUN_ID, _resilient_event())
+    assert first.run is not None
+
+    second = await world.events_create(RUN_ID, _resilient_event())
+
+    assert second.run is not None
+    assert second.run.status == "running"
+    assert second.run.started_at == first.run.started_at
+    assert [e.event_type for e in (await world.events_list(RUN_ID)).data] == [
+        "run_created",
+        "run_started",
+    ]
+
+
+async def test_bare_run_started_on_a_running_run_appends_no_event(tmp_path, monkeypatch) -> None:
+    """Same for a re-enqueue, which carries no `runInput` at all."""
+    world = _world(tmp_path, monkeypatch)
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1", workflowName="add_ten", input=ser.dehydrate([1])
+        ).into_event(),
+    )
+    assert created.run is not None
+    run_id = created.run.run_id
+    await world.events_create(run_id, w.RunStartedEvent())
+
+    result = await world.events_create(run_id, w.RunStartedEvent())
+
+    assert result.run is not None and result.run.status == "running"
+    assert [e.event_type for e in (await world.events_list(run_id)).data] == [
+        "run_created",
+        "run_started",
+    ]
+
+
+async def test_encryption_public_key_survives_the_lifecycle(tmp_path, monkeypatch) -> None:
+    """Every transition rewrites the whole row, so a field the model does not
+    carry is erased on the next event."""
+    world = _world(tmp_path, monkeypatch)
+    await world.events_create(
+        RUN_ID, _resilient_event(_run_input(encryptionPublicKey="cHVibGljLWtleQ=="))
+    )
+
+    await world.events_create(
+        RUN_ID, w.RunCompletedEventData(output=ser.dehydrate(17)).into_event()
+    )
+
+    run = await world.runs_get(RUN_ID)
+    assert run.status == "completed"
+    assert run.encryption_public_key == "cHVibGljLWtleQ=="
+    # And on disk, where a TS reader looks for it.
+    row = json.loads((tmp_path / "runs" / f"{RUN_ID}.json").read_text())
+    assert row["encryptionPublicKey"] == "cHVibGljLWtleQ=="
+
+
+async def test_no_encryption_key_is_absent_not_null(tmp_path, monkeypatch) -> None:
+    """The TS run schema types it `undefined`; an explicit null is rejected."""
+    world = _world(tmp_path, monkeypatch)
+
+    await world.events_create(RUN_ID, _resilient_event())
+
+    row = json.loads((tmp_path / "runs" / f"{RUN_ID}.json").read_text())
+    assert "encryptionPublicKey" not in row


### PR DESCRIPTION
Second of three. Stacked on #282.

A `run_started` for a run with no row is a legal state, not an error one — see #282 for why `start()` does not order its two writes. This teaches `LocalWorld` to recover, mirroring `@workflow/world-local`'s `events-storage.ts`.

## What's here

- **Create the run from the event's `eventData`** when the row is missing. The create is exclusive, so a concurrent `run_created` from `start()` keeps the row and we continue on top of it rather than clobbering a run that may already be running.
- **Write the `run_created` the log never got**, drawn into an earlier event-id slot so replay reads it first.
- **Strip `eventData` from the stored `run_started`** — it belongs to `run_created`, and leaving it would put the run's input in the log twice.
- **Make `run_started` idempotent for a run already in `running`**: return the run without appending a second event. #283 stops reading the run before deciding whether to write this event, so it will be issued on *every* delivery rather than only the first — a log that grew an entry per replay would be unbounded. This is the contract the upstream runtime comment names explicitly.

## Two pre-existing divergences this required closing

Neither is caused by the change; both would have made the recovery path silently lossy.

- **A `run_started` or `run_failed` for a run that does not exist was being persisted anyway**, leaving the caller to trip over the missing run later with no context. Now rejected, as the Vercel world's 404 does — upstream rejects these "to match the postgres and vercel worlds".
- **Run rows were losing `encryptionPublicKey`.** The model did not carry it, so `extra="ignore"` dropped it on read and every lifecycle transition rewrote the row without it. Harmless while nothing wrote one, but resilient start is exactly the path where the key would be lost for the rest of the run's life — so the field is now modelled and forwarded through all four transitions.

## Test plan

17 new tests. Each assertion was mutation-checked: breaking the exclusive write, the event ordering, the `eventData` strip, the spec-version passthrough, or the key forwarding each fails at least one test. One of my own tests was initially passing vacuously (it wrote the racing row *before* the call, so the recovery path was never entered) — the mutation run is what caught that.

`uv run poe qa` green at this commit.