### PR TITLE
workflow: fail more reliably on nondeterminism errors

### DIFF
--- a/changes/vercel-workflow/unsuppressable-nondeterminism.bugfix.md
+++ b/changes/vercel-workflow/unsuppressable-nondeterminism.bugfix.md
@@ -1,0 +1,4 @@
+More reliably fail runs whose replay diverges from the event log.
+
+Runs will now fail even in the case where the main thread of execution
+is not directly blocked on the suspension that is erroring.

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -320,8 +320,8 @@ async def test_nondeterminism_fails_the_run() -> None:
 
     # The error is raised out of the body's own await, so its traceback shows
     # where in the workflow the divergence happened.
-    frames = traceback.extract_tb(excinfo.value.__traceback__)
-    assert any(frame.name == "_diverging" for frame in frames)
+    formatted_traceback = "".join(traceback.format_exception(excinfo.value))
+    assert 'return await _record(name="b")' in formatted_traceback
 
 
 async def test_nondeterminism_cannot_be_suppressed_by_the_body() -> None:
@@ -331,17 +331,6 @@ async def test_nondeterminism_cannot_be_suppressed_by_the_body() -> None:
 
     with pytest.raises(runtime.NondeterminismError):
         ctx.run_workflow(_running_run(_suppressing.workflow_id))
-
-
-async def test_nondeterminism_surfaced_by_the_body_wins() -> None:
-    """A body that lets (or re-raises) the divergence error out keeps its own
-    instance -- and with it the traceback -- over the stashed one."""
-    ctx = runtime.WorkflowOrchestratorContext(
-        _diverged_log(), run_id="wrun_test", seed="wrun_test", started_at=0, registry=_run_registry
-    )
-
-    with pytest.raises(runtime.NondeterminismError, match="surfaced by the body"):
-        ctx.run_workflow(_running_run(_reraising.workflow_id))
 
 
 # --- now(): deterministic clock anchored to replay progress, not list tail ------

