### PR TITLE
Expand CI test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,66 @@ on:
 permissions: {}
 
 jobs:
-  lint-test-and-build:
-    name: test (py${{ matrix.python-version }})
+  lint-and-typecheck:
+    name: Lint and typecheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Sync dependencies
+        run: uv sync --all-packages --locked --python 3.12
+
+      - name: Lint
+        run: uv run poe lint
+
+      - name: Typecheck
+        run: uv run poe typecheck
+
+  test:
+    name: Test (${{ matrix.os.name }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os.runner }}
     environment: ci
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - name: Linux
+            runner: ubuntu-latest
+            redis-image: redis:7-alpine
+            redis-url: redis://localhost:6379/9
+          - name: macOS
+            runner: macos-latest
+            redis-image: ""
+            redis-url: ""
+          - name: Windows
+            runner: windows-latest
+            redis-image: ""
+            redis-url: ""
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       # The vercel-apscheduler driver tests exercise their Lua scripts against
-      # a real Redis; without this service they skip silently.
+      # a real Redis on Linux; without this service they skip silently.
       redis:
-        image: redis:7-alpine
+        image: ${{ matrix.os.redis-image }} # zizmor: ignore[unpinned-images]
         ports:
           - 6379:6379
     env:
-      APSCHEDULER_TEST_REDIS_URL: redis://localhost:6379/9
+      APSCHEDULER_TEST_REDIS_URL: ${{ matrix.os.redis-url }}
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
@@ -82,14 +123,8 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-packages --locked --python ${{ matrix.python-version }}
 
-      - name: Lint
-        run: ./scripts/lint.sh
-
-      - name: Typecheck
-        run: ./scripts/typecheck.sh
-
       - name: Test
-        run: ./scripts/test.sh
+        run: uv run poe test
         env:
           VERCEL_DEVALUE_JS: ${{ runner.temp }}/devalue
           VERCEL_WORKFLOW_CLI: ${{ runner.temp }}/workflow-cli/node_modules/workflow
@@ -98,5 +133,41 @@ jobs:
         if: matrix.python-version == '3.12'
         run: uv run poe test-examples
 
+  build:
+    name: Build packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Sync dependencies
+        run: uv sync --all-packages --locked --python 3.12
+
       - name: Build package
-        run: ./scripts/build.sh
+        run: uv run poe dist
+
+  overall:
+    name: CI Overall
+    if: always()
+    needs:
+      - build
+      - lint-and-typecheck
+      - test
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check CI results
+        if: >-
+          needs.build.result != 'success' ||
+          needs.lint-and-typecheck.result != 'success' ||
+          needs.test.result != 'success'
+        run: exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
     "hypothesis>=6.0.0,<7",
     "respx>=0.21.0,<1",
     "cryptography>=48.0.1",
-    "uvloop<1",
+    "uvloop<1; sys_platform != 'win32'",
     "mypy>=1.20.2,<2",
     "django-stubs>=6.0.6,<7",
     "build<2",
@@ -31,7 +31,7 @@ dev = [
     "tomli>=2.0.0,<3; python_version < '3.11'",
     "vendoring>=1,<2",
     "lograil~=0.7.0",
-    "ggt>=1.5.5; python_version >= '3.11'",
+    "ggt>=1.5.6; python_version >= '3.11'",
 ]
 
 [tool.uv]

--- a/scripts/poe/README.md
+++ b/scripts/poe/README.md
@@ -238,8 +238,8 @@ When changing this system, verify all shell code with system's default bash
 (helps catching new bash-isms on macOS).
 
 ```sh
-shellcheck -x scripts/build.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
-/bin/bash -n scripts/build.sh scripts/poe/tasks/poe scripts/poe/tasks/tool
+shellcheck -x scripts/build.sh
+/bin/bash -n scripts/build.sh
 python3 -m py_compile scripts/poe/workspace_poe.py scripts/poe/workspace_poe_resolve.py scripts/workspace-task.sh scripts/qa.sh scripts/workspace-root-task.sh
 ```
 

--- a/scripts/poe/poe.toml
+++ b/scripts/poe/poe.toml
@@ -1,12 +1,12 @@
 [tool.poe.env]
-POE = { default = "${POE_CONF_DIR}/tasks/poe" }
-PYTEST = { default = "${POE_CONF_DIR}/tasks/pytest" }
-RUFF_CHECK = { default = "${POE_CONF_DIR}/tasks/ruff-check" }
-RUFF_CHECK_FIX = { default = "${POE_CONF_DIR}/tasks/ruff-check-fix" }
-RUFF_FORMAT = { default = "${POE_CONF_DIR}/tasks/ruff-format" }
-RUFF_FORMAT_FIX = { default = "${POE_CONF_DIR}/tasks/ruff-format-fix" }
-TY = { default = "${POE_CONF_DIR}/tasks/ty" }
-MYPY = { default = "${POE_CONF_DIR}/tasks/mypy" }
+POE = { default = "python ${POE_CONF_DIR}/tasks/poe" }
+PYTEST = { default = "python ${POE_CONF_DIR}/tasks/tool pytest" }
+RUFF_CHECK = { default = "python ${POE_CONF_DIR}/tasks/tool ruff-check" }
+RUFF_CHECK_FIX = { default = "python ${POE_CONF_DIR}/tasks/tool ruff-check-fix" }
+RUFF_FORMAT = { default = "python ${POE_CONF_DIR}/tasks/tool ruff-format" }
+RUFF_FORMAT_FIX = { default = "python ${POE_CONF_DIR}/tasks/tool ruff-format-fix" }
+TY = { default = "python ${POE_CONF_DIR}/tasks/tool ty" }
+MYPY = { default = "python ${POE_CONF_DIR}/tasks/tool mypy" }
 
 [tool.poe.tasks.fix]
 cmd = "$POE_CONF_DIR/workspace_poe.py tool-group fix"

