### PR TITLE
workflow: refactor to eliminate camel cases in code

### DIFF
--- a/changes/vercel-workflow/wire-model-field-names.internal.md
+++ b/changes/vercel-workflow/wire-model-field-names.internal.md
@@ -1,0 +1,1 @@
+Construct the protocol models by Python field name.

--- a/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
@@ -134,12 +134,12 @@ class Resume:
     def as_input(self, deployment_id: str | None = None) -> w.HookResumeInput:
         """What both of this resume's writes carry."""
         return w.HookResumeInput(
-            resumeId=self.resume_id,
-            hookId=self.hook.hook_id,
+            resume_id=self.resume_id,
+            hook_id=self.hook.hook_id,
             token=self.hook.token,
             payload=self.payload,
-            payloadDigest=self.digest,
-            deploymentId=deployment_id,
+            payload_digest=self.digest,
+            deployment_id=deployment_id,
         )
 
     @classmethod
@@ -159,8 +159,8 @@ async def publish(world: local_mod.LocalWorld, resume: Resume) -> None:
     await world.queue(
         w.get_queue_name(run.workflow_name, None),
         w.WorkflowInvokePayload(
-            runId=resume.hook.run_id,
-            hookInput=resume.as_input(run.deployment_id),
+            run_id=resume.hook.run_id,
+            hook_input=resume.as_input(run.deployment_id),
         ),
     )
 
@@ -169,9 +169,9 @@ async def write_event(world: local_mod.LocalWorld, resume: Resume) -> None:
     """The fast path's direct `hook_received` write, carrying the same identity."""
     run = await world.runs_get(resume.hook.run_id)
     event = w.HookReceivedEvent(
-        correlationId=resume.hook.hook_id,
-        eventData=w.HookReceivedEventData(payload=resume.payload, token=resume.hook.token),
-        specVersion=run.spec_version or w.SPEC_VERSION_CURRENT,
+        correlation_id=resume.hook.hook_id,
+        event_data=w.HookReceivedEventData(payload=resume.payload, token=resume.hook.token),
+        spec_version=run.spec_version or w.SPEC_VERSION_CURRENT,
     )
     event._queue_input = resume.as_input()
     await world.events_create(resume.hook.run_id, event)

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -52,7 +52,7 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event(cid)
+        w.StepCreatedEventData(step_name=step.name, input=_args(name="a")).into_event(cid)
     ]
     ctx = _context(events)
     sus = _suspension(cid, _args(name="b"))
@@ -69,7 +69,7 @@ async def test_matching_step_parks_without_nondeterminism() -> None:
     step = core.Step(_greet)
     cid = "step_1"
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event(cid)
+        w.StepCreatedEventData(step_name=step.name, input=_args(name="a")).into_event(cid)
     ]
     ctx = _context(events)
     sus = _suspension(cid, _args(name="a"))
@@ -92,7 +92,7 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     """
     step = core.Step(_greet)
     events: list[w.Event] = [
-        w.StepCreatedEventData(stepName=step.name, input=_args(name="a")).into_event("step_1")
+        w.StepCreatedEventData(step_name=step.name, input=_args(name="a")).into_event("step_1")
     ]
     ctx = _context(events)
     wait = runtime.Wait(
@@ -121,7 +121,7 @@ _ARGS = _args(name="a")
 
 
 def _created(step: "core.Step[Any, Any]", cid: str) -> w.Event:
-    return w.StepCreatedEventData(stepName=step.name, input=_ARGS).into_event(cid)
+    return w.StepCreatedEventData(step_name=step.name, input=_ARGS).into_event(cid)
 
 
 def _completed(cid: str, result: Any) -> w.Event:
@@ -256,7 +256,7 @@ async def test_idle_resume_parks_when_nothing_to_deliver() -> None:
 
 def _stamp(event: w.Event, ts: datetime, *, event_id: str) -> w.Event:
     return event.model_copy(
-        update={"server_props": w.ServerProps(runId="wrun_test", eventId=event_id, createdAt=ts)}
+        update={"server_props": w.ServerProps(run_id="wrun_test", event_id=event_id, created_at=ts)}
     )
 
 

--- a/src/vercel-workflow/tests/unit/test_workflow_encryption.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_encryption.py
@@ -870,10 +870,10 @@ async def test_a_plaintext_run_never_resolves_a_key() -> None:
     run = _run(input=ser.dehydrate([]))
     events: list[w.Event] = [
         w.StepCreatedEventData(
-            stepName="pay", input=ser.dehydrate(ser.step_arguments((), {}))
+            step_name="pay", input=ser.dehydrate(ser.step_arguments((), {}))
         ).into_event("step_0"),
         w.StepCompletedEventData(result=ser.dehydrate(42)).into_event("step_0"),
-        w.StepStartedEvent(correlationId="step_0"),
+        w.StepStartedEvent(correlation_id="step_0"),
         w.RunStartedEvent(),
     ]
 
@@ -899,7 +899,7 @@ async def test_one_encrypted_payload_anywhere_resolves_the_key_once(where: str) 
     run = _run(input=payload("input", ser.dehydrate([])))
     events: list[w.Event] = [
         w.StepCreatedEventData(
-            stepName="pay", input=payload("step input", ser.dehydrate({"args": []}))
+            step_name="pay", input=payload("step input", ser.dehydrate({"args": []}))
         ).into_event("step_0"),
         w.StepCompletedEventData(result=payload("step result", ser.dehydrate(42))).into_event(
             "step_0"

--- a/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
@@ -67,14 +67,14 @@ class FakeWorld(NoStreams, w.World):
         if data.event_type == "step_started":
             return w.EventResult(
                 step=w.NonFinalWorkflowStep(
-                    runId=RUN_ID,
-                    stepId=STEP_ID,
-                    stepName=data.correlation_id or "",
+                    run_id=RUN_ID,
+                    step_id=STEP_ID,
+                    step_name=data.correlation_id or "",
                     status="running",
                     attempt=1,
-                    createdAt=NOW,
-                    updatedAt=NOW,
-                    startedAt=NOW,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    started_at=NOW,
                     input=self.step_input,
                 )
             )
@@ -107,9 +107,9 @@ def registry() -> core.Workflows:
 
 async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
     payload = w.WorkflowInvokePayload(
-        runId=RUN_ID,
-        stepId=STEP_ID,
-        stepName=step_name,
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name=step_name,
     )
     return await runtime.workflow_handler(
         payload.model_dump(by_alias=True),

--- a/src/vercel-workflow/tests/unit/test_workflow_health_check.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_health_check.py
@@ -186,7 +186,7 @@ async def test_a_probe_naming_a_run_is_still_a_probe(registry) -> None:
     world = StreamsWorld()
     w.set_world(world)
 
-    assert await _probe(registry, runId="wrun_not_created_yet") is None
+    assert await _probe(registry, run_id="wrun_not_created_yet") is None
 
     assert world.closes == [(RUN_ID, STREAM)]
 

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_disposal.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_disposal.py
@@ -27,10 +27,10 @@ async def test_redispose_raises_hook_not_found(tmp_path, monkeypatch) -> None:
     # which the runtime swallows.
     world = _world(tmp_path, monkeypatch)
     await world.events_create(RUN_ID, w.HookCreatedEventData(token=TOKEN).into_event("hook_1"))
-    await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+    await world.events_create(RUN_ID, w.HookDisposedEvent(correlation_id="hook_1"))
 
     try:
-        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlation_id="hook_1"))
     except w.HookNotFoundError:
         pass
     else:
@@ -60,7 +60,7 @@ async def test_concurrent_dispose_loser_gets_entity_conflict(tmp_path, monkeypat
     lock_path.write_text("")
 
     try:
-        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlation_id="hook_1"))
     except w.EntityConflictError:
         pass
     else:

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_metadata.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_metadata.py
@@ -86,14 +86,14 @@ async def registered(tmp_path, monkeypatch) -> _RecordingLocalWorld:
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="",
-            workflowName=approvals.workflow_id,
+            deployment_id="",
+            workflow_name=approvals.workflow_id,
             input=ser.dehydrate([]),
         ).into_event(),
     )
     assert created.run is not None
     await runtime.workflow_handler(
-        w.WorkflowInvokePayload(runId=created.run.run_id).model_dump(by_alias=True),
+        w.WorkflowInvokePayload(run_id=created.run.run_id).model_dump(by_alias=True),
         attempt=1,
         queue_name=w.get_queue_name(approvals.workflow_id),
         message_id="msg_1",
@@ -205,7 +205,7 @@ async def test_encrypted_metadata_is_opened_with_the_run_key(tmp_path, monkeypat
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1", workflowName="wf", input=ser.dehydrate([])
+            deployment_id="dpl_1", workflow_name="wf", input=ser.dehydrate([])
         ).into_event(),
     )
     assert created.run is not None

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_not_found.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_not_found.py
@@ -31,7 +31,7 @@ async def test_hook_disposed_404_maps_to_hook_not_found() -> None:
     )
 
     with pytest.raises(w.HookNotFoundError):
-        await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId="hook_1"))
+        await world.events_create(RUN_ID, w.HookDisposedEvent(correlation_id="hook_1"))
 
 
 @respx.mock

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
@@ -66,7 +66,7 @@ async def _run_with_hook(world: _RecordingLocalWorld) -> str:
     result = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1", workflowName="test-wf", input=ser.dehydrate([])
+            deployment_id="dpl_1", workflow_name="test-wf", input=ser.dehydrate([])
         ).into_event(),
     )
     assert result.run is not None

--- a/src/vercel-workflow/tests/unit/test_workflow_lazy_hook_resume_handler.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_lazy_hook_resume_handler.py
@@ -151,7 +151,7 @@ class FakeWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
-        return w.PaginatedResult(data=list(self.events), cursor=None, hasMore=False)
+        return w.PaginatedResult(data=list(self.events), cursor=None, has_more=False)
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         if data.event_type == "run_started":

--- a/src/vercel-workflow/tests/unit/test_workflow_local_hook_resume.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_hook_resume.py
@@ -55,11 +55,11 @@ def _received(
     event = w.HookReceivedEventData(payload=dehydrated, token=TOKEN).into_event(hook)
     if resume_id is not None:
         event._queue_input = w.HookResumeInput(
-            resumeId=resume_id,
-            hookId=hook,
+            resume_id=resume_id,
+            hook_id=hook,
             token=TOKEN,
             payload=dehydrated,
-            payloadDigest=digest,
+            payload_digest=digest,
         )
     return event
 
@@ -200,7 +200,7 @@ async def test_a_claim_is_converged_on_by_the_resume_id_not_the_position(
         ),
         encoding="utf-8",
     )
-    _write_claim(world, eventId=occupied)
+    _write_claim(world, event_id=occupied)
 
     again = await world.events_create(RUN_ID, _received())
 
@@ -221,7 +221,7 @@ async def test_another_payload_at_the_claimed_position_is_not_adopted(
     # A plain sequential resume of the same hook: right hook, no resume id.
     other = await world.events_create(RUN_ID, _received("unrelated", resume_id=None))
     assert other.event is not None and other.event.server_props is not None
-    _write_claim(world, eventId=other.event.server_props.event_id)
+    _write_claim(world, event_id=other.event.server_props.event_id)
 
     with pytest.raises(w.EntityConflictError, match="not observable yet"):
         await world.events_create(RUN_ID, _received())
@@ -235,7 +235,7 @@ async def test_convergence_survives_the_hook_being_disposed(tmp_path, monkeypatc
     resume" and acks a message that may hold the only copy of the payload."""
     world = await _world(tmp_path, monkeypatch)
     first = await world.events_create(RUN_ID, _received())
