### PR TITLE
Turn on check_untyped_defs, add some more annotations

### DIFF
--- a/changes/vercel-headers/mypy-request-protocol.bugfix.md
+++ b/changes/vercel-headers/mypy-request-protocol.bugfix.md
@@ -1,0 +1,1 @@
+Accept request objects with concrete header implementations in the IP address and geolocation type annotations.

--- a/changes/vercel-workflow/mypy-untyped-bodies.internal.md
+++ b/changes/vercel-workflow/mypy-untyped-bodies.internal.md
@@ -1,0 +1,1 @@
+Correct internal workflow type annotations found by checking untyped function bodies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ commands = [["./scripts/test.sh", { replace = "posargs", extend = true }]]
 [tool.mypy]
 python_version = "3.10"
 cache_dir = "$MYPY_CONFIG_FILE_DIR/.mypy_cache/root"
+check_untyped_defs = true
 ignore_missing_imports = true
 explicit_package_bases = true
 mypy_path = [

--- a/src/vercel-headers/vercel/headers/__init__.py
+++ b/src/vercel-headers/vercel/headers/__init__.py
@@ -68,7 +68,8 @@ class _HeadersLike(Protocol):
 
 
 class _RequestLike(Protocol):
-    headers: _HeadersLike
+    @property
+    def headers(self) -> _HeadersLike: ...
 
 
 class Geo(TypedDict, total=False):

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -472,7 +472,7 @@ class TestAsyncioRestrictions:
 
             loop = asyncio.get_running_loop()
             with pytest.raises(SandboxRestrictionError, match="loop.create_connection"):
-                loop.create_connection(None, "localhost", 80)
+                loop.create_connection(None, "localhost", 80)  # type: ignore[call-overload]
 
     @pytest.mark.asyncio
     async def test_loop_subprocess_exec_blocked(self):
@@ -481,7 +481,7 @@ class TestAsyncioRestrictions:
 
             loop = asyncio.get_running_loop()
             with pytest.raises(SandboxRestrictionError, match="loop.subprocess_exec"):
-                loop.subprocess_exec(None, "echo")
+                loop.subprocess_exec(None, "echo")  # type: ignore[arg-type,unused-coroutine]
 
     @pytest.mark.asyncio
     async def test_loop_subprocess_shell_blocked(self):
@@ -490,7 +490,7 @@ class TestAsyncioRestrictions:
 
             loop = asyncio.get_running_loop()
             with pytest.raises(SandboxRestrictionError, match="loop.subprocess_shell"):
-                loop.subprocess_shell(None, "echo")
+                loop.subprocess_shell(None, "echo")  # type: ignore[arg-type,unused-coroutine]
 
     @pytest.mark.asyncio
     async def test_loop_call_soon_allowed(self):
@@ -498,7 +498,7 @@ class TestAsyncioRestrictions:
             import asyncio
 
             loop = asyncio.get_running_loop()
-            called = []
+            called: list[int] = []
             loop.call_soon(called.append, 1)
             await asyncio.sleep(0)  # yield to let call_soon fire
             # call_soon should not raise — we can't easily assert it fired
@@ -543,7 +543,7 @@ class TestAsyncioRestrictions:
             async def worker(value: int) -> None:
                 results.append(value)
 
-            async with asyncio.TaskGroup() as tg:
+            async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
                 tg.create_task(worker(1))
                 tg.create_task(worker(2))
 
@@ -575,8 +575,8 @@ class TestAsyncioRestrictions:
                     cancelled.set()
                     raise
 
-            with pytest.raises(ExceptionGroup) as exc_info:  # noqa: F821
-                async with asyncio.TaskGroup() as tg:
+            with pytest.raises(ExceptionGroup) as exc_info:  # type: ignore[name-defined] # noqa: F821
+                async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
                     tg.create_task(slow())
                     tg.create_task(failing())
 
@@ -639,7 +639,9 @@ class TestUvloopProxy:
 
                 proxy_loop = asyncio.get_running_loop()
                 with pytest.raises(SandboxRestrictionError, match="loop.create_connection"):
-                    proxy_loop.create_connection(None, "localhost", 80)
+                    proxy_loop.create_connection(  # type: ignore[call-overload]
+                        None, "localhost", 80
+                    )
 
         self._run_async(go(), loop)
 
@@ -652,7 +654,10 @@ class TestUvloopProxy:
 
                 proxy_loop = asyncio.get_running_loop()
                 with pytest.raises(SandboxRestrictionError, match="loop.subprocess_exec"):
-                    proxy_loop.subprocess_exec(None, "echo")
+                    proxy_loop.subprocess_exec(  # type: ignore[arg-type,unused-coroutine]
+                        None,  # type: ignore[arg-type]
+                        "echo",
+                    )
 
         self._run_async(go(), loop)
 
@@ -664,7 +669,7 @@ class TestUvloopProxy:
                 import asyncio
 
                 proxy_loop = asyncio.get_running_loop()
-                called = []
+                called: list[int] = []
                 proxy_loop.call_soon(called.append, 1)
                 await asyncio.sleep(0)
                 # call_soon should not raise

--- a/src/vercel-workflow/vercel/workflow/_internal/loop.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/loop.py
@@ -1,23 +1,30 @@
 import asyncio
+import contextvars
+import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 11):
+    from typing import TypeVarTuple, Unpack
+else:
+    from typing_extensions import TypeVarTuple, Unpack
 
 if TYPE_CHECKING:
     import collections
 
