### PR TITLE
workflow: refactor resume() to not have a loop

### DIFF
--- a/changes/vercel-workflow/refactored-event-replay.internal.md
+++ b/changes/vercel-workflow/refactored-event-replay.internal.md
@@ -1,0 +1,1 @@
+Refactored event replay.

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -47,18 +47,6 @@ def _suspension(correlation_id: str, args: bytes) -> runtime.Suspension:
     return runtime.Suspension(correlation_id=correlation_id, step=core.Step(_greet), input=args)
 
 
-def _resume_until_suspended(ctx: runtime.WorkflowOrchestratorContext) -> None:
-    async def resume() -> None:
-        ctx.resume()
-        # Cancellation is delivered at the next suspension point.
-        await asyncio.sleep(0)
-
-    with pytest.raises(asyncio.CancelledError):
-        runtime._run_isolated(resume(), loop_factory=workflow_loop.WorkflowLoop)
-
-    assert ctx.suspended
-
-
 async def test_reordered_step_args_raise_nondeterminism() -> None:
     """Recorded step input "a" but the body now calls the same step with "b"
     on replay -> NondeterminismError."""
@@ -75,23 +63,6 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
 
     assert sus.future.done()
     assert isinstance(sus.future.exception(), runtime.NondeterminismError)
-
-
-async def test_matching_step_parks_without_nondeterminism() -> None:
-    """Same step + same input -> suspension is replayed, then the run parks."""
-    step = core.Step(_greet)
-    cid = "step_1"
-    events: list[w.Event] = [
-        w.StepCreatedEventData(step_name=step.name, input=_args(name="a")).into_event(cid)
-    ]
-    ctx = _context(events)
-    sus = _suspension(cid, _args(name="a"))
-    ctx.suspensions[cid] = sus
-
-    _resume_until_suspended(ctx)
-
-    assert not sus.future.done()
-    assert sus.has_created_event
 
 
 async def test_wait_step_swap_raises_nondeterminism() -> None:
@@ -118,6 +89,15 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     assert isinstance(wait.future.exception(), runtime.NondeterminismError)
 
 
+async def test_created_event_without_suspension_raises_runtime_error() -> None:
+    """A creation event cannot precede the body's matching suspension."""
+    step = core.Step(_greet)
+    ctx = _context([_created(step, "step_1")])
+
+    with pytest.raises(RuntimeError, match="has not registered its suspension"):
+        ctx.resume()
+
+
 # --- concurrent delivery: the loop idle hook + resume single-step ----------------
 #
 # When a body issues several calls from concurrent coroutines, recorded
@@ -141,24 +121,17 @@ def _completed(cid: str, result: Any) -> w.Event:
 
 
 async def test_cancelled_step_ignores_later_completion() -> None:
-    """A launched step can be cancelled before its completion is replayed.
+    """A step can be cancelled before its completion is replayed.
 
     The completion event still needs to be consumed, but setting a result on
     the cancelled future would raise ``InvalidStateError``.
     """
-    step = core.Step(_greet)
-    events: list[w.Event] = [_created(step, "step_1")]
+    events: list[w.Event] = [_completed("step_1", "one")]
     ctx = _context(events)
     sus = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus
 
-    # Replay the launch, then model the workflow task being cancelled while
-    # the step is in flight. The completion arrives in a later event batch.
-    _resume_until_suspended(ctx)
-    assert sus.has_created_event
     assert sus.future.cancel()
-
-    events.append(_completed("step_1", "one"))
     ctx.resume()
 
     assert sus.future.cancelled()
@@ -168,10 +141,7 @@ async def test_cancelled_step_ignores_later_completion() -> None:
 async def test_single_step_delivers_one_completion_per_pass() -> None:
     """Two concurrently-issued steps both have results in the log, but a single
     resume() pass resolves only the first; the rest is left for the next pass."""
-    step = core.Step(_greet)
     events: list[w.Event] = [
-        _created(step, "step_1"),
-        _created(step, "step_2"),
         _completed("step_1", "one"),
         _completed("step_2", "two"),
     ]
@@ -194,9 +164,7 @@ async def test_single_step_delivers_one_completion_per_pass() -> None:
 
 async def test_workflow_loop_runs_pending_work_before_resume() -> None:
     """The idle hook runs only after the body's pending callbacks are drained."""
-    step = core.Step(_greet)
     events: list[w.Event] = [
-        _created(step, "step_1"),
         _completed("step_1", "one"),
     ]
     ctx = _context(events)
