### PR TITLE
workflow: make sleep() interpret int/float as seconds, not ms

### DIFF
--- a/changes/vercel-workflow/numeric-duration-seconds.breaking.md
+++ b/changes/vercel-workflow/numeric-duration-seconds.breaking.md
@@ -1,0 +1,3 @@
+Make sleep() and retry delays treat numbers as seconds, not ms
+
+This matches Python standard library APIs.

--- a/src/vercel-workflow/README.md
+++ b/src/vercel-workflow/README.md
@@ -55,7 +55,7 @@ async def charge_customer(customer_id: str) -> None:
 ```
 
 `retry_after` accepts the same values `sleep()` accepts — `"10s"`, a number of
-milliseconds, a `datetime.timedelta`, or an absolute timezone-aware `datetime`
+seconds, a `datetime.timedelta`, or an absolute timezone-aware `datetime`
 — and defaults to one second. It changes when the next attempt runs, not how
 many attempts there are:
 a step that has used up its retries fails whichever error it raised.

--- a/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
@@ -51,12 +51,13 @@ def test_retry_after_defaults_to_a_second() -> None:
     "retry_after,expected",
     [
         ("10s", timedelta(seconds=10)),
-        (1_500, timedelta(milliseconds=1_500)),
+        (2, timedelta(seconds=2)),
+        (1.5, timedelta(seconds=1.5)),
         (timedelta(seconds=10), timedelta(seconds=10)),
     ],
 )
 def test_retry_after_takes_the_durations_sleep_takes(
-    retry_after: str | int | timedelta, expected: timedelta
+    retry_after: str | int | float | timedelta, expected: timedelta
 ) -> None:
     before = datetime.now(UTC)
     err = RetryableError("later", retry_after=retry_after)

--- a/src/vercel-workflow/vercel/workflow/_internal/duration.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/duration.py
@@ -47,7 +47,7 @@ def parse_duration_to_date(param: DurationParam) -> datetime:
     elif isinstance(param, (int, float)):
         if param < 0:
             raise RuntimeError(f"Duration parameter must be non-negative: {param}")
-        return datetime.now(UTC) + timedelta(milliseconds=param)
+        return datetime.now(UTC) + timedelta(seconds=param)
 
     elif isinstance(param, timedelta):
         if param < timedelta(0):

--- a/src/vercel-workflow/vercel/workflow/_internal/errors.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/errors.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .duration import DurationParam, parse_duration_to_date
 
-DEFAULT_RETRY_AFTER_MS = 1_000
+DEFAULT_RETRY_AFTER_SECONDS = 1
 
 
 class FatalError(Exception):
@@ -44,7 +44,7 @@ class RetryableError(Exception):
         raise RetryableError("rate limited", retry_after="10s")
 
     ``retry_after`` accepts the same values ``sleep()`` accepts: a duration
-    string, a number of milliseconds, a ``timedelta``, or an absolute
+    string, a number of seconds, a ``timedelta``, or an absolute
     timezone-aware ``datetime``. It defaults to one second from now, as ``RetryableError``
     in ``@workflow/errors`` does.
 
@@ -64,7 +64,7 @@ class RetryableError(Exception):
     ) -> None:
         super().__init__(message)
         if retry_after is None:
-            retry_after = DEFAULT_RETRY_AFTER_MS
+            retry_after = DEFAULT_RETRY_AFTER_SECONDS
         self.retry_at = parse_duration_to_date(retry_after)
 
 


### PR DESCRIPTION
This is standard for Python APIs.

This is a breaking change. We will regret it if we don't do it, though.
