### PR TITLE
Drop aggregate dependency upper bounds

### DIFF
--- a/changes/vercel/aggregate-dependency-bounds.bugfix.md
+++ b/changes/vercel/aggregate-dependency-bounds.bugfix.md
@@ -1,0 +1,1 @@
+Remove upper bounds on aggregate Sandbox and Workflow dependencies so sibling releases cannot make the `vercel` package un-installable.

--- a/src/vercel/pyproject.toml
+++ b/src/vercel/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
     "vercel-internal-telemetry>=0.6.0",
     "vercel-oidc>=0.6.0",
     "vercel-queue>=0.6.0",
-    "vercel-sandbox>=0.2.0,<0.5.0",
-    "vercel-workflow>=0.9.0,<1.1.0",
+    "vercel-sandbox>=0.2.0",
+    "vercel-workflow>=0.9.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The aggregate `vercel` package carried upper bounds for `vercel-sandbox` and `vercel-workflow`, while the release metadata hook also raises their lower bounds to the current workspace versions; when a sibling reaches an upper bound, this produces an unsatisfiable requirement and blocks the release. Remove those upper bounds so aggregate releases always select the contemporaneous sibling packages without requiring manual bound updates.