@@ -218,25 +186,6 @@ async def test_workflow_loop_runs_pending_work_before_resume() -> None:
         loop.call_soon(pending)
         loop._run_once()
 
-        assert sus1.future.done() and sus1.future.result() == "one"
-    finally:
-        loop.close()
-
-
-async def test_workflow_loop_runs_resume_when_quiescent() -> None:
-    """With the ready queue empty, the idle hook delivers one completion."""
-    step = core.Step(_greet)
-    events: list[w.Event] = [
-        _created(step, "step_1"),
-        _completed("step_1", "one"),
-    ]
-    ctx = _context(events)
-    sus1 = _suspension("step_1", _ARGS)
-    ctx.suspensions["step_1"] = sus1
-
-    loop = workflow_loop.WorkflowLoop(idle_hook=ctx.resume)
-    try:
-        loop._run_once()
         assert sus1.future.done() and sus1.future.result() == "one"
     finally:
         loop.close()
@@ -308,7 +257,10 @@ async def test_now_advances_with_replay_index() -> None:
     sus1 = _suspension("step_1", _ARGS)
     ctx.suspensions["step_1"] = sus1
 
-    ctx.resume()
+    for _ in events:
+        ctx.resume()
+        if sus1.future.done():
+            break
 
     assert sus1.future.done() and sus1.future.result() == "one"
     assert ctx.now() == t1

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -858,214 +858,187 @@ class WorkflowOrchestratorContext:
         they are one at a time, and it needs to be indistinguishable
         from that.)
 
