### PR TITLE
workflow: fix failing cipher calls in sandbox

### DIFF
--- a/changes/vercel-workflow/cryptography-deferred-imports.bugfix.md
+++ b/changes/vercel-workflow/cryptography-deferred-imports.bugfix.md
@@ -1,0 +1,1 @@
+Fix failing or even crashing cipher calls inside the workflow sandbox.

--- a/src/vercel-workflow/tests/unit/test_workflow_encryption.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_encryption.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import base64
 import builtins
 import os
+import subprocess
 import sys
 import typing
 from typing import Any
@@ -309,6 +310,70 @@ def test_decryption_works_inside_the_workflow_sandbox() -> None:
 
     with py_sandbox.workflow_sandbox():
         assert ser.hydrate(payload, what="the input of run wrun_1", key=key) == [{"amount": 21}]
+
+
+def _first_call_of_a_fresh_interpreter(body: str, payload: bytes) -> str:
+    """Run *body* with *payload* in ``sys.argv[1]``, in an interpreter of its own.
+
+    The two tests below need the process to have made no cipher call at all
+    before the one they make, and `cryptography` caches its deferred imports for
+    the life of a process, so nothing a test does can put a warmed interpreter
+    back. A fresh one per test is the only way to see the first call. It also
+    means the payload has to be built out here and handed over as hex: sealing it
+    in the child would be a cipher call, which is the thing being kept for later.
+    """
+    finished = subprocess.run(
+        [sys.executable, "-c", body, payload.hex()],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert finished.returncode == 0, (
+        f"exit {finished.returncode}\nstdout: {finished.stdout}\nstderr: {finished.stderr}"
+    )
+    return finished.stdout.strip()
+
+
+_DECRYPT_IN_SANDBOX = """\
+import sys
+from vercel.workflow._internal import encryption, py_sandbox, serialization as ser
+
+key = encryption.derive_run_key(bytes(range(32)), project_id="prj_test", run_id="wrun_test")
+with py_sandbox.workflow_sandbox():
+    print(ser.hydrate(bytes.fromhex(sys.argv[1]), what="the input of run wrun_1", key=key))
+"""
+
+_FAIL_TO_DECRYPT_IN_SANDBOX = """\
+import sys
+from vercel.workflow._internal import encryption, py_sandbox
+
+key = encryption.derive_run_key(bytes(range(32)), project_id="prj_test", run_id="wrun_test")
+with py_sandbox.workflow_sandbox():
+    try:
+        encryption.open_envelope(key, bytes.fromhex(sys.argv[1]))
+    except encryption.DecryptionError as exc:
+        print(exc)
+"""
+
+
+def test_the_first_decrypt_of_a_process_can_be_the_one_inside_the_sandbox() -> None:
+    payload = seal(RUN_KEY, ser.dehydrate([{"amount": 21}]))
+
+    assert _first_call_of_a_fresh_interpreter(_DECRYPT_IN_SANDBOX, payload) == "[{'amount': 21}]"
+
+
+def test_the_first_failure_of_a_process_can_be_the_one_inside_the_sandbox() -> None:
+    # Failing is its own path: raising `InvalidTag` is what imports
+    # `cryptography.exceptions`, and every release defers that import to the
+    # first call that needs it, on every Python. Reached inside the sandbox it
+    # raises `SystemError` instead of reporting a bad payload, and aborts the
+    # process outright on Python 3.14 -- so a run handed a payload it cannot
+    # open has to be able to say so from here.
+    payload = seal(AESGCM.generate_key(bit_length=256), b"devl[42]")
+
+    said = _first_call_of_a_fresh_interpreter(_FAIL_TO_DECRYPT_IN_SANDBOX, payload[4:])
+    assert "authentication failed" in said
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/vercel-workflow/vercel/workflow/_internal/encryption.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/encryption.py
@@ -57,6 +57,25 @@ def _aes_gcm_decrypt(key: bytes, nonce: bytes, sealed: bytes) -> bytes | None:
         return None
 
 
+# Make `cryptography` do its internal imports now.
+#
+# It's not enough to just import `cryptography` at the beginning of this file.
+# The *first* cipher call imports two more things, even when both are already
+# imported:
+#
+# - the native extension, on cryptography below 45 or on Python 3.10;
+# - `cryptography.exceptions`, on every version, when the call fails and has to
+#   raise `InvalidTag`. Importing that module loads the extension as well.
+#
+# The cipher call may happen inside a sandbox, where imports resolve against a
+# private module table. Either import then loads the native extension a second
+# time and dies there: `SystemError` on Python 3.10, an aborted process on 3.14.
+#
+# Enforcing a silently-failing (to go down the `cryptography.exceptions` path)
+# cipher call here in the host fixes all issues above.
+_aes_gcm_decrypt(bytes(KEY_LENGTH), bytes(NONCE_LENGTH), bytes(TAG_LENGTH))
+
+
 class RunKeyPair(NamedTuple):
     """A run's X25519 keypair, both halves derived from its key material."""
 


### PR DESCRIPTION
This was caught in #294 CI, but applies to any workflow runs. In short, decryption in a workflow sandbox may fail or crash because cryptography have some lazy imports (refs [1](https://github.com/pyca/cryptography/blob/50.0.0/src/rust/src/types.rs#L489-L500), [2](https://github.com/pyca/cryptography/blob/50.0.0/src/rust/src/types.rs#L22-L31), [3](https://github.com/pyca/cryptography/blob/50.0.0/src/rust/src/buf.rs#L53-L79), [4](https://github.com/pyca/cryptography/blob/50.0.0/src/rust/src/exceptions.rs#L35), and pyca/cryptography#12857) during **first** run to built its static cache. The fix here is to just make sure that **first** run happens in the host, covering the call branches we need later at runtime.

---

`cryptography` defers some of its internal imports to the first cipher call, and makes them whether or not the modules are already imported. There are two:

| deferred import | needed by | when |
| --- | --- | --- |
| the native extension | every call | cryptography < 45, or Python 3.10 |
| `cryptography.exceptions` | a call that fails to authenticate | every release, every Python |

A payload is decrypted inside the workflow sandbox, where imports resolve against a private module table, so either import loads the native extension a second time and dies there:

```
File ".../cryptography/exceptions.py", line 9, in <module>
    from cryptography.hazmat.bindings._rust import exceptions as rust_exceptions
File ".../py_sandbox.py", line 813, in _sandbox_import
    return importlib.__import__(name, globals, locals, fromlist or (), level)
...
SystemError: Objects/dictobject.c:2722: bad argument to internal function
```

On Python 3.10 that is where it stops: `SystemError` propagates and the run fails. On 3.14 pyo3 panics at the FFI boundary and the process aborts: `failed to import exception cryptography.exceptions.InvalidTag: SystemError ... thread caused non-unwinding panic. aborting.`

One silently-failing decrypt at import time makes both imports while the host import system is still the one answering. It covers everything this module does, since the cipher, the DER loaders and the X25519 exchange all need the same extension. Failing is the point — a call that succeeds leaves the `exceptions` import for later.

It is unconditional because no version test would be right: the `exceptions` import is deferred on every combination measured, and the extension import depends on the `cryptography` release as much as on the Python version, while `vercel-workflow` accepts `cryptography>=43.0.0` and the lockfile pins one release. The cost is one OpenSSL start-up, around 1 ms, when this module is imported.

## What was broken

- A run handed a payload it cannot open — wrong key, modified payload — raised `SystemError` instead of reporting a `DecryptionError`, and on Python 3.14 took the whole process down with it. Every release, every Python.
- On Python 3.10, a payload that opens perfectly well broke the same way, when the run's first cipher call happened inside the sandbox.

## Tests

Two tests, each in an interpreter of its own: a first decrypt inside the sandbox, and a first authentication failure inside the sandbox. A subprocess is not decoration — the deferred imports are cached for the life of a process, so no test can put a warmed interpreter back, and the payload has to be sealed outside and handed over as hex.

Verified to discriminate. With the import-time call removed, on py3.10 both fail (`SystemError`, exit 1) and on py3.14 the failure test aborts (exit -6); with it in place, both pass on py3.10, py3.14 and the full matrix.

The existing `test_cryptography_is_probed_once_at_import` and `test_x25519_is_bound_once_at_import` do not cover this. The first catches the extension import only on 3.10 and only when its worker has not already made a cipher call — the ordering dependency that turned #294 red. The second seals its payload before blocking imports, so it warms what it means to test. Neither exercises a failure inside the sandbox, which is why `main` is green on 3.11+ with the bug present.

## Verification

- `uv run poe qa vercel-workflow`: 1034 tests, pass
- py3.10 `pytest tests -n auto`, as CI runs it: 1028 passed, 6 skipped
- py3.14 `pytest tests -n auto`: 1030 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)