--- a/scripts/poe/tasks/poe
+++ b/scripts/poe/tasks/poe
@@ -1,13 +1,28 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python
+from __future__ import annotations
 
-if (($# == 0)); then
-  echo "usage: $0 <poe-task> [args ...]" >&2
-  exit 2
-fi
+import subprocess
+import sys
+from collections.abc import Sequence
 
-task="$1"
-shift
 
-poe --dry-run "$task" "$@" 2>&1 | sed 's/^Poe => //'
-exec poe -q "$task" "$@"
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args:
+        raise SystemExit(f"usage: {sys.argv[0]} <poe-task> [args ...]")
+
+    preview = subprocess.run(
+        ("poe", "--dry-run", *args),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    sys.stdout.write(preview.stdout.replace("Poe => ", "", 1))
+    if preview.returncode:
+        return preview.returncode
+    return subprocess.call(("poe", "-q", *args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/poe/tasks/tool
+++ b/scripts/poe/tasks/tool
@@ -1,310 +1,185 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python
+from __future__ import annotations
 
-task_name="$(basename "$0")"
-script_dir="$(cd "$(dirname "$0")" && pwd -P)"
-workspace_root="$(cd "$script_dir/../../.." && pwd -P)"
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
 
-workspace_poe_parallel_enabled() {
-  case "${WORKSPACE_POE_PARALLEL:-}" in
-    0|false|no)
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-}
+FALSE_VALUES = {"0", "false", "no"}
+TRUE_VALUES = {"1", "true", "yes"}
+WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
 
-workspace_poe_pytest_forced() {
-  case "${FORCE_PYTEST:-}" in
-    1|true|yes)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
 
-workspace_poe_mypy_cache_package() {
-  if [[ -n "${WORKSPACE_POE_PACKAGE:-}" ]]; then
-    printf '%s\n' "$WORKSPACE_POE_PACKAGE"
-  elif [[ "$(pwd -P)" == "$workspace_root" ]]; then
-    printf 'root\n'
-  else
-    basename "$(pwd -P)"
-  fi
-}
+def enabled(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() not in FALSE_VALUES
 
-workspace_poe_drop_duplicate_extra_args() {
-  local start
-  local index
-  local matched
 
-  if ((${#extra_args[@]} == 0 || ${#scope_args[@]} < ${#extra_args[@]})); then
-    return
-  fi
+def split_env(name: str) -> list[str]:
+    value = os.environ.get(name, "")
+    return shlex.split(value) if value else []
 
-  for ((start = 0; start <= ${#scope_args[@]} - ${#extra_args[@]}; start++)); do
-    matched=1
-    for ((index = 0; index < ${#extra_args[@]}; index++)); do
-      if [[ "${scope_args[start + index]}" != "${extra_args[index]}" ]]; then
-        matched=0
-        break
-      fi
-    done
-    if ((matched)); then
-      extra_args=()
-      return
-    fi
-  done
-}
 
-case "$task_name" in
-  pytest)
-    if [[ "${WORKSPACE_POE_TEST_RUNNER:-}" == ggt ]]; then
-      command=(ggt)
-      test_runner=ggt
-    elif [[ "${WORKSPACE_POE_TEST_RUNNER:-}" == pytest ]]; then
-      command=(pytest)
-      test_runner=pytest
-    elif ! workspace_poe_pytest_forced && command -v ggt >/dev/null 2>&1; then
-      command=(ggt)
-      test_runner=ggt
-    else
-      command=(pytest)
-      test_runner=pytest
-    fi
-    if [[ "$test_runner" == ggt ]] &&
-      [[ "${WORKSPACE_POE_LOGRAIL_PROGRESS:-}" == 1 ]]; then
-      command+=(--output-format json)
-    fi
-    ;;
-  ruff-check)
-    command=(ruff check)
-    ;;
-  ruff-check-fix)
-    command=(ruff check --fix)
-    ;;
-  ruff-format)
-    command=(ruff format --check)
-    ;;
-  ruff-format-fix)
-    command=(ruff format)
-    ;;
-  ty)
-    command=(ty check)
-    ;;
-  mypy)
-    command=(mypy)
-    ;;
-  *)
-    echo "unsupported poe tool wrapper: $task_name" >&2
-    exit 2
-    ;;
-esac
+def has_option(
+    args: Iterable[str],
+    *,
+    flags: set[str],
+    prefixes: tuple[str, ...],
+) -> bool:
+    return any(arg in flags or arg.startswith(prefixes) for arg in args)
 
-extra_args=()
-if [[ -n "${POE_EXTRA_ARGS:-}" ]]; then
-  eval "extra_args=(${POE_EXTRA_ARGS})"
-fi
-if [[ "${extra_args[0]:-}" == -- ]]; then
-  extra_args=("${extra_args[@]:1}")
-fi
 
-scope_args=("$@")
-if [[ "$task_name" == ruff-* && -z "${RUFF_CACHE_DIR:-}" ]]; then
-  export RUFF_CACHE_DIR="$workspace_root/.ruff_cache"
-fi
-if [[ "$task_name" == mypy ]]; then
-  cache_dir=""
-  has_config_file=0
-  has_cache_dir=0
-  option_value=0
-  if ((${#scope_args[@]})); then
-    for arg in "${scope_args[@]}"; do
-      if ((option_value)); then
-        option_value=0
-        continue
-      fi
-      case "$arg" in
-        --config-file)
-          has_config_file=1
-          option_value=1
-          ;;
-        --config-file=*)
-          has_config_file=1
-          ;;
-        --cache-dir)
-          has_cache_dir=1
-          option_value=1
-          ;;
-        --cache-dir=*)
-          has_cache_dir=1
-          ;;
-      esac
-    done
-  fi
-  if ((${#extra_args[@]})); then
-    for arg in "${extra_args[@]}"; do
-      if ((option_value)); then
-        option_value=0
-        continue
-      fi
-      case "$arg" in
-        --config-file)
-          has_config_file=1
-          option_value=1
-          ;;
-        --config-file=*)
-          has_config_file=1
-          ;;
-        --cache-dir)
-          has_cache_dir=1
-          option_value=1
-          ;;
-        --cache-dir=*)
-          has_cache_dir=1
-          ;;
-      esac
-    done
-  fi
-  if ((has_config_file == 0)); then
-    if ((${#scope_args[@]})); then
-      scope_args=(--config-file "$workspace_root/pyproject.toml" "${scope_args[@]}")
-    else
-      scope_args=(--config-file "$workspace_root/pyproject.toml")
-    fi
-  fi
-  if ((has_cache_dir == 0)); then
-    cache_dir="$workspace_root/.mypy_cache/$(workspace_poe_mypy_cache_package)"
-    if ((${#scope_args[@]})); then
-      scope_args=(--cache-dir "$cache_dir" "${scope_args[@]}")
-    else
-      scope_args=(--cache-dir "$cache_dir")
-    fi
-  fi
-fi
-if ((${#scope_args[@]} == 0)) && [[ -n "${WORKSPACE_POE_SCOPE_ARGS:-}" ]]; then
-  eval "scope_args=(${WORKSPACE_POE_SCOPE_ARGS})"
-fi
-if [[ "$task_name" == mypy ]]; then
-  has_target=0
-  option_value=0
-  if ((${#scope_args[@]})); then
-    for arg in "${scope_args[@]}"; do
-      if ((option_value)); then
-        option_value=0
-        continue
-      fi
-      case "$arg" in
-        --cache-dir|--config-file|--python-version)
-          option_value=1
-          ;;
-        --cache-dir=*|--config-file=*|--python-version=*)
-          ;;
-        --*)
-          ;;
-        *)
-          has_target=1
-          ;;
-      esac
-    done
-  fi
-  if ((has_target == 0)); then
-    if [[ -n "${WORKSPACE_POE_SCOPE_ARGS:-}" ]]; then
-      eval "scope_args+=( ${WORKSPACE_POE_SCOPE_ARGS} )"
-    else
-      scope_args+=(.)
-    fi
-  fi
-fi
-if [[ "$task_name" == pytest ]]; then
-  has_workers=0
-  has_verbosity=0
-  option_value=0
-  if ((${#scope_args[@]})); then
-    for arg in "${scope_args[@]}"; do
-      if ((option_value)); then
-        option_value=0
-        continue
-      fi
-      case "$arg" in
-        -n|--numprocesses|-j|--jobs)
-          has_workers=1
-          option_value=1
-          ;;
-        -n*|--numprocesses=*|-j*|--jobs=*)
-          has_workers=1
-          ;;
-        -q|--quiet|-v|--verbose)
-          has_verbosity=1
-          ;;
-        -q*|-v*)
-          has_verbosity=1
-          ;;
-      esac
-    done
-  fi
-  if ((${#extra_args[@]})); then
-    for arg in "${extra_args[@]}"; do
-      if ((option_value)); then
-        option_value=0
-        continue
-      fi
-      case "$arg" in
-        -n|--numprocesses|-j|--jobs)
-          has_workers=1
-          option_value=1
-          ;;
-        -n*|--numprocesses=*|-j*|--jobs=*)
-          has_workers=1
-          ;;
-        -q|--quiet|-v|--verbose)
-          has_verbosity=1
-          ;;
-        -q*|-v*)
-          has_verbosity=1
-          ;;
-      esac
-    done
-  fi
-  if ((has_verbosity == 0)) &&
-    [[ "${WORKSPACE_POE_LOGRAIL_PROGRESS:-}" == 1 ]] &&
-    [[ "$test_runner" == pytest ]]; then
-    if ((${#scope_args[@]})); then
-      scope_args=(-v "${scope_args[@]}")
-    else
-      scope_args=(-v)
-    fi
-  fi
-  if ((has_workers == 0)); then
-    if [[ "$test_runner" == pytest ]] && workspace_poe_parallel_enabled; then
-      scope_args=(-n auto "${scope_args[@]}")
-    elif [[ "$test_runner" == ggt ]] && ! workspace_poe_parallel_enabled; then
-      scope_args=(-j 1 "${scope_args[@]}")
-    fi
-  fi
-fi
-if ((${#scope_args[@]} == 0)); then
-  if [[ "$task_name" == ruff-* && "$(pwd -P)" == "$workspace_root" ]]; then
-    scope_args=(tests examples)
-  else
-    scope_args=(.)
-  fi
-fi
+def has_mypy_target(args: Sequence[str]) -> bool:
+    takes_value = False
+    for arg in args:
+        if takes_value:
+            takes_value = False
+            continue
+        if arg in {"--cache-dir", "--config-file", "--python-version"}:
+            takes_value = True
+        elif arg.startswith(("--cache-dir=", "--config-file=", "--python-version=")):
+            continue
+        elif not arg.startswith("--"):
+            return True
+    return False
 
-workspace_poe_drop_duplicate_extra_args
 
-run_args=("${command[@]}")
-if ((${#scope_args[@]})); then
-  run_args+=("${scope_args[@]}")
-fi
-if ((${#extra_args[@]})); then
-  run_args+=("${extra_args[@]}")
-fi
+def drop_duplicate_args(scope_args: list[str], extra_args: list[str]) -> list[str]:
+    size = len(extra_args)
+    if not size or len(scope_args) < size:
+        return extra_args
+    if any(
+        scope_args[index : index + size] == extra_args
+        for index in range(len(scope_args) - size + 1)
+    ):
+        return []
+    return extra_args
 
-printf '%q ' "${run_args[@]}"
-printf '\n'
-exec "${run_args[@]}"
+
+def pytest_command() -> tuple[list[str], str]:
+    selected = os.environ.get("WORKSPACE_POE_TEST_RUNNER")
+    force_pytest = os.environ.get("FORCE_PYTEST", "").lower() in TRUE_VALUES
+    if selected == "ggt" or (selected != "pytest" and not force_pytest and shutil.which("ggt")):
+        command = ["ggt"]
+        runner = "ggt"
+    else:
+        command = ["pytest"]
+        runner = "pytest"
+    if runner == "ggt" and os.environ.get("WORKSPACE_POE_LOGRAIL_PROGRESS") == "1":
+        command.extend(("--output-format", "json"))
+    return command, runner
+
+
+def build_command(task_name: str, argv: Sequence[str]) -> list[str]:
+    test_runner: str | None = None
+    if task_name == "pytest":
+        command, test_runner = pytest_command()
+    else:
+        commands = {
+            "ruff-check": ["ruff", "check"],
+            "ruff-check-fix": ["ruff", "check", "--fix"],
+            "ruff-format": ["ruff", "format", "--check"],
+            "ruff-format-fix": ["ruff", "format"],
+            "ty": ["ty", "check"],
+            "mypy": ["mypy"],
+        }
+        try:
+            command = commands[task_name]
+        except KeyError:
+            raise SystemExit(f"unsupported poe tool wrapper: {task_name}") from None
+
+    extra_args = split_env("POE_EXTRA_ARGS")
+    if extra_args[:1] == ["--"]:
+        extra_args.pop(0)
+    scope_args = list(argv)
+
+    if task_name.startswith("ruff-"):
+        os.environ.setdefault("RUFF_CACHE_DIR", str(WORKSPACE_ROOT / ".ruff_cache"))
+
+    if task_name == "mypy":
+        all_args = [*scope_args, *extra_args]
+        if not has_option(
+            all_args,
+            flags={"--config-file"},
+            prefixes=("--config-file=",),
+        ):
+            scope_args[:0] = [
+                "--config-file",
+                str(WORKSPACE_ROOT / "pyproject.toml"),
+            ]
+        if not has_option(
+            all_args,
+            flags={"--cache-dir"},
+            prefixes=("--cache-dir=",),
+        ):
+            package = os.environ.get("WORKSPACE_POE_PACKAGE")
+            if not package:
+                package = "root" if Path.cwd().resolve() == WORKSPACE_ROOT else Path.cwd().name
+            scope_args[:0] = [
+                "--cache-dir",
+                str(WORKSPACE_ROOT / ".mypy_cache" / package),
+            ]
+
+    if not scope_args:
+        scope_args = split_env("WORKSPACE_POE_SCOPE_ARGS")
+
+    if task_name == "mypy" and not has_mypy_target(scope_args):
+        scope_args.extend(split_env("WORKSPACE_POE_SCOPE_ARGS") or ["."])
+
+    if task_name == "pytest":
+        all_args = [*scope_args, *extra_args]
+        has_workers = has_option(
+            all_args,
+            flags={"-n", "--numprocesses", "-j", "--jobs"},
+            prefixes=("-n", "--numprocesses=", "-j", "--jobs="),
+        )
+        has_verbosity = has_option(
+            all_args,
+            flags={"-q", "--quiet", "-v", "--verbose"},
+            prefixes=("-q", "-v"),
+        )
+        parallel = enabled("WORKSPACE_POE_PARALLEL", default=True)
+        if (
+            not has_verbosity
+            and os.environ.get("WORKSPACE_POE_LOGRAIL_PROGRESS") == "1"
+            and test_runner == "pytest"
+        ):
+            scope_args.insert(0, "-v")
+        if not has_workers:
+            if test_runner == "pytest" and parallel:
+                scope_args[:0] = ["-n", "auto"]
+            elif test_runner == "ggt" and not parallel:
+                scope_args[:0] = ["-j", "1"]
+
+    if not scope_args:
+        if task_name.startswith("ruff-") and Path.cwd().resolve() == WORKSPACE_ROOT:
+            scope_args = ["tests", "examples"]
+        else:
+            scope_args = ["."]
+
+    extra_args = drop_duplicate_args(scope_args, extra_args)
+    return [*command, *scope_args, *extra_args]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    invoked_name = Path(sys.argv[0]).name
+    if invoked_name == "tool":
+        if not args:
+            raise SystemExit("missing poe tool name")
+        task_name = args.pop(0)
+    else:
+        task_name = invoked_name
+    command = build_command(task_name, args)
+    print(shlex.join(command), flush=True)
+    return subprocess.call(command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/poe/workspace_poe.py
+++ b/scripts/poe/workspace_poe.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -18,6 +18,7 @@ RESOLVER = SCRIPT_DIR / "workspace_poe_resolve.py"
 PARALLEL_FALSE = {"0", "false", "no"}
 FAILURE_TAIL_LINES = 20
 QUIET_FAILURE_DETAIL = "workspace_poe.failure.detail"
+TEST_FAILURE_DETAILS = "workspace_poe.test.failure_details"
 ROOT_TASKS = {
     "fix": "fix-root",
     "lint": "lint-root",
@@ -402,26 +403,26 @@ def run_root_task(task: str, argv: Sequence[str]) -> int:
         else:
             args.append("tests/unit")
         args.extend(extra_args)
-        return run_command(
-            env_command(
-                "pytest",
-                shlex.join((os.environ["PYTEST"], *args)),
-                category="test",
-                parser="pytest",
-            )
-        )
+        return run_command(root_pytest_command(args, category="test"))
     if task == "test-examples-root":
         extra_args = list(argv) or poe_extra_args()
         args = ["tests/test_examples.py", *extra_args]
-        return run_command(
-            env_command(
-                "pytest",
-                shlex.join((os.environ["PYTEST"], *args)),
-                category="test-examples",
-                parser="pytest",
-            )
-        )
+        return run_command(root_pytest_command(args, category="test-examples"))
     raise SystemExit(f"unsupported root task: {task}")
+
+
+def root_pytest_command(args: Sequence[str], *, category: str) -> CommandSpec:
+    subject = os.environ.get("WORKSPACE_POE_PACKAGE") or Path.cwd().name
+    return CommandSpec(
+        label=lograil_name("pytest", subject),
+        argv=(sys.executable, str(SCRIPT_DIR / "tasks" / "tool"), "pytest", *args),
+        cwd=Path.cwd(),
+        env=os.environ.copy(),
+        display_label="pytest",
+        category=category,
+        subject=subject,
+        parser="pytest",
+    )
 
 
 def env_command(
@@ -470,7 +471,7 @@ def run_group(
     for command in commands:
         remaps = list(DEFAULT_REMAPS)
         if command.category in PYTEST_TASKS and command.parser == "generic":
-            remaps.append(_preserve_test_scope_identity)
+            remaps.append(_ggt_entry_remap())
         if command.suppress_output:
             remaps.append(_quiet_entry)
         specs.append(
@@ -518,7 +519,13 @@ def print_failure_summary(processes: Sequence[Any]) -> None:
 
 def failure_tail_lines(entries: Sequence[dict[str, Any]]) -> list[str]:
     lines: list[str] = []
+    retained: list[str] = []
     for entry in entries:
+        details = entry.get(TEST_FAILURE_DETAILS)
+        if isinstance(details, (list, tuple)):
+            for detail in details:
+                if isinstance(detail, str) and detail and detail not in retained:
+                    retained.append(detail)
         message = entry.get("message") or entry.get(QUIET_FAILURE_DETAIL)
         if not isinstance(message, str):
             continue
@@ -528,7 +535,10 @@ def failure_tail_lines(entries: Sequence[dict[str, Any]]) -> list[str]:
         if is_low_signal_failure_tail_line(message):
             continue
         lines.append(message)
-    return lines[-FAILURE_TAIL_LINES:]
+    retained = retained[-FAILURE_TAIL_LINES:]
+    lines = [line for line in lines if line not in retained]
+    available = FAILURE_TAIL_LINES - len(retained)
+    return [*retained, *(lines[-available:] if available else [])]
 
 
 def is_low_signal_failure_tail_line(message: str) -> bool:
@@ -538,6 +548,8 @@ def is_low_signal_failure_tail_line(message: str) -> bool:
     if stripped.startswith("[") and "]" in stripped and "::" in stripped:
         return True
     if stripped.startswith("tests/") and "::" in stripped and "PASSED" in stripped:
+        return True
+    if stripped.startswith("PASSED "):
         return True
     return False
 
@@ -552,11 +564,32 @@ def _quiet_entry(entry: dict[str, Any]) -> dict[str, Any]:
     return entry
 
 
-def _preserve_test_scope_identity(entry: dict[str, Any]) -> dict[str, Any]:
-    """Keep the package label while accepting native ggt progress detail."""
-    entry.pop("lograil.progress.process", None)
-    entry.pop("lograil.progress.subject", None)
-    return entry
+def _ggt_entry_remap() -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Keep package identity and retain failures past lograil's bounded tail."""
+    failures: list[str] = []
+
+    def remap(entry: dict[str, Any]) -> dict[str, Any]:
+        entry.pop("lograil.progress.process", None)
+        entry.pop("lograil.progress.subject", None)
+        if entry.get("levelname") in {"ERROR", "CRITICAL"}:
+            message = entry.get("message")
+            detail = entry.get("ggt.detail")
+            detail_messages = (
+                tuple(
+                    detail.get(field)
+                    for field in ("error_message", "server_traceback", "stdout", "stderr")
+                )
+                if isinstance(detail, dict)
+                else ()
+            )
+            for failure in (message, *detail_messages):
+                if isinstance(failure, str) and failure and failure not in failures:
+                    failures.append(failure)
+        if failures:
+            entry[TEST_FAILURE_DETAILS] = tuple(failures[-FAILURE_TAIL_LINES:])
+        return entry
+
+    return remap
 
 
 def run_sequential(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -431,7 +431,14 @@ def _release_pr_numbers(releases: list[Release]) -> dict[Path, int]:
 def _fragment_pr_number(path: Path) -> int | None:
     try:
         log = subprocess.check_output(
-            ["git", "log", "--full-history", "--format=%s", "--", str(path.relative_to(ROOT))],
+            [
+                "git",
+                "log",
+                "--full-history",
+                "--format=%s",
+                "--",
+                path.relative_to(ROOT).as_posix(),
+            ],
             cwd=ROOT,
             text=True,
         )

--- a/tests/unit/test_clogapp.py
+++ b/tests/unit/test_clogapp.py
@@ -370,7 +370,10 @@ async def test_clogedit_escape_returns_to_previous_step() -> None:
     assert pilot.app.return_value == []
 
 
-async def test_clogedit_single_escape_on_package_step_arms_exit() -> None:
+async def test_clogedit_single_escape_on_package_step_arms_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 30)
     selection = clogedit.ChangelogSelection(
         {
             "pkg": clogedit.PackageNewsState(
@@ -397,7 +400,10 @@ async def test_clogedit_single_escape_on_package_step_arms_exit() -> None:
     assert pilot.app.return_value == []
 
 
-async def test_clogedit_double_escape_on_package_step_exits() -> None:
+async def test_clogedit_double_escape_on_package_step_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 30)
     selection = clogedit.ChangelogSelection(
         {
             "pkg": clogedit.PackageNewsState(
@@ -415,7 +421,8 @@ async def test_clogedit_double_escape_on_package_step_exits() -> None:
     )
 
     async with app.run_test() as pilot:
-        await pilot.press("escape", "escape")
+        await pilot.press("escape")
+        await pilot.press("escape")
 
     assert pilot.app.return_value == []
 
@@ -443,7 +450,7 @@ async def test_clogedit_escape_exit_timeout_resets(monkeypatch: pytest.MonkeyPat
         await pilot.pause(0.03)
         assert app.escape_exit_timer is None
         assert app.status == clogedit.PACKAGE_STATUS
-        monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 0.5)
+        monkeypatch.setattr(clogedit, "ESC_EXIT_SECONDS", 30)
         await pilot.press("escape")
         assert app.escape_exit_timer is not None
         await pilot.press("ctrl+d")

--- a/tests/unit/test_poe_tool.py
+++ b/tests/unit/test_poe_tool.py
@@ -1,105 +1,90 @@
 from __future__ import annotations
 
-import os
-import subprocess
+import importlib.machinery
+import importlib.util
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-
-TOOL = Path(__file__).resolve().parents[2] / "scripts" / "poe" / "tasks" / "pytest"
-
-
-def _runner(path: Path, name: str) -> None:
-    executable = path / name
-    executable.write_text('#!/bin/sh\nprintf \'%s\\n\' "$0" "$@"\n')
-    executable.chmod(0o755)
+TOOL = Path(__file__).resolve().parents[2] / "scripts" / "poe" / "tasks" / "tool"
+LOADER = importlib.machinery.SourceFileLoader("poe_tool", str(TOOL))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+poe_tool = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = poe_tool
+LOADER.exec_module(poe_tool)
 
 
-def _run(
-    tmp_path: Path,
-    args: Sequence[str],
+def _command(
+    monkeypatch,
+    args: tuple[str, ...],
     *,
+    ggt_available: bool = True,
     force_pytest: bool = False,
     lograil_progress: bool = False,
     parallel: bool = True,
 ) -> list[str]:
-    env = os.environ.copy()
-    env["PATH"] = os.pathsep.join((str(tmp_path), "/usr/bin", "/bin"))
-    env.pop("POE_EXTRA_ARGS", None)
-    env.pop("WORKSPACE_POE_TEST_RUNNER", None)
-    if lograil_progress:
-        env["WORKSPACE_POE_LOGRAIL_PROGRESS"] = "1"
-    else:
-        env.pop("WORKSPACE_POE_LOGRAIL_PROGRESS", None)
-    env.pop("WORKSPACE_POE_SCOPE_ARGS", None)
-    if force_pytest:
-        env["FORCE_PYTEST"] = "1"
-    else:
-        env.pop("FORCE_PYTEST", None)
-    if parallel:
-        env.pop("WORKSPACE_POE_PARALLEL", None)
-    else:
-        env["WORKSPACE_POE_PARALLEL"] = "0"
-    result = subprocess.run(
-        (TOOL, *args),
-        check=True,
-        capture_output=True,
-        cwd=tmp_path,
-        env=env,
-        text=True,
+    monkeypatch.delenv("POE_EXTRA_ARGS", raising=False)
+    monkeypatch.delenv("WORKSPACE_POE_TEST_RUNNER", raising=False)
+    monkeypatch.delenv("WORKSPACE_POE_SCOPE_ARGS", raising=False)
+    monkeypatch.setattr(
+        poe_tool.shutil,
+        "which",
+        lambda command: f"/bin/{command}" if command == "ggt" and ggt_available else None,
     )
-    return result.stdout.splitlines()
+    if lograil_progress:
+        monkeypatch.setenv("WORKSPACE_POE_LOGRAIL_PROGRESS", "1")
+    else:
+        monkeypatch.delenv("WORKSPACE_POE_LOGRAIL_PROGRESS", raising=False)
+    if force_pytest:
+        monkeypatch.setenv("FORCE_PYTEST", "1")
+    else:
+        monkeypatch.delenv("FORCE_PYTEST", raising=False)
+    if parallel:
+        monkeypatch.delenv("WORKSPACE_POE_PARALLEL", raising=False)
+    else:
+        monkeypatch.setenv("WORKSPACE_POE_PARALLEL", "0")
+    return poe_tool.build_command("pytest", args)
 
 
-def test_pytest_wrapper_prefers_ggt(tmp_path: Path) -> None:
-    _runner(tmp_path, "ggt")
-    _runner(tmp_path, "pytest")
-
-    output = _run(tmp_path, ("tests",))
-
-    assert output[-2:] == [str(tmp_path / "ggt"), "tests"]
+def test_pytest_wrapper_prefers_ggt(monkeypatch) -> None:
+    assert _command(monkeypatch, ("tests",)) == ["ggt", "tests"]
 
 
 def test_pytest_wrapper_runs_ggt_sequentially_when_parallel_is_disabled(
-    tmp_path: Path,
+    monkeypatch,
 ) -> None:
-    _runner(tmp_path, "ggt")
-
-    output = _run(tmp_path, ("tests",), parallel=False)
-
-    assert output[-4:] == [str(tmp_path / "ggt"), "-j", "1", "tests"]
+    assert _command(monkeypatch, ("tests",), parallel=False) == [
+        "ggt",
+        "-j",
+        "1",
+        "tests",
+    ]
 
 
 def test_pytest_wrapper_uses_structured_ggt_output_for_lograil(
-    tmp_path: Path,
+    monkeypatch,
 ) -> None:
-    _runner(tmp_path, "ggt")
-
-    output = _run(tmp_path, ("tests",), lograil_progress=True)
-
-    assert output[-4:] == [
-        str(tmp_path / "ggt"),
+    assert _command(monkeypatch, ("tests",), lograil_progress=True) == [
+        "ggt",
         "--output-format",
         "json",
         "tests",
     ]
 
 
-def test_pytest_wrapper_falls_back_to_parallel_pytest(tmp_path: Path) -> None:
-    _runner(tmp_path, "pytest")
+def test_pytest_wrapper_falls_back_to_parallel_pytest(monkeypatch) -> None:
+    assert _command(monkeypatch, ("tests",), ggt_available=False) == [
+        "pytest",
+        "-n",
+        "auto",
+        "tests",
+    ]
 
-    output = _run(tmp_path, ("tests",))
 
-    assert output[-4:] == [str(tmp_path / "pytest"), "-n", "auto", "tests"]
-
-
-def test_pytest_wrapper_can_force_pytest(tmp_path: Path) -> None:
-    _runner(tmp_path, "ggt")
-    _runner(tmp_path, "pytest")
-
-    output = _run(tmp_path, ("tests",), force_pytest=True)
-
-    assert output[-4:] == [str(tmp_path / "pytest"), "-n", "auto", "tests"]
+def test_pytest_wrapper_can_force_pytest(monkeypatch) -> None:
+    assert _command(monkeypatch, ("tests",), force_pytest=True) == [
+        "pytest",
+        "-n",
+        "auto",
+        "tests",
+    ]

--- a/tests/unit/test_workspace_poe.py
+++ b/tests/unit/test_workspace_poe.py
@@ -105,6 +105,7 @@ def test_scope_command_lograil_name_includes_task_and_package() -> None:
 
 
 def test_example_scope_command_maps_root_to_internal_task(monkeypatch) -> None:
+    monkeypatch.delenv("FORCE_PYTEST", raising=False)
     monkeypatch.setattr(
         workspace_poe.shutil,
         "which",
@@ -131,6 +132,7 @@ def test_example_scope_command_maps_root_to_internal_task(monkeypatch) -> None:
 
 
 def test_example_scope_command_preserves_package_passthrough(monkeypatch) -> None:
+    monkeypatch.delenv("FORCE_PYTEST", raising=False)
     monkeypatch.setattr(
         workspace_poe.shutil,
         "which",
@@ -150,6 +152,28 @@ def test_example_scope_command_preserves_package_passthrough(monkeypatch) -> Non
 
     assert command.argv[-3:] == ("test-examples", "-k", "sessions_and_resume")
     assert command.parser == "generic"
+
+
+def test_root_test_builds_native_pytest_wrapper_argv(monkeypatch) -> None:
+    recorded = []
+    monkeypatch.setenv("PYTEST", "python scripts/poe/tasks/tool pytest")
+    monkeypatch.delenv("POE_EXTRA_ARGS", raising=False)
+    monkeypatch.delenv("WORKSPACE_POE_SCOPE_ARGS", raising=False)
+
+    def run_command(command):
+        recorded.append(command)
+        return 0
+
+    monkeypatch.setattr(workspace_poe, "run_command", run_command)
+
+    assert workspace_poe.run_root_task("test-root", ()) == 0
+
+    assert recorded[0].argv[:4] == (
+        sys.executable,
+        str(workspace_poe.SCRIPT_DIR / "tasks" / "tool"),
+        "pytest",
+        "tests/unit",
+    )
 
 
 def test_test_scope_uses_pytest_parser_for_pytest_fallback(monkeypatch) -> None:
@@ -240,6 +264,48 @@ def test_run_group_requests_progress_layout_for_tests(monkeypatch) -> None:
     assert "lograil.progress.process" not in mapped
     assert "lograil.progress.subject" not in mapped
     assert mapped["lograil.progress.description"] == "tests/test_api.py::test_get"
+
+
+def test_ggt_remap_retains_failure_after_later_passes() -> None:
+    remap = workspace_poe._ggt_entry_remap()
+    entries = [
+        remap(
+            {
+                "levelname": "ERROR",
+                "message": "ERROR test_verify.test_refresh: RuntimeError: refresh failed",
+            }
+        )
+    ]
+    entries.extend(
+        remap({"levelname": "INFO", "message": f"PASSED test_verify.test_{index}"})
+        for index in range(60)
+    )
+
+    lines = workspace_poe.failure_tail_lines(entries[-50:])
+
+    assert lines == ["ERROR test_verify.test_refresh: RuntimeError: refresh failed"]
+    assert workspace_poe.failure_tail_lines(entries) == lines
+
+
+def test_ggt_remap_retains_teardown_traceback_without_a_message() -> None:
+    remap = workspace_poe._ggt_entry_remap()
+    entries = [
+        remap(
+            {
+                "levelname": "ERROR",
+                "ggt.detail": {
+                    "kind": "error",
+                    "error_message": "fixture teardown failed\nRuntimeError: cleanup failed",
+                },
+            }
+        ),
+        remap({"levelname": "INFO", "message": "FAILURE: 85 tests, 1 errors"}),
+    ]
+
+    assert workspace_poe.failure_tail_lines(entries) == [
+        "fixture teardown failed\nRuntimeError: cleanup failed",
+        "FAILURE: 85 tests, 1 errors",
+    ]
 
 
 def test_run_sequential_can_stop_after_first_failure(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ dev = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "django-stubs", specifier = ">=6.0.6,<7" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
-    { name = "ggt", marker = "python_full_version >= '3.11'", specifier = ">=1.5.5" },
+    { name = "ggt", marker = "python_full_version >= '3.11'", specifier = ">=1.5.6" },
     { name = "hatchling", specifier = ">=1.27.0,<2" },
     { name = "hypothesis", specifier = ">=6.0.0,<7" },
     { name = "lograil", specifier = "~=0.7.0" },
@@ -60,7 +60,7 @@ dev = [
     { name = "twine", specifier = "<7" },
     { name = "ty", specifier = "==0.0.55" },
     { name = "uvicorn", specifier = ">=0.30.0,<1" },
-    { name = "uvloop", specifier = "<1" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = "<1" },
     { name = "vendoring", specifier = ">=1,<2" },
     { name = "zizmor", specifier = ">=1.24.1,<2" },
 ]
@@ -729,14 +729,14 @@ wheels = [
 
 [[package]]
 name = "ggt"
-version = "1.5.5"
+version = "1.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/ca/4fe1070242edd6f1981ca53ebe6c0175f32eaa72e046462c0cc84ce1cfb4/ggt-1.5.5.tar.gz", hash = "sha256:20a671444ee1b26aadb623ab951ac1ea4f17023b333dff7cbb4feed75227a903", size = 199433, upload-time = "2026-08-26T16:46:34.585Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/40/f4943f0de73a99c98595f23b0127ae56acb75d076671af171946d474d5be/ggt-1.5.6.tar.gz", hash = "sha256:7a43ed482b1b1741bbdeb798e8379b0d0cda189889ed354220363df0531bb475", size = 199752, upload-time = "2026-08-26T19:22:40.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/2f/15d2f9bea4df60080ff19bf7ae7c16d4e82c5cbe8338f46d829a260e5632/ggt-1.5.5-py3-none-any.whl", hash = "sha256:0b0d9beec4290f382ac210c2479bb6782c66082d40ff23d17582e9e1f57f7ddc", size = 124216, upload-time = "2026-08-26T16:46:33.353Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/12027320cf0a6f7017f87b6a4c02c3532bf51b03d8e281f7f64aa20009e5/ggt-1.5.6-py3-none-any.whl", hash = "sha256:a39a01ac509438573cbdff3a13528d059183d7b485e9ccd25e04f2a979690ff4", size = 124283, upload-time = "2026-08-26T19:22:38.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Run lint and type checking once instead of repeating them across the
Python matrix, but expand tests and distribution builds to macOS
and Windows.  Use `poe` directly instead of calling legacy scripts.