+_Ts = TypeVarTuple("_Ts")
+
 
 class WorkflowLoop(asyncio.BaseEventLoop):
-    idle_hook = None
-
     if TYPE_CHECKING:
         _ready: collections.deque[Any]
         _stopping: bool
 
     def __init__(self, *, idle_hook: Callable[[], None] | None = None) -> None:
         super().__init__()
-        self.idle_hook = idle_hook
+        self.idle_hook: Callable[[], None] | None = idle_hook
 
-    def _run_once(self):
+    def _run_once(self) -> None:
         while self._ready and not self._stopping:
             handle = self._ready.popleft()
             if handle._cancelled:
@@ -28,16 +35,28 @@ class WorkflowLoop(asyncio.BaseEventLoop):
         if self.idle_hook and not self._stopping:
             self.idle_hook()
 
-    def _write_to_self(self):
+    def _write_to_self(self) -> None:
         # The loop has no way to suspend so we don't need to do
         # anything to wake it up.
         pass
 
-    def call_later(self, delay, callback, *args, context=None):
+    def call_later(
+        self,
+        delay: float,
+        callback: Callable[[Unpack[_Ts]], object],
+        *args: Unpack[_Ts],
+        context: contextvars.Context | None = None,
+    ) -> asyncio.TimerHandle:
         raise NotImplementedError
 
-    def call_at(self, when, callback, *args, context=None):
+    def call_at(
+        self,
+        when: float,
+        callback: Callable[[Unpack[_Ts]], object],
+        *args: Unpack[_Ts],
+        context: contextvars.Context | None = None,
+    ) -> asyncio.TimerHandle:
         raise NotImplementedError
 
-    def time(self):
+    def time(self) -> float:
         raise NotImplementedError

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -170,10 +170,14 @@ class _RestrictedRandomMeta(type):
 
 
 class _RestrictedRandom(random.Random, metaclass=_RestrictedRandomMeta):
-    def seed(self, a=None, **kwargs):
+    def seed(
+        self,
+        a: Any = None,
+        version: int = 2,
+    ) -> None:
         if a is None:
             _restricted("random.Random.seed")()
