### PR TITLE
sandbox: Skip httpx client timeout for unbounded operations

### DIFF
--- a/changes/vercel-internal-core/20260818160900.internal.md
+++ b/changes/vercel-internal-core/20260818160900.internal.md
@@ -1,0 +1,1 @@
+Support disabling HTTP timeouts for selected SDK operations while preserving the client default elsewhere.

--- a/changes/vercel-sandbox/20260818161000.bugfix.md
+++ b/changes/vercel-sandbox/20260818161000.bugfix.md
@@ -1,0 +1,1 @@
+Allow Sandbox process waits and log streams to remain idle longer than the session HTTP timeout.

--- a/src/vercel-connect/tests/test_connect_api_client.py
+++ b/src/vercel-connect/tests/test_connect_api_client.py
@@ -12,7 +12,13 @@ from typing import Any
 import httpx
 import pytest
 
-from vercel._internal.core.http import BaseTransport, JSONBody, ReadResponsePolicy, RequestBody
+from vercel._internal.core.http import (
+    BaseTransport,
+    JSONBody,
+    ReadResponsePolicy,
+    RequestBody,
+    RequestTimeout,
+)
 from vercel._internal.core.http.transport import HeaderTypes, QueryParamTypes
 from vercel.connect import (
     ConnectAppTokenSubject,
@@ -43,7 +49,7 @@ class FakeTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,

--- a/src/vercel-internal-core/tests/test_http_transport_timeout.py
+++ b/src/vercel-internal-core/tests/test_http_transport_timeout.py
@@ -9,7 +9,7 @@ import pytest
 import respx
 from httpx import Response
 
-from vercel._internal.core.http import AsyncTransport, SyncTransport
+from vercel._internal.core.http import NO_TIMEOUT, AsyncTransport, SyncTransport
 from vercel._internal.core.iter_coroutine import iter_coroutine
 
 CLIENT_TIMEOUT = {
@@ -23,6 +23,12 @@ REQUEST_TIMEOUT = {
     "read": 9.0,
     "write": 9.0,
     "pool": 9.0,
+}
+DISABLED_TIMEOUT = {
+    "connect": None,
+    "read": None,
+    "write": None,
+    "pool": None,
 }
 
 
@@ -66,6 +72,21 @@ def test_sync_request_timeout_overrides_client_default() -> None:
 
 
 @respx.mock
+def test_sync_request_can_disable_client_timeout() -> None:
+    base_url = "https://api.example.com"
+    route = respx.get(f"{base_url}/ping").mock(return_value=Response(200, json={"ok": True}))
+    transport = SyncTransport(httpx.Client(base_url=base_url, timeout=_client_timeout()))
+
+    try:
+        response = iter_coroutine(transport.send("GET", "/ping", timeout=NO_TIMEOUT))
+        assert response.status_code == 200
+    finally:
+        transport.close()
+
+    assert route.calls.last.request.extensions["timeout"] == DISABLED_TIMEOUT
+
+
+@respx.mock
 @pytest.mark.asyncio
 async def test_async_request_without_timeout_uses_client_default() -> None:
     base_url = "https://api.example.com"
@@ -95,3 +116,19 @@ async def test_async_request_timeout_overrides_client_default() -> None:
         await transport.aclose()
 
     assert route.calls.last.request.extensions["timeout"] == REQUEST_TIMEOUT
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_request_can_disable_client_timeout() -> None:
+    base_url = "https://api.example.com"
+    route = respx.get(f"{base_url}/ping").mock(return_value=Response(200, json={"ok": True}))
+    transport = AsyncTransport(httpx.AsyncClient(base_url=base_url, timeout=_client_timeout()))
+
+    try:
+        response = await transport.send("GET", "/ping", timeout=NO_TIMEOUT)
+        assert response.status_code == 200
+    finally:
+        await transport.aclose()
+
+    assert route.calls.last.request.extensions["timeout"] == DISABLED_TIMEOUT

--- a/src/vercel-internal-core/vercel/_internal/core/http/__init__.py
+++ b/src/vercel-internal-core/vercel/_internal/core/http/__init__.py
@@ -10,6 +10,7 @@ from vercel._internal.core.http.retry import (
     SleepFn,
 )
 from vercel._internal.core.http.transport import (
+    NO_TIMEOUT,
     AsyncTransport,
     BaseTransport,
     BytesBody,
@@ -17,6 +18,7 @@ from vercel._internal.core.http.transport import (
     RawBody,
     ReadResponsePolicy,
     RequestBody,
+    RequestTimeout,
     StreamingRequest,
     StreamingResponse,
     SyncTransport,
@@ -33,9 +35,11 @@ __all__ = [
     "TransportOptions",
     "JSONBody",
     "BytesBody",
+    "NO_TIMEOUT",
     "RawBody",
     "ReadResponsePolicy",
     "RequestBody",
+    "RequestTimeout",
     "StreamingRequest",
     "StreamingResponse",
     "RetryPolicy",

--- a/src/vercel-internal-core/vercel/_internal/core/http/transport.py
+++ b/src/vercel-internal-core/vercel/_internal/core/http/transport.py
@@ -64,6 +64,16 @@ class RawBody:
 RequestBody = JSONBody | BytesBody | RawBody | None
 
 
+class _NoTimeout:
+    """Select no HTTPX timeout instead of inheriting the client default."""
+
+    __slots__ = ()
+
+
+NO_TIMEOUT = _NoTimeout()
+RequestTimeout: TypeAlias = timedelta | _NoTimeout | None
+
+
 class ReadResponsePolicy(StrEnum):
     ALWAYS = "always"
     NON_SUCCESS_ONLY = "non_success_only"
@@ -89,7 +99,7 @@ class BaseTransport(abc.ABC):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
@@ -104,7 +114,7 @@ class BaseTransport(abc.ABC):
         token: str | None = None,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         response_chunk_size: int | None = None,
@@ -121,7 +131,7 @@ class BaseTransport(abc.ABC):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         chunk_size: int | None = None,
@@ -139,7 +149,7 @@ class BaseTransport(abc.ABC):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
     ) -> httpx.Request:
         headers = httpx.Headers(headers)
         if token is not None:
@@ -156,7 +166,18 @@ class BaseTransport(abc.ABC):
             case RawBody():
                 content = body.data
 
-        if timeout is not None:
+        if timeout is NO_TIMEOUT:
+            return client.build_request(
+                method,
+                _normalize_path(path),
+                params=params,
+                timeout=None,
+                headers=headers,
+                json=json,
+                content=content,
+            )
+
+        if isinstance(timeout, timedelta):
             return client.build_request(
                 method,
                 _normalize_path(path),
@@ -604,7 +625,7 @@ class SyncTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
@@ -638,7 +659,7 @@ class SyncTransport(BaseTransport):
         token: str | None = None,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         response_chunk_size: int | None = None,
@@ -683,7 +704,7 @@ class SyncTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         chunk_size: int | None = None,
@@ -741,7 +762,7 @@ class AsyncTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
@@ -776,7 +797,7 @@ class AsyncTransport(BaseTransport):
         token: str | None = None,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         response_chunk_size: int | None = None,
@@ -838,7 +859,7 @@ class AsyncTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
         chunk_size: int | None = None,

--- a/src/vercel-internal-core/vercel/_internal/core/http/transport.py
+++ b/src/vercel-internal-core/vercel/_internal/core/http/transport.py
@@ -11,7 +11,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from types import TracebackType
-from typing import Any, TypeAlias
+from typing import Any, Final, TypeAlias, final
 
 import anyio
 import httpx
@@ -64,13 +64,14 @@ class RawBody:
 RequestBody = JSONBody | BytesBody | RawBody | None
 
 
+@final
 class _NoTimeout:
     """Select no HTTPX timeout instead of inheriting the client default."""
 
     __slots__ = ()
 
 
-NO_TIMEOUT = _NoTimeout()
+NO_TIMEOUT: Final = _NoTimeout()
 RequestTimeout: TypeAlias = timedelta | _NoTimeout | None
 
 

--- a/src/vercel-sandbox/tests/test_sandbox_api_client.py
+++ b/src/vercel-sandbox/tests/test_sandbox_api_client.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 
 import httpx
@@ -5,10 +6,12 @@ import pytest
 from httpx._types import HeaderTypes, QueryParamTypes
 
 from vercel._internal.core.http import (
+    NO_TIMEOUT,
     BaseTransport,
     JSONBody,
     ReadResponsePolicy,
     RequestBody,
+    RequestTimeout,
     StreamingRequest,
     StreamingResponse,
 )
@@ -16,6 +19,7 @@ from vercel._internal.core.url import format_url_path
 from vercel.sandbox._internal.api_client import SandboxApiClient, _WriteFilesUpload
 from vercel.sandbox._internal.errors import SandboxApiError, SandboxResponseError
 from vercel.sandbox._internal.options import SandboxCredentials
+from vercel.sandbox._internal.process_output import ProcessOutputRouter
 
 
 class InvalidJsonTransport(BaseTransport):
@@ -31,7 +35,7 @@ class InvalidJsonTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
@@ -57,7 +61,7 @@ class JsonTransport(BaseTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
@@ -69,6 +73,7 @@ class RecordingJsonTransport(JsonTransport):
     def __init__(self, data: object) -> None:
         super().__init__(data)
         self.request: tuple[str, str, str | None, QueryParamTypes | None, RequestBody] | None = None
+        self.timeout: RequestTimeout = None
 
     async def send(
         self,
@@ -79,12 +84,13 @@ class RecordingJsonTransport(JsonTransport):
         params: QueryParamTypes | None = None,
         body: RequestBody = None,
         headers: HeaderTypes | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
         follow_redirects: bool | None = None,
         stream: bool = False,
         read_response: ReadResponsePolicy = ReadResponsePolicy.NEVER,
     ) -> httpx.Response:
         self.request = (method, path, token, params, body)
+        self.timeout = timeout
         return await super().send(
             method,
             path,
@@ -100,16 +106,17 @@ class RecordingJsonTransport(JsonTransport):
 
 
 class _CompletedResponse(StreamingResponse):
-    def __init__(self, response: httpx.Response) -> None:
+    def __init__(self, response: httpx.Response, *, lines: tuple[str, ...] = ()) -> None:
         self.response = response
         self.closed = False
+        self.lines = lines
 
     async def __anext__(self) -> bytes:
         raise StopAsyncIteration
 
     async def aiter_lines(self):  # type: ignore[no-untyped-def]
-        if False:
-            yield ""
+        for line in self.lines:
+            yield line
 
     async def aclose(self) -> None:
         self.closed = True
@@ -129,6 +136,31 @@ class _CompletedRequest(StreamingRequest):
         raise NotImplementedError
 
 
+class RecordingStreamTransport(JsonTransport):
+    def __init__(self, *, lines: tuple[str, ...] = ()) -> None:
+        super().__init__({})
+        self.lines = lines
+        self.timeout: RequestTimeout = None
+
+    async def open_response_stream(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        params: QueryParamTypes | None = None,
+        body: RequestBody = None,
+        headers: HeaderTypes | None = None,
+        timeout: RequestTimeout = None,
+        follow_redirects: bool | None = None,
+        read_response: ReadResponsePolicy = ReadResponsePolicy.NON_SUCCESS_ONLY,
+        chunk_size: int | None = None,
+    ) -> StreamingResponse:
+        self.timeout = timeout
+        response = httpx.Response(200, request=httpx.Request(method, path))
+        return _CompletedResponse(response, lines=self.lines)
+
+
 def _sandbox_client(transport: BaseTransport) -> SandboxApiClient:
     async def credentials_factory() -> SandboxCredentials:
         return SandboxCredentials(
@@ -143,6 +175,76 @@ def _sandbox_client(transport: BaseTransport) -> SandboxApiClient:
         transport=transport,
         file_transfer_timeout=timedelta(minutes=5),
     )
+
+
+def _command_response(*, exit_code: int | None) -> dict[str, object]:
+    return {
+        "command": {
+            "id": "cmd_1",
+            "name": "python",
+            "args": [],
+            "cwd": "/vercel/sandbox",
+            "sessionId": "sbx_1",
+            "exitCode": exit_code,
+            "startedAt": 1,
+        }
+    }
+
+
+async def test_waiting_for_command_disables_client_timeout() -> None:
+    transport = RecordingJsonTransport(_command_response(exit_code=0))
+    client = _sandbox_client(transport)
+
+    await client.get_command(session_id="sbx_1", command_id="cmd_1", wait=True)
+
+    assert transport.timeout is NO_TIMEOUT
+
+
+async def test_polling_command_uses_client_timeout() -> None:
+    transport = RecordingJsonTransport(_command_response(exit_code=None))
+    client = _sandbox_client(transport)
+
+    await client.get_command(session_id="sbx_1", command_id="cmd_1", wait=False)
+
+    assert transport.timeout is None
+
+
+async def test_run_process_disables_client_timeout() -> None:
+    transport = RecordingStreamTransport(
+        lines=(
+            json.dumps(_command_response(exit_code=None)),
+            json.dumps(_command_response(exit_code=0)),
+        )
+    )
+    client = _sandbox_client(transport)
+
+    await client.run_process(
+        session_id="sbx_1",
+        command="python",
+        output_router=ProcessOutputRouter(stdout=None, stderr=None, capture_output=False),
+    )
+
+    assert transport.timeout is NO_TIMEOUT
+
+
+async def test_command_logs_disable_client_timeout() -> None:
+    transport = RecordingStreamTransport()
+    client = _sandbox_client(transport)
+
+    response = await client.command_logs_response(session_id="sbx_1", command_id="cmd_1")
+    await response.aclose()
+
+    assert transport.timeout is NO_TIMEOUT
+
+
+async def test_file_read_uses_file_transfer_timeout() -> None:
+    transport = RecordingStreamTransport()
+    client = _sandbox_client(transport)
+
+    response = await client.open_read_response(session_id="sbx_1", path="large.bin")
+    await response.aclose()
+
+    assert transport.timeout == timedelta(minutes=5)
 
 
 async def test_invalid_json_response_raises_response_error(mock_env_clear: None) -> None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -22,10 +22,12 @@ from pydantic import (
 )
 
 from vercel._internal.core.http import (
+    NO_TIMEOUT,
     BaseTransport,
     JSONBody,
     ReadResponsePolicy,
     RequestBody,
+    RequestTimeout,
     StreamingRequest,
     StreamingResponse,
     extract_structured_error,
@@ -801,7 +803,7 @@ class SandboxApiClient:
         body: RequestBody = None,
         params: Mapping[str, JSONValue | None] | None = None,
         headers: Mapping[str, str] | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
     ) -> Response:
         query = cast(
             QueryParamTypes,
@@ -842,7 +844,7 @@ class SandboxApiClient:
         body: RequestBody = None,
         params: Mapping[str, JSONValue | None] | None = None,
         headers: Mapping[str, str] | None = None,
-        timeout: timedelta | None = None,
+        timeout: RequestTimeout = None,
     ) -> StreamingResponse:
         query = cast(
             QueryParamTypes,
@@ -885,6 +887,7 @@ class SandboxApiClient:
         credentials: SandboxCredentials,
         body: JSONValue | None = None,
         params: Mapping[str, JSONValue | None] | None = None,
+        timeout: RequestTimeout = None,
     ) -> JSONObject:
         response = await self._request(
             method,
@@ -893,6 +896,7 @@ class SandboxApiClient:
             body=JSONBody(body) if body is not None else None,
             params=params,
             headers={"content-type": "application/json"},
+            timeout=timeout,
         )
 
         try:
@@ -1352,6 +1356,7 @@ class SandboxApiClient:
             params={"wait": "true", "logs": "true"},
             body=JSONBody(request.to_api_dict()),
             headers={"connection": "close"},
+            timeout=NO_TIMEOUT,
         )
 
         initial: ProcessState | None = None
@@ -1430,6 +1435,7 @@ class SandboxApiClient:
             ),
             credentials=credentials,
             params={"wait": "true" if wait else "false"},
+            timeout=NO_TIMEOUT if wait else None,
         )
         return _validate_response(_CommandResponse, data).to_command()
 
@@ -1543,4 +1549,5 @@ class SandboxApiClient:
             ),
             credentials=credentials,
             headers={"connection": "close"},
+            timeout=NO_TIMEOUT,
         )


### PR DESCRIPTION
- Add support for "no timeout" value to pass to the transport's client on a per-call basis. `None` was already taken to mean "use the default", so instead of a special value like `timedelta(seconds=0)`, I went with a sentinel object for expressing no timeout.
- Use this new no-timeout request for undefined/unbounded latency operations on Sandbox (e.g. command streaming). The further fix here is to wrap these operations in a durable, long-running, fault tolerant wrapper, but for now this will hold open the connection as long as it can.