### PR TITLE
sandbox: Align create_process(stdout=None) to stdlib

### DIFF
--- a/changes/vercel-sandbox/create-process-output.breaking.md
+++ b/changes/vercel-sandbox/create-process-output.breaking.md
@@ -1,0 +1,3 @@
+Align `create_process` output handling with `subprocess.Popen`: inherit stdout and stderr by default, and support writable text streams alongside `PIPE`, `DEVNULL`, and `STDOUT`.
+
+This is a breaking change because callers that relied on the previous implicit `PIPE` behavior must now pass `stdout=subprocess.PIPE` or `stderr=subprocess.PIPE` to capture output.

--- a/changes/vercel-sandbox/create-process-output.feature.md
+++ b/changes/vercel-sandbox/create-process-output.feature.md
@@ -1,0 +1,1 @@
+Align `create_process` output handling with `subprocess.Popen`: inherit stdout and stderr by default, and support writable text streams alongside `PIPE`, `DEVNULL`, and `STDOUT`.

--- a/changes/vercel-sandbox/create-process-output.feature.md
+++ b/changes/vercel-sandbox/create-process-output.feature.md
@@ -1,1 +1,0 @@
-Align `create_process` output handling with `subprocess.Popen`: inherit stdout and stderr by default, and support writable text streams alongside `PIPE`, `DEVNULL`, and `STDOUT`.