--- a/src/vercel-workflow/tests/unit/test_workflow_determinism.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_determinism.py
@@ -7,6 +7,7 @@ loudly rather than silently returning the wrong value.
 """
 
 import asyncio
+import traceback
 from datetime import datetime, timezone
 from typing import Any
 
@@ -47,6 +48,22 @@ def _suspension(correlation_id: str, args: bytes) -> runtime.Suspension:
     return runtime.Suspension(correlation_id=correlation_id, step=core.Step(_greet), input=args)
 
 
+def _resume_isolated(ctx: runtime.WorkflowOrchestratorContext) -> None:
+    """One resume() pass in a throwaway loop.
+
+    A nondeterminism failure suspends the run, which cancels every task in the
+    running loop -- including the test's own task, were resume() called in it.
+    """
+
+    async def body() -> None:
+        ctx.resume()
+
+    try:
+        runtime._run_isolated(body(), loop_factory=asyncio.new_event_loop)
+    except asyncio.CancelledError:
+        pass
+
+
 async def test_reordered_step_args_raise_nondeterminism() -> None:
     """Recorded step input "a" but the body now calls the same step with "b"
     on replay -> NondeterminismError."""
@@ -59,10 +76,14 @@ async def test_reordered_step_args_raise_nondeterminism() -> None:
     sus = _suspension(cid, _args(name="b"))
     ctx.suspensions[cid] = sus
 
-    ctx.resume()
+    _resume_isolated(ctx)
 
     assert sus.future.done()
     assert isinstance(sus.future.exception(), runtime.NondeterminismError)
+    # Stashed for run_workflow() to raise, and the run is suspended, so the
+    # failure holds even if the body never awaits (or catches) the future.
+    assert ctx.resume_exception is sus.future.exception()
+    assert ctx.suspended
 
 
 async def test_wait_step_swap_raises_nondeterminism() -> None:
@@ -83,10 +104,12 @@ async def test_wait_step_swap_raises_nondeterminism() -> None:
     )
     ctx.suspensions["wait_1"] = wait
 
-    ctx.resume()
+    _resume_isolated(ctx)
 
     assert wait.future.done()
     assert isinstance(wait.future.exception(), runtime.NondeterminismError)
+    assert ctx.resume_exception is wait.future.exception()
+    assert ctx.suspended
 
 
 async def test_created_event_without_suspension_raises_runtime_error() -> None:
@@ -226,6 +249,99 @@ async def test_idle_resume_parks_when_nothing_to_deliver() -> None:
     assert ctx.suspended
     assert sus1.has_created_event
     assert not sus1.future.done()
+
+
+# --- nondeterminism fails the run whatever the body does -------------------------
+#
+# Failing the diverged suspension's future is not enough on its own: the body
+# may not be blocked on that future, and even when it is, user code can catch
+# the error. run_workflow() must fail the run either way.
+
+_run_registry = core.Workflows(as_vercel_job=False)
+
+
+@_run_registry.step
+async def _record(*, name: str) -> str:
+    return name
+
+
+@_run_registry.workflow
+async def _diverging() -> str:
+    return await _record(name="b")
+
+
+@_run_registry.workflow
+async def _suppressing() -> str:
+    try:
+        return await _record(name="b")
+    except BaseException:  # noqa: B036
+        return "swallowed"
+
+
+@_run_registry.workflow
+async def _reraising() -> str:
+    try:
+        return await _record(name="b")
+    except BaseException:  # noqa: B036
+        raise runtime.NondeterminismError("surfaced by the body") from None
+
+
+def _running_run(workflow_id: str) -> w.WorkflowRun:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return w.NonFinalWorkflowRun(
+        run_id="wrun_test",
+        status="running",
+        deployment_id="",
+        workflow_name=workflow_id,
+        input=ser.dehydrate(ser.argument_array((), {})),
+        created_at=now,
+        updated_at=now,
+        started_at=now,
+    )
+
+
+def _diverged_log() -> list[w.Event]:
+    """A recorded first step whose input differs from what the body issues.
+
+    The probe context shares the run's seed, so its first ULID is the one the
+    body's first call will be assigned.
+    """
+    cid = f"step_{_context([]).generate_ulid()}"
+    return [w.StepCreatedEventData(step_name=_record.name, input=_args(name="a")).into_event(cid)]
+
+
+async def test_nondeterminism_fails_the_run() -> None:
+    ctx = runtime.WorkflowOrchestratorContext(
+        _diverged_log(), run_id="wrun_test", seed="wrun_test", started_at=0, registry=_run_registry
+    )
+
+    with pytest.raises(runtime.NondeterminismError) as excinfo:
+        ctx.run_workflow(_running_run(_diverging.workflow_id))
+
+    # The error is raised out of the body's own await, so its traceback shows
+    # where in the workflow the divergence happened.
+    frames = traceback.extract_tb(excinfo.value.__traceback__)
+    assert any(frame.name == "_diverging" for frame in frames)
+
+
+async def test_nondeterminism_cannot_be_suppressed_by_the_body() -> None:
+    ctx = runtime.WorkflowOrchestratorContext(
+        _diverged_log(), run_id="wrun_test", seed="wrun_test", started_at=0, registry=_run_registry
+    )
+
+    with pytest.raises(runtime.NondeterminismError):
+        ctx.run_workflow(_running_run(_suppressing.workflow_id))
+
+
+async def test_nondeterminism_surfaced_by_the_body_wins() -> None:
+    """A body that lets (or re-raises) the divergence error out keeps its own
+    instance -- and with it the traceback -- over the stashed one."""
+    ctx = runtime.WorkflowOrchestratorContext(
+        _diverged_log(), run_id="wrun_test", seed="wrun_test", started_at=0, registry=_run_registry
+    )
+
+    with pytest.raises(runtime.NondeterminismError, match="surfaced by the body"):
+        ctx.run_workflow(_running_run(_reraising.workflow_id))
 
 
 # --- now(): deterministic clock anchored to replay progress, not list tail ------

--- a/src/vercel-workflow/vercel/workflow/_internal/loop.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/loop.py
@@ -76,7 +76,6 @@ class WorkflowLoop(asyncio.BaseEventLoop):
                     }
                 )
                 # Signal anyway, to avoid some weird hangs.
-                # TODO: More decisive failures on this case.
                 self._ready.append(timer)
             else:
                 self._ready.append(timer)

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -659,6 +659,9 @@ class WorkflowOrchestratorContext:
         self.registry = registry
 
         self.suspended = False
+        # An error the run must fail with regardless of what the body does;
+        # raised by run_workflow(). See _fail_nondeterminism.
+        self.resume_exception: Exception | None = None
 
     @classmethod
     def current(cls) -> Self:
@@ -697,6 +700,19 @@ class WorkflowOrchestratorContext:
         self.suspended = True
         # Close down the tasks
         for task in asyncio.all_tasks(asyncio.get_event_loop()):
+            # If the task is blocked on a future that has already
+            # finished with an exception, skip cancelling it.
+            #
+            # The goal here is to give the raised-on-a-task version of
+            # resume_exception a chance to bring down the workflow
+            # itself, so that the final exception has a useful
+            # traceback.
+            # If it doesn't work, the task will get cancelled the
+            # next time through the resume() loop.
+            fut: asyncio.Future[object] | None = task._fut_waiter  # type: ignore[attr-defined]
+            if fut and fut.done() and not fut.cancelled() and fut.exception():
+                continue
+
             task.cancel()
 
     def run_workflow(self: Self, workflow_run: w.WorkflowRun) -> bytes | None:
@@ -741,6 +757,12 @@ class WorkflowOrchestratorContext:
                     )
                 )
             except BaseException as ex:
+                if self.resume_exception is not None:
+                    # If the body surfaced the error itself, keep its
+                    # traceback.
+                    if type(ex) is type(self.resume_exception):
+                        raise
+                    raise self.resume_exception from None
                 # Turn suspended into a None return regardless of what the
                 # task actually did with it.
                 if self.suspended:
@@ -750,6 +772,8 @@ class WorkflowOrchestratorContext:
                 else:
                     raise
             else:
+                if self.resume_exception is not None:
+                    raise self.resume_exception
                 if self.suspended:
                     return None
             finally:
@@ -848,11 +872,7 @@ class WorkflowOrchestratorContext:
         self.suspensions.pop(correlation_id, None)
 
     def _fail_suspension(self, sus: BaseSuspension, exc: Exception) -> None:
-        """Surface ``exc`` on whichever future(s) a suspension is awaiting.
-
-        The error propagates through the body's ``await`` of the step/wait/hook,
-        out of ``run_workflow``, and into the run-failed path.
-        """
+        """Surface ``exc`` on whichever future(s) a suspension is awaiting."""
         if isinstance(sus, Hook):
             while sus.futures:
                 fut = sus.futures.popleft()
@@ -860,6 +880,19 @@ class WorkflowOrchestratorContext:
                     fut.set_exception(exc)
         elif isinstance(sus, (Suspension, Wait, Attributes)) and not sus.future.done():
             sus.future.set_exception(exc)
+
+    def _fail_nondeterminism(self, sus: BaseSuspension, exc: Exception) -> None:
+        """Fail the run with a replay-divergence error the body cannot suppress.
+
+        The diverged suspension may not be what the body is currently blocked
+        on, so failing its future alone might never surface anywhere -- and a
+        body that is awaiting it could catch the error. So the exception is
+        also stashed for ``run_workflow`` to raise, and the run is suspended
+        so nothing else executes.
+        """
+        self._fail_suspension(sus, exc)
+        self.resume_exception = exc
+        self.suspend()
 
     def resume(self) -> None:
         """Run over the the event log and try to apply an event.
