### PR TITLE
workflow: attach metadata to a hook

### DIFF
--- a/changes/vercel-workflow/hook-metadata.feature.md
+++ b/changes/vercel-workflow/hook-metadata.feature.md
@@ -1,0 +1,1 @@
+`BaseHook.wait()` accepts `metadata` to record on the hook, and `get_hook_by_token()` reads it back for a resumer.

--- a/src/vercel-workflow/README.md
+++ b/src/vercel-workflow/README.md
@@ -65,6 +65,32 @@ async def wait_for_approval() -> bool:
 
 `BaseHook` supports dataclasses and Pydantic models for external resume events.
 
+Pass `metadata` to record data on the hook itself, for whoever resumes it:
+
+```python
+@app.workflow
+async def wait_for_approval(order_id: str) -> bool:
+    approval = await Approval.wait(token=f"order:{order_id}", metadata={"order": order_id})
+    return bool(approval and approval.approved)
+```
+
+Metadata is written once, when the hook is registered, and is not part of the
+payload. The resumer reads it back with `get_hook_by_token()`, already decoded,
+which is how a run tells it what it is waiting for:
+
+```python
+from vercel.workflow import get_hook_by_token
+
+hook = await get_hook_by_token(f"order:{order_id}")
+if hook.metadata["order"] == order_id:
+    await Approval(approved=True).resume(hook)
+```
+
+That `Hook` carries the token, hook and run ids, when it was created, and the
+decoded metadata. Pass it back to `resume()` rather than the token to reuse the
+lookup. `get_hook_by_token()` raises `HookNotFoundError` when no live hook holds
+the token.
+
 ## Streaming
 
 Every run has a stream a step can write to while it runs, so a client sees

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_metadata.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_metadata.py
@@ -1,0 +1,241 @@
+"""Metadata attached to a hook at ``wait()``, and how a resumer reads it back.
+
+``createHook({ metadata })`` records arbitrary data *on the hook*, not on its
+payload, and whoever resumes the hook reads it off the hook entity to decide
+what to send. It is often the only channel a run has to that resumer, so the
+value has to survive the whole way: authoring API -> ``hook_created`` event ->
+hook entity -> ``get_hook_by_token()``.
+
+Most of this drives that path against a real ``LocalWorld``, from a body that
+really suspends, so both halves are asserted where they are actually used --
+the bytes on the entity, which is what a TypeScript resumer reads, and the
+decoded value this SDK's own resumer gets.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pydantic
+import pytest
+
+from vercel.workflow import BaseHook, HookNotFoundError, get_hook_by_token
+from vercel.workflow._internal import core, runtime, serialization as ser, world as w
+from vercel.workflow._internal.worlds import local as local_mod
+
+TOKEN = "order-42"
+METADATA = {"customData": "orange"}
+
+registry = core.Workflows(as_vercel_job=False)
+
+
+class Approval(BaseHook, pydantic.BaseModel):
+    decision: str
+
+
+@registry.workflow
+async def approvals() -> str:
+    """Module level, because the sandbox re-imports the body by qualname."""
+    approval = await Approval.wait(token=TOKEN, metadata=METADATA)
+    return approval.decision if approval is not None else "disposed"
+
+
+class _RecordingLocalWorld(local_mod.LocalWorld):
+    """Real storage; the outbound queue and the run key are the only stubs.
+
+    ``queue`` would otherwise stand up the embedded queue service, and counting
+    lookups is how the "pass the hook back" path is checked for what it claims
+    to save.
+    """
+
+    def __init__(self, run_key: bytes | None = None) -> None:
+        super().__init__()
+        self.queued: list[tuple[str, w.QueuePayload]] = []
+        self.lookups: list[str] = []
+        self._run_key = run_key
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_test"
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        self.lookups.append(token)
+        return await super().hooks_get_by_token(token)
+
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        return self._run_key
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+@pytest.fixture
+async def registered(tmp_path, monkeypatch) -> _RecordingLocalWorld:
+    """A run of `approvals` suspended on its hook, on a real ``LocalWorld``.
+
+    Nothing about the hook is hand-written: the body ran, the flush wrote the
+    ``hook_created`` event, and the world registered the token from it.
+    """
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = _RecordingLocalWorld()
+    w.set_world(world)
+
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="",
+            workflowName=approvals.workflow_id,
+            input=ser.dehydrate([]),
+        ).into_event(),
+    )
+    assert created.run is not None
+    await runtime.workflow_handler(
+        w.WorkflowInvokePayload(runId=created.run.run_id).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(approvals.workflow_id),
+        message_id="msg_1",
+        registry=registry,
+    )
+    world.lookups.clear()
+    return world
+
+
+def _context() -> runtime.WorkflowOrchestratorContext:
+    return runtime.WorkflowOrchestratorContext(
+        [],
+        run_id="wrun_test",
+        seed="wrun_test",
+        started_at=0,
+        registry=registry,
+    )
+
+
+# ── writing it ─────────────────────────────────────────────────────────────
+
+
+def test_metadata_is_encoded_when_the_hook_is_created() -> None:
+    ctx = _context()
+
+    event = ctx.create_hook(TOKEN, Approval, metadata=METADATA)
+
+    hook = ctx.hooks[event._correlation_id]
+    assert hook.metadata == ser.dehydrate(METADATA)
+
+
+def test_an_unserializable_value_fails_at_the_wait_call() -> None:
+    """Rather than in the flush, where nothing names the offending hook."""
+    ctx = _context()
+
+    with pytest.raises(ser.SerializationError):
+        ctx.create_hook(TOKEN, Approval, metadata=object())
+
+
+def test_a_hook_without_metadata_omits_the_field() -> None:
+    """There is no way to record a null, matching `createHook()` treating
+    `undefined` as absent -- and an omitted field is what TypeScript writes."""
+    ctx = _context()
+
+    event = ctx.create_hook(TOKEN, Approval)
+
+    hook = ctx.hooks[event._correlation_id]
+    assert hook.metadata is None
+    dumped = w.HookCreatedEventData(token=TOKEN).model_dump(by_alias=True)
+    assert "metadata" not in dumped
+
+
+async def test_metadata_reaches_the_hook_entity(registered) -> None:
+    """The bytes a TypeScript resumer reads: one serialized payload on the
+    entity, in the same format every other payload uses."""
+    hook = await w.get_world().hooks_get_by_token(TOKEN)
+
+    assert hook.metadata is not None
+    assert hook.metadata.startswith(ser.DEVALUE_V1)
+    assert ser.hydrate(hook.metadata, what="the metadata of the hook") == METADATA
+
+
+# ── reading it back ────────────────────────────────────────────────────────
+
+
+async def test_the_resumer_reads_the_metadata_back(registered) -> None:
+    hook = await get_hook_by_token(TOKEN)
+
+    assert hook.metadata == METADATA
+    assert hook.token == TOKEN
+    assert hook.run_id.startswith("wrun_")
+    assert hook.hook_id.startswith("hook_")
+    assert hook.created_at == (await registered.hooks_get_by_token(TOKEN)).created_at
+
+
+async def test_a_hook_without_metadata_reads_as_none(registered) -> None:
+    world = w.get_world()
+    await world.events_create(
+        (await get_hook_by_token(TOKEN)).run_id,
+        w.HookCreatedEventData(token="plain").into_event("hook_plain"),
+    )
+
+    assert (await get_hook_by_token("plain")).metadata is None
+
+
+async def test_an_unregistered_token_is_not_found(registered) -> None:
+    """Same error a disposed hook gives: nothing distinguishes them, so a token
+    cannot be probed for whether it was ever real."""
+    with pytest.raises(HookNotFoundError):
+        await get_hook_by_token("no-such-token")
+
+
+async def test_encrypted_metadata_is_opened_with_the_run_key(tmp_path, monkeypatch) -> None:
+    """Metadata written by a deployment that encrypts. The key costs an API
+    round trip on the Vercel world, so it is resolved only for a payload that
+    needs one -- which the plaintext tests above cover from the other side."""
+    # Imported here, not at module scope: the sandbox re-executes this module
+    # to reach the workflow body above, and `cryptography` cannot be imported
+    # inside it.
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    key = bytes(range(32))
+    world = _RecordingLocalWorld(run_key=key)
+    w.set_world(world)
+    nonce = os.urandom(12)
+    sealed = ser.ENCRYPTED + nonce + AESGCM(key).encrypt(nonce, ser.dehydrate(METADATA), None)
+
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deploymentId="dpl_1", workflowName="wf", input=ser.dehydrate([])
+        ).into_event(),
+    )
+    assert created.run is not None
+    await world.events_create(
+        created.run.run_id,
+        w.HookCreatedEventData(token=TOKEN, metadata=sealed).into_event("hook_0"),
+    )
+
+    assert (await get_hook_by_token(TOKEN)).metadata == METADATA
+
+
+async def test_resuming_with_the_hook_skips_a_second_lookup(registered) -> None:
+    """What the public `Hook` is for: the resumer that read the metadata to
+    decide what to send does not pay for the hook twice."""
+    hook = await get_hook_by_token(TOKEN)
+    registered.lookups.clear()
+
+    resumed = await Approval(decision="ok").resume(hook)
+
+    assert registered.lookups == []
+    assert resumed == hook
+    # The payload really did land on the run's log, addressed to the hook.
+    events = (await registered.events_list(hook.run_id)).data
+    (received,) = [e for e in events if isinstance(e, w.HookReceivedEvent)]
+    assert received.correlation_id == hook.hook_id
+    assert ser.hydrate(received.event_data.payload, what="the payload") == {"decision": "ok"}
+
+
+async def test_resuming_with_a_token_still_answers_with_the_hook(registered) -> None:
+    resumed = await Approval(decision="ok").resume(TOKEN)
+
+    assert registered.lookups == [TOKEN]
+    assert resumed.metadata == METADATA

--- a/src/vercel-workflow/tests/unit/test_workflow_queue_namespace.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_queue_namespace.py
@@ -28,16 +28,10 @@ def _run(execution_context: dict[str, Any] | None = None) -> w.WorkflowRun:
     )
 
 
-def _hook() -> w.Hook:
-    return w.Hook(
-        runId=RUN_ID,
-        hookId="hook_test",
-        token="hook-token",
-        ownerId="team_test",
-        projectId="prj_test",
-        environment="development",
-        createdAt=NOW,
-    )
+def _hook() -> core.Hook:
+    """A hook as `get_hook_by_token()` hands it back, which is what
+    `resume_hook` takes -- the entity itself never leaves the world."""
+    return core.Hook(token="hook-token", hook_id="hook_test", run_id=RUN_ID, created_at=NOW)
 
 
 class FakeWorld(NoStreams, w.World):

--- a/src/vercel-workflow/vercel/workflow/__init__.py
+++ b/src/vercel-workflow/vercel/workflow/__init__.py
@@ -1,5 +1,6 @@
 from vercel.workflow._internal.core import (
     BaseHook,
+    Hook,
     HookEvent,
     Workflows,
     now,
@@ -10,6 +11,7 @@ from vercel.workflow._internal.core import (
 from vercel.workflow._internal.runtime import (
     Run,
     StepInfo,
+    get_hook_by_token,
     get_step_metadata,
     get_writable,
     read_stream,
@@ -44,7 +46,9 @@ __all__ = [
     "time_ns",
     "Run",
     "BaseHook",
+    "Hook",
     "HookEvent",
+    "get_hook_by_token",
     "get_step_metadata",
     "get_writable",
     "read_stream",

--- a/src/vercel-workflow/vercel/workflow/_internal/core.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/core.py
@@ -6,7 +6,7 @@ import functools
 import inspect
 import random as _random
 from collections.abc import AsyncIterator, Callable, Coroutine, Generator
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, overload
+from typing import Any, Generic, ParamSpec, TypeVar, overload
 
 import pydantic
 
@@ -14,10 +14,6 @@ from vercel._internal.core.polyfills import Self
 
 from . import py_sandbox
 from .world import validate_queue_namespace
-
-if TYPE_CHECKING:
-    from . import world as w
-
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -233,9 +229,18 @@ class HookEvent(Generic[T]):
         ctx.dispose_hook(correlation_id=self._correlation_id)
 
 
+@dataclasses.dataclass(frozen=True)
+class Hook:
+    token: str
+    hook_id: str
+    run_id: str
+    created_at: datetime.datetime
+    metadata: Any = None
+
+
 class BaseHook:
     @classmethod
-    def wait(cls, *, token: str | None = None) -> HookEvent[Self]:
+    def wait(cls, *, token: str | None = None, metadata: Any = None) -> HookEvent[Self]:
         from . import runtime
 
         try:
@@ -243,9 +248,9 @@ class BaseHook:
         except LookupError:
             raise RuntimeError("cannot call wait() outside workflow") from None
         else:
-            return ctx.create_hook(token, cls)
+            return ctx.create_hook(token, cls, metadata=metadata)
 
-    async def resume(self, token_or_hook: str | w.Hook, **kwargs) -> w.Hook:
+    async def resume(self, token_or_hook: str | Hook, **kwargs) -> Hook:
         from . import runtime
 
         try:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -91,6 +91,7 @@ class Hook(BaseSuspension, Generic[T]):
     has_dispose_event: bool = False
     futures: deque[asyncio.Future[T]] = dataclasses.field(default_factory=deque)
     hook_cls: type[T]
+    metadata: bytes | None = None
 
     def set_result(self, raw_data: Any) -> None:
         if dataclasses.is_dataclass(self.hook_cls):
@@ -522,11 +523,14 @@ class WorkflowOrchestratorContext:
             self.run_id, streams.workflow_run_stream_id(self.run_id, namespace)
         )
 
-    def create_hook(self, token: str | None, hook_cls: type[T]) -> core.HookEvent[T]:
+    def create_hook(
+        self, token: str | None, hook_cls: type[T], *, metadata: Any = None
+    ) -> core.HookEvent[T]:
         hook = Hook(
             correlation_id=f"hook_{self.generate_ulid()}",
             token=token or self.generate_nanoid(),
             hook_cls=hook_cls,
+            metadata=None if metadata is None else ser.dehydrate(metadata),
         )
         self.hooks[hook.correlation_id] = hook
         return core.HookEvent(correlation_id=hook.correlation_id, token=hook.token)
@@ -1056,7 +1060,7 @@ async def workflow_handler(
             elif isinstance(sus, Hook):
 
                 async def create_hook(s=sus):
-                    hook_data = w.HookCreatedEventData(token=s.token)
+                    hook_data = w.HookCreatedEventData(token=s.token, metadata=s.metadata)
                     try:
                         await world.events_create(run_id, hook_data.into_event(s.correlation_id))
                     except w.EntityConflictError:
@@ -1658,13 +1662,40 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     return Run(run_id)
 
 
-async def resume_hook(token_or_hook: str | w.Hook, payload: Any) -> w.Hook:
+async def _public_hook(
+    world: w.World, hook: w.Hook, *, run: w.WorkflowRun | None = None
+) -> core.Hook:
+    metadata = hook.metadata
+    if metadata is not None:
+        key = None
+        if ser.is_encrypted(metadata):
+            if run is None:
+                run = await world.runs_get(hook.run_id)
+            key = await world.run_key(run.run_id, deployment_id=run.deployment_id)
+        metadata = ser.hydrate(metadata, what=f"the metadata of hook {hook.hook_id}", key=key)
+    return core.Hook(
+        token=hook.token,
+        hook_id=hook.hook_id,
+        run_id=hook.run_id,
+        created_at=hook.created_at,
+        metadata=metadata,
+    )
+
+
+async def get_hook_by_token(token: str) -> core.Hook:
+    world = w.get_world()
+    return await _public_hook(world, await world.hooks_get_by_token(token))
+
+
+async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook:
     world = w.get_world()
     if isinstance(token_or_hook, str):
-        hook = await world.hooks_get_by_token(token_or_hook)
+        entity = await world.hooks_get_by_token(token_or_hook)
+        run = await world.runs_get(entity.run_id)
+        hook = await _public_hook(world, entity, run=run)
     else:
         hook = token_or_hook
-    run = await world.runs_get(hook.run_id)
+        run = await world.runs_get(hook.run_id)
     data = w.HookReceivedEventData(payload=ser.dehydrate(payload))
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}


### PR DESCRIPTION
This PR adds a public API that allow attaching arbitrary metadata to hooks, and API to read it back.

```python
from dataclasses import dataclass
from vercel.workflow import BaseHook, Workflows

app = Workflows()


@dataclass
class Approval(BaseHook):
    approved: bool


@app.workflow
async def wait_for_approval(order_id: str) -> bool:
    approval = await Approval.wait(token=f"order:{order_id}", metadata={"order": order_id})
    return bool(approval and approval.approved)
```

```python
from vercel.workflow import get_hook_by_token

hook = await get_hook_by_token(f"order:{order_id}")
if hook.metadata["order"] == order_id:
    await Approval(approved=True).resume(hook)
```


This is needed by e2e test.

An alternative solution is to define a typed metadata as a nested class of user `BaseHook` subclasses, but that is not immediately required, and I think can be added later without breaking the API.

---

Hooks can carry metadata now, and a resumer can read it back.

`createHook({ metadata })` records arbitrary data *on the hook* rather than on
its payload. Whoever resumes the hook reads it to decide what to send, which is
often the only channel the run has to that resumer — eight fixtures in the
TypeScript e2e suite depend on it, and most of them fail rather than degrade
without it.

## Writing it

Everything below the authoring API was already here: `Hook.metadata` on the
entity, `metadata` on `HookCreatedEventData` (excluded when absent), and
`HookCreatedEvent.payloads()` already putting it in the key-resolution path. So
this is the parameter and its three touch points:

```python
approval = await Approval.wait(token=f"order:{order_id}", metadata={"order": order_id})
```

The value is encoded at the `wait()` call rather than in the flush, so a value
the body cannot serialize fails where it was offered — the flush runs with no
frame naming either the hook or that line.

## Reading it back

`get_hook_by_token()` mirrors `getHookByToken()` in `@workflow/core`, so either
SDK can resume a hook the other created:

```python
hook = await get_hook_by_token(f"order:{order_id}")
if hook.metadata["order"] == order_id:
    await Approval(approved=True).resume(hook)
```

It answers with a public `Hook` — token, hook and run ids, creation time, and
the *decoded* metadata. Only metadata that is actually encrypted resolves a run
key, which on the Vercel world is an API round trip and which the common hook,
carrying no metadata at all, skips entirely.

`resume()` accepts that `Hook` in place of a token, so a resumer that looked the
hook up to read its metadata does not pay for it twice. Upstream's
`resumeHook(tokenOrHook)` takes the same pair.

The public `Hook` replaces the internal world entity in both signatures. That
entity had been leaking through `BaseHook.resume()` while being unexported and
carrying `metadata` as raw bytes; it now stays behind the World. Its remaining
fields — owner, project, environment, spec version — describe the record rather
than the wait, so they are left off until something needs them.

## Tests

Ten, in `test_workflow_hook_metadata.py`. Four cover the write side, including
the encode-time failure and the field being omitted rather than written null.
The rest drive a real `LocalWorld` from a body that actually suspends, and
assert both halves where they are used: the bytes on the entity, which is what
a TypeScript resumer reads, and the decoded value this SDK's resumer gets —
plus `encr` metadata opening with the run key, the not-found error, and the
lookup that passing the hook back saves (counted, not assumed).

Verified the end-to-end test fails without the flush change, so it is not
vacuous. The eight e2e fixtures are not proven from this repo: they live in
`workbench/python` and three of them also need `hook.getConflict()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
