### PR TITLE
workflow: prevent workflows from having side effects while suspending

### DIFF
--- a/changes/vercel-workflow/suspended-finalizers.bugfix.md
+++ b/changes/vercel-workflow/suspended-finalizers.bugfix.md
@@ -1,0 +1,5 @@
+Prevent workflows from having side effects while suspending.
+
+`hook.dispose()` will now work properly in a `finally` block.  (That
+is, the hook will be disposed only when the workflow is actually
+terminating, and not every time it gets replayed.)

--- a/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
@@ -38,6 +38,8 @@ from vercel.workflow._internal.worlds import local as local_mod
 
 RUN_DEADLINE_SECONDS = 30
 TOKEN = "resume-token"
+FINALLY_TOKEN = "finally-resume-token"
+FINALLY_STEP_TOKEN = "finally-step-resume-token"
 
 # Module level, not function level: replay re-imports the workflow's defining
 # module by name inside the sandbox, so it has to live somewhere importable.
@@ -71,6 +73,28 @@ async def collect() -> list[int]:
         seen.append(await double(n=payload.n))
     hook.dispose()
     return seen
+
+
+@registry.workflow
+async def receive_one_with_finally() -> int:
+    hook = Ping.wait(token=FINALLY_TOKEN)
+    try:
+        payload = await hook
+        assert payload is not None and payload.n is not None
+        return payload.n
+    finally:
+        hook.dispose()
+
+
+@registry.workflow
+async def receive_one_with_finally_step() -> int:
+    hook = Ping.wait(token=FINALLY_STEP_TOKEN)
+    try:
+        payload = await hook
+        assert payload is not None and payload.n is not None
+        return payload.n
+    finally:
+        await double(n=21)
 
 
 @pytest.fixture(autouse=True)
@@ -230,6 +254,27 @@ async def test_a_run_completes_on_carried_payloads_alone(tmp_path, monkeypatch) 
         result = await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS)
         assert result == [2, 4]
         assert (await event_types(world, run.run_id)).count("hook_received") == 3
