### PR TITLE
workflow: implement call_later/call_at in custom event loop

### DIFF
--- a/changes/vercel-workflow/call_later.feature.md
+++ b/changes/vercel-workflow/call_later.feature.md
@@ -1,0 +1,4 @@
+Support `call_later`, `call_at`, and `now` in the event loop implementation.
+
+This enables use of `asyncio.sleep()` as well as `asyncio.timeout` and
+the `timeout` parameter of `asyncio.wait_for`.

--- a/src/vercel-workflow/tests/integration/test_workflow_attributes.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_attributes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import sys
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -31,7 +32,7 @@ from vercel.workflow._internal import core, runtime, world as w
 from vercel.workflow._internal.worlds import local as local_mod
 
 # How long a run gets before the test fails instead of hanging. Every run here
-# finishes in well under a second.
+# finishes quickly, including the workflow sleep test.
 RUN_DEADLINE_SECONDS = 30
 
 # Module level, not function level: replay re-imports the workflow's defining
@@ -47,6 +48,48 @@ async def sets_attributes(value: int, /) -> int:
     await set_attributes({"phase": "done"})
     await remove_attributes("source")
     return tripled
+
+
+@registry.workflow
+async def sleeps_between_values() -> list[str]:
+    values = ["before"]
+    await asyncio.sleep(1)
+    values.append("between")
+    await asyncio.sleep(1)
+    values.append("after")
+    return values
+
+
+@registry.workflow
+async def wait_for_sleep_to_finish() -> str:
+    await asyncio.wait_for(asyncio.sleep(1), timeout=20)
+    return "finished"
+
+
+@registry.workflow
+async def wait_for_sleep_to_time_out() -> str:
+    try:
+        await asyncio.wait_for(asyncio.sleep(20), timeout=1)
+    except asyncio.TimeoutError:
+        return "timed out"
+    return "unexpectedly finished"
+
+
+class NeverSignaled(core.BaseHook):
+    pass
+
+
+@registry.workflow
+async def wait_for_never_signaled_hook() -> str:
+    hook = NeverSignaled.wait(token="never-signaled")
+    try:
+        async with asyncio.timeout(1):  # type: ignore[attr-defined]
+            await hook
+    except TimeoutError:
+        return "timed out"
+    finally:
+        hook.dispose()
+    return "unexpectedly finished"
 
 
 @registry.step
