### PR TITLE
Guard unpublished package versions

### DIFF
--- a/.github/workflows/news-fragments.yml
+++ b/.github/workflows/news-fragments.yml
@@ -27,3 +27,8 @@ jobs:
         run: uv run --locked poe check-news-fragments
         env:
           WORKSPACE_POE_GIT_BASE: ${{ github.event.pull_request.base.sha }}
+
+      - name: Check new package versions
+        run: uv run --locked poe check-new-package-versions
+        env:
+          WORKSPACE_POE_GIT_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,8 @@ jobs:
               packages = subprocess.check_output(
                   [
                       "python",
-                      "scripts/workspace.py",
-                      "list",
-                      "--names",
-                      "--topological",
+                      "scripts/release.py",
+                      "publishable",
                   ],
                   text=True,
               ).splitlines()
@@ -153,6 +151,10 @@ jobs:
             else
               version=$(python scripts/get-version.py "$package")
               publish_shared_vendored_deps=false
+            fi
+            if [ "$is_shared_vendored_deps" != "true" ] && [ "$version" = "0.0.0" ]; then
+              echo "$package is at the unpublished sentinel version, skipping publish"
+              continue
             fi
             tag="$package-v$version"
             if [ "$is_shared_vendored_deps" != "true" ] || [ "$publish_shared_vendored_deps" = "true" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,12 @@ changes.
 
 The `pre-commit.checks` hook runs `uv run poe pre-commit`, which runs lint and
 typecheck in parallel with buffered output. The `pre-push.checks` hook runs
-`uv run poe pre-push`, which runs news-fragment, lint, typecheck, and test
-checks in parallel with buffered output. The news-fragment check requires
-changed package code to have a news fragment. Git hooks are local clone state,
-so each checkout needs this once.
+`uv run poe pre-push`, which runs new-package version, news-fragment, lint,
+typecheck, and test checks in parallel with buffered output. New packages must
+start at the unpublished `0.0.0` sentinel; the release workflow assigns their
+first publishable version. Unpublished packages are exempt from news-fragment
+enforcement until a fragment is added deliberately to request their first
+release. Git hooks are local clone state, so each checkout needs this once.
 
 ## Development Commands
 
@@ -110,7 +112,9 @@ changes/vercel-cache/123.bugfix.md
 
 Use `uv run poe lint-towncrier` to validate existing news fragments. The Git
 `pre-push.news-fragments` hook enforces that changed package code has a
-news fragment, but it does not replace the full lint/test/typecheck suite.
+news fragment, except while a package remains at the unpublished `0.0.0`
+sentinel. Add its first fragment when the package is ready for its initial
+`0.1.0` release. The hook does not replace the full lint/test/typecheck suite.
 
 Release PR mechanics, version bump rules, dependency cascades, and publishing
 are documented in `RELEASING.md`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,11 @@ release script adds `- ` when a line does not already start with a bullet.
 Dependency-only cascade releases do not need handwritten news fragments. The
 release script writes `Update dependencies.` for those changelog entries.
 
+Packages at `0.0.0` are unpublished and exempt from news-fragment enforcement
+and dependency-only cascades. Add a fragment deliberately when such a package
+is ready to publish; its first release is promoted to `0.1.0` regardless of the
+fragment type.
+
 ## Release Prep
 
 Run:
@@ -165,7 +170,8 @@ For broader confidence, run:
 types, and non-empty news fragment content. The Git `pre-push-news-fragments`
 hook generated from `scripts/githooks/pre-push.news-fragments.sh` runs `uv run
 poe check-news-fragments` to require news fragments for changed package code
-without maintaining a hard-coded package registry. `sync-githooks` installs
+except for unpublished `0.0.0` packages, without maintaining a hard-coded
+package registry. `sync-githooks` installs
 pre-push hooks with `WORKSPACE_POE_GIT_SCOPE=commit`, so this check runs against
 the commit tree being pushed. The news fragment format is Towncrier-style, but
 enforcement is repo-local because stock Towncrier does not support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,15 @@ dev = [
     "tox-uv-bare",
     "tomli>=2.0.0,<3; python_version < '3.11'",
     "vendoring>=1,<2",
-    "lograil~=0.7.0",
-    "ggt>=1.5.6; python_version >= '3.11'",
+    "lograil~=0.8.1",
+    "ggt>=1.6.0; python_version >= '3.11'",
 ]
 
 [tool.uv]
 default-groups = ["dev"]
 package = false
 exclude-newer = "2 days"
-exclude-newer-package = { ggt = "2026-08-27T00:00:00Z", lograil = "2026-08-10T21:20:07.442Z" }
+exclude-newer-package = { ggt = "2026-09-01T00:00:00Z", lograil = "2026-08-21T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["src/*", "integrations/*"]
@@ -130,6 +130,12 @@ cmd = "scripts/poe/workspace_poe.py root-task check-news-fragments-root"
 
 [tool.poe.tasks.check-news-fragments-root]
 cmd = "python scripts/release.py check-news-fragments"
+
+[tool.poe.tasks.check-new-package-versions]
+cmd = "scripts/poe/workspace_poe.py root-task check-new-package-versions-root"
+
+[tool.poe.tasks.check-new-package-versions-root]
+cmd = "python scripts/release.py check-new-package-versions"
 
 [tool.poe.tasks.fix]
 cmd = "scripts/poe/workspace_poe.py workspace fix --poe-verbose ${verbose:-false} ${scopes}"

--- a/scripts/clogedit.py
+++ b/scripts/clogedit.py
@@ -410,13 +410,16 @@ def initial_changelog_selection(
     packages_by_name: dict[str, workspace.Package], changed: set[str], covered: set[str]
 ) -> ChangelogSelection:
     ordered = workspace.topological_names(packages_by_name)
+    publishable_changed = set(
+        release.publishable_packages(changed, packages_by_name=packages_by_name)
+    )
     return ChangelogSelection(
         {
             name: PackageNewsState(
                 name=name,
                 changed=name in changed,
                 covered=name in covered,
-                selected=name in changed and name not in covered,
+                selected=name in publishable_changed and name not in covered,
             )
             for name in ordered
         }

--- a/scripts/poe/workspace_poe.py
+++ b/scripts/poe/workspace_poe.py
@@ -187,9 +187,15 @@ class WorkspaceRunner:
         if name == "pre-commit":
             tasks = ("lint", "typecheck")
         else:
-            tasks = ("check-news-fragments", "lint", "typecheck", "test")
+            tasks = (
+                "check-news-fragments",
+                "check-new-package-versions",
+                "lint",
+                "typecheck",
+                "test",
+            )
         for task in tasks:
-            if task == "check-news-fragments":
+            if task in {"check-news-fragments", "check-new-package-versions"}:
                 commands.append(self.top_level_poe_command(task, (), ()))
             else:
                 commands.extend(self.workspace_commands(task, (), ()))
@@ -377,6 +383,8 @@ def run_tool_group(task: str) -> int:
 def run_root_task(task: str, argv: Sequence[str]) -> int:
     if task == "check-news-fragments-root":
         return subprocess.call((sys.executable, "scripts/release.py", "check-news-fragments"))
+    if task == "check-new-package-versions-root":
+        return subprocess.call((sys.executable, "scripts/release.py", "check-new-package-versions"))
     if task == "fix-root":
         return run_tool_group("fix")
     if task == "lint-root":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -25,6 +25,7 @@ CHANGES = ROOT / "changes"
 IGNORED_FRAGMENT_FILES = {".gitignore", ".gitkeep", ".keep"}
 BUMP_ORDER = {"patch": 0, "minor": 1, "major": 2}
 BUMP_NAMES = {value: key for key, value in BUMP_ORDER.items()}
+UNPUBLISHED_VERSION = "0.0.0"
 FRAGMENT_TYPES = {
     "breaking": "Breaking Changes",
     "feature": "Features",
@@ -111,6 +112,8 @@ def parse_fragments(packages: set[str]) -> list[Fragment]:
 
 
 def _bump_for_fragment(kind: str, version: str) -> str:
+    if version == UNPUBLISHED_VERSION:
+        return "minor"
     bump = TYPE_BUMPS[kind]
     major = int(version.split(".", 1)[0])
     if major == 0 and bump == "major":
@@ -147,6 +150,8 @@ def compute_releases(*, force_bump: str | None = None) -> list[Release]:
 
     if force_bump:
         for name in packages_by_name:
+            if versions[name] == UNPUBLISHED_VERSION:
+                continue
             bumps[name] = _larger(bumps.get(name, "patch"), force_bump)
 
     reverse_edges = workspace.reverse_dependencies(packages_by_name)
@@ -154,7 +159,7 @@ def compute_releases(*, force_bump: str | None = None) -> list[Release]:
     while queue:
         package = queue.pop(0)
         for dependent in sorted(reverse_edges[package]):
-            if dependent not in bumps:
+            if dependent not in bumps and versions[dependent] != UNPUBLISHED_VERSION:
                 bumps[dependent] = "patch"
                 queue.append(dependent)
 
@@ -745,6 +750,7 @@ def check_fragments(base: str | None = None) -> int:
     changed -= {
         name for name, package in packages_by_name.items() if package.version_file in changed_paths
     }
+    changed = set(publishable_packages(changed, packages_by_name=packages_by_name))
     packages_with_fragments = {
         fragment.package for fragment in fragments if fragment.path in changed_paths
     }
@@ -760,14 +766,61 @@ def check_fragments(base: str | None = None) -> int:
     return 0
 
 
+def check_new_package_versions(base: str | None = None) -> int:
+    packages_by_name = workspace.packages()
+    head = os.environ.get("WORKSPACE_POE_GIT_COMMIT")
+    if base is None:
+        base = os.environ.get("WORKSPACE_POE_GIT_BASE") or _default_base_ref()
+    if base is None:
+        print("Could not detect a base branch for new package version enforcement.")
+        return 1
+
+    added_paths = _added_paths(base=base, head=head)
+    invalid: list[tuple[str, str]] = []
+    for name, package in sorted(packages_by_name.items()):
+        if package.path / "pyproject.toml" not in added_paths:
+            continue
+        version = workspace.read_version(package.version_file)
+        if version != UNPUBLISHED_VERSION:
+            invalid.append((name, version))
+    if invalid:
+        packages = ", ".join(f"{name} ({version})" for name, version in invalid)
+        print(f"New packages must start at {UNPUBLISHED_VERSION}: {packages}")
+        print("The release workflow assigns the first publishable version.")
+        return 1
+    return 0
+
+
 def changed_packages(base: str = "HEAD^", head: str = "HEAD") -> list[str]:
     packages_by_name = workspace.packages()
     changed = _changed_packages(packages_by_name, base=base, head=head, code_only=False)
-    return [name for name in workspace.topological_names(packages_by_name) if name in changed]
+    return publishable_packages(changed, packages_by_name=packages_by_name)
+
+
+def publishable_packages(
+    names: Iterable[str] | None = None,
+    *,
+    packages_by_name: dict[str, workspace.Package] | None = None,
+) -> list[str]:
+    if packages_by_name is None:
+        packages_by_name = workspace.packages()
+    selected = set(packages_by_name) if names is None else set(names)
+    return [
+        name
+        for name in workspace.topological_names(packages_by_name)
+        if name in selected
+        and workspace.read_version(packages_by_name[name].version_file) != UNPUBLISHED_VERSION
+    ]
 
 
 def print_changed_packages(args: argparse.Namespace) -> int:
     for name in changed_packages(base=args.base, head=args.head):
+        print(name)
+    return 0
+
+
+def print_publishable_packages(_args: argparse.Namespace) -> int:
+    for name in publishable_packages():
         print(name)
     return 0
 
@@ -790,6 +843,14 @@ def _changed_paths(*, base: str, head: str | None) -> set[Path]:
     diff_range = [f"{base}..{head}"] if head is not None else [base]
     output = subprocess.check_output(
         ["git", "diff", "--name-only", *diff_range], cwd=ROOT, text=True
+    )
+    return {ROOT / line for line in output.splitlines() if line}
+
+
+def _added_paths(*, base: str, head: str | None) -> set[Path]:
+    diff_range = [f"{base}..{head}"] if head is not None else [base]
+    output = subprocess.check_output(
+        ["git", "diff", "--diff-filter=A", "--name-only", *diff_range], cwd=ROOT, text=True
     )
     return {ROOT / line for line in output.splitlines() if line}
 
@@ -834,6 +895,7 @@ def main(argv: list[str] | None = None) -> int:
     changed_parser.add_argument("--base", default="HEAD^")
     changed_parser.add_argument("--head", default="HEAD")
     changed_parser.set_defaults(func=print_changed_packages)
+    subparsers.add_parser("publishable").set_defaults(func=print_publishable_packages)
 
     github_release_body_parser = subparsers.add_parser("github-release-body")
     github_release_body_parser.add_argument("package")
@@ -851,6 +913,10 @@ def main(argv: list[str] | None = None) -> int:
     check_parser = subparsers.add_parser("check-news-fragments")
     check_parser.add_argument("--base")
     check_parser.set_defaults(func=lambda args: check_fragments(args.base))
+
+    package_versions_parser = subparsers.add_parser("check-new-package-versions")
+    package_versions_parser.add_argument("--base")
+    package_versions_parser.set_defaults(func=lambda args: check_new_package_versions(args.base))
 
     subparsers.add_parser("lint-towncrier").set_defaults(func=lambda _args: lint_towncrier())
     args = parser.parse_args(argv)

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -63,6 +63,72 @@ def test_compute_releases_cascades_dependency_only_patch(
     ]
 
 
+def test_compute_releases_promotes_unpublished_feature_to_initial_minor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    fragment_dir = changes / "pkg"
+    fragment_dir.mkdir(parents=True)
+    (fragment_dir / "initial.feature.md").write_text("Add package.\n", encoding="utf-8")
+
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+
+    releases = release.compute_releases()
+
+    assert [(item.old_version, item.new_version) for item in releases] == [("0.0.0", "0.1.0")]
+
+
+def test_compute_releases_promotes_any_unpublished_fragment_to_initial_minor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    fragment_dir = changes / "pkg"
+    fragment_dir.mkdir(parents=True)
+    (fragment_dir / "initial.internal.md").write_text("Prepare package.\n", encoding="utf-8")
+
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+
+    releases = release.compute_releases()
+
+    assert [(item.old_version, item.new_version) for item in releases] == [("0.0.0", "0.1.0")]
+
+
+def test_compute_releases_does_not_cascade_to_unpublished_dependent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    fragment_dir = changes / "lib"
+    fragment_dir.mkdir(parents=True)
+    (fragment_dir / "123.bugfix.md").write_text("Fix library.\n", encoding="utf-8")
+
+    lib_version = tmp_path / "lib/version.py"
+    app_version = tmp_path / "app/version.py"
+    lib_version.parent.mkdir()
+    app_version.parent.mkdir()
+    lib_version.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+    app_version.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    packages = {
+        "lib": workspace.Package("lib", tmp_path / "lib", lib_version, ()),
+        "app": workspace.Package("app", tmp_path / "app", app_version, ("lib",)),
+    }
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+
+    releases = release.compute_releases()
+
+    assert [(item.package, item.new_version) for item in releases] == [("lib", "1.2.4")]
+
+
 def test_split_release_graph_propagates_in_publication_order(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -268,6 +334,23 @@ def test_compute_releases_force_accepts_patch_bump(
     assert [(item.package, item.new_version, item.bump, item.forced) for item in releases] == [
         ("pkg", "1.2.4", "patch", True)
     ]
+
+
+def test_compute_releases_force_does_not_publish_unpublished_package(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changes = tmp_path / "changes"
+    changes.mkdir()
+
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(release, "CHANGES", changes)
+    monkeypatch.setattr(workspace, "packages", lambda: packages)
+
+    assert release.compute_releases(force_bump="minor") == []
 
 
 def test_compute_releases_force_preserves_larger_fragment_bump(
@@ -821,6 +904,7 @@ def test_check_fragments_requires_changed_package_fragment(
 ) -> None:
     version_file = tmp_path / "pkg/version.py"
     version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
     monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
     monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
@@ -834,6 +918,24 @@ def test_check_fragments_requires_changed_package_fragment(
     output = capsys.readouterr().out
     assert "Missing news fragments for changed packages: pkg" in output
     assert "Run `poe changelog`" in output
+
+
+def test_check_fragments_exempts_unpublished_package_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(release, "parse_fragments", lambda _packages: [])
+    monkeypatch.setattr(
+        release,
+        "_changed_paths",
+        lambda *, base, head: {tmp_path / "pkg/code.py"},
+    )
+
+    assert release.check_fragments(base="origin/main") == 0
 
 
 def test_check_fragments_uses_environment_base(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -872,6 +974,62 @@ def test_check_fragments_explicit_base_overrides_environment(
     assert seen == ["explicit-base"]
 
 
+def test_check_new_package_versions_rejects_publishable_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    package_path = tmp_path / "pkg"
+    version_file = package_path / "version.py"
+    package_path.mkdir()
+    version_file.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    package = workspace.Package("pkg", package_path, version_file, ())
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(
+        release,
+        "_added_paths",
+        lambda *, base, head: {package_path / "pyproject.toml", version_file},
+    )
+
+    assert release.check_new_package_versions(base="origin/main") == 1
+    assert "New packages must start at 0.0.0: pkg (0.1.0)" in capsys.readouterr().out
+
+
+def test_check_new_package_versions_accepts_unpublished_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    package_path = tmp_path / "pkg"
+    version_file = package_path / "version.py"
+    package_path.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    package = workspace.Package("pkg", package_path, version_file, ())
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setenv("WORKSPACE_POE_GIT_BASE", "stack-base")
+    monkeypatch.setenv("WORKSPACE_POE_GIT_COMMIT", "pushed-head")
+    seen: list[tuple[str, str | None]] = []
+
+    def added_paths(*, base: str, head: str | None) -> set[Path]:
+        seen.append((base, head))
+        return {package_path / "pyproject.toml", version_file}
+
+    monkeypatch.setattr(release, "_added_paths", added_paths)
+
+    assert release.check_new_package_versions() == 0
+    assert seen == [("stack-base", "pushed-head")]
+
+
+def test_check_new_package_versions_ignores_existing_package_bump(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    package_path = tmp_path / "pkg"
+    version_file = package_path / "version.py"
+    package_path.mkdir()
+    version_file.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    package = workspace.Package("pkg", package_path, version_file, ())
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(release, "_added_paths", lambda *, base, head: {version_file})
+
+    assert release.check_new_package_versions(base="origin/main") == 0
+
+
 def test_check_fragments_exempts_release_prep_version_bumps(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -893,6 +1051,8 @@ def test_check_fragments_ignores_unchanged_fragment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     fragment_path = tmp_path / "changes/pkg/old.bugfix.md"
     package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
     fragment = release.Fragment("pkg", fragment_path, "bugfix", "Fix an older bug.")
@@ -908,6 +1068,8 @@ def test_check_fragments_accepts_changed_fragment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     fragment_path = tmp_path / "changes/pkg/new.bugfix.md"
     package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
     fragment = release.Fragment("pkg", fragment_path, "bugfix", "Fix the current bug.")
@@ -942,7 +1104,10 @@ def test_changed_paths_uses_index_diff_when_head_is_none(
 def test_changed_packages_accepts_explicit_range(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    package = workspace.Package("pkg", tmp_path / "pkg", tmp_path / "pkg/version.py", ())
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+    package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
     monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
     monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["pkg"])
 
@@ -962,6 +1127,20 @@ def test_changed_packages_accepts_explicit_range(
 
     assert release.changed_packages(base="abc", head="def") == ["pkg"]
     assert seen == {"base": "abc", "head": "def", "code_only": False}
+
+
+def test_changed_packages_excludes_unpublished_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    package = workspace.Package("pkg", tmp_path / "pkg", version_file, ())
+    monkeypatch.setattr(workspace, "packages", lambda: {"pkg": package})
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["pkg"])
+    monkeypatch.setattr(release, "_changed_packages", lambda *_args, **_kwargs: {"pkg"})
+
+    assert release.changed_packages() == []
 
 
 def test_collect_changelog_diff_paths_staged_uses_cached_diff(
@@ -1072,9 +1251,15 @@ def test_changelog_base_lower_bound_requires_base_ref(
 def test_initial_changelog_selection_marks_changed_uncovered_packages(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    lib_version = tmp_path / "lib/version.py"
+    app_version = tmp_path / "app/version.py"
+    lib_version.parent.mkdir()
+    app_version.parent.mkdir()
+    lib_version.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+    app_version.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     packages = {
-        "lib": workspace.Package("lib", tmp_path / "lib", tmp_path / "lib/version.py", ()),
-        "app": workspace.Package("app", tmp_path / "app", tmp_path / "app/version.py", ("lib",)),
+        "lib": workspace.Package("lib", tmp_path / "lib", lib_version, ()),
+        "app": workspace.Package("app", tmp_path / "app", app_version, ("lib",)),
     }
     monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["lib", "app"])
 
@@ -1084,6 +1269,21 @@ def test_initial_changelog_selection_marks_changed_uncovered_packages(
     assert selection.packages["lib"].selected is True
     assert selection.packages["app"].selected is False
     assert selection.packages["app"].covered is True
+
+
+def test_initial_changelog_selection_does_not_preselect_unpublished_package(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    version_file = tmp_path / "pkg/version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.0.0"\n', encoding="utf-8")
+    packages = {"pkg": workspace.Package("pkg", tmp_path / "pkg", version_file, ())}
+    monkeypatch.setattr(workspace, "topological_names", lambda _packages: ["pkg"])
+
+    selection = clogedit.initial_changelog_selection(packages, {"pkg"}, set())
+
+    assert selection.packages["pkg"].changed is True
+    assert selection.packages["pkg"].selected is False
 
 
 def test_packages_for_paths_detects_package_code(tmp_path: Path) -> None:

--- a/tests/unit/test_workspace_poe.py
+++ b/tests/unit/test_workspace_poe.py
@@ -356,6 +356,30 @@ def test_hook_commands_are_verbose_and_not_suppressed(monkeypatch) -> None:
     assert [command.subject for command in commands] == ["root", "vercel-celery"]
 
 
+def test_pre_push_runs_new_package_version_check(monkeypatch) -> None:
+    runner = object.__new__(workspace_poe.WorkspaceRunner)
+    runner.root = Path.cwd()
+    runner.project_root = None
+    tasks = []
+
+    monkeypatch.setattr(runner, "enter_tree", lambda: None)
+
+    def top_level_poe_command(task, scopes, poe_flags):
+        tasks.append(task)
+        return workspace_poe.CommandSpec(task, (task,), Path.cwd(), {})
+
+    monkeypatch.setattr(
+        runner,
+        "top_level_poe_command",
+        top_level_poe_command,
+    )
+    monkeypatch.setattr(runner, "workspace_commands", lambda task, scopes, args: [])
+    monkeypatch.setattr(workspace_poe, "run_group", lambda commands, **kwargs: 0)
+
+    assert runner.run_hook("pre-push") == 0
+    assert tasks == ["check-news-fragments", "check-new-package-versions"]
+
+
 def test_failure_tail_lines_filter_progress_noise() -> None:
     entries = [
         {"message": "[gw0] [ 10%] PASSED tests/unit/test_ok.py::test_ok"},

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
-ggt = "2026-08-27T00:00:00Z"
-lograil = "2026-08-10T21:20:07.442Z"
+ggt = "2026-09-01T00:00:00Z"
+lograil = "2026-08-21T00:00:00Z"
 
 [manifest]
 members = [
@@ -40,10 +40,10 @@ dev = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "django-stubs", specifier = ">=6.0.6,<7" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
-    { name = "ggt", marker = "python_full_version >= '3.11'", specifier = ">=1.5.6" },
+    { name = "ggt", marker = "python_full_version >= '3.11'", specifier = ">=1.6.0" },
     { name = "hatchling", specifier = ">=1.27.0,<2" },
     { name = "hypothesis", specifier = ">=6.0.0,<7" },
-    { name = "lograil", specifier = "~=0.7.0" },
+    { name = "lograil", specifier = "~=0.8.1" },
     { name = "mypy", specifier = ">=1.20.2,<2" },
     { name = "poethepoet", specifier = ">=0.48.0" },
     { name = "pytest", specifier = ">=7.0.0,<10" },
@@ -729,14 +729,14 @@ wheels = [
 
 [[package]]
 name = "ggt"
-version = "1.5.6"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/40/f4943f0de73a99c98595f23b0127ae56acb75d076671af171946d474d5be/ggt-1.5.6.tar.gz", hash = "sha256:7a43ed482b1b1741bbdeb798e8379b0d0cda189889ed354220363df0531bb475", size = 199752, upload-time = "2026-08-26T19:22:40.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/e5/b125686afaed90b803c91a4394d6fb3520df53734bcd1cea3410645c1265/ggt-1.6.0.tar.gz", hash = "sha256:c2bee3eeeb847da985bdf4a41a0c90220d76c69126c88ba0bcf6d5b6e9d57505", size = 206975, upload-time = "2026-08-31T21:54:03.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/87/12027320cf0a6f7017f87b6a4c02c3532bf51b03d8e281f7f64aa20009e5/ggt-1.5.6-py3-none-any.whl", hash = "sha256:a39a01ac509438573cbdff3a13528d059183d7b485e9ccd25e04f2a979690ff4", size = 124283, upload-time = "2026-08-26T19:22:38.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/0f/800b548512e16082abe157e74e00c9f3f4fdbec41cb9cb553fbe80a5c9a3/ggt-1.6.0-py3-none-any.whl", hash = "sha256:52fe480fd2ace23a6c4f3964e7c6f29342ebdbb60de758f43ed204d7e6e1fe96", size = 129008, upload-time = "2026-08-31T21:54:02.334Z" },
 ]
 
 [[package]]
@@ -1088,16 +1088,16 @@ wheels = [
 
 [[package]]
 name = "lograil"
-version = "0.7.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/07/a0f6999275bfa35112cd9714943a2baebc21397231ad495740aba7827e83/lograil-0.7.0.tar.gz", hash = "sha256:d3b2b0d84830f8dfa1f0d14126babec6531339aa183f181eba25dfdede19c900", size = 171478, upload-time = "2026-08-10T21:20:08.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/25/037be528d2ee78b5b3083dd1cbb9ee1fae4a00b58ca91dd6db0d702ce0dd/lograil-0.8.1.tar.gz", hash = "sha256:d21712e6d03af7b9c5f04616e0f2a45c06111e5fdc5d6c6783b59a790d220afc", size = 180055, upload-time = "2026-08-20T17:53:46.74Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e6/f821850bb8c05bf64aa016b44dce4d41850abfd390fdcb56ee2aed5e9df7/lograil-0.7.0-py3-none-any.whl", hash = "sha256:1f7635d7195555b4feef7b9b1e0608206de537c49be99af9d685060f1855ce76", size = 75025, upload-time = "2026-08-10T21:20:07.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/71/4dd387bbe304ff39631df386655eae39f695ed3c44b590d3b35e7f7a8c70/lograil-0.8.1-py3-none-any.whl", hash = "sha256:5031c6775865a10bfb2b3c4f81b7f8d931497dfbe18e27e52d0fbc8d7d5706b4", size = 82665, upload-time = "2026-08-20T17:53:45.366Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Treat 0.0.0 as the sentinel for packages that have not been published to
PyPI yet (aka new packages).  Skip sentinel packages during publishing
and require newly added packages to use it so merging package code
cannot publish to PyPI unintentionally.
