### PR TITLE
workflow: fail runs on hook conflicts

### DIFF
--- a/changes/vercel-workflow/hook-conflict-replay.bugfix.md
+++ b/changes/vercel-workflow/hook-conflict-replay.bugfix.md
@@ -1,0 +1,1 @@
+Fail a workflow run with `HookConflictError` when another run already owns its hook token instead of leaving it running indefinitely.

--- a/src/vercel-workflow/tests/unit/test_workflow_error_serialization.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_error_serialization.py
@@ -9,6 +9,7 @@ import pytest
 from vercel._internal.core.polyfills import UTC
 from vercel.workflow import (
     FatalError,
+    HookConflictError,
     RemoteError,
     RetryableError,
     WorkflowRunFailedError,
@@ -39,6 +40,16 @@ def _raised(error: Exception) -> Exception:
 
 def test_fatal_error_uses_the_typescript_tag() -> None:
     assert _wire(FatalError("card declined")) == '[["FatalError",1],{"message":2},"card declined"]'
+
+
+def test_hook_conflict_uses_the_typescript_tag() -> None:
+    error = HookConflictError("shared-token", "wrun_owner")
+
+    assert _wire(error) == (
+        '[["HookConflictError",1],{"message":2,"token":3,"conflictingRunId":4},'
+        '"Hook token \\"shared-token\\" is already in use by another workflow '
+        '(run \\"wrun_owner\\")","shared-token","wrun_owner"]'
+    )
 
 
 def test_cause_uses_its_own_error_tag() -> None:
@@ -93,6 +104,12 @@ TS_FATAL_WITH_CAUSE = ser.DEVALUE_V1 + (
     b'"TypeError: underlying type error\\n    at throwFatalErrorWithCause (99_e2e.ts:1364:16)"]'
 )
 
+TS_HOOK_CONFLICT = ser.DEVALUE_V1 + (
+    b'[["HookConflictError",1],{"message":2,"token":3,"conflictingRunId":4},'
+    b'"Hook token \\"shared-token\\" is already in use by another workflow '
+    b'(run \\"wrun_owner\\")","shared-token","wrun_owner"]'
+)
+
 
 def test_typescript_fatal_error_hydrates_to_python_fatal_error() -> None:
     error = ser.hydrate_error(TS_FATAL_WITH_CAUSE, what="the error of step step_0")
@@ -101,6 +118,17 @@ def test_typescript_fatal_error_hydrates_to_python_fatal_error() -> None:
     assert str(error) == "fatal with cause"
     assert isinstance(error.__cause__, TypeError)
     assert str(error.__cause__) == "underlying type error"
+
+
+def test_typescript_hook_conflict_hydrates_to_python_hook_conflict() -> None:
+    error = ser.hydrate_error(TS_HOOK_CONFLICT, what="an error")
+
+    assert isinstance(error, HookConflictError)
+    assert error.token == "shared-token"
+    assert error.conflicting_run_id == "wrun_owner"
+    assert str(error) == (
+        'Hook token "shared-token" is already in use by another workflow (run "wrun_owner")'
+    )
 
 
 def test_error_payload_requires_a_message() -> None:
@@ -226,6 +254,14 @@ def test_fatal_error_and_cause_survive_a_round_trip() -> None:
     assert str(error) == "fatal with cause"
     assert isinstance(error.__cause__, TypeError)
     assert str(error.__cause__) == "underlying type error"
+
+
+def test_hook_conflict_survives_a_round_trip_without_an_owner() -> None:
+    error = _round_trip(HookConflictError("shared-token"))
+
+    assert isinstance(error, HookConflictError)
+    assert error.token == "shared-token"
+    assert error.conflicting_run_id is None
 
 
 @pytest.mark.parametrize(

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
@@ -10,20 +10,115 @@ them apart:
   swallows), mirroring the backend's hookId-keyed idempotency.
 - a *different* hook claiming a token already in use -- a genuine cross-workflow
   conflict, surfaced as a ``HookConflictEvent``.
+
+The handler tests also pin the replay boundary around that conflict: a returned
+``hook_conflict`` replays immediately, while a successful registration does not.
 """
 
 from __future__ import annotations
 
-from vercel.workflow._internal import world as w
+import asyncio
+from typing import Any
+
+import pytest
+
+from vercel.workflow import HookConflictError, WorkflowRunFailedError, sleep
+from vercel.workflow._internal import core, runtime, serialization as ser, world as w
 from vercel.workflow._internal.worlds import local as local_mod
 
 RUN_ID = "wrun_test"
 TOKEN = "shared-token"
 
+registry = core.Workflows(as_vercel_job=False)
 
-def _world(tmp_path, monkeypatch) -> local_mod.LocalWorld:
+
+class Claim(core.BaseHook):
+    pass
+
+
+@registry.workflow
+async def wait_for_claim() -> str:
+    await Claim.wait(token=TOKEN)
+    return "received"
+
+
+@registry.step
+async def pending_step() -> str:
+    return "done"
+
+
+@registry.workflow
+async def wait_for_step() -> str:
+    return await pending_step()
+
+
+@registry.workflow
+async def wait_for_claim_and_sleep() -> None:
+    await asyncio.gather(Claim.wait(token=TOKEN), sleep("1h"))
+
+
+class RecordingLocalWorld(local_mod.LocalWorld):
+    def __init__(self) -> None:
+        super().__init__()
+        self.event_list_calls = 0
+        self.run_started_calls = 0
+        self.queued: list[tuple[str, w.QueuePayload]] = []
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        if isinstance(data, w.RunStartedEvent):
+            self.run_started_calls += 1
+        return await super().events_create(run_id, data)
+
+    async def events_list(
+        self,
+        run_id: str,
+        *,
+        pagination: w.PaginationOptions | None = None,
+    ) -> w.PaginatedResult[w.Event]:
+        self.event_list_calls += 1
+        return await super().events_list(run_id, pagination=pagination)
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_test"
+
+
+def _world(tmp_path, monkeypatch) -> RecordingLocalWorld:
     monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
-    return local_mod.LocalWorld()
+    return RecordingLocalWorld()
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+async def _create_run(
+    world: local_mod.LocalWorld, workflow_name: str = wait_for_claim.workflow_id
+) -> str:
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deployment_id="",
+            workflow_name=workflow_name,
+            input=ser.dehydrate(ser.argument_array((), {})),
+        ).into_event(),
+    )
+    assert result.run is not None
+    return result.run.run_id
+
+
+async def _invoke(
+    run_id: str, workflow_name: str = wait_for_claim.workflow_id
+) -> w.QueueContinuation | None:
+    return await runtime.workflow_handler(
+        w.WorkflowInvokePayload(run_id=run_id).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(workflow_name),
+        message_id="msg_1",
+        registry=registry,
+    )
 
 
 async def test_same_hook_reclaim_raises_entity_conflict(tmp_path, monkeypatch) -> None:
@@ -50,3 +145,72 @@ async def test_different_hook_same_token_conflicts(tmp_path, monkeypatch) -> Non
 
     assert isinstance(result.event, w.HookConflictEvent)
     assert result.event.event_data.token == TOKEN
+
+
+async def test_hook_conflict_replays_and_fails_the_losing_run(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    w.set_world(world)
+    winner = await _create_run(world)
+    loser = await _create_run(world)
+
+    await _invoke(winner)
+    await _invoke(loser)
+
+    run = await world.runs_get(loser)
+    events = (await world.events_list(loser)).data
+
+    assert run.status == "failed"
+    # One setup write per run; the loser's in-process replay does not repeat it.
+    assert world.run_started_calls == 2
+    assert [event.event_type for event in events] == [
+        "run_created",
+        "run_started",
+        "hook_conflict",
+        "run_failed",
+    ]
+    with pytest.raises(WorkflowRunFailedError) as exc_info:
+        await runtime.Run(loser).return_value()
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, HookConflictError)
+    assert cause.token == TOKEN
+    assert cause.conflicting_run_id is None
+
+
+async def test_hook_conflict_replays_even_with_a_pending_wait(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    w.set_world(world)
+    winner = await _create_run(world)
+    loser = await _create_run(world, wait_for_claim_and_sleep.workflow_id)
+
+    await _invoke(winner)
+    continuation = await _invoke(loser, wait_for_claim_and_sleep.workflow_id)
+
+    assert continuation is None
+    assert (await world.runs_get(loser)).status == "failed"
+
+
+async def test_successful_hook_creation_does_not_replay(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    w.set_world(world)
+    run_id = await _create_run(world)
+
+    await _invoke(run_id)
+
+    assert world.event_list_calls == 1
+    assert (await world.runs_get(run_id)).status == "running"
+
+
+async def test_step_creation_waits_for_its_result_instead_of_replaying(
+    tmp_path, monkeypatch
+) -> None:
+    world = _world(tmp_path, monkeypatch)
+    w.set_world(world)
+    run_id = await _create_run(world, wait_for_step.workflow_id)
+
+    await _invoke(run_id, wait_for_step.workflow_id)
+
+    assert world.event_list_calls == 1
+    assert len(world.queued) == 1
+    queued = world.queued[0][1]
+    assert isinstance(queued, w.WorkflowInvokePayload)
+    assert queued.step_id is not None

--- a/src/vercel-workflow/vercel/workflow/__init__.py
+++ b/src/vercel-workflow/vercel/workflow/__init__.py
@@ -36,6 +36,7 @@ from . import sandbox
 from .errors import (
     EntityConflictError,
     FatalError,
+    HookConflictError,
     HookNotFoundError,
     RemoteError,
     RetryableError,
@@ -82,6 +83,7 @@ __all__ = [
     "register_serializable",
     "EntityConflictError",
     "FatalError",
+    "HookConflictError",
     "HookNotFoundError",
     "RemoteError",
     "RetryableError",

--- a/src/vercel-workflow/vercel/workflow/_internal/error_serde.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/error_serde.py
@@ -10,7 +10,7 @@ from typing import Any, TypedDict, cast
 
 from vercel._internal.core.polyfills import UTC
 
-from .errors import FatalError, RemoteError, RetryableError
+from .errors import FatalError, HookConflictError, RemoteError, RetryableError
 
 
 class _OptionalErrorFields(TypedDict, total=False):
@@ -30,6 +30,14 @@ class RetryableErrorPayload(ErrorPayload):
     retryAfter: int
 
 
+class _OptionalHookConflictFields(TypedDict, total=False):
+    conflictingRunId: str
+
+
+class HookConflictErrorPayload(ErrorPayload, _OptionalHookConflictFields):
+    token: str
+
+
 _ERROR_CLASS_BY_TAG: dict[str, type[Exception]] = {
     "FatalError": FatalError,
     "TypeError": TypeError,
@@ -39,6 +47,7 @@ _ERROR_CLASS_BY_TAG: dict[str, type[Exception]] = {
 }
 
 ERROR_TAG = "Error"
+HOOK_CONFLICT_ERROR_TAG = "HookConflictError"
 RETRYABLE_ERROR_TAG = "RetryableError"
 
 # Error tags without Python counterparts. RemoteError retains their original
@@ -48,7 +57,6 @@ _FOREIGN_ERROR_TAGS = (
     "URIError",
     "DOMException",
     "AggregateError",
-    "HookConflictError",
     "RuntimeDecryptionError",
 )
 
@@ -142,6 +150,31 @@ def _revive_error_class(cls: type[Exception]) -> Callable[[Any], Any]:
     return revive
 
 
+def _reduce_hook_conflict_error(value: Any) -> HookConflictErrorPayload | bool:
+    if not isinstance(value, HookConflictError):
+        return False
+    payload: HookConflictErrorPayload = {
+        **_error_payload(value),
+        "token": value.token,
+    }
+    if value.conflicting_run_id is not None:
+        payload["conflictingRunId"] = value.conflicting_run_id
+    return payload
+
+
+def _revive_hook_conflict_error(value: Any) -> HookConflictError:
+    payload = _require_error_payload(value)
+    token = value.get("token")
+    if not isinstance(token, str):
+        raise ValueError(f"invalid HookConflictError token: {token!r}")
+    conflicting_run_id = value.get("conflictingRunId")
+    if conflicting_run_id is not None and not isinstance(conflicting_run_id, str):
+        raise ValueError(f"invalid HookConflictError conflictingRunId: {conflicting_run_id!r}")
+    exc = HookConflictError(token, conflicting_run_id)
+    _apply_error_payload(exc, payload)
+    return exc
+
+
 def _reduce_retryable_error(value: Any) -> RetryableErrorPayload | bool:
     if not isinstance(value, RetryableError):
         return False
@@ -214,6 +247,7 @@ REDUCERS: dict[str, Callable[[Any], Any]] = {
         tag: _reduce_error_class(cls, subclasses=cls is FatalError)
         for tag, cls in _ERROR_CLASS_BY_TAG.items()
     },
+    HOOK_CONFLICT_ERROR_TAG: _reduce_hook_conflict_error,
     RETRYABLE_ERROR_TAG: _reduce_retryable_error,
     **{tag: _reduce_foreign_error(tag) for tag in _FOREIGN_ERROR_TAGS},
     ERROR_TAG: reduce_error,
@@ -222,6 +256,7 @@ REDUCERS: dict[str, Callable[[Any], Any]] = {
 REVIVERS: dict[str, Callable[[Any], Any]] = {
     **{tag: _revive_error_class(cls) for tag, cls in _ERROR_CLASS_BY_TAG.items()},
     **{tag: _revive_foreign_error(tag) for tag in _FOREIGN_ERROR_TAGS},
+    HOOK_CONFLICT_ERROR_TAG: _revive_hook_conflict_error,
     RETRYABLE_ERROR_TAG: _revive_retryable_error,
     ERROR_TAG: revive_error,
 }

--- a/src/vercel-workflow/vercel/workflow/_internal/errors.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/errors.py
@@ -15,6 +15,19 @@ class FatalError(Exception):
     fatal = True
 
 
+class HookConflictError(Exception):
+    """A hook token already owned by another active workflow run."""
+
+    token: str
+    conflicting_run_id: str | None
+
+    def __init__(self, token: str, conflicting_run_id: str | None = None) -> None:
+        owner = f' (run "{conflicting_run_id}")' if conflicting_run_id else ""
+        super().__init__(f'Hook token "{token}" is already in use by another workflow{owner}')
+        self.token = token
+        self.conflicting_run_id = conflicting_run_id
+
+
 class RemoteError(Exception):
     """An error whose class is unavailable in Python."""
 

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -990,11 +990,10 @@ class WorkflowOrchestratorContext:
                     hook = self.suspensions.pop(event.correlation_id, None)
                     if hook is not None:
                         assert isinstance(hook, Hook)
-                        conflict = f'Hook token "{token}" is already in use by another workflow'
                         while hook.futures:
                             future = hook.futures.popleft()
                             if not future.cancelled():
-                                future.set_exception(RuntimeError(conflict))
+                                future.set_exception(errors.HookConflictError(token))
 
                 case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                     hook = self.suspensions[event.correlation_id]
@@ -1215,6 +1214,13 @@ def refuse_cross_environment_delivery(
     return True
 
 
+class _ReplayImmediately:
+    """Ask the current queue delivery to cold-replay without acknowledging it."""
+
+
+_REPLAY_IMMEDIATELY = _ReplayImmediately()
+
+
 async def workflow_handler(
     message: Any,
     *,
@@ -1280,6 +1286,29 @@ async def workflow_handler(
     if workflow_run.status != "running":
         # Workflow has already completed or failed, so we can skip it
         return None
+
+    while True:
+        replay_result = await _workflow_replay_pass(
+            req=req,
+            workflow_run=workflow_run,
+            workflow_started_at=workflow_started_at,
+            registry=registry,
+            namespace=namespace,
+        )
+        if not isinstance(replay_result, _ReplayImmediately):
+            return replay_result
+
+
+async def _workflow_replay_pass(
+    *,
+    req: w.WorkflowInvokePayload,
+    workflow_run: w.WorkflowRun,
+    workflow_started_at: int,
+    registry: core.Workflows,
+    namespace: str | None,
+) -> w.QueueContinuation | _ReplayImmediately | None:
+    world = w.get_world()
+    run_id = req.run_id
 
     # Load all events into memory before running
     loaded = await get_all_workflow_run_events(run_id)
@@ -1408,7 +1437,8 @@ async def workflow_handler(
 
     # Now that the workflow is fully suspended, we can create all pending events in parallel
     events_created = False
-    attributes_written = False
+    immediate_replay_reasons: set[str] = set()
+
     async with anyio.create_task_group() as tg:
         for sus in context.suspensions.values():
             if sus.has_created_event:
@@ -1460,9 +1490,14 @@ async def workflow_handler(
                 async def create_hook(s=sus):
                     hook_data = w.HookCreatedEventData(token=s.token, metadata=s.metadata)
                     try:
-                        await world.events_create(run_id, hook_data.into_event(s.correlation_id))
+                        result = await world.events_create(
+                            run_id, hook_data.into_event(s.correlation_id)
+                        )
                     except w.EntityConflictError:
                         logger.debug(f"Workflow hook {s.correlation_id!r} has already been created")
+                    else:
+                        if isinstance(result.event, w.HookConflictEvent):
+                            immediate_replay_reasons.add("hook_conflict")
 
                 tg.start_soon(create_hook)
                 events_created = True
@@ -1481,10 +1516,10 @@ async def workflow_handler(
                         logger.debug(
                             f"Workflow attributes {s.correlation_id!r} have already been set"
                         )
+                    immediate_replay_reasons.add("attr_set")
 
                 tg.start_soon(set_attr)
                 events_created = True
-                attributes_written = True
 
         for hook in context.hooks.values():
             if hook.disposed and not hook.has_dispose_event:
@@ -1503,18 +1538,18 @@ async def workflow_handler(
                 tg.start_soon(dispose_hook)
                 events_created = True
 
-    if attributes_written or (not context.suspensions and events_created):
-        # An attribute write is immediately ready after the replay, so we can just
-        # run replay again without requeuing. The second case is caused by a disposed
-        # hook that cleared its suspensions, so do the same if event log changed.
-        return await workflow_handler(
-            message,
-            attempt=attempt,
-            queue_name=queue_name,
-            message_id=message_id,
-            registry=registry,
-            namespace=namespace,
+    if not context.suspensions and events_created:
+        # A disposed hook can clear the last suspension while its lifecycle
+        # event is still being flushed. Replay it before acknowledging.
+        immediate_replay_reasons.add("suspensions_cleared")
+
+    if immediate_replay_reasons:
+        logger.debug(
+            "[Workflows] '%s' - replaying after durable local progress: %s",
+            run_id,
+            ", ".join(sorted(immediate_replay_reasons)),
         )
+        return _REPLAY_IMMEDIATELY
 
     now = datetime.now(UTC)
     min_timeout_seconds = -1.0

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -1215,7 +1215,7 @@ def refuse_cross_environment_delivery(
 
 
 class _ReplayImmediately:
-    """Ask the current queue delivery to cold-replay without acknowledging it."""
+    """Sentinel to have workflow_handler rerun _workflow_replay_pass"""
 
 
 _REPLAY_IMMEDIATELY = _ReplayImmediately()

--- a/src/vercel-workflow/vercel/workflow/errors.py
+++ b/src/vercel-workflow/vercel/workflow/errors.py
@@ -1,5 +1,6 @@
 from vercel.workflow._internal.errors import (
     FatalError,
+    HookConflictError,
     RemoteError,
     RetryableError,
     WorkflowRunFailedError,
@@ -18,6 +19,7 @@ from vercel.workflow._internal.world import (
 __all__ = [
     "EntityConflictError",
     "FatalError",
+    "HookConflictError",
     "HookNotFoundError",
     "RemoteError",
     "RetryableError",


### PR DESCRIPTION
This PR fixes a bug that, `await UserHook.wait(token=SAME_TOKEN)` may hang forever under a race condition.

> When two active runs claimed the same token, the World correctly persisted a `hook_conflict` event for the loser, but the Python handler ignored the event returned from `hook_created` and acknowledged the queue delivery. Nothing then woke the run to pass that conflict back to the workflow.

The handler now performs another replay pass inside the same delivery, after receiving the `hook_conflict` from the world, to fail the run. `BaseHook.wait()` may now raise a newly-added `vercel.workflow.HookConflictError` (new public API), carrying the conflicting `token` and an optional `conflicting_run_id`

---

## Summary

- Detect hook conflict events returned from hook creation and cold-replay the workflow immediately.
- Add a public `HookConflictError` with Python/TypeScript-compatible serialization.
- Cover conflict liveness, pending waits, typed causes, and non-conflicting registration behavior.