@@ -139,6 +182,45 @@ async def _run(world: local_mod.LocalWorld, wf: Any, *args: Any) -> tuple[str, A
     run = await runtime.start(wf, *args)
     result = await asyncio.wait_for(run.return_value(), RUN_DEADLINE_SECONDS)
     return run.run_id, result
+
+
+async def test_a_workflow_can_sleep_and_resume(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run_id, result = await _run(world, sleeps_between_values)
+
+        assert result == ["before", "between", "after"]
+        events = (await world.events_list(run_id)).data
+        waits = [event for event in events if event.event_type == "wait_created"]
+        completions = [event for event in events if event.event_type == "wait_completed"]
+        assert len(waits) == len(completions) == 2
+        assert [event.correlation_id for event in waits] == [
+            event.correlation_id for event in completions
+        ]
+
+
+async def test_asyncio_wait_for_allows_a_workflow_sleep_to_finish(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        _, result = await _run(world, wait_for_sleep_to_finish)
+
+        assert result == "finished"
+
+
+async def test_asyncio_wait_for_times_out_a_workflow_sleep(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        _, result = await _run(world, wait_for_sleep_to_time_out)
+
+        assert result == "timed out"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio.timeout requires Python 3.11")
+async def test_asyncio_timeout_times_out_a_never_signaled_hook(tmp_path, monkeypatch) -> None:
+    async with running_world(tmp_path, monkeypatch) as world:
+        run_id, result = await _run(world, wait_for_never_signaled_hook)
+
+        assert result == "timed out"
+        events = (await world.events_list(run_id)).data
+        assert [event.event_type for event in events].count("hook_created") == 1
+        assert not any(event.event_type == "hook_received" for event in events)
 
 
 async def test_a_body_write_lands_on_the_run(tmp_path, monkeypatch) -> None:

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -448,24 +448,6 @@ class TestAsyncioRestrictions:
         _run_in_sandbox("import asyncio")
 
     @pytest.mark.asyncio
-    async def test_loop_call_later_blocked(self):
-        with workflow_sandbox():
-            import asyncio
-
-            loop = asyncio.get_running_loop()
-            with pytest.raises(SandboxRestrictionError, match="loop.call_later"):
-                loop.call_later(0, lambda: None)
-
-    @pytest.mark.asyncio
-    async def test_loop_call_at_blocked(self):
-        with workflow_sandbox():
-            import asyncio
-
-            loop = asyncio.get_running_loop()
-            with pytest.raises(SandboxRestrictionError, match="loop.call_at"):
-                loop.call_at(0, lambda: None)
-
-    @pytest.mark.asyncio
     async def test_loop_create_connection_blocked(self):
         with workflow_sandbox():
             import asyncio
@@ -604,32 +586,6 @@ class TestUvloopProxy:
     def _run_async(self, coro, loop):
         return loop.run_until_complete(coro)
 
-    def test_uvloop_call_later_blocked(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                with pytest.raises(SandboxRestrictionError, match="loop.call_later"):
-                    proxy_loop.call_later(0, lambda: None)
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_call_at_blocked(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                with pytest.raises(SandboxRestrictionError, match="loop.call_at"):
-                    proxy_loop.call_at(0, lambda: None)
-
-        self._run_async(go(), loop)
-
     def test_uvloop_create_connection_blocked(self, _use_uvloop):
         loop = _use_uvloop
 
@@ -702,19 +658,6 @@ class TestUvloopProxy:
                 proxy_loop = asyncio.get_running_loop()
                 fut = proxy_loop.create_future()
                 assert not fut.done()
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_time_blocked(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                with pytest.raises(SandboxRestrictionError, match="loop.time"):
-                    proxy_loop.time()
 
         self._run_async(go(), loop)
 

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -98,7 +98,7 @@ async def test_created_event_without_suspension_raises_runtime_error() -> None:
         ctx.resume()
 
 
-# --- concurrent delivery: the loop idle hook + resume single-step ----------------
+# --- concurrent delivery: the loop workflow + resume single-step -----------------
 #
 # When a body issues several calls from concurrent coroutines, recorded
 # completions must be delivered ONE AT A TIME, each only once the body has fully
@@ -106,7 +106,8 @@ async def test_created_event_without_suspension_raises_runtime_error() -> None:
 # still-running one and the two issue their next calls in a different order than
 # at record time -> the positional correlation IDs no longer line up ->
 # NondeterminismError. Two pieces cooperate:
-#   * WorkflowLoop calls resume() only when its ready queue is empty (quiescent).
+#   * WorkflowLoop calls workflow.resume() only when its ready queue is empty
+#     (quiescent).
 #   * resume() applies at most one recorded event (single-step), or parks.
 
 _ARGS = _args(name="a")
@@ -181,7 +182,20 @@ async def test_workflow_loop_runs_pending_work_before_resume() -> None:
         assert pending_ran
         ctx.resume()
 
-    loop = workflow_loop.WorkflowLoop(idle_hook=resume)
+    class Workflow:
+        def resume(self) -> None:
+            resume()
+
+        def time(self) -> float:
+            raise NotImplementedError
+
+        def check_suspended(self) -> None:
+            pass
+
+        def run_wait(self, param: Any) -> asyncio.Future[None]:
+            raise NotImplementedError
+
+    loop = workflow_loop.WorkflowLoop(workflow=Workflow())
     try:
         loop.call_soon(pending)
         loop._run_once()
@@ -206,7 +220,7 @@ async def test_idle_resume_parks_when_nothing_to_deliver() -> None:
     with pytest.raises(asyncio.CancelledError):
         runtime._run_isolated(
             wait_forever(),
-            loop_factory=lambda: workflow_loop.WorkflowLoop(idle_hook=ctx.resume),
+            loop_factory=lambda: workflow_loop.WorkflowLoop(workflow=ctx),
         )
 
     assert ctx.suspended

--- a/src/vercel-workflow/tests/unit/test_workflow_run_isolated.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_run_isolated.py
@@ -8,14 +8,29 @@ the outer task is still current.
 """
 
 import asyncio
+from typing import Any
 
 import pytest
 
 from vercel.workflow._internal import loop, runtime
 
 
+class _Workflow:
+    def resume(self) -> None:
+        pass
+
+    def time(self) -> float:
+        raise NotImplementedError
+
+    def check_suspended(self) -> None:
+        pass
+
+    def run_wait(self, param: Any) -> asyncio.Future[None]:
+        raise NotImplementedError
+
+
 def _loop_factory() -> asyncio.AbstractEventLoop:
-    return loop.WorkflowLoop()
+    return loop.WorkflowLoop(workflow=_Workflow())
 
 
 def test_run_in_loop_cleans_up_tasks() -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/loop.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/loop.py
@@ -1,8 +1,11 @@
 import asyncio
 import contextvars
+import datetime
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
+
+from vercel._internal.core.polyfills import UTC
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack
@@ -15,14 +18,25 @@ if TYPE_CHECKING:
 _Ts = TypeVarTuple("_Ts")
 
 
+class Workflow(Protocol):
+    def resume(self) -> None: ...
+
+    def time(self) -> float: ...
+
+    def check_suspended(self) -> None: ...
+
+    def run_wait(self, param: datetime.datetime | datetime.timedelta) -> asyncio.Future[None]: ...
+
+
 class WorkflowLoop(asyncio.BaseEventLoop):
     if TYPE_CHECKING:
         _ready: collections.deque[Any]
         _stopping: bool
 
-    def __init__(self, *, idle_hook: Callable[[], None] | None = None) -> None:
+    def __init__(self, *, workflow: Workflow) -> None:
         super().__init__()
-        self.idle_hook: Callable[[], None] | None = idle_hook
+        self.workflow = workflow
+        self._timers: dict[asyncio.TimerHandle, asyncio.Future[None]] = {}
 
     def _run_once(self) -> None:
         while self._ready and not self._stopping:
@@ -32,13 +46,45 @@ class WorkflowLoop(asyncio.BaseEventLoop):
             handle._run()
         handle = None  # Needed to break cycles when an exception occurs.
 
-        if self.idle_hook and not self._stopping:
-            self.idle_hook()
+        if not self._stopping:
+            self.workflow.resume()
 
     def _write_to_self(self) -> None:
         # The loop has no way to suspend so we don't need to do
         # anything to wake it up.
         pass
+
+    def _timer_handle_cancelled(self, handle: asyncio.TimerHandle) -> None:
+        if handle in self._timers:
+            self._timers[handle].cancel()
+        super()._timer_handle_cancelled(handle)  # type: ignore[misc]
+
+    def _call_sleep(
+        self,
+        sleep_spec: datetime.datetime | datetime.timedelta,
+        timer: asyncio.TimerHandle,
+    ) -> asyncio.TimerHandle:
+        def cb(fut: asyncio.Future[None]) -> None:
+            self._timers.pop(timer, None)
+            if fut.cancelled():
+                pass
+            elif fut.exception():
+                self.call_exception_handler(
+                    {
+                        "message": "an error occurred waiting for a workflow sleep",
+                        "exception": fut.exception(),
+                    }
+                )
+            else:
+                self._ready.append(timer)
+
+        self.workflow.check_suspended()
+        wait_fut = self.workflow.run_wait(sleep_spec)
+        wait_fut.add_done_callback(cb)
+        self._timers[timer] = wait_fut
+        timer._scheduled = True  # type: ignore[attr-defined]
+
+        return timer
 
     def call_later(
         self,
@@ -47,7 +93,13 @@ class WorkflowLoop(asyncio.BaseEventLoop):
         *args: Unpack[_Ts],
         context: contextvars.Context | None = None,
     ) -> asyncio.TimerHandle:
-        raise NotImplementedError
+        # Note: the "when" on the TimerHandle is kind of a fib. We
+        # calculate it based on now(), which is the latest time from
+        # the workflow, but we arrange so that workflow sleep will
+        # call it using the current time.
+        delta = datetime.timedelta(seconds=max(delay, 0))
+        timer = asyncio.TimerHandle(self.time() + delay, callback, args, self, context)
+        return self._call_sleep(delta, timer)
 
     def call_at(
         self,
@@ -56,7 +108,9 @@ class WorkflowLoop(asyncio.BaseEventLoop):
         *args: Unpack[_Ts],
         context: contextvars.Context | None = None,
     ) -> asyncio.TimerHandle:
-        raise NotImplementedError
+        timestamp = datetime.datetime.fromtimestamp(when, tz=UTC)
+        timer = asyncio.TimerHandle(when, callback, args, self, context)
+        return self._call_sleep(timestamp, timer)
 
     def time(self) -> float:
-        raise NotImplementedError
+        return self.workflow.time()

--- a/src/vercel-workflow/vercel/workflow/_internal/loop.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/loop.py
@@ -75,6 +75,9 @@ class WorkflowLoop(asyncio.BaseEventLoop):
                         "exception": fut.exception(),
                     }
                 )
+                # Signal anyway, to avoid some weird hangs.
+                # TODO: More decisive failures on this case.
+                self._ready.append(timer)
             else:
                 self._ready.append(timer)
 

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -210,6 +210,11 @@ def _wrap_get_loop(real_fn: Callable[..., Any]) -> Callable[..., Any]:
                 "shutdown_default_executor",
                 # Deterministic scheduling
                 "call_soon",
+                # Sleep based scheduling (does a workflow sleep)
+                "call_at",
+                "call_later",
+                # Time (uses deterministic time)
+                "time",
                 # Task / future creation
                 "create_future",
                 "create_task",

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -665,9 +665,12 @@ class WorkflowOrchestratorContext:
         cur = cls._ctx.get()
         # If the workflow is suspended, keep cancelling the task.
         # See comment in suspend, below.
-        if cur.suspended:
-            raise asyncio.CancelledError("workflow execution is suspended")
+        cur.check_suspended()
         return cur
+
+    def check_suspended(self) -> None:
+        if self.suspended:
+            raise asyncio.CancelledError("workflow execution is suspended")
 
     def suspend(self) -> None:
         # When a workflow gets suspended, we would ideally just throw
@@ -733,7 +736,7 @@ class WorkflowOrchestratorContext:
                     obj.codec.dump_return(
                         _run_isolated(
                             obj.func(*args, **kwargs),
-                            loop_factory=lambda: loop.WorkflowLoop(idle_hook=self.resume),
+                            loop_factory=lambda: loop.WorkflowLoop(workflow=self),
                         )
                     )
                 )
@@ -748,7 +751,9 @@ class WorkflowOrchestratorContext:
                 if self.suspended:
                     return None  # noqa: B012
 
-    async def run_step(self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    def run_step(
+        self, step: core.Step[P, T], *args: P.args, **kwargs: P.kwargs
+    ) -> asyncio.Future[T]:
         # Bound to the step's own signature, so the recorded bytes depend on it
         # rather than on how the body spelled the call -- see
         # `core._bind_arguments`, which the determinism check relies on.
@@ -757,26 +762,26 @@ class WorkflowOrchestratorContext:
         input_data = ser.dehydrate(ser.step_arguments(dumped_args, dumped_kwargs))
         sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
-        return await sus.future
+        return sus.future
 
-    async def run_wait(self, param: DurationParam) -> None:
+    def run_wait(self, param: DurationParam) -> asyncio.Future[None]:
         wait = Wait(
             correlation_id=f"wait_{self.generate_ulid()}",
             resume_at=(parse_duration_to_date(param)),
         )
         self.suspensions[wait.correlation_id] = wait
-        await wait.future
+        return wait.future
 
-    async def set_attributes(
+    def set_attributes(
         self, changes: list[w.AttributeChange], *, allow_reserved: bool
-    ) -> None:
+    ) -> asyncio.Future[None]:
         attr_sus = Attributes(
             correlation_id=f"attr_{self.generate_ulid()}",
             changes=changes,
             allow_reserved=allow_reserved,
         )
         self.suspensions[attr_sus.correlation_id] = attr_sus
-        await attr_sus.future
+        return attr_sus.future
 
     def now(self) -> datetime:
         if not self.events:
@@ -784,6 +789,10 @@ class WorkflowOrchestratorContext:
         event = self.events[max(self.replay_index - 1, 0)]
         assert event.server_props is not None
         return event.server_props.created_at
+
+    def time(self) -> float:
+        delta = self.now() - _EPOCH
+        return delta.total_seconds()
 
     def time_ns(self) -> int:
         delta = self.now() - _EPOCH
@@ -814,14 +823,14 @@ class WorkflowOrchestratorContext:
         self.hooks[hook.correlation_id] = hook
         return core.HookEvent(correlation_id=hook.correlation_id, token=hook.token)
 
-    async def run_hook(self, *, correlation_id: str) -> T:
+    def run_hook(self, *, correlation_id: str) -> asyncio.Future[T]:
         hook = self.hooks[correlation_id]
         if hook.disposed:
             raise StopAsyncIteration
         self.suspensions[hook.correlation_id] = hook
         fut = asyncio.Future[T]()
         hook.futures.append(fut)
-        return await fut
+        return fut
 
     def dispose_hook(self, *, correlation_id: str) -> None:
         hook = self.hooks[correlation_id]


### PR DESCRIPTION
The implementation is built on top of run_wait in our workflow core;
we just needed to hook up the future from that to an
asyncio.TimeHandle.

run_wait() goes from being a coroutine to being a regular function
that returns a future, so that the loop can directly install a
callback on it without needing to create a task.
The other run_*() methods get a similar treatment for consistency.
(It's probably a very small microoptimization, too.)

This unlocks `asyncio.sleep` but probably more importantly it unlocks
all of asyncio's timeout features.