-        Resolves at most one suspension before breaking.
+        Resolves at most one suspension.
 
         If the event log is exhausted, suspend the workflow.
         """
 
         # NOTE: resume() does single-step delivery, so we resolve at most
         # one suspension per invocation of resume().
-        # As an optimization for processing StepCreatedEvent and similar,
-        # we still structure this as a loop, though.
-        # The cases that do *not* invoke a suspension will continue,
-        # and the main bottom of the loop will break.
         #
         # This makes sure that resume() gets interleaved directly one
         # to one with event deliveries, instead of sometimes having
-        # multiple deliveries bunched up before a resume(), which can
+        # multiple deliveries bunched up before a resume(), which could
         # lead to mismatches between a recording trace and a replaying
         # one.
-        while (
-            self.replay_index < len(self.events) or self.ooo_hook_received_events
-        ) and self.suspensions:
-            event: w.Event | None = None
-            # Look for any out-of-order hooks that can be applied
-            for event in self.ooo_hook_received_events:
-                if event.correlation_id in self.suspensions:
-                    self.ooo_hook_received_events.remove(event)
-                    break
-            else:
-                event = None
-
-            if event is None:
-                if self.replay_index < len(self.events):
-                    event = self.events[self.replay_index]
-                    if event.correlation_id not in self.suspensions:
-                        match event:
-                            # A step's attribute write. It answers no call in
-                            # this body, so consume it and move on.
-                            case (
-                                w.AttrSetEvent(correlation_id=None)
-                                | w.AttrSetEvent(
-                                    event_data=w.AttrSetEventData(writer=w.StepAttributeWriter())
-                                )
-                            ):
-                                self.replay_index += 1
-                                continue
-                            # In case of multitasking, one task may progress twice in a row,
-                            # when we see the replayed event before actually having the
-                            # suspension from the task. So we yield here and let the task
-                            # suspend and resume again in next iteration.
-                            case (
-                                w.StepCreatedEvent(correlation_id=str() as slot_id)
-                                | w.HookCreatedEvent(correlation_id=str() as slot_id)
-                                | w.WaitCreatedEvent(correlation_id=str() as slot_id)
-                                | w.AttrSetEvent(correlation_id=str() as slot_id)
-                            ):
-                                # ...unless the body already registered a different-kind
-                                # call at this positional slot (same ULID, different
-                                # prefix). A same-kind match would have hit the dict
-                                # lookup above, so a ULID collision here is a step/wait/
-                                # hook swap -- the body is non-deterministic. Fail loudly
-                                # instead of yielding forever (the matching ID will never
-                                # appear, so plain `return` would deadlock the run).
-                                pos = _correlation_ulid(slot_id)
-                                for sus in self.suspensions.values():
-                                    if _correlation_ulid(sus.correlation_id) == pos:
-                                        self._fail_suspension(
-                                            sus,
-                                            NondeterminismError(
-                                                f"workflow replay diverged at position "
-                                                f"{pos}: recorded a "
-                                                f"{_correlation_kind(slot_id)!r} "
-                                                f"call, but the body now issues a "
-                                                f"{_correlation_kind(sus.correlation_id)!r} "
-                                                "call. The workflow body is "
-                                                "non-deterministic."
-                                            ),
-                                        )
-                                        return
-                                return
-                            # HookReceivedEvent is not created from workflows, it may arrive
-                            # at any time out of order. At this momemnt we don't need one,
-                            # so we just stash it and continue with the event log.
-                            case w.HookReceivedEvent():
-                                self.ooo_hook_received_events.append(event)
-                                self.replay_index += 1
-                                continue
-                    self.replay_index += 1
-                else:
-                    # There are OOO hooks that don't apply but there
-                    # aren't any events. We need to suspend.
-                    # TODO: untangle the control flow
-                    self.suspend()
-                    return
-
-            match event:
-                case w.StepCreatedEvent(
-                    event_data=w.StepCreatedEventData(step_name=name, input=recorded_input)
-                ):
-                    sus = self.suspensions[event.correlation_id]
-                    assert isinstance(sus, Suspension)
-                    # The recorded step at this (positional) correlation ID must be
-                    # the same call the body just issued; a mismatch means the body
-                    # is non-deterministic.
-                    if sus.step.name != name or sus.input != recorded_input:
-                        self._fail_suspension(
-                            sus,
-                            NondeterminismError(
-                                f"workflow replay diverged at {event.correlation_id}: "
-                                f"recorded step {name!r}, but the body now calls "
-                                f"{sus.step.name!r} with different arguments. The workflow "
-                                "body is non-deterministic."
-                            ),
-                        )
-                        return
-                    sus.has_created_event = True
-                    continue
-
-                case w.HookCreatedEvent() | w.WaitCreatedEvent():
-                    self.suspensions[event.correlation_id].has_created_event = True
-                    continue
-
-                case w.AttrSetEvent(
-                    correlation_id=str() as attr_id,
-                    event_data=w.AttrSetEventData(changes=recorded_changes),
-                ):
-                    attr_sus = self.suspensions.pop(attr_id)
-                    assert isinstance(attr_sus, Attributes)
-                    if recorded_changes != attr_sus.changes:
-                        self._fail_suspension(
-                            attr_sus,
-                            NondeterminismError(
-                                f"workflow replay diverged at {attr_id}: "
-                                f"recorded attributes {recorded_changes!r}, but the body "
-                                f"now sets {attr_sus.changes!r}. The workflow body is "
-                                "non-deterministic."
-                            ),
-                        )
-                        return
-                    if not attr_sus.future.cancelled():
-                        attr_sus.future.set_result(None)
-
-                case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
-                    sus = self.suspensions.pop(event.correlation_id)
-                    assert isinstance(sus, Suspension)
-                    result = ser.hydrate(
-                        data,
-                        what=f"the result of step {event.correlation_id}",
-                        key=self.run_key,
-                    )
-                    if not sus.future.cancelled():
-                        try:
-                            validated = sus.step.codec.validate_return(result)
-                        except signature_codec.TypeValidationError as error:
-                            sus.future.set_exception(error)
-                        else:
-                            sus.future.set_result(validated)
-
-                case w.WaitCompletedEvent():
-                    wait = self.suspensions.pop(event.correlation_id)
-                    assert isinstance(wait, Wait)
-                    if not wait.future.cancelled():
-                        wait.future.set_result(None)
-
-                case w.StepFailedEvent(event_data=w.StepFailedEventData(error=data)):
-                    sus = self.suspensions.pop(event.correlation_id)
-                    assert isinstance(sus, Suspension)
-                    what = f"the error of step {event.correlation_id}"
-                    try:
-                        failure = ser.hydrate_error(data, what=what, key=self.run_key)
-                    except ser.SerializationError as error:
-                        failure = errors.FatalError(f"Cannot read {what}: {error}")
-                    if not sus.future.cancelled():
-                        sus.future.set_exception(failure)
-
-                case w.HookConflictEvent(event_data=w.HookConflictEventData(token=token)):
-                    hook = self.suspensions.pop(event.correlation_id, None)
-                    if hook is not None:
-                        assert isinstance(hook, Hook)
-                        conflict = f'Hook token "{token}" is already in use by another workflow'
-                        while hook.futures:
-                            future = hook.futures.popleft()
-                            if not future.cancelled():
-                                future.set_exception(RuntimeError(conflict))
-
-                case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
-                    hook = self.suspensions[event.correlation_id]
-                    assert isinstance(hook, Hook)
-                    result = ser.hydrate(
-                        data,
-                        what=f"the payload of hook {event.correlation_id}",
-                        key=self.run_key,
-                    )
-                    hook.set_result(result)
-                    if not hook.futures:
-                        self.suspensions.pop(event.correlation_id)
-
-                case w.HookDisposedEvent():
-                    self.hooks[event.correlation_id].has_dispose_event = True
-                    self.dispose_hook(correlation_id=event.correlation_id)
-
-            # One wake per pass: yield to the body so it drains to its next
-            # suspension before we deliver the next recorded event.
-            break
-
-        # If we did not break out of the loop, that means that the
-        # event log exhausted without doing any work.
-        # Suspend.
+        event: w.Event | None = None
+        # Look for any out-of-order hooks that can be applied
+        for event in self.ooo_hook_received_events:
+            if event.correlation_id in self.suspensions:
+                self.ooo_hook_received_events.remove(event)
+                break
         else:
+            event = None
+
+        if event is None and self.replay_index < len(self.events):
+            event = self.events[self.replay_index]
+            if event.correlation_id not in self.suspensions:
+                match event:
+                    # A step's attribute write. It answers no call in
+                    # this body, so consume it and move on.
+                    case (
+                        w.AttrSetEvent(correlation_id=None)
+                        | w.AttrSetEvent(
+                            event_data=w.AttrSetEventData(writer=w.StepAttributeWriter())
+                        )
+                    ):
+                        self.replay_index += 1
+                        return
+                    case (
+                        w.StepCreatedEvent(correlation_id=str() as slot_id)
+                        | w.HookCreatedEvent(correlation_id=str() as slot_id)
+                        | w.WaitCreatedEvent(correlation_id=str() as slot_id)
+                        | w.AttrSetEvent(correlation_id=str() as slot_id)
+                    ):
+                        # Error if body already registered a different-kind
+                        # call at this positional slot (same ULID, different
+                        # prefix). A same-kind match would have hit the dict
+                        # lookup above, so a ULID collision here is a step/wait/
+                        # hook swap -- the body is non-deterministic. Fail loudly
+                        # instead of yielding forever (the matching ID will never
+                        # appear, so plain `return` would deadlock the run).
+                        pos = _correlation_ulid(slot_id)
+                        for sus in self.suspensions.values():
+                            if _correlation_ulid(sus.correlation_id) == pos:
+                                self._fail_suspension(
+                                    sus,
+                                    NondeterminismError(
+                                        f"workflow replay diverged at position {pos}: recorded a "
+                                        f"{_correlation_kind(slot_id)!r} call, but the body now "
+                                        f"issues a {_correlation_kind(sus.correlation_id)!r} call. "
+                                        "The workflow body is non-deterministic."
+                                    ),
+                                )
+                                return
+                        raise RuntimeError(
+                            f"workflow replay cannot deliver {slot_id!r}: "
+                            "the workflow body has not registered its suspension"
+                        )
+                    # HookReceivedEvent is not created from workflows, it may arrive
+                    # at any time out of order. At this momemnt we don't need one,
+                    # so we just stash it and continue with the event log.
+                    case w.HookReceivedEvent():
+                        self.ooo_hook_received_events.append(event)
+                        self.replay_index += 1
+                        return
+            self.replay_index += 1
+
+        # No events to process. Suspend.
+        if not event:
             self.suspend()
+            return
+
+        match event:
+            case w.StepCreatedEvent(
+                event_data=w.StepCreatedEventData(step_name=name, input=recorded_input)
+            ):
+                sus = self.suspensions[event.correlation_id]
+                assert isinstance(sus, Suspension)
+                # The recorded step at this (positional) correlation ID must be
+                # the same call the body just issued; a mismatch means the body
+                # is non-deterministic.
+                if sus.step.name != name or sus.input != recorded_input:
+                    self._fail_suspension(
+                        sus,
+                        NondeterminismError(
+                            f"workflow replay diverged at {event.correlation_id}: recorded "
+                            f"step {name!r}, but the body now calls {sus.step.name!r} with "
+                            "different arguments. The workflow body is non-deterministic."
+                        ),
+                    )
+                    return
+                sus.has_created_event = True
+
+            case w.HookCreatedEvent() | w.WaitCreatedEvent():
+                self.suspensions[event.correlation_id].has_created_event = True
+
+            case w.AttrSetEvent(
+                correlation_id=str() as attr_id,
+                event_data=w.AttrSetEventData(changes=recorded_changes),
+            ):
+                attr_sus = self.suspensions.pop(attr_id)
+                assert isinstance(attr_sus, Attributes)
+                if recorded_changes != attr_sus.changes:
+                    self._fail_suspension(
+                        attr_sus,
+                        NondeterminismError(
+                            f"workflow replay diverged at {attr_id}: recorded attributes "
+                            f"{recorded_changes!r}, but the body now sets "
+                            f"{attr_sus.changes!r}. The workflow body is non-deterministic."
+                        ),
+                    )
+                    return
+                if not attr_sus.future.cancelled():
+                    attr_sus.future.set_result(None)
+
+            case w.StepCompletedEvent(event_data=w.StepCompletedEventData(result=data)):
+                sus = self.suspensions.pop(event.correlation_id)
+                assert isinstance(sus, Suspension)
+                result = ser.hydrate(
+                    data,
+                    what=f"the result of step {event.correlation_id}",
+                    key=self.run_key,
+                )
+                if not sus.future.cancelled():
+                    try:
+                        validated = sus.step.codec.validate_return(result)
+                    except signature_codec.TypeValidationError as error:
+                        sus.future.set_exception(error)
+                    else:
+                        sus.future.set_result(validated)
+
+            case w.WaitCompletedEvent():
+                wait = self.suspensions.pop(event.correlation_id)
+                assert isinstance(wait, Wait)
+                if not wait.future.cancelled():
+                    wait.future.set_result(None)
+
+            case w.StepFailedEvent(event_data=w.StepFailedEventData(error=data)):
+                sus = self.suspensions.pop(event.correlation_id)
+                assert isinstance(sus, Suspension)
+                what = f"the error of step {event.correlation_id}"
+                try:
+                    failure = ser.hydrate_error(data, what=what, key=self.run_key)
+                except ser.SerializationError as error:
+                    failure = errors.FatalError(f"Cannot read {what}: {error}")
+                if not sus.future.cancelled():
+                    sus.future.set_exception(failure)
+
+            case w.HookConflictEvent(event_data=w.HookConflictEventData(token=token)):
+                hook = self.suspensions.pop(event.correlation_id, None)
+                if hook is not None:
+                    assert isinstance(hook, Hook)
+                    conflict = f'Hook token "{token}" is already in use by another workflow'
+                    while hook.futures:
+                        future = hook.futures.popleft()
+                        if not future.cancelled():
+                            future.set_exception(RuntimeError(conflict))
+
+            case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
+                hook = self.suspensions[event.correlation_id]
+                assert isinstance(hook, Hook)
+                result = ser.hydrate(
+                    data,
+                    what=f"the payload of hook {event.correlation_id}",
+                    key=self.run_key,
+                )
+                hook.set_result(result)
+                if not hook.futures:
+                    self.suspensions.pop(event.correlation_id)
+
+            case w.HookDisposedEvent():
+                self.hooks[event.correlation_id].has_dispose_event = True
+                self.dispose_hook(correlation_id=event.correlation_id)
 
 
 # ── lazy hook resume ───────────────────────────────────────────────────────


### PR DESCRIPTION
resume() is currently structured as a loop that tries to process
events until it processes one that wakes up a suspension, at which
point it breaks. If it wakes nothing, it suspends the workflow.

When I reworked resume in #156 I left it as a loop to make the diff
more manageable (... though comments claimed it is an optimization,
which it very slightly is), but at the cost of leaving a loop with
*extremely* gnarly control flow. (It has `continue`, `break`, and
`return` all inside the loop, an *unconditional* `break` at the bottom
of the loop, and an `else` branch.)

Get rid of the loop and reduce a bunch of nesting depth.  Now the
function always resolves either zero or one event and suspends if it
resolved zero. The one callsite is already called inside a loop that
has a check for runnable tasks, so we don't need to embed that logic
ourselves.

I had previously written a bunch of slop tests for resume which
started failing even though the new version still obeys the documented
API of the function.

The updated tests work with the old version too. They might still be
slop that isn't worth having though?