@@ -877,6 +910,13 @@ class WorkflowOrchestratorContext:
 
         If the event log is exhausted, suspend the workflow.
         """
+
+        # Once suspended, replaying further events could only deliver results
+        # onto failed or cancelled futures. Just keep cancelling whatever the
+        # body is still running until the loop winds down.
+        if self.suspended:
+            self.suspend()
+            return
 
         # NOTE: resume() does single-step delivery, so we resolve at most
         # one suspension per invocation of resume().
@@ -925,7 +965,7 @@ class WorkflowOrchestratorContext:
                         pos = _correlation_ulid(slot_id)
                         for sus in self.suspensions.values():
                             if _correlation_ulid(sus.correlation_id) == pos:
-                                self._fail_suspension(
+                                self._fail_nondeterminism(
                                     sus,
                                     NondeterminismError(
                                         f"workflow replay diverged at position {pos}: recorded a "
@@ -963,7 +1003,7 @@ class WorkflowOrchestratorContext:
                 # the same call the body just issued; a mismatch means the body
                 # is non-deterministic.
                 if sus.step.name != name or sus.input != recorded_input:
-                    self._fail_suspension(
+                    self._fail_nondeterminism(
                         sus,
                         NondeterminismError(
                             f"workflow replay diverged at {event.correlation_id}: recorded "
@@ -984,7 +1024,7 @@ class WorkflowOrchestratorContext:
                 attr_sus = self.suspensions.pop(attr_id)
                 assert isinstance(attr_sus, Attributes)
                 if recorded_changes != attr_sus.changes:
-                    self._fail_suspension(
+                    self._fail_nondeterminism(
                         attr_sus,
                         NondeterminismError(
                             f"workflow replay diverged at {attr_id}: recorded attributes "

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -703,10 +703,10 @@ class WorkflowOrchestratorContext:
             # If the task is blocked on a future that has already
             # finished with an exception, skip cancelling it.
             #
-            # The goal here is to give the raised-on-a-task version of
-            # resume_exception a chance to bring down the workflow
-            # itself, so that the final exception has a useful
-            # traceback.
+            # The goal here is to give resume_exception a chance to
+            # bring down the workflow itself, so that a useful
+            # traceback gets attached to it.
+            #
             # If it doesn't work, the task will get cancelled the
             # next time through the resume() loop.
             fut: asyncio.Future[object] | None = task._fut_waiter  # type: ignore[attr-defined]
@@ -758,10 +758,9 @@ class WorkflowOrchestratorContext:
                 )
             except BaseException as ex:
                 if self.resume_exception is not None:
-                    # If the body surfaced the error itself, keep its
-                    # traceback.
-                    if type(ex) is type(self.resume_exception):
-                        raise
+                    # Since resume_exception actually got raised on a
+                    # future, hopefully it has picked up a useful
+                    # traceback!
                     raise self.resume_exception from None
                 # Turn suspended into a None return regardless of what the
                 # task actually did with it.


### PR DESCRIPTION
We need to make sure that a nondeterminism error terminates the run
promptly, even if the application swallows it or is not directly
waiting on it.

Do this by:
 - Stashing the error in the workflow context
 - Suspending the task
 - Raising the error as a top priority once the workflow task stops
 - Some extra cleverness to preserve the real traceback in the common
   case where the exception *did* get raised without trouble.