-    await world.events_create(RUN_ID, w.HookDisposedEvent(correlationId=HOOK))
+    await world.events_create(RUN_ID, w.HookDisposedEvent(correlation_id=HOOK))
 
     again = await world.events_create(RUN_ID, _received())
 

--- a/src/vercel-workflow/tests/unit/test_workflow_local_queue_codec.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_queue_codec.py
@@ -28,8 +28,8 @@ INPUT = ser.dehydrate([[1], 123])
 
 def _payload() -> w.WorkflowInvokePayload:
     return w.WorkflowInvokePayload(
-        runId=RUN_ID,
-        runInput=w.RunInput.from_wire(
+        run_id=RUN_ID,
+        run_input=w.RunInput.from_wire(
             {
                 "input": INPUT,
                 "deploymentId": "dpl_local",
@@ -88,14 +88,14 @@ def test_a_ts_written_envelope_is_accepted() -> None:
     assert parsed.run_input is not None and parsed.run_input.input == INPUT
     # The whole point: this is what `_resilient_create_run` feeds the run row.
     run = w.NonFinalWorkflowRun(
-        runId=RUN_ID,
-        deploymentId="dpl_local",
+        run_id=RUN_ID,
+        deployment_id="dpl_local",
         status="pending",
-        workflowName=WORKFLOW,
-        specVersion=6,
+        workflow_name=WORKFLOW,
+        spec_version=6,
         input=parsed.run_input.input,
-        createdAt=local_mod.js_now(),
-        updatedAt=local_mod.js_now(),
+        created_at=local_mod.js_now(),
+        updated_at=local_mod.js_now(),
     )
     assert run.input == INPUT
 
@@ -112,7 +112,7 @@ def test_re_enqueue_round_trips() -> None:
 
 def test_a_payload_without_bytes_is_unchanged() -> None:
     """A re-enqueue carries no `runInput`, and must not grow anything."""
-    bare = w.WorkflowInvokePayload(runId=RUN_ID)
+    bare = w.WorkflowInvokePayload(run_id=RUN_ID)
 
     wire = _on_the_wire(bare)
 

--- a/src/vercel-workflow/tests/unit/test_workflow_local_resilient_start.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_resilient_start.py
@@ -127,8 +127,8 @@ async def test_existing_run_is_untouched_by_event_data(tmp_path, monkeypatch) ->
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_real",
-            workflowName="add_ten",
+            deployment_id="dpl_real",
+            workflow_name="add_ten",
             input=ser.dehydrate([1]),
         ).into_event(),
     )
@@ -159,14 +159,14 @@ async def test_concurrent_run_created_wins_the_row(tmp_path, monkeypatch) -> Non
     real_input = ser.dehydrate([1])
     real_row = local_mod.dumps_js(
         w.NonFinalWorkflowRun(
-            runId=RUN_ID,
-            deploymentId="dpl_real",
+            run_id=RUN_ID,
+            deployment_id="dpl_real",
             status="pending",
-            workflowName="add_ten",
-            specVersion=6,
+            workflow_name="add_ten",
+            spec_version=6,
             input=real_input,
-            createdAt=local_mod.js_now(),
-            updatedAt=local_mod.js_now(),
+            created_at=local_mod.js_now(),
+            updated_at=local_mod.js_now(),
         ).model_dump(exclude_none=True)
     ).decode()
     real = local_mod.write_exclusive
@@ -234,7 +234,8 @@ async def test_incomplete_event_data_creates_nothing(tmp_path, monkeypatch, fiel
 
     with pytest.raises(RuntimeError, match="not found"):
         await world.events_create(
-            RUN_ID, w.RunStartedEvent(eventData=w.RunStartedEventData.from_wire(data))
+            RUN_ID,
+            w.RunStartedEvent(event_data=w.RunStartedEventData.from_wire(data)),
         )
 
     with pytest.raises(RuntimeError, match="not found"):
@@ -247,7 +248,7 @@ async def test_terminal_run_still_conflicts(tmp_path, monkeypatch) -> None:
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1", workflowName="add_ten", input=ser.dehydrate([1])
+            deployment_id="dpl_1", workflow_name="add_ten", input=ser.dehydrate([1])
         ).into_event(),
     )
     assert created.run is not None
@@ -285,7 +286,7 @@ async def test_bare_run_started_on_a_running_run_appends_no_event(tmp_path, monk
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1", workflowName="add_ten", input=ser.dehydrate([1])
+            deployment_id="dpl_1", workflow_name="add_ten", input=ser.dehydrate([1])
         ).into_event(),
     )
     assert created.run is not None