--- a/src/vercel-sandbox/examples/sandbox_08_create_process.py
+++ b/src/vercel-sandbox/examples/sandbox_08_create_process.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Start Sandbox processes with inherited and captured output."""
+
+import io
+import subprocess
+from contextlib import redirect_stdout
+from datetime import timedelta
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from vercel.api import session
+from vercel.sandbox import sync as sandbox
+
+load_dotenv()
+
+
+def main() -> None:
+    name = f"vercel-py-process-{uuid4().hex[:12]}"
+
+    with (
+        session(),
+        sandbox.create_sandbox(
+            name=name,
+            execution_time_limit=timedelta(minutes=1),
+        ) as box,
+    ):
+        inherited = io.StringIO()
+        with redirect_stdout(inherited):
+            process = box.create_process("printf", ["inherited output\\n"])
+            assert process.wait() == 0
+        assert inherited.getvalue() == "inherited output\n"
+
+        process = box.create_process(
+            "printf",
+            ["captured output\\n"],
+            stdout=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+        assert stdout == "captured output\n"
+        assert stderr is None
+
+    print("create_process inherited stdout and captured explicit PIPE output")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -212,7 +212,7 @@ async def test_async_process_readers_wait_and_signals(mock_env_clear: None) -> N
 
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
-        process = await box.create_process("python")
+        process = await box.create_process("python", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert process.name == "python"
         assert process.args == []
         assert process.cwd == "/vercel/sandbox"
@@ -267,13 +267,74 @@ def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
 
     with session(service_options=_session_options()):
         box = sandbox_sync.create_sandbox(name="preview")
-        process = box.create_process("python")
+        process = box.create_process("python", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert process.communicate() == ("out-1\nout-2", "err\n")
         assert process.returncode == 0
         process.terminate()
         process.kill()
 
     assert signals == [signal.SIGTERM, signal.SIGKILL]
+
+
+@respx.mock
+async def test_async_create_process_defaults_to_inherited_output(mock_env_clear: None) -> None:
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
+        return_value=httpx.Response(200, json=_process_response())
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1").mock(
+        return_value=httpx.Response(200, json=_process_response(0))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs").mock(
+        side_effect=lambda _request: _logs_response()
+    )
+    stdout = _RecordingTextIO()
+    stderr = _RecordingTextIO()
+
+    async with session(service_options=_session_options()):
+        box = await sandbox.create_sandbox(name="preview")
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr("sys.stdout", stdout)
+            monkeypatch.setattr("sys.stderr", stderr)
+            process = await box.create_process("python")
+            assert process.stdout is None
+            assert process.stderr is None
+            assert await process.wait() == 0
+
+    assert stdout.getvalue() == "out-1\nout-2"
+    assert stderr.getvalue() == "err\n"
+    assert stdout.flush_count == 1
+    assert stderr.flush_count == 1
+
+
+@respx.mock
+def test_sync_create_process_routes_pipe_and_inherited_stderr(mock_env_clear: None) -> None:
+    respx.post("https://sandbox.test/v3/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+    respx.post("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd").mock(
+        return_value=httpx.Response(200, json=_process_response())
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1").mock(
+        return_value=httpx.Response(200, json=_process_response(0))
+    )
+    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs").mock(
+        side_effect=lambda _request: _logs_response()
+    )
+    stderr = _RecordingTextIO()
+
+    with session(service_options=_session_options()):
+        box = sandbox_sync.create_sandbox(name="preview")
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr("sys.stderr", stderr)
+            process = box.create_process("python", stdout=subprocess.PIPE)
+            assert process.stdout is not None
+            assert process.stderr is None
+            assert process.communicate() == ("out-1\nout-2", None)
+
+    assert stderr.getvalue() == "err\n"
 
 
 @respx.mock
@@ -295,7 +356,9 @@ async def test_async_create_process_merges_stderr_into_stdout_reader(
 
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
-        process = await box.create_process("python", stderr=subprocess.STDOUT)
+        process = await box.create_process(
+            "python", stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
         assert process.stderr is None
         assert process.stdout is not None
         assert await process.communicate() == ("out-1\nout-2err\n", None)
@@ -321,7 +384,9 @@ async def test_async_create_process_devnull_drops_reader(mock_env_clear: None) -
 
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
-        process = await box.create_process("python", stderr=subprocess.DEVNULL)
+        process = await box.create_process(
+            "python", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
         assert process.stderr is None
         assert await process.communicate() == ("out-1\nout-2", None)
 
@@ -357,11 +422,8 @@ async def test_async_create_process_with_no_readers_never_requests_logs(
     "kwargs",
     [
         {"stdout": subprocess.STDOUT},
-        {"stdout": None},
-        {"stderr": None},
         {"stdout": 42},
         {"stderr": 42},
-        {"stdout": io.StringIO()},
         {"stderr": io.BytesIO()},
     ],
 )
@@ -399,7 +461,7 @@ def test_sync_create_process_merges_stderr_into_stdout_reader(mock_env_clear: No
 
     with session(service_options=_session_options()):
         box = sandbox_sync.create_sandbox(name="preview")
-        process = box.create_process("python", stderr=subprocess.STDOUT)
+        process = box.create_process("python", stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         assert process.stderr is None
         assert process.stdout is not None
         assert process.communicate() == ("out-1\nout-2err\n", None)
@@ -734,7 +796,7 @@ async def test_async_process_readers_read_chunked_ndjson(mock_env_clear: None) -
 
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
-        process = await box.create_process("python")
+        process = await box.create_process("python", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output = await process.communicate()
 
     assert output == ("café\n", "雪\n")
@@ -764,7 +826,7 @@ def test_sync_process_readers_read_chunked_ndjson(mock_env_clear: None) -> None:
 
     with session(service_options=_session_options()):
         box = sandbox_sync.create_sandbox(name="preview")
-        process = box.create_process("python")
+        process = box.create_process("python", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output = process.communicate()
 
     assert output == ("café\n", "雪\n")

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -277,9 +277,7 @@ def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
 
 
 @respx.mock
-async def test_async_create_process_defaults_to_inherited_output(
-    mock_env_clear: None, capsys: pytest.CaptureFixture[str]
-) -> None:
+async def test_async_create_process_defaults_to_inherited_output(mock_env_clear: None) -> None:
     respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
@@ -289,8 +287,8 @@ async def test_async_create_process_defaults_to_inherited_output(
     respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1").mock(
         return_value=httpx.Response(200, json=_process_response(0))
     )
-    respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs").mock(
-        side_effect=lambda _request: _logs_response()
+    logs = respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs").mock(
+        return_value=httpx.Response(200, text="")
     )
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
@@ -299,7 +297,7 @@ async def test_async_create_process_defaults_to_inherited_output(
         assert process.stderr is None
         assert await process.wait() == 0
 
-    assert capsys.readouterr() == ("out-1\nout-2", "err\n")
+    assert logs.called
 
 
 @respx.mock

--- a/src/vercel-sandbox/tests/test_sandbox_process.py
+++ b/src/vercel-sandbox/tests/test_sandbox_process.py
@@ -277,7 +277,9 @@ def test_sync_process_readers_wait_and_signals(mock_env_clear: None) -> None:
 
 
 @respx.mock
-async def test_async_create_process_defaults_to_inherited_output(mock_env_clear: None) -> None:
+async def test_async_create_process_defaults_to_inherited_output(
+    mock_env_clear: None, capsys: pytest.CaptureFixture[str]
+) -> None:
     respx.post("https://sandbox.test/v3/sandboxes").mock(
         return_value=httpx.Response(200, json=_sandbox_response())
     )
@@ -290,23 +292,14 @@ async def test_async_create_process_defaults_to_inherited_output(mock_env_clear:
     respx.get("https://sandbox.test/v2/sandboxes/sessions/sbx_1/cmd/cmd_1/logs").mock(
         side_effect=lambda _request: _logs_response()
     )
-    stdout = _RecordingTextIO()
-    stderr = _RecordingTextIO()
-
     async with session(service_options=_session_options()):
         box = await sandbox.create_sandbox(name="preview")
-        with pytest.MonkeyPatch.context() as monkeypatch:
-            monkeypatch.setattr("sys.stdout", stdout)
-            monkeypatch.setattr("sys.stderr", stderr)
-            process = await box.create_process("python")
-            assert process.stdout is None
-            assert process.stderr is None
-            assert await process.wait() == 0
+        process = await box.create_process("python")
+        assert process.stdout is None
+        assert process.stderr is None
+        assert await process.wait() == 0
 
-    assert stdout.getvalue() == "out-1\nout-2"
-    assert stderr.getvalue() == "err\n"
-    assert stdout.flush_count == 1
-    assert stderr.flush_count == 1
+    assert capsys.readouterr() == ("out-1\nout-2", "err\n")
 
 
 @respx.mock

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import json
+import subprocess
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -1899,7 +1900,7 @@ async def test_closed_session_rejects_handles_and_lazy_readers(mock_env_clear: N
         resumed = await sandbox.resume_sandbox(name="preview")
         assert resumed.current_session is not None
         runtime_session = resumed.current_session
-        command = await handle.create_process("sleep", ["30"])
+        command = await handle.create_process("sleep", ["30"], stdout=subprocess.PIPE)
         snapshot = await handle.snapshot()
         assert snapshot.region == "iad1"
         assert snapshot.regions == ("iad1", "sfo1", "cle1")

--- a/src/vercel-sandbox/tests/test_sandbox_text_reader.py
+++ b/src/vercel-sandbox/tests/test_sandbox_text_reader.py
@@ -1,3 +1,4 @@
+import io
 import json
 import subprocess
 from collections.abc import AsyncIterator, Iterator
@@ -7,8 +8,14 @@ import httpx
 import pytest
 
 from vercel._internal.core.http import StreamingResponse
+from vercel._internal.core.iter_coroutine import iter_coroutine
 from vercel.sandbox._internal.errors import SandboxStreamError
-from vercel.sandbox._internal.text_reader import _sync_text_readers, _text_readers
+from vercel.sandbox._internal.text_reader import (
+    _sync_text_readers,
+    _sync_text_transport_and_readers,
+    _text_readers,
+    _text_transport_and_readers,
+)
 
 
 class _TestStreamingResponse(StreamingResponse):
@@ -109,6 +116,29 @@ async def test_async_text_reader_lines_shared_cursor_eof_and_close(anyio_backend
     assert await peer.read() == "ignored\n"
     with pytest.raises(anyio.ClosedResourceError):
         await reader.read()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_text_reader_close_preserves_stream_destination(
+    anyio_backend: str,
+) -> None:
+    stderr = io.StringIO()
+    transport, reader, peer = _text_transport_and_readers(
+        lambda: _logs_response(
+            {"stream": "stdout", "data": "captured\n"},
+            {"stream": "stderr", "data": "inherited\n"},
+        ),
+        stdout=subprocess.PIPE,
+        stderr=stderr,
+    )
+    assert transport is not None and reader is not None and peer is None
+
+    assert await reader.readline() == "captured\n"
+    await reader.aclose()
+    await transport.drain()
+
+    assert stderr.getvalue() == "inherited\n"
 
 
 @pytest.mark.anyio
@@ -217,6 +247,25 @@ def test_sync_text_reader_lines_shared_cursor_eof_and_close() -> None:
     assert peer.read() == "ignored\n"
     with pytest.raises(anyio.ClosedResourceError):
         reader.read()
+
+
+def test_sync_text_reader_close_preserves_stream_destination() -> None:
+    stderr = io.StringIO()
+    transport, reader, peer = _sync_text_transport_and_readers(
+        lambda: _logs_response(
+            {"stream": "stdout", "data": "captured\n"},
+            {"stream": "stderr", "data": "inherited\n"},
+        ),
+        stdout=subprocess.PIPE,
+        stderr=stderr,
+    )
+    assert transport is not None and reader is not None and peer is None
+
+    assert reader.readline() == "captured\n"
+    reader.close()
+    iter_coroutine(transport.drain())
+
+    assert stderr.getvalue() == "inherited\n"
 
 
 def test_sync_text_reader_propagates_in_band_errors() -> None:

--- a/src/vercel-sandbox/tests/test_sandbox_text_reader.py
+++ b/src/vercel-sandbox/tests/test_sandbox_text_reader.py
@@ -143,6 +143,30 @@ async def test_async_text_reader_close_preserves_stream_destination(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+async def test_async_text_reader_close_all_readers_finishes_transport(
+    anyio_backend: str,
+) -> None:
+    opened = 0
+
+    async def open_response() -> StreamingResponse:
+        nonlocal opened
+        opened += 1
+        return _logs_response()
+
+    transport, stdout, stderr = _text_transport_and_readers(
+        open_response, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert transport is not None and stdout is not None and stderr is not None
+
+    await stdout.aclose()
+    await stderr.aclose()
+    await transport.drain()
+
+    assert opened == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_async_text_reader_rejects_concurrent_reads(anyio_backend: str) -> None:
     started = anyio.Event()
     release = anyio.Event()
@@ -266,6 +290,26 @@ def test_sync_text_reader_close_preserves_stream_destination() -> None:
     iter_coroutine(transport.drain())
 
     assert stderr.getvalue() == "inherited\n"
+
+
+def test_sync_text_reader_close_all_readers_finishes_transport() -> None:
+    opened = 0
+
+    def open_response() -> StreamingResponse:
+        nonlocal opened
+        opened += 1
+        return _logs_response()
+
+    transport, stdout, stderr = _sync_text_transport_and_readers(
+        open_response, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert transport is not None and stdout is not None and stderr is not None
+
+    stdout.close()
+    stderr.close()
+    iter_coroutine(transport.drain())
+
+    assert opened == 0
 
 
 def test_sync_text_reader_propagates_in_band_errors() -> None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -98,7 +98,7 @@ from vercel.sandbox._internal.state import (
     SnapshotSessionState,
     SnapshotState,
 )
-from vercel.sandbox._internal.text_reader import TextReader, _text_readers
+from vercel.sandbox._internal.text_reader import TextReader, _text_transport_and_readers
 
 
 def _terminal_error(error: _SandboxTerminalState, sandbox: object) -> SandboxTerminalStateError:
@@ -118,7 +118,7 @@ class Process(_ProcessHandleState):
     ``subprocess.DEVNULL`` or merged with ``subprocess.STDOUT``.
     """
 