+
+
+async def test_dispose_in_finally_does_not_dispose_a_suspended_hook(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run = await runtime.start(receive_one_with_finally)
+        hook = await wait_for_hook(world, FINALLY_TOKEN)
+
+        await publish(world, Resume.of(hook, {"n": 7}))
+
+        assert await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS) == 7
+
+
+async def test_a_step_in_finally_runs_after_the_hook_resumes(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run = await runtime.start(receive_one_with_finally_step)
+        hook = await wait_for_hook(world, FINALLY_STEP_TOKEN)
+
+        await publish(world, Resume.of(hook, {"n": 7}))
+
+        assert await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS) == 7
+        assert (await event_types(world, run.run_id)).count("step_completed") == 1
 
 
 async def test_the_producers_own_write_converges_on_the_re_ensured_event(

--- a/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_lazy_hook_resume.py
@@ -40,6 +40,8 @@ RUN_DEADLINE_SECONDS = 30
 TOKEN = "resume-token"
 FINALLY_TOKEN = "finally-resume-token"
 FINALLY_STEP_TOKEN = "finally-step-resume-token"
+CANCELLED_ERROR_TOKEN = "cancelled-error-token"
+REPLACED_CANCELLED_ERROR_TOKEN = "replaced-cancelled-error-token"
 
 # Module level, not function level: replay re-imports the workflow's defining
 # module by name inside the sandbox, so it has to live somewhere importable.
@@ -95,6 +97,28 @@ async def receive_one_with_finally_step() -> int:
         return payload.n
     finally:
         await double(n=21)
+
+
+@registry.workflow
+async def catch_cancelled_error() -> int:
+    hook = Ping.wait(token=CANCELLED_ERROR_TOKEN)
+    try:
+        payload = await hook
+    except asyncio.CancelledError:
+        return -1
+    assert payload is not None and payload.n is not None
+    return payload.n
+
+
+@registry.workflow
+async def replace_cancelled_error() -> int:
+    hook = Ping.wait(token=REPLACED_CANCELLED_ERROR_TOKEN)
+    try:
+        payload = await hook
+    except asyncio.CancelledError:
+        raise RuntimeError("replaced workflow cancellation") from None
+    assert payload is not None and payload.n is not None
+    return payload.n
 
 
 @pytest.fixture(autouse=True)
@@ -211,6 +235,22 @@ async def wait_for_hook(world: local_mod.LocalWorld, token: str) -> w.Hook:
     raise AssertionError(f"hook {token!r} was never registered")
 
 
+async def wait_for_hook_without_run_finishing(
+    world: local_mod.LocalWorld, run_id: str, token: str
+) -> w.Hook:
+    for _ in range(200):
+        try:
+            return await world.hooks_get_by_token(token)
+        except w.HookNotFoundError:
+            run = await world.runs_get(run_id)
+            if run.status in {"completed", "failed", "cancelled"}:
+                raise AssertionError(
+                    f"run finished as {run.status!r} before hook {token!r} was registered"
+                ) from None
+            await asyncio.sleep(0.05)
+    raise AssertionError(f"hook {token!r} was never registered")
+
+
 async def event_types(world: local_mod.LocalWorld, run_id: str) -> list[str]:
     return [e.event_type for e in (await world.events_list(run_id)).data]
 
@@ -275,6 +315,32 @@ async def test_a_step_in_finally_runs_after_the_hook_resumes(tmp_path, monkeypat
 
         assert await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS) == 7
         assert (await event_types(world, run.run_id)).count("step_completed") == 1
+
+
+async def test_catching_cancelled_error_cannot_complete_a_suspended_workflow(
+    tmp_path, monkeypatch
+) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run = await runtime.start(catch_cancelled_error)
+        hook = await wait_for_hook_without_run_finishing(world, run.run_id, CANCELLED_ERROR_TOKEN)
+
+        await publish(world, Resume.of(hook, {"n": 7}))
+
+        assert await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS) == 7
+
+
+async def test_replacing_cancelled_error_cannot_fail_a_suspended_workflow(
+    tmp_path, monkeypatch
+) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run = await runtime.start(replace_cancelled_error)
+        hook = await wait_for_hook_without_run_finishing(
+            world, run.run_id, REPLACED_CANCELLED_ERROR_TOKEN
+        )
+
+        await publish(world, Resume.of(hook, {"n": 7}))
+
+        assert await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS) == 7
 
 
 async def test_the_producers_own_write_converges_on_the_re_ensured_event(

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -6,6 +6,7 @@ results matched onto the wrong calls. ``resume()`` must detect this and fail
 loudly rather than silently returning the wrong value.
 """
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
@@ -46,6 +47,18 @@ def _suspension(correlation_id: str, args: bytes) -> runtime.Suspension:
     return runtime.Suspension(correlation_id=correlation_id, step=core.Step(_greet), input=args)
 
 
+def _resume_until_suspended(ctx: runtime.WorkflowOrchestratorContext) -> None:
+    async def resume() -> None:
+        ctx.resume()
+        # Cancellation is delivered at the next suspension point.
+        await asyncio.sleep(0)
+
+    with pytest.raises(asyncio.CancelledError):
+        runtime._run_isolated(resume(), loop_factory=workflow_loop.WorkflowLoop)
+
+    assert ctx.suspended
+
+
 async def test_reordered_step_args_raise_nondeterminism() -> None:
     """Recorded step input "a" but the body now calls the same step with "b"
     on replay -> NondeterminismError."""
@@ -75,8 +88,7 @@ async def test_matching_step_parks_without_nondeterminism() -> None:
     sus = _suspension(cid, _args(name="a"))
     ctx.suspensions[cid] = sus
 
-    with pytest.raises(runtime._SuspendException):
-        ctx.resume()
+    _resume_until_suspended(ctx)
 
     assert not sus.future.done()
     assert sus.has_created_event
@@ -142,8 +154,7 @@ async def test_cancelled_step_ignores_later_completion() -> None:
 
     # Replay the launch, then model the workflow task being cancelled while
     # the step is in flight. The completion arrives in a later event batch.
-    with pytest.raises(runtime._SuspendException):
-        ctx.resume()
+    _resume_until_suspended(ctx)
     assert sus.has_created_event
     assert sus.future.cancel()
 
@@ -240,15 +251,18 @@ async def test_idle_resume_parks_when_nothing_to_deliver() -> None:
     sus1 = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus1
 
-    loop = workflow_loop.WorkflowLoop(idle_hook=ctx.resume)
-    try:
-        with pytest.raises(runtime._SuspendException):
-            loop._run_once()
+    async def wait_forever() -> None:
+        await asyncio.Future()
 
-        assert sus1.has_created_event
-        assert not sus1.future.done()
-    finally:
-        loop.close()
+    with pytest.raises(asyncio.CancelledError):
+        runtime._run_isolated(
+            wait_forever(),
+            loop_factory=lambda: workflow_loop.WorkflowLoop(idle_hook=ctx.resume),
+        )
+
+    assert ctx.suspended
+    assert sus1.has_created_event
+    assert not sus1.future.done()
 
 
 # --- now(): deterministic clock anchored to replay progress, not list tail ------

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -717,9 +717,13 @@ class WorkflowOrchestratorContext:
             except asyncio.CancelledError:
                 if not self.suspended:
                     raise RuntimeError("workflow was cancelled") from None
-                return None
             finally:
                 self._ctx.reset(token)
+                # Turn suspended into a None return regardless of what the
+                # task actually did with it.
+                # noqa because we are *intentionally* silencing an exception here.
+                if self.suspended:
+                    return None  # noqa: B012
 
     async def run_step(self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         # Bound to the step's own signature, so the recorded bytes depend on it

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -14,7 +14,7 @@ import traceback
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping
 from datetime import datetime
-from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast
+from typing import Any, Generic, Literal, NoReturn, ParamSpec, TypeVar, cast
 from urllib.parse import parse_qsl, urlsplit
 
 import anyio
@@ -639,9 +639,41 @@ class WorkflowOrchestratorContext:
         self.hooks: dict[str, Hook] = {}
         self.registry = registry
 
+        self.suspended = False
+
     @classmethod
     def current(cls) -> Self:
-        return cls._ctx.get()
+        cur = cls._ctx.get()
+        # If the workflow is suspended, keep cancelling the task.
+        # See comment in suspend, below.
+        if cur.suspended:
+            raise asyncio.CancelledError("workflow execution is suspended")
+        return cur
+
+    def suspend(self) -> NoReturn:
+        # When a workflow gets suspended, we would ideally just throw
+        # away all of the inflight coroutines and never finishing
+        # executing them at all.
+        #
+        # In particular, we don't actually want exception handlers and
+        # finally blocks to run, because from the perspective of the
+        # workflow programming model, there is no exception.
+        #
+        # Unfortunately for our case (though /probably/ fortunately in
+        # general), Python insists on always closing
+        # generator/coroutine objects by throwing a GeneratorExit into
+        # them if they haven't already finished.
+        #
+        # So instead, when we suspend the workflow, we set the
+        # suspended flag, and when current() (above) is called and the
+        # workflow is suspended, it raises a CancelledError.
+        #
+        # All user-facing workflow operations go through current(), and
+        # so this means that if a workflow attempts to *do* anything
+        # while being suspended (dispose() a hook, call a step, etc),
+        # it will immediately fail.
+        self.suspended = True
+        raise _SuspendException()
 
     def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> bytes:
         """Run the body inside the sandbox, returning its result serialized there."""
@@ -797,8 +829,7 @@ class WorkflowOrchestratorContext:
 
         Resolves at most one suspension before breaking.
 
-        If the event log is exhausted, cancel the future and suspend
-        the workflow.
+        If the event log is exhausted, suspend the workflow.
         """
 
         # NOTE: resume() does single-step delivery, so we resolve at most
@@ -992,7 +1023,7 @@ class WorkflowOrchestratorContext:
         # event log exhausted without doing any work.
         # Suspend.
         else:
-            raise _SuspendException()
+            self.suspend()
 
 
 # ── lazy hook resume ───────────────────────────────────────────────────────

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -14,7 +14,7 @@ import traceback
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping
 from datetime import datetime
-from typing import Any, Generic, Literal, NoReturn, ParamSpec, TypeVar, cast
+from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast
 from urllib.parse import parse_qsl, urlsplit
 
 import anyio
@@ -60,10 +60,6 @@ def _wait_continuation_dispatch(
     delay = min(timeout_seconds, WAIT_CONTINUATION_MAX_DELAY_SECONDS)
     key = wait_correlation_id if hop == 1 else f"{wait_correlation_id}:hop-{hop}"
     return delay, key
-
-
-class _SuspendException(BaseException):
-    """Raised to trigger suspending of the workflow."""
 
 
 class NondeterminismError(Exception):
@@ -650,7 +646,7 @@ class WorkflowOrchestratorContext:
             raise asyncio.CancelledError("workflow execution is suspended")
         return cur
 
-    def suspend(self) -> NoReturn:
+    def suspend(self) -> None:
         # When a workflow gets suspended, we would ideally just throw
         # away all of the inflight coroutines and never finishing
         # executing them at all.
@@ -673,10 +669,14 @@ class WorkflowOrchestratorContext:
         # while being suspended (dispose() a hook, call a step, etc),
         # it will immediately fail.
         self.suspended = True
-        raise _SuspendException()
+        # Close down the tasks
+        for task in asyncio.all_tasks(asyncio.get_event_loop()):
+            task.cancel()
 
-    def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> bytes:
-        """Run the body inside the sandbox, returning its result serialized there."""
+    def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> bytes | None:
+        """Run the body inside the sandbox, returning its result serialized there.
+
+        Returns None if the workflow execution is suspended."""
         wf = self.registry._get_workflow(workflow_run.workflow_name)
         if not workflow_run.input:
             raise RuntimeError(f"Invalid workflow input for run {workflow_run.run_id}")
@@ -714,6 +714,10 @@ class WorkflowOrchestratorContext:
                         )
                     )
                 )
