### PR TITLE
[apscheduler] fail preview chains safe when the idle deadline is lost

### DIFF
--- a/changes/vercel-apscheduler/preview-idle-failsafe.bugfix.md
+++ b/changes/vercel-apscheduler/preview-idle-failsafe.bugfix.md
@@ -1,0 +1,8 @@
+An opted-in preview whose driver document was evicted could lose its idle
+deadline: the next wake adopted the chain from the message and kept it
+running with no traffic requirement until the deployment was deleted. Start
+and wake payloads now carry an `idle_bounded` marker, and a claim refuses to
+adopt an idle-bounded chain into a document without a deadline, so an
+evicted preview stops early and the next real request re-activates it. The
+driver also logs whenever it rebuilds state from a message, making cache
+eviction observable.

--- a/integrations/vercel-apscheduler/SCHEDULER.md
+++ b/integrations/vercel-apscheduler/SCHEDULER.md
@@ -225,6 +225,14 @@ closed:
 - work already in flight may finish, but cannot extend the chain; and
 - no periodic message keeps an abandoned preview alive.
 
+The deadline lives only in the driver document, so its absence must also
+fail closed. Start and wake payloads carry an `idle_bounded` marker derived
+from configuration, and a claim refuses to adopt an idle-bounded chain into
+a document that carries no deadline. An evicted preview document therefore
+stops the chain instead of resurrecting it unbounded — the one deliberate
+exception to the message-is-the-authority adoption rule, because for a
+disposable preview, absence maps to stopped.
+
 The next real request changes `inactive` to `running`, increments the
 generation, and publishes one start identity. Activation rebases persisted
 jobs to that request time, so the inactive interval is skipped rather than

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -212,6 +212,50 @@ def test_cache_driver_adopts_newer_wake_and_fences_older() -> None:
     assert driver.claim_wake(older, "owner-3", now).state == "stale"
 
 
+def test_cache_driver_idle_bounded_adoption_fails_stale() -> None:
+    """An evicted preview document must stop the chain, not unbound it.
+
+    The idle deadline lives only in the document; adopting an idle-bounded
+    chain into an empty document would resurrect it with no deadline and no
+    traffic requirement — a runaway preview.
+    """
+    driver = cache_driver()
+    now = datetime.now(UTC)
+    token = WakeToken(generation=3, sequence=7, logical_time=now)
+
+    assert driver.claim_wake(token, "owner-1", now, idle_bounded=True).state == "stale"
+    assert driver.claim_start(3, "owner-2", now, idle_bounded=True).state == "stale"
+    # The refusal writes nothing: the document stays absent.
+    assert driver.snapshot().generation == 0
+
+
+def test_cache_driver_idle_bounded_adoption_needs_an_unexpired_deadline() -> None:
+    driver = cache_driver()
+    now = datetime.now(UTC)
+
+    # A document with a live deadline accepts newer idle-bounded deliveries.
+    driver.start(now, idle_timeout_seconds=1800)
+    assert driver.claim_start(2, "owner-1", now, idle_bounded=True).state == "claimed"
+    finish = driver.finish_start(2, "owner-1", now + timedelta(minutes=1), now)
+    assert finish.state == "advanced"
+    assert finish.wake is not None
+    ahead = WakeToken(
+        generation=2,
+        sequence=finish.wake.sequence + 3,
+        logical_time=now + timedelta(minutes=5),
+    )
+    assert driver.claim_wake(ahead, "owner-2", now, idle_bounded=True).state == "claimed"
+
+
+def test_cache_driver_unbounded_adoption_is_unchanged_by_the_flag_default() -> None:
+    """Production and development chains keep adopting from empty documents."""
+    driver = cache_driver()
+    now = datetime.now(UTC)
+    token = WakeToken(generation=2, sequence=5, logical_time=now)
+
+    assert driver.claim_wake(token, "owner-1", now).state == "claimed"
+
+
 def test_cache_driver_resume_generation_revives_paused_document() -> None:
     driver = cache_driver()
     now = datetime.now(UTC)

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_driver.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_driver.py
@@ -21,6 +21,36 @@ def test_payloads_round_trip_generation_and_sequence() -> None:
     assert WakeupPayload.from_payload(wake.to_payload()) == wake
 
 