-    __slots__ = ("_service", "stderr", "stdout")
+    __slots__ = ("_service", "_transport", "stderr", "stdout")
 
     stdout: TextReader | None
     stderr: TextReader | None
@@ -128,12 +128,12 @@ class Process(_ProcessHandleState):
         *,
         payload: ProcessState,
         service: SandboxService,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = subprocess.PIPE,
+        stderr: TextIO | int | None = subprocess.PIPE,
     ) -> None:
         super().__init__(payload)
         self._service = service
-        self.stdout, self.stderr = _text_readers(
+        self._transport, self.stdout, self.stderr = _text_transport_and_readers(
             lambda: service.process_logs_response(session_id=self._session_id, process_id=self.id),
             stdout=stdout,
             stderr=stderr,
@@ -145,13 +145,18 @@ class Process(_ProcessHandleState):
         self._apply_payload(payload)
         return self
 
+    async def _drain_output(self) -> None:
+        if self._transport is not None:
+            await self._transport.drain()
+
     async def wait(self) -> int:
-        """Wait for the process to exit and return its exit code.
+        """Drain process output, wait for exit, and return the exit code.
 
         Raises:
             SandboxResponseError: If the service response omits the process
                 return code.
         """
+        await self._drain_output()
         payload = await self._service.get_process(
             session_id=self._session_id, process_id=self.id, wait=True
         )
@@ -177,6 +182,7 @@ class Process(_ProcessHandleState):
         """
         if input is not None:
             raise NotImplementedError("process stdin is not supported")
+        await self._drain_output()
         stdout = None if self.stdout is None else await self.stdout.read()
         stderr = None if self.stderr is None else await self.stderr.read()
         await self.wait()
@@ -791,8 +797,8 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
         env: Mapping[str, str] | None = None,
         sudo: bool = False,
         kill_after: float | timedelta | None = None,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = None,
+        stderr: TextIO | int | None = None,
     ) -> Process:
         """Start a process without waiting for it to exit.
 
@@ -804,11 +810,13 @@ class SandboxRuntimeSession(RuntimeSessionHandleBase):
             sudo: Whether to run with elevated privileges.
             kill_after: Duration after which the service kills the process
                 with ``SIGKILL``.
-            stdout: ``subprocess.PIPE`` (default) for a live reader or
-                ``subprocess.DEVNULL`` to drop the stream.
-            stderr: ``subprocess.PIPE`` (default), ``subprocess.DEVNULL``, or
-                ``subprocess.STDOUT`` to merge stderr into the stdout reader
-                in arrival order.
+            stdout: Writable text stream or subprocess output sentinel.
+                ``None`` inherits the local stdout stream, ``PIPE`` provides a
+                live reader, and ``DEVNULL`` drops the stream.
+            stderr: Writable text stream or subprocess output sentinel.
+                ``None`` inherits the local stderr stream, ``PIPE`` provides a
+                live reader, ``DEVNULL`` drops the stream, and ``STDOUT`` routes
+                stderr to the stdout destination in arrival order.
 
         Returns:
             A handle for monitoring and controlling the process.
@@ -1102,8 +1110,8 @@ class Sandbox(SandboxHandleBase[SandboxRuntimeSession]):
         env: Mapping[str, str] | None = None,
         sudo: bool = False,
         kill_after: float | timedelta | None = None,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = None,
+        stderr: TextIO | int | None = None,
     ) -> Process:
         """Start a process in the current session without waiting for it.
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -114,8 +114,8 @@ class Process(_ProcessHandleState):
 
     The ``stdout`` and ``stderr`` readers each consume their process log
     stream once; reads make forward progress through the stream and cannot
-    rewind. A reader is ``None`` when its stream was dropped with
-    ``subprocess.DEVNULL`` or merged with ``subprocess.STDOUT``.
+    rewind. A reader exists only when its stream uses ``subprocess.PIPE``;
+    inherited, redirected, dropped, and merged streams have no reader.
     """
 
     __slots__ = ("_service", "_transport", "stderr", "stdout")

--- a/src/vercel-sandbox/vercel/sandbox/_internal/process_output.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/process_output.py
@@ -69,7 +69,8 @@ def _validate_reader_destination(
         if allow_stdout_merge:
             return subprocess.STDOUT
         raise ValueError("STDOUT is only supported for stderr")
-    _resolve_target(destination, inherited=sys.stdout, name=name)
+    inherited = sys.stderr if name == "stderr" else sys.stdout
+    _resolve_target(destination, inherited=inherited, name=name)
     return destination
 
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/process_output.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/process_output.py
@@ -62,23 +62,15 @@ class ProcessOutputRouter:
 
 
 def _validate_reader_destination(
-    destination: object, *, name: str, allow_stdout_merge: bool = False
-) -> int:
-    """Validate a Popen-style destination for a live process reader.
-
-    Live readers support only the ``subprocess`` sentinels: ``PIPE``,
-    ``DEVNULL``, and (for stderr) ``STDOUT``. Inherit and file-sink modes
-    exist only on ``run_process``, which routes completed output.
-    """
-    if isinstance(destination, int):
-        if destination == subprocess.STDOUT:
-            if allow_stdout_merge:
-                return subprocess.STDOUT
-            raise ValueError("STDOUT is only supported for stderr")
-        if destination == subprocess.PIPE or destination == subprocess.DEVNULL:
-            return destination
-        raise ValueError(f"unsupported {name} value: {destination}")
-    raise TypeError(f"{name} must be subprocess.PIPE, subprocess.DEVNULL, or subprocess.STDOUT")
+    destination: TextIO | int | None, *, name: str, allow_stdout_merge: bool = False
+) -> TextIO | int | None:
+    """Validate a Popen-style destination for a live process stream."""
+    if destination == subprocess.STDOUT:
+        if allow_stdout_merge:
+            return subprocess.STDOUT
+        raise ValueError("STDOUT is only supported for stderr")
+    _resolve_target(destination, inherited=sys.stdout, name=name)
+    return destination
 
 
 def _resolve_target(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -117,8 +117,8 @@ class SyncProcess(_ProcessHandleState):
 
     The ``stdout`` and ``stderr`` readers each consume their process log
     stream once; reads make forward progress through the stream and cannot
-    rewind. A reader is ``None`` when its stream was dropped with
-    ``subprocess.DEVNULL`` or merged with ``subprocess.STDOUT``.
+    rewind. A reader exists only when its stream uses ``subprocess.PIPE``;
+    inherited, redirected, dropped, and merged streams have no reader.
     """
 
     __slots__ = ("_service", "_transport", "stderr", "stdout")

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -98,7 +98,10 @@ from vercel.sandbox._internal.sync_filesystem_handle import (
     SyncSandboxTextReader,
     SyncSandboxTextWriter,
 )
-from vercel.sandbox._internal.text_reader import SyncTextReader, _sync_text_readers
+from vercel.sandbox._internal.text_reader import (
+    SyncTextReader,
+    _sync_text_transport_and_readers,
+)
 
 
 def _terminal_error(error: _SandboxTerminalState, sandbox: object) -> SandboxTerminalStateError:
@@ -118,7 +121,7 @@ class SyncProcess(_ProcessHandleState):
     ``subprocess.DEVNULL`` or merged with ``subprocess.STDOUT``.
     """
 
-    __slots__ = ("_service", "stderr", "stdout")
+    __slots__ = ("_service", "_transport", "stderr", "stdout")
 
     stdout: SyncTextReader | None
     stderr: SyncTextReader | None
@@ -128,12 +131,12 @@ class SyncProcess(_ProcessHandleState):
         *,
         payload: ProcessState,
         service: SandboxService,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = subprocess.PIPE,
+        stderr: TextIO | int | None = subprocess.PIPE,
     ) -> None:
         super().__init__(payload)
         self._service = service
-        self.stdout, self.stderr = _sync_text_readers(
+        self._transport, self.stdout, self.stderr = _sync_text_transport_and_readers(
             lambda: service.process_logs_response(session_id=self._session_id, process_id=self.id),
             stdout=stdout,
             stderr=stderr,
@@ -147,13 +150,18 @@ class SyncProcess(_ProcessHandleState):
         self._apply_payload(payload)
         return self
 
+    def _drain_output(self) -> None:
+        if self._transport is not None:
+            iter_coroutine(self._transport.drain())
+
     def wait(self) -> int:
-        """Wait for the process to exit and return its exit code.
+        """Drain process output, wait for exit, and return the exit code.
 
         Raises:
             SandboxResponseError: If the service response omits the process
                 return code.
         """
+        self._drain_output()
         payload = iter_coroutine(
             self._service.get_process(session_id=self._session_id, process_id=self.id, wait=True)
         )
@@ -179,6 +187,7 @@ class SyncProcess(_ProcessHandleState):
         """
         if input is not None:
             raise NotImplementedError("process stdin is not supported")
+        self._drain_output()
         stdout = None if self.stdout is None else self.stdout.read()
         stderr = None if self.stderr is None else self.stderr.read()
         self.wait()
@@ -840,8 +849,8 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
         env: Mapping[str, str] | None = None,
         sudo: bool = False,
         kill_after: float | timedelta | None = None,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = None,
+        stderr: TextIO | int | None = None,
     ) -> SyncProcess:
         """Start a process without waiting for it to exit.
 
@@ -853,11 +862,13 @@ class SyncSandboxRuntimeSession(RuntimeSessionHandleBase):
             sudo: Whether to run with elevated privileges.
             kill_after: Duration after which the service kills the process
                 with ``SIGKILL``.
-            stdout: ``subprocess.PIPE`` (default) for a live reader or
-                ``subprocess.DEVNULL`` to drop the stream.
-            stderr: ``subprocess.PIPE`` (default), ``subprocess.DEVNULL``, or
-                ``subprocess.STDOUT`` to merge stderr into the stdout reader
-                in arrival order.
+            stdout: Writable text stream or subprocess output sentinel.
+                ``None`` inherits the local stdout stream, ``PIPE`` provides a
+                live reader, and ``DEVNULL`` drops the stream.
+            stderr: Writable text stream or subprocess output sentinel.
+                ``None`` inherits the local stderr stream, ``PIPE`` provides a
+                live reader, ``DEVNULL`` drops the stream, and ``STDOUT`` routes
+                stderr to the stdout destination in arrival order.
 
         Returns:
             A handle for monitoring and controlling the process.
@@ -1213,8 +1224,8 @@ class SyncSandbox(SandboxHandleBase[SyncSandboxRuntimeSession]):
         env: Mapping[str, str] | None = None,
         sudo: bool = False,
         kill_after: float | timedelta | None = None,
-        stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stdout: TextIO | int | None = None,
+        stderr: TextIO | int | None = None,
     ) -> SyncProcess:
         """Start a process in the current session without waiting for it.
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/text_reader.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/text_reader.py
@@ -2,12 +2,13 @@
 
 import inspect
 import subprocess
+import sys
 import threading
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from types import TracebackType
-from typing import Protocol, TypeAlias
+from typing import Protocol, TextIO, TypeAlias
 
 import anyio
 
@@ -113,8 +114,17 @@ class SyncTextReader(ABC):
         self.close()
 
 
-def _distinct_buffers(routes: Mapping[ProcessLogStream, _TextBuffer | None]) -> list[_TextBuffer]:
-    return list({id(buffer): buffer for buffer in routes.values() if buffer is not None}.values())
+_TextDestination: TypeAlias = _TextBuffer | TextIO | None
+
+
+def _distinct_buffers(routes: Mapping[ProcessLogStream, _TextDestination]) -> list[_TextBuffer]:
+    return list(
+        {
+            id(destination): destination
+            for destination in routes.values()
+            if isinstance(destination, _TextBuffer)
+        }.values()
+    )
 
 
 class _PumpLock(Protocol):
@@ -163,15 +173,15 @@ class _TextTransportCore:
     def __init__(
         self,
         open_response: Callable[[], Awaitable[StreamingResponse]],
-        routes: Mapping[ProcessLogStream, _TextBuffer | None],
+        routes: Mapping[ProcessLogStream, _TextDestination],
         lock: _PumpLock,
     ) -> None:
         self._open_response = open_response
         self._response: StreamingResponse | None = None
         self._lines: AsyncIterator[str] | None = None
         self._routes = dict(routes)
-        self._live = len(_distinct_buffers(routes))
         self._broken = False
+        self._eof = False
         self._lock = lock
 
     async def _cleanup(self) -> None:
@@ -183,6 +193,8 @@ class _TextTransportCore:
     async def pump(self) -> None:
         if self._broken:
             raise anyio.BrokenResourceError
+        if self._eof:
+            return
         await self._lock.acquire()
         try:
             if self._broken:
@@ -198,6 +210,7 @@ class _TextTransportCore:
                     except StopAsyncIteration:
                         for buffer in _distinct_buffers(self._routes):
                             buffer.eof = True
+                        self._eof = True
                         await self._cleanup()
                         return
                     if not line:
@@ -205,8 +218,11 @@ class _TextTransportCore:
                     event = _parse_command_log_record(line)
                     if event is not None:
                         target = self._routes[event.stream]
-                        if target is not None:
+                        if isinstance(target, _TextBuffer):
                             target.append(event.data)
+                        elif target is not None:
+                            target.write(event.data)
+                            target.flush()
                         return
             except BaseException:
                 self._broken = True
@@ -217,6 +233,10 @@ class _TextTransportCore:
         finally:
             self._lock.release()
 
+    async def drain(self) -> None:
+        while not self._eof:
+            await self.pump()
+
     async def close(self, buffer: _TextBuffer) -> None:
         await self._lock.acquire()
         try:
@@ -225,8 +245,7 @@ class _TextTransportCore:
             for stream, target in self._routes.items():
                 if target is buffer:
                     self._routes[stream] = None
-            self._live -= 1
-            if self._live == 0:
+            if all(target is None for target in self._routes.values()):
                 await self._cleanup()
         finally:
             self._lock.release()
@@ -314,64 +333,103 @@ class _SyncTextReader(SyncTextReader):
         iter_coroutine(self._core.close())
 
 
-def _reader_buffers(stdout: int, stderr: int) -> tuple[_TextBuffer | None, _TextBuffer | None]:
-    stdout_buffer = _TextBuffer() if stdout == subprocess.PIPE else None
-    if stderr == subprocess.STDOUT:
-        stderr_buffer = stdout_buffer
-    elif stderr == subprocess.PIPE:
-        stderr_buffer = _TextBuffer()
-    else:
-        stderr_buffer = None
-    return stdout_buffer, stderr_buffer
+def _destination(value: TextIO | int | None, inherited: TextIO) -> _TextDestination:
+    if value is None:
+        return inherited
+    if value == subprocess.PIPE:
+        return _TextBuffer()
+    if value == subprocess.DEVNULL:
+        return None
+    if isinstance(value, int):
+        raise ValueError(f"unsupported output destination: {value}")
+    return value
 
 
 def _cores(
     open_response: Callable[[], Awaitable[StreamingResponse]],
-    stdout: int,
-    stderr: int,
+    stdout: TextIO | int | None,
+    stderr: TextIO | int | None,
     lock: _PumpLock,
-) -> tuple[_ReaderCore | None, _ReaderCore | None]:
-    stdout_buffer, stderr_buffer = _reader_buffers(stdout, stderr)
-    if stdout_buffer is None and stderr_buffer is None:
-        return None, None
+) -> tuple[_TextTransportCore | None, _ReaderCore | None, _ReaderCore | None]:
+    stdout_destination = _destination(stdout, sys.stdout)
+    stderr_destination = (
+        stdout_destination if stderr == subprocess.STDOUT else _destination(stderr, sys.stderr)
+    )
+    if stdout_destination is None and stderr_destination is None:
+        return None, None, None
     transport = _TextTransportCore(
         open_response,
-        {ProcessLogStream.STDOUT: stdout_buffer, ProcessLogStream.STDERR: stderr_buffer},
+        {
+            ProcessLogStream.STDOUT: stdout_destination,
+            ProcessLogStream.STDERR: stderr_destination,
+        },
         lock,
     )
+    stdout_core = (
+        _ReaderCore(transport, stdout_destination)
+        if isinstance(stdout_destination, _TextBuffer)
+        else None
+    )
+    stderr_core = (
+        _ReaderCore(transport, stderr_destination)
+        if isinstance(stderr_destination, _TextBuffer)
+        and stderr_destination is not stdout_destination
+        else None
+    )
+    return transport, stdout_core, stderr_core
+
+
+def _text_transport_and_readers(
+    open_response: _OpenResponse,
+    *,
+    stdout: TextIO | int | None,
+    stderr: TextIO | int | None,
+) -> tuple[_TextTransportCore | None, TextReader | None, TextReader | None]:
+    transport, stdout_core, stderr_core = _cores(
+        _normalize_open_response(open_response), stdout, stderr, _AsyncPumpLock()
+    )
     return (
-        None if stdout_buffer is None else _ReaderCore(transport, stdout_buffer),
-        None
-        if stderr_buffer is None or stderr_buffer is stdout_buffer
-        else _ReaderCore(transport, stderr_buffer),
+        transport,
+        None if stdout_core is None else _TextReader(stdout_core),
+        None if stderr_core is None else _TextReader(stderr_core),
     )
 
 
 def _text_readers(
     open_response: _OpenResponse,
     *,
-    stdout: int = subprocess.PIPE,
-    stderr: int = subprocess.PIPE,
+    stdout: TextIO | int | None = subprocess.PIPE,
+    stderr: TextIO | int | None = subprocess.PIPE,
 ) -> tuple[TextReader | None, TextReader | None]:
-    stdout_core, stderr_core = _cores(
-        _normalize_open_response(open_response), stdout, stderr, _AsyncPumpLock()
+    _, stdout_reader, stderr_reader = _text_transport_and_readers(
+        open_response, stdout=stdout, stderr=stderr
+    )
+    return stdout_reader, stderr_reader
+
+
+def _sync_text_transport_and_readers(
+    open_response: _OpenResponse,
+    *,
+    stdout: TextIO | int | None,
+    stderr: TextIO | int | None,
+) -> tuple[_TextTransportCore | None, SyncTextReader | None, SyncTextReader | None]:
+    transport, stdout_core, stderr_core = _cores(
+        _normalize_open_response(open_response), stdout, stderr, _SyncPumpLock()
     )
     return (
-        None if stdout_core is None else _TextReader(stdout_core),
-        None if stderr_core is None else _TextReader(stderr_core),
+        transport,
+        None if stdout_core is None else _SyncTextReader(stdout_core),
+        None if stderr_core is None else _SyncTextReader(stderr_core),
     )
 
 
 def _sync_text_readers(
     open_response: _OpenResponse,
     *,
-    stdout: int = subprocess.PIPE,
-    stderr: int = subprocess.PIPE,
+    stdout: TextIO | int | None = subprocess.PIPE,
+    stderr: TextIO | int | None = subprocess.PIPE,
 ) -> tuple[SyncTextReader | None, SyncTextReader | None]:
-    stdout_core, stderr_core = _cores(
-        _normalize_open_response(open_response), stdout, stderr, _SyncPumpLock()
+    _, stdout_reader, stderr_reader = _sync_text_transport_and_readers(
+        open_response, stdout=stdout, stderr=stderr
     )
-    return (
-        None if stdout_core is None else _SyncTextReader(stdout_core),
-        None if stderr_core is None else _SyncTextReader(stderr_core),
-    )
+    return stdout_reader, stderr_reader

--- a/src/vercel-sandbox/vercel/sandbox/_internal/text_reader.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/text_reader.py
@@ -246,6 +246,7 @@ class _TextTransportCore:
                 if target is buffer:
                     self._routes[stream] = None
             if all(target is None for target in self._routes.values()):
+                self._eof = True
                 await self._cleanup()
         finally:
             self._lock.release()


### PR DESCRIPTION
Match `Popen` and `run_process` by inheriting output by default. Accept text streams so callers can stream directly without manually consuming readers. Drain the log transport before reporting completion so inherited streams receive all output and `PIPE` readers reach EOF reliably.