--- a/src/vercel-workflow/tests/unit/test_workflow_local_streamer.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_streamer.py
@@ -225,14 +225,14 @@ class TestLiveRead:
 
 class TestSnapshot:
     async def test_get_info_reports_the_tail_and_the_closed_flag(self, world) -> None:
-        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=-1, done=False)
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tail_index=-1, done=False)
 
         await world.streams_write(RUN_ID, NAME, b"a")
         await world.streams_write(RUN_ID, NAME, b"b")
-        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=1, done=False)
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tail_index=1, done=False)
 
         await world.streams_close(RUN_ID, NAME)
-        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=1, done=True)
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tail_index=1, done=True)
 
     async def test_get_chunks_returns_a_snapshot_not_a_live_read(self, world) -> None:
         for i in range(3):

--- a/src/vercel-workflow/tests/unit/test_workflow_local_world_format.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_world_format.py
@@ -41,10 +41,10 @@ async def _populate(world) -> str:
     result = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1",
-            workflowName="workflow//./src/wf//main",
+            deployment_id="dpl_1",
+            workflow_name="workflow//./src/wf//main",
             input=ser.dehydrate([]),
-            executionContext={"workflowCoreVersion": "5.0.0"},
+            execution_context={"workflowCoreVersion": "5.0.0"},
         ).into_event(),
     )
     assert result.run is not None
@@ -53,7 +53,7 @@ async def _populate(world) -> str:
     await world.events_create(
         run_id,
         w.StepCreatedEventData(
-            stepName="step//./src/wf//pay", input=ser.dehydrate(ser.step_arguments((), {}))
+            step_name="step//./src/wf//pay", input=ser.dehydrate(ser.step_arguments((), {}))
         ).into_event("step_0"),
     )
     await world.events_create(run_id, w.StepStartedEventData().into_event("step_0"))
@@ -187,8 +187,8 @@ async def test_timestamps_survive_the_round_trip(tmp_path, monkeypatch) -> None:
     result = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1",
-            workflowName="workflow//./src/wf//main",
+            deployment_id="dpl_1",
+            workflow_name="workflow//./src/wf//main",
             input=ser.dehydrate([]),
         ).into_event(),
     )