+def test_payloads_round_trip_idle_boundedness() -> None:
+    start = StartPayload("scheduler_scheduler", 3, idle_bounded=True)
+    wake = WakeupPayload(
+        "scheduler_scheduler",
+        3,
+        7,
+        datetime(2026, 7, 30, 12, 0, tzinfo=UTC),
+        idle_bounded=True,
+    )
+
+    assert StartPayload.from_payload(start.to_payload()).idle_bounded is True
+    assert WakeupPayload.from_payload(wake.to_payload()).idle_bounded is True
+
+
+def test_payloads_without_the_idle_field_parse_as_unbounded() -> None:
+    """Messages published before the field existed keep working."""
+    start = StartPayload("scheduler_scheduler", 3).to_payload()
+    wake = WakeupPayload(
+        "scheduler_scheduler",
+        3,
+        7,
+        datetime(2026, 7, 30, 12, 0, tzinfo=UTC),
+    ).to_payload()
+    del start["idle_bounded"]
+    del wake["idle_bounded"]
+
+    assert StartPayload.from_payload(start).idle_bounded is False
+    assert WakeupPayload.from_payload(wake).idle_bounded is False
+
+
 def test_far_future_wakes_bridge_without_an_idle_poll() -> None:
     now = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
     due = now + timedelta(seconds=70)

--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_integration.py
@@ -263,7 +263,10 @@ class FakeDriver:
         generation: int,
         owner: str,
         now: datetime,
+        *,
+        idle_bounded: bool = False,
     ) -> ClaimResult:
+        del idle_bounded
         with self.lock:
             if (
                 self.state != "running"
@@ -328,8 +331,10 @@ class FakeDriver:
         token: WakeToken,
         owner: str,
         now: datetime,
+        *,
+        idle_bounded: bool = False,
     ) -> ClaimResult:
-        del now
+        del now, idle_bounded
         with self.lock:
             if (
                 self.state != "running"
@@ -422,6 +427,7 @@ def runtime(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.delenv("VERCEL_TARGET_ENV", raising=False)
     monkeypatch.delenv("VERCEL_PYTHON_SUBSCRIBER_ID", raising=False)
     monkeypatch.delenv("VERCEL_APSCHEDULER_BACKEND", raising=False)
+    monkeypatch.delenv("VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS", raising=False)
     monkeypatch.setenv(
         "VERCEL_APSCHEDULER_SUBSCRIBERS",
         (
@@ -1131,6 +1137,36 @@ def test_runtime_mutations_are_rejected() -> None:
     assert persisted.next_run_time == persisted_run_time
     assert persisted.trigger.interval == timedelta(hours=2)
     assert driver.current == armed
+
+
+def test_opted_in_preview_publishes_idle_bounded_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Idle-boundedness is config-derived and stamped on every publication."""
+    monkeypatch.setenv("VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS", "1800")
+    scheduler, _adapter, _driver = scheduler_with_driver()
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_start",
+    ) as send:
+        scheduler.start()
+
+    payload = send.call_args.args[1]
+    assert payload["idle_bounded"] is True
+
+
+def test_unbounded_environments_publish_unbounded_payloads() -> None:
+    scheduler, _adapter, _driver = scheduler_with_driver()
+
+    with patch(
+        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+        return_value="msg_start",
+    ) as send:
+        scheduler.start()
+
+    payload = send.call_args.args[1]
+    assert payload["idle_bounded"] is False
 
 
 def test_runtime_job_creation_is_rejected() -> None:

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_adapter.py
@@ -418,6 +418,13 @@ class SchedulerAdapter:
 
         return _preview_idle_timeout()
 
+    def _idle_bounded(self) -> bool:
+        """Whether this chain is subject to a preview idle deadline.
+
+        Configuration-derived, so racing publishers stamp identical payloads.
+        """
+        return self._preview_idle_timeout_seconds() is not None
+
     def _publish_start_if_needed(
         self,
         decision: StartDecision,
@@ -429,6 +436,7 @@ class SchedulerAdapter:
         payload = StartPayload(
             scheduler_id=self.identity.scheduler_id,
             generation=decision.generation,
+            idle_bounded=self._idle_bounded(),
         ).to_payload()
         idempotency_key = (
             f"{WAKEUP_KEY_PREFIX}:start:{self.scope}:"
@@ -465,6 +473,7 @@ class SchedulerAdapter:
         payload = WakeupPayload.from_token(
             self.identity.scheduler_id,
             token,
+            idle_bounded=self._idle_bounded(),
         ).to_payload()
         try:
             message_id = vqs_sync.send(

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/_protocols.py
@@ -70,7 +70,17 @@ class Driver(Protocol):
         generation: int,
         owner: str,
         now: datetime,
-    ) -> ClaimResult: ...
+        *,
+        idle_bounded: bool = False,
+    ) -> ClaimResult:
+        """Claim a start delivery.
+
+        ``idle_bounded`` is the message's statement that this chain is
+        subject to a preview idle deadline; adopting such a chain into a
+        document that carries no deadline must fail stale instead of
+        resurrecting an unbounded chain.
+        """
+        ...
 
     def finish_start(
         self,
@@ -87,7 +97,16 @@ class Driver(Protocol):
         now: datetime,
     ) -> None: ...
 
-    def claim_wake(self, token: WakeToken, owner: str, now: datetime) -> ClaimResult: ...
+    def claim_wake(
+        self,
+        token: WakeToken,
+        owner: str,
+        now: datetime,
+        *,
+        idle_bounded: bool = False,
+    ) -> ClaimResult:
+        """Claim a wake delivery; see ``claim_start`` for ``idle_bounded``."""
+        ...
 
     def finish_wake(
         self,

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_backends/cache/_driver.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 
 from vercel.cache import get_cache
 
+from ..._options import resolve_environment
 from ..._time import as_utc
 from ..._types import (
     WAKE_REPAIR_GRACE_SECONDS,
@@ -83,6 +84,42 @@ class CacheDriver:
             sequence=int(current.get("sequence") or 0),
             logical_time=logical_time,
             status=str(current.get("status") or "pending"),
+        )
+
+    def _log_adoption(self, kind: str, doc: dict[str, Any], generation: int) -> None:
+        """Make eviction observable: adoption means the document was behind.
+
+        Under ``vercel dev`` the cache is per-process memory, so every
+        sidecar's first claim adopts; that is routine, not a loss signal.
+        """
+        missing = not doc
+        if resolve_environment().casefold() == "development":
+            LOGGER.debug(
+                'Adopted %s generation %s for scheduler "%s" from the message',
+                kind,
+                generation,
+                self.scheduler_id,
+            )
+            return
+        LOGGER.log(
+            logging.WARNING if missing else logging.INFO,
+            'Rebuilt the driver document for scheduler "%s" from a %s message '
+            "(generation %s): the local document was %s",
+            self.scheduler_id,
+            kind,
+            generation,
+            "missing (possible cache eviction)" if missing else "behind the chain",
+        )
+
+    def _log_idle_bounded_refusal(self, kind: str, generation: int) -> None:
+        LOGGER.warning(
+            'Refused to adopt %s generation %s for scheduler "%s": the chain '
+            "is idle-bounded but the local document carries no idle deadline "
+            "(possible cache eviction); the next request re-activates the "
+            "preview",
+            kind,
+            generation,
+            self.scheduler_id,
         )
 
     def _idle_lapsed(self, doc: dict[str, Any], now: datetime) -> bool:
@@ -286,7 +323,14 @@ class CacheDriver:
             doc["start_status"] = "published"
             self._write(doc, as_utc(now, name="now"))
 
-    def claim_start(self, generation: int, owner: str, now: datetime) -> ClaimResult:
+    def claim_start(
+        self,
+        generation: int,
+        owner: str,
+        now: datetime,
+        *,
+        idle_bounded: bool = False,
+    ) -> ClaimResult:
         """Claim a start delivery, adopting newer generations from the message.
 
         Cache documents are reconstructable hints — evictable in deployments,
@@ -294,6 +338,11 @@ class CacheDriver:
         chain progress. A generation ahead of the local document is adopted
         wholesale; ``paused`` fences only its own and older generations, so a
         resume (which mints a new generation) revives a paused document.
+
+        The one exception is an idle-bounded chain: its deadline lives only
+        in the document, so adopting it into a document without a deadline
+        would resurrect the chain unbounded. Absence fails stale instead;
+        the next real request re-activates the preview.
         """
         now = as_utc(now, name="now")
         doc = self._read()
@@ -316,6 +365,10 @@ class CacheDriver:
             doc["start_claimed_at"] = iso(now)
             self._write(doc, now)
             return ClaimResult(state="claimed", activation_time=activation_time)
+        if idle_bounded and from_iso(doc.get("idle_expires_at")) is None:
+            self._log_idle_bounded_refusal("start", generation)
+            return ClaimResult(state="stale")
+        self._log_adoption("start", doc, generation)
         doc.update(
             state="running",
             generation=generation,
@@ -389,13 +442,21 @@ class CacheDriver:
         expected = (token.generation, token.sequence, token.logical_time)
         return record if actual == expected else None
 
-    def claim_wake(self, token: WakeToken, owner: str, now: datetime) -> ClaimResult:
+    def claim_wake(
+        self,
+        token: WakeToken,
+        owner: str,
+        now: datetime,
+        *,
+        idle_bounded: bool = False,
+    ) -> ClaimResult:
         """Claim a wake delivery, adopting chain progress from the message.
 
         Same authority rule as ``claim_start``: the local document loses to a
         strictly newer ``(generation, sequence)``. An exact match claims the
         recorded token; anything older is stale. ``paused`` fences its own
-        generation only.
+        generation only. An idle-bounded chain refuses adoption into a
+        document without a deadline (see ``claim_start``).
         """
         now = as_utc(now, name="now")
         doc = self._read()
@@ -422,6 +483,10 @@ class CacheDriver:
         if token.generation == local_generation and doc.get("state") != "running":
             # Same-generation pause fences its remaining wakes.
             return ClaimResult(state="stale")
+        if idle_bounded and from_iso(doc.get("idle_expires_at")) is None:
+            self._log_idle_bounded_refusal("wake", token.generation)
+            return ClaimResult(state="stale")
+        self._log_adoption("wake", doc, token.generation)
         activation_time = from_iso(doc.get("activation_time")) or now
         doc.update(
             state="running",

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_payload.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_payload.py
@@ -22,6 +22,11 @@ __all__ = ["StartPayload", "WakeupPayload"]
 class StartPayload:
     scheduler_id: str
     generation: int
+    # Whether this chain is bounded by a preview idle deadline. Derived from
+    # configuration, so racing publishers agree; carried in the message so a
+    # claim never adopts an idle-bounded chain into a document that has lost
+    # its deadline.
+    idle_bounded: bool = False
 
     def __post_init__(self) -> None:
         if not self.scheduler_id:
@@ -34,6 +39,7 @@ class StartPayload:
             "vercel": {"kind": START_KIND, "version": START_VERSION},
             "scheduler_id": self.scheduler_id,
             "generation": self.generation,
+            "idle_bounded": self.idle_bounded,
         }
 
     @classmethod
@@ -43,7 +49,11 @@ class StartPayload:
         if not isinstance(scheduler_id, str) or not scheduler_id:
             raise ValueError("Invalid start payload: missing scheduler_id")
         generation = _positive_int(envelope.get("generation"), name="generation")
-        return cls(scheduler_id=scheduler_id, generation=generation)
+        return cls(
+            scheduler_id=scheduler_id,
+            generation=generation,
+            idle_bounded=bool(envelope.get("idle_bounded", False)),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +62,8 @@ class WakeupPayload:
     generation: int
     sequence: int
     logical_time: datetime
+    # See StartPayload.idle_bounded.
+    idle_bounded: bool = False
 
     def __post_init__(self) -> None:
         if not self.scheduler_id:
@@ -67,12 +79,19 @@ class WakeupPayload:
         )
 
     @classmethod
-    def from_token(cls, scheduler_id: str, token: WakeToken) -> WakeupPayload:
+    def from_token(
+        cls,
+        scheduler_id: str,
+        token: WakeToken,
+        *,
+        idle_bounded: bool = False,
+    ) -> WakeupPayload:
         return cls(
             scheduler_id=scheduler_id,
             generation=token.generation,
             sequence=token.sequence,
             logical_time=token.logical_time,
+            idle_bounded=idle_bounded,
         )
 
     def to_token(self) -> WakeToken:
@@ -89,6 +108,7 @@ class WakeupPayload:
             "generation": self.generation,
             "sequence": self.sequence,
             "logical_time": self.logical_time.isoformat(),
+            "idle_bounded": self.idle_bounded,
         }
 
     @classmethod
@@ -112,6 +132,7 @@ class WakeupPayload:
             ),
             sequence=_positive_int(envelope.get("sequence"), name="sequence"),
             logical_time=logical_time,
+            idle_bounded=bool(envelope.get("idle_bounded", False)),
         )
 
 

--- a/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
+++ b/integrations/vercel-apscheduler/vercel/integrations/apscheduler/_subscriber.py
@@ -91,6 +91,7 @@ def _process_start(
         payload.generation,
         owner,
         datetime.now(UTC),
+        idle_bounded=payload.idle_bounded,
     )
     if claim.state == "busy":
         raise vqs.RetryAfter(BUSY_RETRY_SECONDS)
@@ -143,7 +144,12 @@ def _process_wakeup(
 
     token = payload.to_token()
     owner = uuid4().hex
-    claim = adapter.driver.claim_wake(token, owner, datetime.now(UTC))
+    claim = adapter.driver.claim_wake(
+        token,
+        owner,
+        datetime.now(UTC),
+        idle_bounded=payload.idle_bounded,
+    )
     if claim.state == "busy":
         raise vqs.RetryAfter(BUSY_RETRY_SECONDS)
     if claim.state == "stale":


### PR DESCRIPTION
### Prevent runaway preview environment chains:

An opted-in preview whose driver document was evicted lost its idle deadline, and the next wake adopted the chain from the message and kept it running with no traffic requirement until the deployment was deleted.

The core intuition: the idle deadline lives only in the document, so for an idle-bounded chain, document absence must mean stop, not run. Start and wake payloads now carry a config-derived `idle_bounded` marker (canonical across racing publishers), and a claim refuses to adopt an idle-bounded chain into a document without a deadline. The next real request re-activates the preview and skips the inactive interval — the already-documented expiry behavior.

Production and development are untouched: they are never idle-bounded, so their adoption rule (message is the authority, absence never strands the chain) is unchanged, including the `vercel dev` sidecar's per-process memory.

Also makes eviction observable: the driver logs whenever it rebuilds state from a message or refuses an idle-bounded adoption. Old messages without the payload field parse as unbounded.