-        super().seed(a, **kwargs)
+        super().seed(a, version=version)
 
 
 def _wrap_get_loop(real_fn: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/vercel-workflow/vercel/workflow/_internal/ulid.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/ulid.py
@@ -9,6 +9,7 @@ timestamps go backwards or are the same.
 import os
 import time
 from collections.abc import Callable
+from typing import Protocol
 
 # Crockford's Base32 alphabet
 ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
@@ -104,7 +105,11 @@ def _increment_base32(base32_str: str) -> str | None:
     return None
 
 
-def monotonic_factory(prng: Callable[[], float] | None = None) -> Callable[[int | None], str]:
+class _MonotonicGenerator(Protocol):
+    def __call__(self, timestamp_ms: int | None = None) -> str: ...
+
+
+def monotonic_factory(prng: Callable[[], float] | None = None) -> _MonotonicGenerator:
     """
     Create a monotonic ULID generator function.
 

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -258,8 +258,8 @@ class _ContextWrapper(Generic[T]):
     def __getattr__(self, item):
         return getattr(self.value, item)
 
-    def __getitem__(self, item):
-        return self.value[item]
+    def __getitem__(self, item: Any) -> Any:
+        return self.value[item]  # type: ignore[index]
 
 
 class BaseWorkflowRun(BaseModel):

--- a/src/vercel/tests/integration/test_blob_sync_async.py
+++ b/src/vercel/tests/integration/test_blob_sync_async.py
@@ -14,6 +14,7 @@ from vercel.blob import (
     AsyncBlobClient,
     BlobClient,
     BlobNotFoundError,
+    UploadProgressEvent,
     aioblob,
     copy,
     copy_async,
@@ -189,7 +190,7 @@ class TestBlobPut:
         from vercel.blob.multipart.uploader import DEFAULT_PART_SIZE
 
         completed_parts: list[dict[str, str | int]] = []
-        progress_events = []
+        progress_events: list[UploadProgressEvent] = []
 
         def mpu_handler(request: httpx.Request) -> httpx.Response:
             action = request.headers["x-mpu-action"]
@@ -301,7 +302,7 @@ class TestBlobPut:
         from vercel.blob.multipart.uploader import DEFAULT_PART_SIZE
 
         completed_parts: list[dict[str, str | int]] = []
-        progress_events = []
+        progress_events: list[UploadProgressEvent] = []
 
         def mpu_handler(request: httpx.Request) -> httpx.Response:
             action = request.headers["x-mpu-action"]

--- a/src/vercel/tests/integration/test_functions_sync_async.py
+++ b/src/vercel/tests/integration/test_functions_sync_async.py
@@ -273,10 +273,13 @@ class TestSetGetHeaders:
         from vercel.functions import get_headers, set_headers
 
         set_headers({"First": "value1"})
-        assert get_headers()["First"] == "value1"
+        headers = get_headers()
+        assert headers is not None
+        assert headers["First"] == "value1"
 
         set_headers({"Second": "value2"})
         headers = get_headers()
+        assert headers is not None
         assert headers.get("First") is None
         assert headers["Second"] == "value2"
 
@@ -313,7 +316,7 @@ class TestEnvImmutability:
         env = get_env()
 
         with pytest.raises(AttributeError):  # Frozen dataclass
-            env.VERCEL = "2"
+            env.VERCEL = "2"  # type: ignore[misc]
 
 
 class TestGeoTypedDict:

--- a/src/vercel/tests/integration/test_projects_sync_async.py
+++ b/src/vercel/tests/integration/test_projects_sync_async.py
@@ -477,7 +477,9 @@ class TestProjectsAPI:
             mock_client_class.return_value = mock_client
 
             project_id = "test_project_123"
-            result = delete_project(project_id, token=mock_token)
+            result = delete_project(  # type: ignore[func-returns-value]
+                project_id, token=mock_token
+            )
 
             # Validate response
             assert result is None
@@ -506,7 +508,9 @@ class TestProjectsAPI:
             mock_client_class.return_value = mock_client
 
             project_id = "test_project_123"
-            result = await delete_project_async(project_id, token=mock_token)
+            result = await delete_project_async(  # type: ignore[func-returns-value]
+                project_id, token=mock_token
+            )
 
             # Validate response
             assert result is None

--- a/src/vercel/tests/test_cron.py
+++ b/src/vercel/tests/test_cron.py
@@ -226,15 +226,21 @@ class TestCronDecorator:
 
     def test_get_crons_string(self):
         module = __name__
-        assert _cron_string.get_crons() == [(f"{module}:_cron_string", "0 0 * * *")]
+        assert _cron_string.get_crons() == [  # type: ignore[attr-defined]
+            (f"{module}:_cron_string", "0 0 * * *")
+        ]
 
     def test_get_crons_kwargs(self):
         module = __name__
-        assert _cron_kwargs.get_crons() == [(f"{module}:_cron_kwargs", "* 6 * * *")]
+        assert _cron_kwargs.get_crons() == [  # type: ignore[attr-defined]
+            (f"{module}:_cron_kwargs", "* 6 * * *")
+        ]
 
     def test_get_crons_schedule(self):
         module = __name__
-        assert _cron_schedule.get_crons() == [(f"{module}:_cron_schedule", "*/5 * * * *")]
+        assert _cron_schedule.get_crons() == [  # type: ignore[attr-defined]
+            (f"{module}:_cron_schedule", "*/5 * * * *")
+        ]
 
     def test_rejects_local_function(self):
         @cron("0 0 * * *")
@@ -242,4 +248,4 @@ class TestCronDecorator:
             pass
 
         with pytest.raises(CronTabError, match="only module-level functions"):
-            local_job.get_crons()
+            local_job.get_crons()  # type: ignore[attr-defined]


### PR DESCRIPTION
check_untyped_defs will keep us from drowning in warnings
about type annotations and stuff in unannotated test methods.