@@ -232,12 +232,12 @@ async def test_reads_a_log_written_at_a_newer_spec_version(tmp_path, monkeypatch
     result = await world.events_create(
         None,
         w.RunCreatedEvent(
-            eventData=w.RunCreatedEventData(
-                deploymentId="dpl_1",
-                workflowName="workflow//./src/wf//main",
+            event_data=w.RunCreatedEventData(
+                deployment_id="dpl_1",
+                workflow_name="workflow//./src/wf//main",
                 input=ser.dehydrate([]),
             ),
-            specVersion=7,
+            spec_version=7,
         ),
     )
     assert result.run is not None
@@ -256,4 +256,4 @@ def test_rejects_a_spec_version_above_the_supported_ceiling() -> None:
         pydantic.ValidationError,
         match=f"less than or equal to {w.SPEC_VERSION_MAX_SUPPORTED}",
     ):
-        w.RunStartedEvent(specVersion=w.SPEC_VERSION_MAX_SUPPORTED + 1)
+        w.RunStartedEvent(spec_version=w.SPEC_VERSION_MAX_SUPPORTED + 1)

--- a/src/vercel-workflow/tests/unit/test_workflow_queue_namespace.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_queue_namespace.py
@@ -18,13 +18,13 @@ WORKFLOW_NAME = "workflow//tests.example"
 
 def _run(execution_context: dict[str, Any] | None = None) -> w.WorkflowRun:
     return w.NonFinalWorkflowRun(
-        runId=RUN_ID,
+        run_id=RUN_ID,
         status="running",
-        deploymentId="dpl_test",
-        workflowName=WORKFLOW_NAME,
-        executionContext=execution_context,
-        createdAt=NOW,
-        updatedAt=NOW,
+        deployment_id="dpl_test",
+        workflow_name=WORKFLOW_NAME,
+        execution_context=execution_context,
+        created_at=NOW,
+        updated_at=NOW,
     )
 
 
@@ -183,9 +183,9 @@ async def test_step_requeues_on_the_topic_it_arrived_on() -> None:
     queue_name = f"__python_wkf_workflow_{WORKFLOW_NAME}"
     await runtime.workflow_handler(
         w.WorkflowInvokePayload(
-            runId=RUN_ID,
-            stepId="step_test",
-            stepName=add.name,
+            run_id=RUN_ID,
+            step_id="step_test",
+            step_name=add.name,
         ).model_dump(by_alias=True),
         attempt=1,
         queue_name=queue_name,

--- a/src/vercel-workflow/tests/unit/test_workflow_resilient_start_handler.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_resilient_start_handler.py
@@ -108,7 +108,7 @@ class FakeWorld(NoStreams, w.World):
 
     async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
         self.events_list_calls.append(run_id)
-        return w.PaginatedResult(data=list(self.events), cursor=None, hasMore=False)
+        return w.PaginatedResult(data=list(self.events), cursor=None, has_more=False)
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         if data.event_type == "run_started":
@@ -221,7 +221,7 @@ async def test_setup_takes_the_run_entity_from_the_response(registry: core.Workf
     module by name, and a test module is not importable that way. Running the
     body end to end is the e2e suite's job.
     """
-    fake = FakeWorld(started_run=_run(status="running", deploymentId="dpl_from_response"))
+    fake = FakeWorld(started_run=_run(status="running", deployment_id="dpl_from_response"))
     w.set_world(fake)
 
     await _invoke(registry, run_input=_run_input())

--- a/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
@@ -76,14 +76,14 @@ def test_retry_after_rejects_a_naive_datetime() -> None:
 
 def _running_step(step_name: str, *, attempt: int) -> w.WorkflowStep:
     return w.NonFinalWorkflowStep(
-        runId=RUN_ID,
-        stepId=STEP_ID,
-        stepName=step_name,
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name=step_name,
         status="running",
         attempt=attempt,
-        createdAt=NOW,
-        updatedAt=NOW,
-        startedAt=NOW,
+        created_at=NOW,
+        updated_at=NOW,
+        started_at=NOW,
         input=ser.dehydrate(ser.step_arguments((), {})),
     )
 
@@ -139,7 +139,7 @@ def registry() -> core.Workflows:
 
 
 async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
-    payload = w.WorkflowInvokePayload(runId=RUN_ID, stepId=STEP_ID, stepName=step_name)
+    payload = w.WorkflowInvokePayload(run_id=RUN_ID, step_id=STEP_ID, step_name=step_name)
     return await runtime.workflow_handler(
         payload.model_dump(by_alias=True),
         attempt=1,
@@ -237,8 +237,8 @@ async def _run_with_started_step(world: local_mod.LocalWorld) -> str:
     created = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="dpl_1",
-            workflowName=WORKFLOW_NAME,
+            deployment_id="dpl_1",
+            workflow_name=WORKFLOW_NAME,
             input=ser.dehydrate(ser.argument_array((), {})),
         ).into_event(),
     )
@@ -247,10 +247,10 @@ async def _run_with_started_step(world: local_mod.LocalWorld) -> str:
     await world.events_create(
         run_id,
         w.StepCreatedEventData(
-            stepName="my_step", input=ser.dehydrate(ser.step_arguments((), {}))
+            step_name="my_step", input=ser.dehydrate(ser.step_arguments((), {}))
         ).into_event(STEP_ID),
     )
-    await world.events_create(run_id, w.StepStartedEvent(correlationId=STEP_ID))
+    await world.events_create(run_id, w.StepStartedEvent(correlation_id=STEP_ID))
     return run_id
 
 
@@ -265,7 +265,7 @@ async def test_local_world_parks_the_step_until_its_deadline(tmp_path, monkeypat
     await world.events_create(
         run_id,
         w.StepRetryingEventData(
-            error="boom", stack="Traceback...", retryAfter=retry_after
+            error="boom", stack="Traceback...", retry_after=retry_after
         ).into_event(STEP_ID),
     )
 
@@ -278,7 +278,7 @@ async def test_local_world_parks_the_step_until_its_deadline(tmp_path, monkeypat
     assert step.started_at is not None
 
     with pytest.raises(w.TooEarlyError) as excinfo:
-        await world.events_create(run_id, w.StepStartedEvent(correlationId=STEP_ID))
+        await world.events_create(run_id, w.StepStartedEvent(correlation_id=STEP_ID))
     # Seconds left until the deadline, rounded up, for the caller to defer by.
     assert excinfo.value.retry_after is not None
     assert 29 <= excinfo.value.retry_after <= 30
@@ -299,12 +299,12 @@ async def test_a_deadline_past_the_queues_limit_reports_all_of_it(tmp_path, monk
     await world.events_create(
         run_id,
         w.StepRetryingEventData(
-            error="rate limited", retryAfter=datetime.now(UTC) + thirty_days
+            error="rate limited", retry_after=datetime.now(UTC) + thirty_days
         ).into_event(STEP_ID),
     )
 
     with pytest.raises(w.TooEarlyError) as excinfo:
-        await world.events_create(run_id, w.StepStartedEvent(correlationId=STEP_ID))
+        await world.events_create(run_id, w.StepStartedEvent(correlation_id=STEP_ID))
     assert excinfo.value.retry_after == pytest.approx(thirty_days.total_seconds(), abs=2)
 
 
@@ -315,10 +315,10 @@ async def test_local_world_starts_the_step_once_the_deadline_passed(tmp_path, mo
     await world.events_create(
         run_id,
         w.StepRetryingEventData(
-            error="boom", retryAfter=datetime.now(UTC) - timedelta(seconds=1)
+            error="boom", retry_after=datetime.now(UTC) - timedelta(seconds=1)
         ).into_event(STEP_ID),
     )
-    result = await world.events_create(run_id, w.StepStartedEvent(correlationId=STEP_ID))
+    result = await world.events_create(run_id, w.StepStartedEvent(correlation_id=STEP_ID))
 
     assert result.step is not None
     assert result.step.status == "running"

--- a/src/vercel-workflow/tests/unit/test_workflow_sealed_log_noop.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_sealed_log_noop.py
@@ -123,10 +123,10 @@ def test_the_read_ceiling_is_the_sealed_log_version() -> None:
     `@workflow/world-vercel` both stamp it now, so a run created by a
     TypeScript driver arrives labelled 7 whether or not it contains a seal."""
     assert w.SPEC_VERSION_MAX_SUPPORTED == 7
-    assert w.RunStartedEvent(specVersion=7).spec_version == 7
+    assert w.RunStartedEvent(spec_version=7).spec_version == 7
 
     with pytest.raises(pydantic.ValidationError, match="less than or equal to 7"):
-        w.RunStartedEvent(specVersion=8)
+        w.RunStartedEvent(spec_version=8)
 
 
 # ── storage: a seal is a row like any other ────────────────────────────────
@@ -143,18 +143,18 @@ async def test_a_sealed_slot_round_trips_through_the_local_world(tmp_path, monke
     result = await world.events_create(
         None,
         w.RunCreatedEvent(
-            eventData=w.RunCreatedEventData(
-                deploymentId="dpl_1",
-                workflowName="workflow//./src/wf//main",
+            event_data=w.RunCreatedEventData(
+                deployment_id="dpl_1",
+                workflow_name="workflow//./src/wf//main",
                 input=ser.dehydrate([]),
             ),
-            specVersion=7,
+            spec_version=7,
         ),
     )
     assert result.run is not None
     run_id = result.run.run_id
     await world.events_create(run_id, _seal(2))
-    await world.events_create(run_id, w.RunStartedEvent(specVersion=7))
+    await world.events_create(run_id, w.RunStartedEvent(spec_version=7))
 
     stored = (await world.events_list(run_id)).data
 
@@ -202,7 +202,7 @@ class _PagedEventsWorld(NoStreams, w.World):
         return w.PaginatedResult(
             data=list(self.pages[index]),
             cursor=self.cursors[index],
-            hasMore=index + 1 < len(self.pages),
+            has_more=index + 1 < len(self.pages),
         )
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
@@ -219,7 +219,7 @@ def _stamp(event: w.Event, position: int, *, created_at: datetime = NOW) -> w.Ev
     return event.model_copy(
         update={
             "server_props": w.ServerProps(
-                runId=RUN_ID, eventId=f"evnt_{_slot(position)}", createdAt=created_at
+                run_id=RUN_ID, event_id=f"evnt_{_slot(position)}", created_at=created_at
             )
         }
     )
@@ -230,8 +230,8 @@ async def test_the_loader_drops_seals_and_keeps_everything_else_in_order() -> No
     them reaches the replay, and the events around them keep their order."""
     real = [
         _stamp(w.RunStartedEvent(), 2),
-        _stamp(w.WaitCreatedEventData(resumeAt=NOW).into_event("wait_1"), 5),
-        _stamp(w.WaitCompletedEvent(correlationId="wait_1"), 8),
+        _stamp(w.WaitCreatedEventData(resume_at=NOW).into_event("wait_1"), 5),
+        _stamp(w.WaitCompletedEvent(correlation_id="wait_1"), 8),
     ]
     world = _PagedEventsWorld(
         [[_seal(1), real[0], _seal(3), _seal(4), real[1], real[2], _seal(9)]],
@@ -337,30 +337,30 @@ def _recorded_log() -> list[w.Event]:
     return [
         _stamp(
             w.RunCreatedEventData(
-                deploymentId="dpl_1",
-                workflowName=WORKFLOW_NAME,
+                deployment_id="dpl_1",
+                workflow_name=WORKFLOW_NAME,
                 input=ser.dehydrate([]),
             ).into_event(),
             1,
             created_at=NOW,
         ),
         _stamp(
-            w.WaitCreatedEventData(resumeAt=resume_at).into_event(first),
+            w.WaitCreatedEventData(resume_at=resume_at).into_event(first),
             2,
             created_at=NOW + timedelta(minutes=1),
         ),
         _stamp(
-            w.WaitCompletedEvent(correlationId=first),
+            w.WaitCompletedEvent(correlation_id=first),
             3,
             created_at=NOW + timedelta(minutes=2),
         ),
         _stamp(
-            w.WaitCreatedEventData(resumeAt=resume_at).into_event(second),
+            w.WaitCreatedEventData(resume_at=resume_at).into_event(second),
             4,
             created_at=NOW + timedelta(minutes=3),
         ),
         _stamp(
-            w.WaitCompletedEvent(correlationId=second),
+            w.WaitCompletedEvent(correlation_id=second),
             5,
             created_at=NOW + timedelta(minutes=4),
         ),
@@ -418,7 +418,7 @@ class _ReplayWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
-        return w.PaginatedResult(data=list(self.log), cursor=None, hasMore=False)
+        return w.PaginatedResult(data=list(self.log), cursor=None, has_more=False)
 
     async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
         self.written.append(data)

--- a/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
@@ -41,14 +41,14 @@ WORKFLOW_NAME = "workflow//tests.wf"
 
 def _running_step(step_name: str, *, attempt: int, input: bytes | None = None) -> w.WorkflowStep:
     return w.NonFinalWorkflowStep(
-        runId=RUN_ID,
-        stepId=STEP_ID,
-        stepName=step_name,
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name=step_name,
         status="running",
         attempt=attempt,
-        createdAt=NOW,
-        updatedAt=NOW,
-        startedAt=NOW,
+        created_at=NOW,
+        updated_at=NOW,
+        started_at=NOW,
         input=input if input is not None else ser.dehydrate(ser.step_arguments((), {})),
     )
 
@@ -125,9 +125,9 @@ WORKFLOW_QUEUE = f"__wkf_workflow_{WORKFLOW_NAME}"
 
 async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuation | None:
     payload = w.WorkflowInvokePayload(
-        runId=RUN_ID,
-        stepId=STEP_ID,
-        stepName=step_name,
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name=step_name,
     )
     return await runtime.workflow_handler(
         payload.model_dump(by_alias=True),
@@ -344,20 +344,20 @@ async def test_local_world_step_started_too_early_raises(tmp_path, monkeypatch) 
 
     future = datetime.now(UTC) + timedelta(seconds=30)
     step = w.NonFinalWorkflowStep(
-        runId=RUN_ID,
-        stepId=STEP_ID,
-        stepName="step//tests.my_step",
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name="step//tests.my_step",
         status="pending",
         attempt=0,
-        createdAt=NOW,
-        updatedAt=NOW,
-        retryAfter=future,
+        created_at=NOW,
+        updated_at=NOW,
+        retry_after=future,
         input=ser.dehydrate(ser.step_arguments((), {})),
     )
     local_mod.write_json(world.data_dir / "steps" / f"{RUN_ID}-{STEP_ID}.json", step.model_dump())
 
     with pytest.raises(w.TooEarlyError) as ei:
-        await world.events_create(RUN_ID, w.StepStartedEvent(correlationId=STEP_ID))
+        await world.events_create(RUN_ID, w.StepStartedEvent(correlation_id=STEP_ID))
 
     assert ei.value.retry_after is not None
     assert 1 <= ei.value.retry_after <= 30

--- a/src/vercel-workflow/tests/unit/test_workflow_step_metadata.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_metadata.py
@@ -56,8 +56,8 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
     run_result = await world.events_create(
         None,
         w.RunCreatedEventData(
-            deploymentId="",
-            workflowName="test-wf",
+            deployment_id="",
+            workflow_name="test-wf",
             input=_run_input(name="world"),
         ).into_event(),
     )
@@ -68,15 +68,15 @@ async def test_step_metadata_available_inside_step(tmp_path, monkeypatch) -> Non
     step_id = "step_testid"
     await world.events_create(
         run_id,
-        w.StepCreatedEventData(stepName=greet.name, input=_step_input(name="world")).into_event(
+        w.StepCreatedEventData(step_name=greet.name, input=_step_input(name="world")).into_event(
             step_id
         ),
     )
 
     payload = w.WorkflowInvokePayload(
-        runId=run_id,
-        stepId=step_id,
-        stepName=greet.name,
+        run_id=run_id,
+        step_id=step_id,
+        step_name=greet.name,
     )
     await runtime.workflow_handler(
         payload.model_dump(by_alias=True),

--- a/src/vercel-workflow/tests/unit/test_workflow_step_retry_dispatch.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_retry_dispatch.py
@@ -58,9 +58,9 @@ async def test_step_retry_timeout_reschedules_step(isolated_subscriptions: None)
     assert async_handler is not None
 
     step_payload = w.WorkflowInvokePayload(
-        runId="wrun_1",
-        stepId="step_1",
-        stepName="step//tests.add",
+        run_id="wrun_1",
+        step_id="step_1",
+        step_name="step//tests.add",
     ).model_dump()
     body = {
         "payload": step_payload,
@@ -108,7 +108,7 @@ async def test_wait_continuation_forwards_idempotency_key(isolated_subscriptions
     async_handler = subscriptions[0].func
     assert async_handler is not None
 
-    wf_payload = w.WorkflowInvokePayload(runId="wrun_1").model_dump()
+    wf_payload = w.WorkflowInvokePayload(run_id="wrun_1").model_dump()
     body = {
         "payload": wf_payload,
         "queueName": "__wkf_workflow_wf",

--- a/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
@@ -279,7 +279,7 @@ class TestRunApi:
     async def test_stream_info_and_list_reach_the_world(self) -> None:
         class Meta(ReplayWorld):
             async def streams_get_info(self, run_id: str, name: str) -> w.StreamInfo:
-                return w.StreamInfo(tailIndex=4, done=True)
+                return w.StreamInfo(tail_index=4, done=True)
 
             async def streams_list(self, run_id: str) -> list[str]:
                 return [NAME]
@@ -287,7 +287,7 @@ class TestRunApi:
         w.set_world(Meta([]))
         run = runtime.Run[Any](RUN_ID)
 
-        assert await run.stream_info() == w.StreamInfo(tailIndex=4, done=True)
+        assert await run.stream_info() == w.StreamInfo(tail_index=4, done=True)
         assert await run.list_streams() == [NAME]
 
     async def test_read_stream_takes_a_name_run_cannot_derive(self) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_vercel_streamer.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_vercel_streamer.py
@@ -243,7 +243,7 @@ class TestSnapshot:
             200, json={"tailIndex": 4, "done": True}
         )
 
-        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tailIndex=4, done=True)
+        assert await world.streams_get_info(RUN_ID, NAME) == w.StreamInfo(tail_index=4, done=True)
 
     @respx.mock
     async def test_get_chunks_passes_paging_and_parses_the_page(self, world) -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -816,9 +816,9 @@ async def _ensure_hook_received(
     # another writer's event and its payload is encoded to that version. Same
     # reason `run_started` carries the version of whoever created the run.
     event = w.HookReceivedEvent(
-        correlationId=hook_input.hook_id,
-        eventData=w.HookReceivedEventData(payload=hook_input.payload, token=hook_input.token),
-        specVersion=run.spec_version or w.SPEC_VERSION_CURRENT,
+        correlation_id=hook_input.hook_id,
+        event_data=w.HookReceivedEventData(payload=hook_input.payload, token=hook_input.token),
+        spec_version=run.spec_version or w.SPEC_VERSION_CURRENT,
     )
     event._queue_input = hook_input
     try:
@@ -988,11 +988,11 @@ async def workflow_handler(
     # already running.
     run_input = req.run_input
     started = w.RunStartedEvent(
-        eventData=(
+        event_data=(
             w.RunStartedEventData.from_run_input(run_input) if run_input is not None else None
         ),
         # The creating client's version, so a run created here is not relabelled.
-        specVersion=(run_input.spec_version if run_input is not None else w.SPEC_VERSION_CURRENT),
+        spec_version=(run_input.spec_version if run_input is not None else w.SPEC_VERSION_CURRENT),
     )
     try:
         result = await world.events_create(run_id, started)
@@ -1057,7 +1057,7 @@ async def workflow_handler(
     for wait_event in waits_to_complete:
         try:
             await world.events_create(
-                run_id, w.WaitCompletedEvent(correlationId=wait_event.correlation_id)
+                run_id, w.WaitCompletedEvent(correlation_id=wait_event.correlation_id)
             )
         except w.EntityConflictError:
             # Another concurrent invocation already completed this wait
@@ -1145,7 +1145,7 @@ async def workflow_handler(
             elif isinstance(sus, Suspension):
 
                 async def create_step(s=sus):
-                    step_data = w.StepCreatedEventData(stepName=s.step.name, input=s.input)
+                    step_data = w.StepCreatedEventData(step_name=s.step.name, input=s.input)
                     try:
                         await world.events_create(run_id, step_data.into_event(s.correlation_id))
                     except w.EntityConflictError:
@@ -1160,10 +1160,10 @@ async def workflow_handler(
                     await world.queue(
                         w.get_queue_name(workflow_run.workflow_name, namespace),
                         w.WorkflowInvokePayload(
-                            runId=run_id,
-                            stepId=s.correlation_id,
-                            stepName=s.step.name,
-                            requestedAt=datetime.now(UTC),
+                            run_id=run_id,
+                            step_id=s.correlation_id,
+                            step_name=s.step.name,
+                            requested_at=datetime.now(UTC),
                         ),
                         idempotency_key=s.correlation_id,
                     )
@@ -1174,7 +1174,7 @@ async def workflow_handler(
             elif isinstance(sus, Wait):
 
                 async def create_wait(s=sus):
-                    wait_data = w.WaitCreatedEventData(resumeAt=s.resume_at)
+                    wait_data = w.WaitCreatedEventData(resume_at=s.resume_at)
                     try:
                         await world.events_create(run_id, wait_data.into_event(s.correlation_id))
                     except w.EntityConflictError:
@@ -1202,7 +1202,7 @@ async def workflow_handler(
                     try:
                         await world.events_create(
                             run_id,
-                            w.HookDisposedEvent(correlationId=h.correlation_id),
+                            w.HookDisposedEvent(correlation_id=h.correlation_id),
                         )
                     except (w.EntityConflictError, w.HookNotFoundError):
                         logger.debug(
@@ -1262,7 +1262,7 @@ async def _execute_step(
     try:
         start_result = await world.events_create(
             req.run_id,
-            w.StepStartedEvent(correlationId=req.step_id),
+            w.StepStartedEvent(correlation_id=req.step_id),
         )
     except w.TooEarlyError as e:
         # retryAfter not reached yet — keep the message visible and retry later.
@@ -1283,8 +1283,8 @@ async def _execute_step(
         await world.queue(
             queue_name,
             w.WorkflowInvokePayload(
-                runId=req.run_id,
-                requestedAt=datetime.now(UTC),
+                run_id=req.run_id,
+                requested_at=datetime.now(UTC),
             ),
         )
         return None
@@ -1317,8 +1317,8 @@ async def _execute_step(
         await world.queue(
             queue_name,
             w.WorkflowInvokePayload(
-                runId=req.run_id,
-                requestedAt=datetime.now(UTC),
+                run_id=req.run_id,
+                requested_at=datetime.now(UTC),
             ),
         )
         return None
@@ -1461,7 +1461,7 @@ async def _execute_step(
             await world.events_create(
                 req.run_id,
                 w.StepRetryingEventData(
-                    error=error_text, stack=error_stack, retryAfter=retry_at
+                    error=error_text, stack=error_stack, retry_after=retry_at
                 ).into_event(req.step_id),
             )
 
@@ -1479,8 +1479,8 @@ async def _execute_step(
     await world.queue(
         queue_name,
         w.WorkflowInvokePayload(
-            runId=req.run_id,
-            requestedAt=datetime.now(UTC),
+            run_id=req.run_id,
+            requested_at=datetime.now(UTC),
         ),
     )
     return None
@@ -1787,10 +1787,10 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     if namespace is not None:
         execution_context["queueNamespace"] = namespace
     data = w.RunCreatedEventData(
-        deploymentId=deployment_id,
-        workflowName=wf.workflow_id,
+        deployment_id=deployment_id,
+        workflow_name=wf.workflow_id,
         input=input_data,
-        executionContext=execution_context,
+        execution_context=execution_context,
     )
     result = await world.events_create(None, data.into_event())
 
@@ -1801,7 +1801,7 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     run_id = result.run.run_id
     await world.queue(
         w.get_queue_name(wf.workflow_id, namespace),
-        w.WorkflowInvokePayload(runId=run_id),
+        w.WorkflowInvokePayload(run_id=run_id),
         deployment_id=deployment_id,
     )
 
@@ -1850,6 +1850,6 @@ async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook
         raise RuntimeError("Workflow run has an invalid queue namespace")
     await world.queue(
         w.get_queue_name(run.workflow_name, namespace),
-        w.WorkflowInvokePayload(runId=hook.run_id),
+        w.WorkflowInvokePayload(run_id=hook.run_id),
     )
     return hook

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -451,7 +451,7 @@ class RunCreatedEventData(BaseModel):
     )
 
     def into_event(self) -> "RunCreatedEvent":
-        return RunCreatedEvent(eventData=self)
+        return RunCreatedEvent(event_data=self)
 
 
 class RunCreatedEvent(BaseEvent):
@@ -493,16 +493,16 @@ class RunStartedEventData(BaseModel):
     def from_run_input(cls, run_input: RunInput) -> "RunStartedEventData":
         return cls(
             input=run_input.input,
-            deploymentId=run_input.deployment_id,
-            workflowName=run_input.workflow_name,
-            executionContext=run_input.execution_context,
+            deployment_id=run_input.deployment_id,
+            workflow_name=run_input.workflow_name,
+            execution_context=run_input.execution_context,
             attributes=run_input.attributes,
-            allowReservedAttributes=run_input.allow_reserved_attributes,
-            encryptionPublicKey=run_input.encryption_public_key,
+            allow_reserved_attributes=run_input.allow_reserved_attributes,
+            encryption_public_key=run_input.encryption_public_key,
         )
 
     def into_event(self, *, spec_version: int = SPEC_VERSION_CURRENT) -> "RunStartedEvent":
-        return RunStartedEvent(eventData=self, specVersion=spec_version)
+        return RunStartedEvent(event_data=self, spec_version=spec_version)
 
 
 class RunStartedEvent(BaseEvent):
@@ -529,7 +529,7 @@ class RunCompletedEventData(BaseModel):
     output: bytes
 
     def into_event(self) -> "RunCompletedEvent":
-        return RunCompletedEvent(eventData=self)
+        return RunCompletedEvent(event_data=self)
 
 
 class RunCompletedEvent(BaseEvent):
@@ -553,7 +553,7 @@ class RunFailedEventData(BaseModel):
     code: str | None = None
 
     def into_event(self) -> "RunFailedEvent":
-        return RunFailedEvent(eventData=self)
+        return RunFailedEvent(event_data=self)
 
 
 class RunFailedEvent(BaseEvent):
@@ -577,7 +577,7 @@ class StepCreatedEventData(BaseModel):
     input: bytes | dict[str, Any]
 
     def into_event(self, correlation_id: str) -> "StepCreatedEvent":
-        return StepCreatedEvent(correlationId=correlation_id, eventData=self)
+        return StepCreatedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class StepCreatedEvent(BaseEvent):
@@ -601,7 +601,7 @@ class StepStartedEventData(BaseModel):
     attempt: int | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
 
     def into_event(self, correlation_id: str) -> "StepStartedEvent":
-        return StepStartedEvent(correlationId=correlation_id, eventData=self)
+        return StepStartedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class StepStartedEvent(BaseEvent):
@@ -623,7 +623,7 @@ class StepRetryingEventData(BaseModel):
     )
 
     def into_event(self, correlation_id: str) -> "StepRetryingEvent":
-        return StepRetryingEvent(correlationId=correlation_id, eventData=self)
+        return StepRetryingEvent(correlation_id=correlation_id, event_data=self)
 
 
 class StepRetryingEvent(BaseEvent):
@@ -648,7 +648,7 @@ class StepCompletedEventData(BaseModel):
     result: bytes | Any = None
 
     def into_event(self, correlation_id: str) -> "StepCompletedEvent":
-        return StepCompletedEvent(correlationId=correlation_id, eventData=self)
+        return StepCompletedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class StepCompletedEvent(BaseEvent):
@@ -668,7 +668,7 @@ class StepFailedEventData(BaseModel):
     stack: str | None = None
 
     def into_event(self, correlation_id: str) -> "StepFailedEvent":
-        return StepFailedEvent(correlationId=correlation_id, eventData=self)
+        return StepFailedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class StepFailedEvent(BaseEvent):
@@ -702,7 +702,7 @@ class HookCreatedEventData(BaseModel):
     metadata: bytes | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
 
     def into_event(self, correlation_id: str) -> "HookCreatedEvent":
-        return HookCreatedEvent(correlationId=correlation_id, eventData=self)
+        return HookCreatedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class HookCreatedEvent(BaseEvent):
@@ -727,7 +727,7 @@ class HookReceivedEventData(BaseModel):
     token: str | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
 
     def into_event(self, correlation_id: str) -> "HookReceivedEvent":
-        return HookReceivedEvent(correlationId=correlation_id, eventData=self)
+        return HookReceivedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class HookReceivedEvent(BaseEvent):
@@ -778,7 +778,7 @@ class WaitCreatedEventData(BaseModel):
     resume_at: datetime = pydantic.Field(alias="resumeAt")
 
     def into_event(self, correlation_id: str) -> "WaitCreatedEvent":
-        return WaitCreatedEvent(correlationId=correlation_id, eventData=self)
+        return WaitCreatedEvent(correlation_id=correlation_id, event_data=self)
 
 
 class WaitCreatedEvent(BaseEvent):

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -133,6 +133,13 @@ HOOK_RESUME_INPUT_VERSION = 1
 
 
 class BaseModel(pydantic.BaseModel):
+    # We use `snake_case = Field(alias="camelCase")` everywhere to support both
+    # the JS-style wire format and Pythonic identifiers in code.  So naturally,
+    # we turned on `serialize_by_alias` globally to `model_dump()` to wire format.
+    # But Pydantic doesn't differentiate model instantiation from validation,
+    # therefore, we validate by Python name here, so that all model constructors
+    # take snake case parameters; while, flip to validate by alias in `from_wire`
+    # below in order to read camel cases from the wire.
     model_config = pydantic.ConfigDict(
         serialize_by_alias=True, validate_by_alias=False, validate_by_name=True
     )

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -133,11 +133,13 @@ HOOK_RESUME_INPUT_VERSION = 1
 
 
 class BaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(serialize_by_alias=True)
+    model_config = pydantic.ConfigDict(
+        serialize_by_alias=True, validate_by_alias=False, validate_by_name=True
+    )
 
     @classmethod
     def from_wire(cls, data: Any) -> Self:
-        return cls.model_validate(data)
+        return cls.model_validate(data, by_alias=True, by_name=False)
 
 
 class WireAdaptor(Generic[T]):
@@ -145,7 +147,7 @@ class WireAdaptor(Generic[T]):
         self._adaptor: pydantic.TypeAdapter[T] = pydantic.TypeAdapter(tp)
 
     def from_wire(self, data: Any) -> T:
-        return self._adaptor.validate_python(data)
+        return self._adaptor.validate_python(data, by_alias=True, by_name=False)
 
 
 class RunInput(BaseModel):

--- a/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
@@ -499,11 +499,11 @@ class LocalWorld(w.World):
         claim = read_json(claim_path, HookResumeClaim)
         if claim is None:
             mine = HookResumeClaim(
-                runId=run_id,
-                resumeId=resume.resume_id,
-                hookId=data.correlation_id,
-                eventId=event_id,
-                payloadDigest=resume.payload_digest,
+                run_id=run_id,
+                resume_id=resume.resume_id,
+                hook_id=data.correlation_id,
+                event_id=event_id,
+                payload_digest=resume.payload_digest,
             )
             if write_exclusive(claim_path, dumps_js(mine.model_dump(exclude_none=True)).decode()):
                 return None
@@ -714,17 +714,17 @@ class LocalWorld(w.World):
             return None
 
         created = w.NonFinalWorkflowRun(
-            runId=run_id,
-            deploymentId=run_data.deployment_id,
+            run_id=run_id,
+            deployment_id=run_data.deployment_id,
             status="pending",
-            workflowName=run_data.workflow_name,
-            specVersion=data.spec_version,
-            executionContext=run_data.execution_context,
+            workflow_name=run_data.workflow_name,
+            spec_version=data.spec_version,
+            execution_context=run_data.execution_context,
             input=run_data.input,
             attributes=run_data.attributes or {},
-            encryptionPublicKey=run_data.encryption_public_key,
-            createdAt=now,
-            updatedAt=now,
+            encryption_public_key=run_data.encryption_public_key,
+            created_at=now,
+            updated_at=now,
         )
         run_path = self.data_dir / "runs" / f"{run_id}.json"
         # Exclusive so a concurrent `run_created` cannot be overwritten — it may
@@ -735,13 +735,13 @@ class LocalWorld(w.World):
         # The log needs the `run_created` it never got, in an earlier slot than
         # the caller's event so replay reads it first.
         run_created = w.RunCreatedEvent(
-            eventData=w.RunCreatedEventData(
-                deploymentId=run_data.deployment_id,
-                workflowName=run_data.workflow_name,
+            event_data=w.RunCreatedEventData(
+                deployment_id=run_data.deployment_id,
+                workflow_name=run_data.workflow_name,
                 input=run_data.input,
-                executionContext=run_data.execution_context,
+                execution_context=run_data.execution_context,
             ),
-            specVersion=data.spec_version,
+            spec_version=data.spec_version,
         )
         run_created_id = self._new_id("evnt")
         event = w.EventAdaptor.from_wire(
@@ -887,20 +887,20 @@ class LocalWorld(w.World):
         if data.event_type == "run_created":
             run_data = data.event_data
             run = w.NonFinalWorkflowRun(
-                runId=effective_run_id,
-                deploymentId=run_data.deployment_id,
+                run_id=effective_run_id,
+                deployment_id=run_data.deployment_id,
                 status="pending",
-                workflowName=run_data.workflow_name,
+                workflow_name=run_data.workflow_name,
                 # The event carries the version, and the row it opens inherits
                 # it — `@workflow/world-local` propagates it the same way
                 # (`storage/events-storage.ts` `effectiveSpecVersion`), so a run
                 # this world creates is labelled by whoever wrote the event
                 # rather than by which SDK happens to be storing it.
-                specVersion=data.spec_version,
-                executionContext=run_data.execution_context,
+                spec_version=data.spec_version,
+                execution_context=run_data.execution_context,
                 input=run_data.input,
-                createdAt=now,
-                updatedAt=now,
+                created_at=now,
+                updated_at=now,
             )
             run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
             write_json(run_path, run)
@@ -908,19 +908,19 @@ class LocalWorld(w.World):
         elif data.event_type == "run_started":
             if current_run:
                 run = w.NonFinalWorkflowRun(
-                    runId=current_run.run_id,
-                    deploymentId=current_run.deployment_id,
-                    workflowName=current_run.workflow_name,
-                    specVersion=current_run.spec_version,
-                    executionContext=current_run.execution_context,
+                    run_id=current_run.run_id,
+                    deployment_id=current_run.deployment_id,
+                    workflow_name=current_run.workflow_name,
+                    spec_version=current_run.spec_version,
+                    execution_context=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
-                    encryptionPublicKey=current_run.encryption_public_key,
-                    createdAt=current_run.created_at,
-                    expiredAt=current_run.expired_at,
+                    encryption_public_key=current_run.encryption_public_key,
+                    created_at=current_run.created_at,
+                    expired_at=current_run.expired_at,
                     status="running",
-                    startedAt=current_run.started_at or now,
-                    updatedAt=now,
+                    started_at=current_run.started_at or now,
+                    updated_at=now,
                 )
                 run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
                 write_json(run_path, run, overwrite=True)
@@ -929,21 +929,21 @@ class LocalWorld(w.World):
             completed_data = data.event_data
             if current_run:
                 run = w.CompletedWorkflowRun(
-                    runId=current_run.run_id,
-                    deploymentId=current_run.deployment_id,
-                    workflowName=current_run.workflow_name,
-                    specVersion=current_run.spec_version,
-                    executionContext=current_run.execution_context,
+                    run_id=current_run.run_id,
+                    deployment_id=current_run.deployment_id,
+                    workflow_name=current_run.workflow_name,
+                    spec_version=current_run.spec_version,
+                    execution_context=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
-                    encryptionPublicKey=current_run.encryption_public_key,
-                    createdAt=current_run.created_at,
-                    expiredAt=current_run.expired_at,
-                    startedAt=current_run.started_at,
+                    encryption_public_key=current_run.encryption_public_key,
+                    created_at=current_run.created_at,
+                    expired_at=current_run.expired_at,
+                    started_at=current_run.started_at,
                     status="completed",
                     output=completed_data.output,
-                    completedAt=now,
-                    updatedAt=now,
+                    completed_at=now,
+                    updated_at=now,
                 )
                 run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
                 write_json(run_path, run, overwrite=True)
@@ -967,25 +967,25 @@ class LocalWorld(w.World):
                 error_stack = None
             if current_run:
                 run = w.FailedWorkflowRun(
-                    runId=current_run.run_id,
-                    deploymentId=current_run.deployment_id,
-                    workflowName=current_run.workflow_name,
-                    specVersion=current_run.spec_version,
-                    executionContext=current_run.execution_context,
+                    run_id=current_run.run_id,
+                    deployment_id=current_run.deployment_id,
+                    workflow_name=current_run.workflow_name,
+                    spec_version=current_run.spec_version,
+                    execution_context=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
-                    encryptionPublicKey=current_run.encryption_public_key,
-                    createdAt=current_run.created_at,
-                    expiredAt=current_run.expired_at,
-                    startedAt=current_run.started_at,
+                    encryption_public_key=current_run.encryption_public_key,
+                    created_at=current_run.created_at,
+                    expired_at=current_run.expired_at,
+                    started_at=current_run.started_at,
                     status="failed",
                     error=w.StructuredError(
                         message=error_msg,
                         stack=error_stack,
                         code=failed_data.code,
                     ),
-                    completedAt=now,
-                    updatedAt=now,
+                    completed_at=now,
+                    updated_at=now,
                 )
                 run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
                 write_json(run_path, run, overwrite=True)
@@ -994,20 +994,20 @@ class LocalWorld(w.World):
         elif data.event_type == "run_cancelled":
             if current_run:
                 run = w.CancelledWorkflowRun(
-                    runId=current_run.run_id,
-                    deploymentId=current_run.deployment_id,
-                    workflowName=current_run.workflow_name,
-                    specVersion=current_run.spec_version,
-                    executionContext=current_run.execution_context,
+                    run_id=current_run.run_id,
+                    deployment_id=current_run.deployment_id,
+                    workflow_name=current_run.workflow_name,
+                    spec_version=current_run.spec_version,
+                    execution_context=current_run.execution_context,
                     input=current_run.input,
                     attributes=current_run.attributes,
-                    encryptionPublicKey=current_run.encryption_public_key,
-                    createdAt=current_run.created_at,
-                    expiredAt=current_run.expired_at,
-                    startedAt=current_run.started_at,
+                    encryption_public_key=current_run.encryption_public_key,
+                    created_at=current_run.created_at,
+                    expired_at=current_run.expired_at,
+                    started_at=current_run.started_at,
                     status="cancelled",
-                    completedAt=now,
-                    updatedAt=now,
+                    completed_at=now,
+                    updated_at=now,
                 )
                 run_path = self.data_dir / "runs" / f"{effective_run_id}.json"
                 write_json(run_path, run, overwrite=True)
@@ -1017,15 +1017,15 @@ class LocalWorld(w.World):
             step_data = data.event_data
             assert isinstance(step_data.input, bytes)
             step = w.NonFinalWorkflowStep(
-                runId=effective_run_id,
-                stepId=data.correlation_id,
-                stepName=step_data.step_name,
+                run_id=effective_run_id,
+                step_id=data.correlation_id,
+                step_name=step_data.step_name,
                 status="pending",
                 input=step_data.input,
                 attempt=0,
-                createdAt=now,
-                updatedAt=now,
-                specVersion=data.spec_version,
+                created_at=now,
+                updated_at=now,
+                spec_version=data.spec_version,
             )
             step_composite_key = f"{effective_run_id}-{data.correlation_id}"
             step_path = self.data_dir / "steps" / f"{step_composite_key}.json"
@@ -1146,12 +1146,12 @@ class LocalWorld(w.World):
                         f'Hook "{data.correlation_id}" has already been created'
                     )
                 conflict_event = w.HookConflictEvent(
-                    correlationId=data.correlation_id,
-                    eventData=w.HookConflictEventData(token=hook_data.token),
+                    correlation_id=data.correlation_id,
+                    event_data=w.HookConflictEventData(token=hook_data.token),
                     server_props=w.ServerProps(
-                        runId=effective_run_id,
-                        eventId=event_id,
-                        createdAt=now,
+                        run_id=effective_run_id,
+                        event_id=event_id,
+                        created_at=now,
                     ),
                 )
                 assert conflict_event.server_props is not None
@@ -1165,17 +1165,17 @@ class LocalWorld(w.World):
                     hook=None,
                 )
             hook = w.Hook(
-                runId=effective_run_id,
-                hookId=data.correlation_id,
+                run_id=effective_run_id,
+                hook_id=data.correlation_id,
                 token=hook_data.token,
                 metadata=hook_data.metadata,
-                ownerId="local-owner",
-                projectId="local-project",
+                owner_id="local-owner",
+                project_id="local-project",
                 environment="local",
-                createdAt=now,
-                specVersion=data.spec_version,
-                isWebhook=False,
-                isSystem=False,
+                created_at=now,
+                spec_version=data.spec_version,
+                is_webhook=False,
+                is_system=False,
             )
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             write_json(hook_path, hook)
@@ -1373,7 +1373,7 @@ class LocalWorld(w.World):
                 for offset, (_, payload) in enumerate(found)
             ],
             cursor=_encode_chunks_cursor(start + len(found)) if has_more else None,
-            hasMore=has_more,
+            has_more=has_more,
             done=done,
         )
 
@@ -1383,7 +1383,7 @@ class LocalWorld(w.World):
         # the whole of this answer.
         files = self._chunk_files(name)
         _, data_count, done = _scan_chunks(files, len(files))
-        return w.StreamInfo(tailIndex=data_count - 1, done=done)
+        return w.StreamInfo(tail_index=data_count - 1, done=done)
 
     async def events_list(
         self,
@@ -1413,5 +1413,5 @@ class LocalWorld(w.World):
         return w.PaginatedResult(
             data=valid_items,
             cursor=None,
-            hasMore=False,
+            has_more=False,
         )


### PR DESCRIPTION
This is an internal refactor only that replaces all camel case schema constructor parameters with snake cases. The 2nd commit is 100% renamings.

[ref](https://github.com/vercel/vercel-py/pull/302#discussion_r3824935585)