+            except asyncio.CancelledError:
+                if not self.suspended:
+                    raise RuntimeError("workflow was cancelled") from None
+                return None
             finally:
                 self._ctx.reset(token)
 
@@ -1382,9 +1386,6 @@ async def workflow_handler(
     )
     try:
         output = context.run_workflow(workflow_run)
-    except _SuspendException:
-        # Workflow suspended, continue outside the try..except block.
-        pass
     except Exception as e:
         error_message = "".join(traceback.format_exception_only(type(e), e)).strip()
         logger.exception("[Workflows] '%s' - workflow run failed: %s", run_id, error_message)
@@ -1399,7 +1400,8 @@ async def workflow_handler(
         except w.EntityConflictError:
             logger.warning(f"Workflow run {run_id} was already completed")
         return None
-    else:
+
+    if output is not None:
         try:
             await world.events_create(
                 run_id,


### PR DESCRIPTION
We would *like* to just free all the coroutines in a suspended
workflow without running any more of their code, but Python doesn't
allow that (if a generator/coroutine isn't closed, it will throw a
GeneratorExit into it while destructing it).

To make sure that nothing untoward happens, add a `suspended` flag and
have all workflow operations raise CancelledError if it is set.

One big thing this fixes is `hook.dispose()` in a `finally` block.
(We could probably make HookEvent a context manager now?)
