### PR TITLE
workflow: add opt-in cancellable steps

### DIFF
--- a/changes/vercel-workflow/cancellable-steps.feature.md
+++ b/changes/vercel-workflow/cancellable-steps.feature.md
@@ -1,0 +1,13 @@
+Add opt-in cancellable steps: `@workflows.step(cancellable=True)`.
+
+When `cancel()` is called on a cancellable step, we send a message on
+a stream that the step will listen for. If it gets a message, it will
+exit.
+
+Note that like regular asyncio tasks, `cancel()` does not cause the
+step to immediately become "cancelled". Waiting on it will still wait
+for the step to actually terminate.
+
+If there are still cancellable steps running when a workflow function
+completes, they will be cancelled and the workflow will wait for them
+to finish before terminating.

--- a/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
@@ -15,6 +15,7 @@ way out.
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar
 
@@ -339,6 +340,10 @@ async def test_throttled_cancellation_signal_is_not_recorded(tmp_path, monkeypat
     assert len(_of_type(await _events(world, run_id), w.HookReceivedEvent)) == 1
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 10),
+    reason="Python 3.10 drops CancelledError messages propagated through tasks",
+)
 async def test_cancelled_step_shuts_down_and_body_gets_its_error(tmp_path, monkeypatch) -> None:
     world = _world(tmp_path, monkeypatch)
     run_id = await _create_run(world, cancel_and_wait.workflow_id)

--- a/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
@@ -1,0 +1,597 @@
+"""Cancellable steps.
+
+Cancelling the task awaiting a step declared ``cancellable=True`` does not
+cancel the await: like ``Task.cancel()``, it is a request. The orchestrator
+records it as a system hook -- ``hook_created`` with an ``abrt_<step-ulid>``
+token, then ``hook_received`` -- and writes one chunk to a
+``strm_<step-ulid>_system_abort`` control stream that the running step listens
+on. The step shuts down with a fatal ``step_failed``, and the awaiting body
+receives that error (or the step's result, if it finished first). Replaying
+the ``hook_received`` clears the pending cancellation so nothing is re-sent,
+and a body that exits with a cancellable step still pending cancels it on the
+way out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any, TypeVar
+
+import pytest
+
+from vercel.workflow._internal import (
+    core,
+    errors,
+    runtime,
+    serialization as ser,
+    streams,
+    world as w,
+)
+from vercel.workflow._internal.worlds import local as local_mod
+
+registry = core.Workflows(as_vercel_job=False)
+
+
+# What slow_step's CancelledError carried; steps run outside the sandbox, so
+# the module state is shared with the test.
+_cancel_messages: list[str | None] = []
+
+
+@registry.step(cancellable=True)
+async def slow_step() -> str:
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError as e:
+        _cancel_messages.append(str(e.args[0]) if e.args else None)
+        raise
+    return "never"
+
+
+@registry.step
+async def quick_step() -> str:
+    return "quick"
+
+
+@registry.step
+async def second_step() -> str:
+    return "second"
+
+
+@registry.step(cancellable=True)
+async def uncancelled_step() -> str:
+    return "ran"
+
+
+@registry.step(cancellable=True)
+async def stubborn_step() -> str:
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        return "survived"
+    return "never"
+
+
+async def _cancel_slow_after_quick() -> str:
+    """Cancel the slow step after the quick one, then await its real outcome."""
+    slow = asyncio.ensure_future(slow_step())
+    first = await quick_step()
+    slow.cancel("no longer needed")
+    try:
+        outcome = await slow
+    except asyncio.CancelledError as e:
+        # The step's recorded death from our cancel arrives as a genuine
+        # CancelledError, so it composes with normal asyncio idioms.
+        outcome = f"cancelled: {e.args[0] if e.args else ''}"
+    return f"{first}+{outcome}"
+
+
+@registry.workflow
+async def cancel_and_wait() -> str:
+    first = await _cancel_slow_after_quick()
+    second = await second_step()
+    return f"{first}:{second}"
+
+
+@registry.workflow
+async def cancel_and_return() -> str:
+    slow = asyncio.ensure_future(slow_step())
+    first = await quick_step()
+    slow.cancel("no longer needed")
+    return first
+
+
+@registry.workflow
+async def abandon_step() -> str:
+    asyncio.ensure_future(slow_step())
+    return await quick_step()
+
+
+@registry.workflow
+async def cancel_twice() -> str:
+    slow = asyncio.ensure_future(slow_step())
+    first = await quick_step()
+    slow.cancel("first request")
+    second = await second_step()
+    slow.cancel("second request")
+    try:
+        outcome = await slow
+    except Exception as e:
+        outcome = str(e)
+    return f"{first}:{second}:{outcome}"
+
+
+async def _await_shielded() -> str:
+    return await asyncio.shield(slow_step())
+
+
+@registry.workflow
+async def cancel_shielded() -> str:
+    wrapper = asyncio.ensure_future(_await_shielded())
+    first = await quick_step()
+    wrapper.cancel()
+    second = await second_step()
+    return f"{first}:{second}"
+
+
+@registry.workflow
+async def cancel_stubborn() -> str:
+    stubborn = asyncio.ensure_future(stubborn_step())
+    first = await quick_step()
+    stubborn.cancel("please stop")
+    outcome = await stubborn
+    return f"{first}:{outcome}"
+
+
+@registry.workflow
+async def run_cancellable() -> str:
+    return await uncancelled_step()
+
+
+class RecordingLocalWorld(local_mod.LocalWorld):
+    def __init__(self) -> None:
+        super().__init__()
+        self.queued: list[tuple[str, w.QueuePayload]] = []
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        self.queued.append((queue_name, message))
+        return "msg_test"
+
+
+def _world(tmp_path, monkeypatch) -> RecordingLocalWorld:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = RecordingLocalWorld()
+    w.set_world(world)
+    return world
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+async def _create_run(world: local_mod.LocalWorld, workflow_name: str) -> str:
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deployment_id="",
+            workflow_name=workflow_name,
+            input=ser.dehydrate(ser.argument_array((), {})),
+        ).into_event(),
+    )
+    assert result.run is not None
+    return result.run.run_id
+
+
+async def _invoke(run_id: str, workflow_name: str) -> w.QueueContinuation | None:
+    return await runtime.workflow_handler(
+        w.WorkflowInvokePayload(run_id=run_id).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(workflow_name),
+        message_id="msg_1",
+        registry=registry,
+    )
+
+
+async def _invoke_step(
+    payload: w.WorkflowInvokePayload, workflow_name: str
+) -> w.QueueContinuation | None:
+    return await runtime.workflow_handler(
+        payload.model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(workflow_name),
+        message_id="msg_2",
+        registry=registry,
+    )
+
+
+def _queued_step(world: RecordingLocalWorld, step_name: str) -> w.WorkflowInvokePayload:
+    for _, payload in world.queued:
+        if isinstance(payload, w.WorkflowInvokePayload) and payload.step_name == step_name:
+            return payload
+    raise AssertionError(f"no queued invocation for step {step_name!r}")
+
+
+async def _events(world: local_mod.LocalWorld, run_id: str) -> list[w.Event]:
+    return (await world.events_list(run_id)).data
+
+
+E = TypeVar("E", bound=w.BaseEvent)
+
+
+def _of_type(events: list[w.Event], event_cls: type[E]) -> list[E]:
+    return [e for e in events if isinstance(e, event_cls)]
+
+
+async def test_cancellation_records_hook_and_signals_stream(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    # Pass 1: both steps issued, nothing cancelled yet. The suspension pass
+    # cancels the body's tasks itself; that must not read as a user cancel.
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    events = await _events(world, run_id)
+    assert not _of_type(events, w.HookCreatedEvent)
+    slow_payload = _queued_step(world, slow_step.name)
+    assert slow_payload.step_id is not None
+
+    # Complete the quick step, then pass 2: the body cancels the slow step and
+    # keeps awaiting it; the cancellation is recorded and signalled.
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+
+    events = await _events(world, run_id)
+    (created,) = _of_type(events, w.HookCreatedEvent)
+    (received,) = _of_type(events, w.HookReceivedEvent)
+    step_ulid = slow_payload.step_id.split("_", 1)[1]
+    assert created.event_data.token == f"abrt_{step_ulid}"
+    assert created.event_data.is_system is True
+    assert received.correlation_id == created.correlation_id
+    assert received.event_data.token == created.event_data.token
+    payload = ser.hydrate(received.event_data.payload, what="the cancellation payload")
+    assert payload == {"aborted": True, "reason": "no longer needed"}
+
+    stream_name = runtime._abort_stream_name(slow_payload.step_id)
+    info = await world.streams_get_info(run_id, stream_name)
+    assert info.done
+    assert info.tail_index == 0
+
+
+async def test_redelivery_does_not_resend_the_cancellation(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    # A redelivered invoke replays the recorded hook_received, which clears
+    # the pending cancellation instead of re-sending it.
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookCreatedEvent)) == 1
+    assert len(_of_type(events, w.HookReceivedEvent)) == 1
+
+
+class _FlakyStreamWorld(RecordingLocalWorld):
+    fail_stream_writes = 0
+    stream_write_status = 503
+
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        if self.fail_stream_writes:
+            self.fail_stream_writes -= 1
+            if self.stream_write_status == 429:
+                raise w.ThrottleError("stream write throttled", status=429)
+            raise w.WorkflowWorldError("stream write lost", status=self.stream_write_status)
+        await super().streams_write(run_id, name, chunk)
+
+
+async def test_lost_cancellation_signal_fails_the_pass_and_is_retried(
+    tmp_path, monkeypatch
+) -> None:
+    """The stream packet is the only way a running step learns of the
+    cancellation, so losing it must fail the pass -- and, since nothing
+    durable was recorded yet, the redelivered pass re-sends everything."""
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = _FlakyStreamWorld()
+    w.set_world(world)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+
+    world.fail_stream_writes = 1
+    with pytest.raises(Exception) as excinfo:
+        await _invoke(run_id, cancel_and_wait.workflow_id)
+    assert "stream write lost" in repr(excinfo.value)
+    events = await _events(world, run_id)
+    assert not _of_type(events, w.HookReceivedEvent)
+
+    # The redelivered pass sends the signal and the events.
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookReceivedEvent)) == 1
+    slow_payload = _queued_step(world, slow_step.name)
+    assert slow_payload.step_id is not None
+    info = await world.streams_get_info(run_id, runtime._abort_stream_name(slow_payload.step_id))
+    assert info.done
+
+
+async def test_throttled_cancellation_signal_is_not_recorded(tmp_path, monkeypatch) -> None:
+    """A rejected append must leave cancellation pending for redelivery."""
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = _FlakyStreamWorld()
+    w.set_world(world)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+
+    world.fail_stream_writes = 1
+    world.stream_write_status = 429
+    with pytest.raises(Exception) as excinfo:
+        await _invoke(run_id, cancel_and_wait.workflow_id)
+    assert "stream write throttled" in repr(excinfo.value)
+    assert not _of_type(await _events(world, run_id), w.HookReceivedEvent)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    assert len(_of_type(await _events(world, run_id), w.HookReceivedEvent)) == 1
+
+
+async def test_cancelled_step_shuts_down_and_body_gets_its_error(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+
+    # The slow step would run for an hour; the abort-stream listener kills it.
+    _cancel_messages.clear()
+    slow_payload = _queued_step(world, slow_step.name)
+    continuation = await _invoke_step(slow_payload, cancel_and_wait.workflow_id)
+
+    assert continuation is None  # failed fatally, not queued for retry
+    # The step function itself saw the body's message on its CancelledError.
+    assert _cancel_messages == ["no longer needed"]
+    events = await _events(world, run_id)
+    assert not _of_type(events, w.StepRetryingEvent)
+    (failed,) = _of_type(events, w.StepFailedEvent)
+    assert failed.correlation_id == slow_payload.step_id
+    assert "no longer needed" in str(failed.event_data.error)
+
+    # The body was still awaiting the cancelled step, so it receives the
+    # step's actual fatal error (not a CancelledError) and carries on.
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, second_step.name), cancel_and_wait.workflow_id)
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    assert (await world.runs_get(run_id)).status == "completed"
+    # The body's own cancel message comes back verbatim on the CancelledError.
+    assert await runtime.Run(run_id).return_value() == "quick+cancelled: no longer needed:second"
+
+
+async def test_body_exit_with_cancelled_step_waits_for_it(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_and_return.workflow_id)
+
+    await _invoke(run_id, cancel_and_return.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_return.workflow_id)
+    # Pass 2: the body cancels the slow step and returns without awaiting it.
+    # The run does not complete yet: the cancellation is sent and the run
+    # suspends until the step has actually finished.
+    await _invoke(run_id, cancel_and_return.workflow_id)
+
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookReceivedEvent)) == 1
+    assert (await world.runs_get(run_id)).status == "running"
+    slow_payload = _queued_step(world, slow_step.name)
+    assert slow_payload.step_id is not None
+    info = await world.streams_get_info(run_id, runtime._abort_stream_name(slow_payload.step_id))
+    assert info.done
+
+    # The step dies from the signal; only then does the run complete.
+    await _invoke_step(slow_payload, cancel_and_return.workflow_id)
+    await _invoke(run_id, cancel_and_return.workflow_id)
+    events = await _events(world, run_id)
+    types = [e.event_type for e in events]
+    assert types.index("step_failed") < types.index("run_completed")
+    assert await runtime.Run(run_id).return_value() == "quick"
+
+
+async def test_body_exit_with_outstanding_step_cancels_and_waits(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, abandon_step.workflow_id)
+
+    await _invoke(run_id, abandon_step.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), abandon_step.workflow_id)
+    # Pass 2: the body returns while the slow step is still pending; the exit
+    # itself cancels it (with no message) and the run suspends.
+    await _invoke(run_id, abandon_step.workflow_id)
+
+    events = await _events(world, run_id)
+    (received,) = _of_type(events, w.HookReceivedEvent)
+    payload = ser.hydrate(received.event_data.payload, what="the cancellation payload")
+    assert payload == {"aborted": True, "reason": None}
+    assert (await world.runs_get(run_id)).status == "running"
+
+    slow_payload = _queued_step(world, slow_step.name)
+    await _invoke_step(slow_payload, abandon_step.workflow_id)
+    await _invoke(run_id, abandon_step.workflow_id)
+    events = await _events(world, run_id)
+    (failed,) = _of_type(events, w.StepFailedEvent)
+    assert "step cancelled by its workflow" in str(failed.event_data.error)
+    assert await runtime.Run(run_id).return_value() == "quick"
+
+
+async def test_repeat_cancel_is_a_no_op(tmp_path, monkeypatch) -> None:
+    """A step is cancelled at most once: a second cancel() -- even after the
+    recorded cancellation has replayed -- sends nothing new. It could not
+    reach the step anyway; the abort stream is closed and its listener gone."""
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_twice.workflow_id)
+
+    await _invoke(run_id, cancel_twice.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_twice.workflow_id)
+    # Pass 2: the first cancel is recorded and sent.
+    await _invoke(run_id, cancel_twice.workflow_id)
+    await _invoke_step(_queued_step(world, second_step.name), cancel_twice.workflow_id)
+    # Pass 3: replay clears the first request, then the body cancels again.
+    await _invoke(run_id, cancel_twice.workflow_id)
+
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookCreatedEvent)) == 1
+    (received,) = _of_type(events, w.HookReceivedEvent)
+    payload = ser.hydrate(received.event_data.payload, what="the cancellation payload")
+    assert payload == {"aborted": True, "reason": "first request"}
+
+
+async def test_shield_defers_cancellation_to_body_exit(tmp_path, monkeypatch) -> None:
+    """Cancelling a task that awaits ``shield(step)`` kills the wrapper, not
+    the step -- plain asyncio semantics. Only the body's exit, which cancels
+    every leftover task the way asyncio.run() does, reaches the step itself."""
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_shielded.workflow_id)
+
+    await _invoke(run_id, cancel_shielded.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_shielded.workflow_id)
+    # Pass 2: the body cancels the shield wrapper and suspends on second_step;
+    # the shielded slow step is NOT cancelled.
+    await _invoke(run_id, cancel_shielded.workflow_id)
+    events = await _events(world, run_id)
+    assert not _of_type(events, w.HookCreatedEvent)
+
+    # Pass 3: the body exits with the shielded step still pending -- now it is
+    # cancelled, and the run waits for it.
+    await _invoke_step(_queued_step(world, second_step.name), cancel_shielded.workflow_id)
+    await _invoke(run_id, cancel_shielded.workflow_id)
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookReceivedEvent)) == 1
+    assert (await world.runs_get(run_id)).status == "running"
+
+    await _invoke_step(_queued_step(world, slow_step.name), cancel_shielded.workflow_id)
+    await _invoke(run_id, cancel_shielded.workflow_id)
+    assert await runtime.Run(run_id).return_value() == "quick:second"
+
+
+async def test_step_that_survives_cancellation_keeps_its_result(tmp_path, monkeypatch) -> None:
+    """A step that catches the cancellation and returns anyway completes with
+    that value, and the awaiting body receives it -- the cancel was only ever
+    a request."""
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, cancel_stubborn.workflow_id)
+
+    await _invoke(run_id, cancel_stubborn.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_stubborn.workflow_id)
+    await _invoke(run_id, cancel_stubborn.workflow_id)
+    await _invoke_step(_queued_step(world, stubborn_step.name), cancel_stubborn.workflow_id)
+    await _invoke(run_id, cancel_stubborn.workflow_id)
+
+    events = await _events(world, run_id)
+    assert len(_of_type(events, w.HookReceivedEvent)) == 1  # the cancel was sent
+    assert not _of_type(events, w.StepFailedEvent)
+    assert len(_of_type(events, w.StepCompletedEvent)) == 2
+    assert await runtime.Run(run_id).return_value() == "quick:survived"
+
+
+async def test_uncancelled_cancellable_step_runs_normally(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    run_id = await _create_run(world, run_cancellable.workflow_id)
+
+    await _invoke(run_id, run_cancellable.workflow_id)
+    # The listener finds no abort chunk and is torn down when the step
+    # finishes; the step completes as usual.
+    await _invoke_step(_queued_step(world, uncancelled_step.name), run_cancellable.workflow_id)
+    await _invoke(run_id, run_cancellable.workflow_id)
+
+    events = await _events(world, run_id)
+    assert not _of_type(events, w.HookCreatedEvent)
+    assert len(_of_type(events, w.StepCompletedEvent)) == 1
+    assert await runtime.Run(run_id).return_value() == "ran"
+
+
+class _AbortListenerWorld:
+    def __init__(self, reason: str, *, break_once: bool = False, split: bool = False) -> None:
+        payload = ser.dehydrate({"aborted": True, "reason": reason})
+        self.wire = streams.encode_frame(payload)
+        self.break_once = break_once
+        self.split = split
+        self.reads: list[int | None] = []
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncGenerator[bytes, None]:
+        self.reads.append(start_index)
+        should_break = self.break_once
+        self.break_once = False
+        return self._serve(should_break)
+
+    async def _serve(self, should_break: bool) -> AsyncGenerator[bytes, None]:
+        if should_break:
+            yield self.wire[:3]
+            raise w.WorkflowWorldError("live read expired", status=500)
+        if self.split:
+            yield self.wire[:2]
+            yield self.wire[2:7]
+            yield self.wire[7:]
+        else:
+            yield self.wire
+
+
+async def _run_abort_listener(world: _AbortListenerWorld, reason: str) -> None:
+    async def waits_forever() -> None:
+        await asyncio.sleep(3600)
+
+    step = core.Step(waits_forever, cancellable=True)
+    with pytest.raises(errors.StepCancelledError, match=reason):
+        await runtime._run_cancellable_step(
+            step,
+            (),
+            {},
+            world=world,  # type: ignore[arg-type]
+            run_id="wrun_test",
+            step_id="step_01M1329YCHWS235PHTPW377KZM",
+        )
+
+
+async def test_abort_listener_reconnects_after_live_read_failure() -> None:
+    reason = "delivered after reconnect"
+    world = _AbortListenerWorld(reason, break_once=True)
+
+    await _run_abort_listener(world, reason)
+
+    assert world.reads == [0, 0]
+
+
+async def test_abort_listener_reassembles_transport_fragments() -> None:
+    reason = "complete fragmented reason"
+    world = _AbortListenerWorld(reason, split=True)
+
+    await _run_abort_listener(world, reason)
+
+
+class _OpenAbortListenerWorld:
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncGenerator[bytes, None]:
+        return self._serve()
+
+    async def _serve(self) -> AsyncGenerator[bytes, None]:
+        await asyncio.sleep(3600)
+        yield b"unreachable"
+
+
+async def test_cancellable_step_error_is_not_wrapped_in_exception_group() -> None:
+    async def fails() -> None:
+        raise LookupError("plain step failure")
+
+    step = core.Step(fails, cancellable=True)
+    with pytest.raises(LookupError, match="plain step failure"):
+        await runtime._run_cancellable_step(
+            step,
+            (),
+            {},
+            world=_OpenAbortListenerWorld(),  # type: ignore[arg-type]
+            run_id="wrun_test",
+            step_id="step_01M1329YCHWS235PHTPW377KZM",
+        )

--- a/src/vercel-workflow/vercel/workflow/_internal/core.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/core.py
@@ -131,11 +131,16 @@ class Workflow(Generic[P, T]):
 
 class Step(Generic[P, T]):
     def __init__(
-        self, func: Callable[P, Coroutine[Any, Any, T]], *, max_retries: int = DEFAULT_MAX_RETRIES
+        self,
+        func: Callable[P, Coroutine[Any, Any, T]],
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        cancellable: bool = False,
     ):
         self.func = func
         self.name = f"step//{func.__module__}//{func.__qualname__}"
         self.max_retries = max_retries
+        self.cancellable = cancellable
         self._signature = inspect.signature(func)
         functools.update_wrapper(self, func)
         # After update_wrapper, which copies the wrapped function's __dict__
@@ -379,7 +384,7 @@ class Workflows:
 
     @overload
     def step(
-        self, *, max_retries: int = ...
+        self, *, max_retries: int = ..., cancellable: bool = ...
     ) -> Callable[[Callable[P, Coroutine[Any, Any, T]]], Step[P, T]]: ...
 
     def step(
@@ -387,9 +392,10 @@ class Workflows:
         func: Callable[P, Coroutine[Any, Any, T]] | None = None,
         *,
         max_retries: int = DEFAULT_MAX_RETRIES,
+        cancellable: bool = False,
     ) -> Step[P, T] | Callable[[Callable[P, Coroutine[Any, Any, T]]], Step[P, T]]:
         def register(f: Callable[P, Coroutine[Any, Any, T]]) -> Step[P, T]:
-            rv = Step(f, max_retries=max_retries)
+            rv = Step(f, max_retries=max_retries, cancellable=cancellable)
             assert rv.name not in self._steps, f"Duplicate step name: {rv.name}"
             self._steps[rv.name] = rv
             return rv

--- a/src/vercel-workflow/vercel/workflow/_internal/error_serde.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/error_serde.py
@@ -10,7 +10,7 @@ from typing import Any, TypedDict, cast
 
 from vercel._internal.core.polyfills import UTC
 
-from .errors import FatalError, HookConflictError, RemoteError, RetryableError
+from .errors import FatalError, HookConflictError, RemoteError, RetryableError, StepCancelledError
 
 
 class _OptionalErrorFields(TypedDict, total=False):
@@ -39,6 +39,8 @@ class HookConflictErrorPayload(ErrorPayload, _OptionalHookConflictFields):
 
 
 _ERROR_CLASS_BY_TAG: dict[str, type[Exception]] = {
+    # Before FatalError, whose reducer claims its subclasses.
+    "StepCancelledError": StepCancelledError,
     "FatalError": FatalError,
     "TypeError": TypeError,
     "SyntaxError": SyntaxError,

--- a/src/vercel-workflow/vercel/workflow/_internal/errors.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/errors.py
@@ -29,6 +29,15 @@ class StepNotRegisteredError(FatalError):
         self.step_name = step_name
 
 
+class StepCancelledError(FatalError):
+    """A cancellable step stopped by its workflow's cancellation request.
+
+    Recorded as the step's terminal failure. A workflow awaiting the step does
+    not see this error: replay delivers it by cancelling the step's future, so
+    the body gets a plain ``asyncio.CancelledError`` with the same message.
+    """
+
+
 class HookConflictError(Exception):
     """A hook token already owned by another active workflow run."""
 

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -138,8 +138,7 @@ class Cancellation(BaseSuspension):
     requested: bool = False
 
     def fail(self, exc: Exception) -> None:
-        # Cancellation suspensions have no direct awaiter. The orchestrator
-        # raises replay-divergence failures separately via ``resume_exception``.
+        # Cancellation suspensions have no awaiter.
         pass
 
 
@@ -1149,12 +1148,14 @@ class WorkflowOrchestratorContext:
 
             case w.HookCreatedEvent():
                 hook = self.suspensions[event.correlation_id]
-                assert isinstance(hook, Hook)
                 hook.has_created_event = True
-                while hook.conflict_futures:
-                    future = hook.conflict_futures.popleft()
-                    if not future.cancelled():
-                        future.set_result(None)
+                if isinstance(hook, Hook):
+                    while hook.conflict_futures:
+                        future = hook.conflict_futures.popleft()
+                        if not future.cancelled():
+                            future.set_result(None)
+                else:
+                    assert isinstance(hook, Cancellation)
 
             case w.WaitCreatedEvent():
                 self.suspensions[event.correlation_id].has_created_event = True

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -131,14 +131,16 @@ class Cancellation(BaseSuspension):
     """
 
     token: str
-    step: Suspension[Any]
+    step_id: str
     reason: str | None = None
     # Has a cancellation been requested ever? Prevents repeat cancellations
     # from being sent.
     requested: bool = False
 
     def fail(self, exc: Exception) -> None:
-        self.step.fail(exc)
+        # Cancellation suspensions have no direct awaiter. The orchestrator
+        # raises replay-divergence failures separately via ``resume_exception``.
+        pass
 
 
 class CallbackCancelFuture(asyncio.Future[T]):
@@ -874,13 +876,14 @@ class WorkflowOrchestratorContext:
         bound_args, bound_kwargs = step.bind_arguments(args, kwargs)
         dumped_args, dumped_kwargs = step.codec.dump_arguments(bound_args, bound_kwargs)
         input_data = ser.dehydrate(ser.step_arguments(dumped_args, dumped_kwargs))
-        sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
+        ulid = self.generate_ulid()
+        sus = Suspension(correlation_id=f"step_{ulid}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
         if step.cancellable:
             cancellation = Cancellation(
                 correlation_id=f"hook_{self.generate_ulid()}",
-                token=f"abrt_{_correlation_ulid(sus.correlation_id)}",
-                step=sus,
+                token=f"abrt_{ulid}",
+                step_id=sus.correlation_id,
             )
             sus.future = CallbackCancelFuture(
                 on_cancel=functools.partial(self._on_step_cancel, cancellation)
@@ -895,7 +898,7 @@ class WorkflowOrchestratorContext:
         when the run suspends and turned into a cancellation.
 
         We suppress the *actual* cancellation of the future, because
-        we anything waiting on the step to still wait until it has
+        we want anything waiting on the step to still wait until it has
         actually stopped (just like waiting on a task).
 
         If the loop is suspended, though, we aren't doing side effects
@@ -906,7 +909,7 @@ class WorkflowOrchestratorContext:
             return True
         if not cancellation.requested:
             cancellation.requested = True
-            cancellation.reason = str(msg) if msg else None
+            cancellation.reason = str(msg) if msg is not None else None
             self.suspensions[cancellation.correlation_id] = cancellation
         return False
 
@@ -1551,7 +1554,7 @@ async def _send_cancellation(world: w.World, run_id: str, cancellation: Cancella
     # Signal the running step first. A failure other than a direct
     # error from streams (because the stream is already closed) is an
     # actual failure, so that we fail and the run will get retried.
-    stream_name = _abort_stream_name(cancellation.step.correlation_id)
+    stream_name = _abort_stream_name(cancellation.step_id)
     try:
         await world.streams_write(run_id, stream_name, streams.encode_frame(payload))
         await world.streams_close(run_id, stream_name)
@@ -1704,8 +1707,6 @@ async def _workflow_replay_pass(
     except Exception as e:
         error_message = "".join(traceback.format_exception_only(type(e), e)).strip()
         logger.exception("[Workflows] '%s' - workflow run failed: %s", run_id, error_message)
-        # Before the terminal event, which would reject them; a failure here
-        # fails the delivery, so the whole pass is retried.
         await _send_cancellations(context)
         try:
             await world.events_create(
@@ -1719,8 +1720,9 @@ async def _workflow_replay_pass(
             logger.warning(f"Workflow run {run_id} was already completed")
         return None
 
+    await _send_cancellations(context)
+
     if output is not None:
-        await _send_cancellations(context)
         try:
             await world.events_create(
                 run_id,
@@ -1729,8 +1731,6 @@ async def _workflow_replay_pass(
         except w.EntityConflictError:
             logger.warning(f"Workflow run {run_id} was already completed")
         return None
-
-    await _send_cancellations(context)
 
     events_created = False
     immediate_replay_reasons: set[str] = set()
@@ -1930,7 +1930,7 @@ async def _run_cancellable_step(
                 except ser.SerializationError:
                     pass
                 else:
-                    if isinstance(data, dict) and data.get("reason"):
+                    if isinstance(data, dict) and data.get("reason") is not None:
                         reason = str(data["reason"])
                 break
         except Exception as error:
@@ -1953,7 +1953,9 @@ async def _run_cancellable_step(
             if not cancelled:
                 raise
 
-            step_error = errors.StepCancelledError(reason or "step cancelled by its workflow")
+            step_error = errors.StepCancelledError(
+                reason if reason is not None else "step cancelled by its workflow"
+            )
         except Exception as error:
             # Save the error to avoid ExceptionGroup wrapping
             step_error = error

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -13,7 +13,7 @@ import random
 import sys
 import traceback
 from collections import deque
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping, Sequence
 from datetime import datetime
 from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast
 from urllib.parse import parse_qsl, urlsplit
@@ -122,6 +122,55 @@ class Suspension(FutureSuspension[T], Generic[T]):
 
 
 @dataclasses.dataclass(kw_only=True)
+class Cancellation(BaseSuspension):
+    """The pending cancellation of a cancellable step.
+
+    Registered in the run's suspensions when the body first cancels the step;
+    removed when the recorded ``hook_received`` replays, so a still-registered
+    one at flush time is exactly a cancellation left to send.
+    """
+
+    token: str
+    step: Suspension[Any]
+    reason: str | None = None
+    # Has a cancellation been requested ever? Prevents repeat cancellations
+    # from being sent.
+    requested: bool = False
+
+    def fail(self, exc: Exception) -> None:
+        self.step.fail(exc)
+
+
+class CallbackCancelFuture(asyncio.Future[T]):
+    """A future whose ``cancel()`` defers to a callback.
+
+    The callback is called on a cancel(); if it returns True, we
+    perform a normal future cancel, otherwise we suppress it.
+
+    The callback ought to make some progress towards really cancelling
+    the future. (This might seem dodgy, but we already have Task as
+    a precedent of a Future that overrides cancel() in a way that
+    does not immediately cancel.)
+    """
+
+    def __init__(self, *, on_cancel: Callable[[str | None], bool]) -> None:
+        super().__init__()
+        self._on_cancel = on_cancel
+
+    def cancel(self, msg: str | None = None) -> bool:
+        if self.done():
+            return False
+        if self._on_cancel(msg):
+            return super().cancel(msg)
+        return True
+
+    def deliver_cancellation(self, msg: str | None = None) -> bool:
+        """Really cancel, bypassing the callback: for delivering a step's
+        recorded outcome when that outcome *is* the cancellation."""
+        return super().cancel(msg)
+
+
+@dataclasses.dataclass(kw_only=True)
 class Wait(FutureSuspension[None]):
     resume_at: datetime
 
@@ -189,6 +238,15 @@ def _correlation_ulid(correlation_id: str) -> str:
     step/wait/hook swap during replay.
     """
     return correlation_id.split("_", 1)[-1]
+
+
+def _abort_stream_name(step_correlation_id: str) -> str:
+    """The control stream a cancellable step listens on for its cancellation.
+
+    The ``strm_<id>_system_abort`` shape matches ``@workflow/core``'s abort
+    streams.
+    """
+    return f"strm_{_correlation_ulid(step_correlation_id)}_system_abort"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -818,7 +876,39 @@ class WorkflowOrchestratorContext:
         input_data = ser.dehydrate(ser.step_arguments(dumped_args, dumped_kwargs))
         sus = Suspension(correlation_id=f"step_{self.generate_ulid()}", step=step, input=input_data)
         self.suspensions[sus.correlation_id] = sus
+        if step.cancellable:
+            cancellation = Cancellation(
+                correlation_id=f"hook_{self.generate_ulid()}",
+                token=f"abrt_{_correlation_ulid(sus.correlation_id)}",
+                step=sus,
+            )
+            sus.future = CallbackCancelFuture(
+                on_cancel=functools.partial(self._on_step_cancel, cancellation)
+            )
         return sus.future
+
+    def _on_step_cancel(self, cancellation: Cancellation, msg: object) -> bool:
+        """Handle cancel() of a cancellable step's future; see CallbackCancelFuture.
+
+        When cancel() is called during normal execution, we install a
+        cancellation suspension for the step, which will get picked up
+        when the run suspends and turned into a cancellation.
+
+        We suppress the *actual* cancellation of the future, because
+        we anything waiting on the step to still wait until it has
+        actually stopped (just like waiting on a task).
+
+        If the loop is suspended, though, we aren't doing side effects
+        and we just want to tear things down, so allow a normal cancel.
+
+        """
+        if self.suspended:
+            return True
+        if not cancellation.requested:
+            cancellation.requested = True
+            cancellation.reason = str(msg) if msg else None
+            self.suspensions[cancellation.correlation_id] = cancellation
+        return False
 
     def run_wait(self, param: DurationParam) -> asyncio.Future[None]:
         wait = Wait(
@@ -1116,7 +1206,14 @@ class WorkflowOrchestratorContext:
                 except ser.SerializationError as error:
                     failure = errors.FatalError(f"Cannot read {what}: {error}")
                 if not sus.future.cancelled():
-                    sus.future.set_exception(failure)
+                    if isinstance(failure, errors.StepCancelledError) and isinstance(
+                        sus.future, CallbackCancelFuture
+                    ):
+                        # Died from the body's own cancellation: deliver it
+                        # as one.
+                        sus.future.deliver_cancellation(str(failure))
+                    else:
+                        sus.future.set_exception(failure)
 
             case w.HookConflictEvent(
                 event_data=w.HookConflictEventData(
@@ -1150,6 +1247,12 @@ class WorkflowOrchestratorContext:
 
             case w.HookReceivedEvent(event_data=w.HookReceivedEventData(payload=data)):
                 hook = self.suspensions[event.correlation_id]
+                if isinstance(hook, Cancellation):
+                    # A step cancellation already recorded: deregister it so
+                    # the flush does not send it again.
+                    self.suspensions.pop(event.correlation_id)
+                    return
+
                 assert isinstance(hook, Hook)
                 result = ser.hydrate(
                     data,
@@ -1442,6 +1545,53 @@ async def workflow_handler(
             return replay_result
 
 
+async def _send_cancellation(world: w.World, run_id: str, cancellation: Cancellation) -> None:
+    payload = ser.dehydrate({"aborted": True, "reason": cancellation.reason})
+
+    # Signal the running step first. A failure other than a direct
+    # error from streams (because the stream is already closed) is an
+    # actual failure, so that we fail and the run will get retried.
+    stream_name = _abort_stream_name(cancellation.step.correlation_id)
+    try:
+        await world.streams_write(run_id, stream_name, streams.encode_frame(payload))
+        await world.streams_close(run_id, stream_name)
+    except w.WorkflowWorldError as error:
+        if error.status != 400:
+            raise
+        logger.debug(f"Cancellation stream {stream_name!r} rejected the signal: {error}")
+
+    # Create the hook if we haven't yet
+    if not cancellation.has_created_event:
+        hook_data = w.HookCreatedEventData(token=cancellation.token, is_system=True)
+        try:
+            await world.events_create(run_id, hook_data.into_event(cancellation.correlation_id))
+        except w.EntityConflictError:
+            logger.debug(f"Cancellation {cancellation.correlation_id!r} has already been created")
+
+    # Mark receipt of it too
+    received = w.HookReceivedEventData(payload=payload, token=cancellation.token)
+    try:
+        await world.events_create(run_id, received.into_event(cancellation.correlation_id))
+    except w.EntityConflictError:
+        logger.debug(f"Cancellation {cancellation.correlation_id!r} has already been received")
+
+
+async def _send_cancellations(context: WorkflowOrchestratorContext) -> None:
+    """Record and signal every pending step cancellation.
+
+    A cancellation whose ``hook_received`` is already in the log was
+    deregistered during replay; whatever is still registered needs to be made
+    durable, whether the run is about to suspend or to finish.
+    """
+    world = w.get_world()
+    pending = [sus for sus in context.suspensions.values() if isinstance(sus, Cancellation)]
+    if not pending:
+        return
+    async with anyio.create_task_group() as tg:
+        for cancellation in pending:
+            tg.start_soon(_send_cancellation, world, context.run_id, cancellation)
+
+
 async def _workflow_replay_pass(
     *,
     req: w.WorkflowInvokePayload,
@@ -1554,6 +1704,9 @@ async def _workflow_replay_pass(
     except Exception as e:
         error_message = "".join(traceback.format_exception_only(type(e), e)).strip()
         logger.exception("[Workflows] '%s' - workflow run failed: %s", run_id, error_message)
+        # Before the terminal event, which would reject them; a failure here
+        # fails the delivery, so the whole pass is retried.
+        await _send_cancellations(context)
         try:
             await world.events_create(
                 run_id,
@@ -1567,6 +1720,7 @@ async def _workflow_replay_pass(
         return None
 
     if output is not None:
+        await _send_cancellations(context)
         try:
             await world.events_create(
                 run_id,
@@ -1575,6 +1729,8 @@ async def _workflow_replay_pass(
         except w.EntityConflictError:
             logger.warning(f"Workflow run {run_id} was already completed")
         return None
+
+    await _send_cancellations(context)
 
     events_created = False
     immediate_replay_reasons: set[str] = set()
@@ -1743,6 +1899,70 @@ async def _retries_exhausted(
     return failure
 
 
+async def _run_cancellable_step(
+    step: core.Step[Any, T],
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    world: w.World,
+    run_id: str,
+    step_id: str,
+) -> T:
+    """Run a cancellable step and a listener for cancellations.
+
+    The listener waits on the steps abort stream, and if it is
+    signalled, cancels.
+    """
+    stream_name = _abort_stream_name(step_id)
+    cancelled = False
+    reason: str | None = None
+    step_error: Exception
+    # Run the step in a task so that it can be cancelled.
+    step_task = asyncio.create_task(step.func(*args, **kwargs))
+
+    async def listen() -> None:
+        nonlocal cancelled, reason
+        try:
+            async for chunk in streams.reconnecting_frames(world, run_id, stream_name):
+                cancelled = True
+                try:
+                    data = ser.hydrate(chunk, what=f"the cancellation of step {step_id}")
+                except ser.SerializationError:
+                    pass
+                else:
+                    if isinstance(data, dict) and data.get("reason"):
+                        reason = str(data["reason"])
+                break
+        except Exception as error:
+            # A dead listener must not fail the step: without the signal
+            # the step simply runs to completion.
+            logger.debug(f"Cancellation listener for step {step_id!r} failed: {error}")
+            return
+        if cancelled:
+            step_task.cancel(reason)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(listen)
+        try:
+            return await step_task
+        except asyncio.CancelledError:
+            # We only want to turn a CancelledError into
+            # StepCancelledError if we actually got a
+            # cancel. Otherwise we assume that the server is shutting
+            # us down or something.
+            if not cancelled:
+                raise
+
+            step_error = errors.StepCancelledError(reason or "step cancelled by its workflow")
+        except Exception as error:
+            # Save the error to avoid ExceptionGroup wrapping
+            step_error = error
+        finally:
+            tg.cancel_scope.cancel()
+
+    raise step_error
+
+
 async def _execute_step(
     req: w.WorkflowInvokePayload,
     *,
@@ -1905,7 +2125,12 @@ async def _execute_step(
                 current_attempt,
             )
             # Execute the step function
-            result = await step.func(*args, **kwargs)
+            if step.cancellable:
+                result = await _run_cancellable_step(
+                    step, args, kwargs, world=world, run_id=req.run_id, step_id=req.step_id
+                )
+            else:
+                result = await step.func(*args, **kwargs)
 
             # A stream write returns as soon as it is buffered, so the chunks
             # this step wrote are not durable yet. Force them out before

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -750,6 +750,9 @@ class Hook(BaseModel):
 class HookCreatedEventData(BaseModel):
     token: str
     metadata: bytes | None = pydantic.Field(default=None, exclude_if=lambda e: e is None)
+    is_system: bool | None = pydantic.Field(
+        default=None, alias="isSystem", exclude_if=lambda e: e is None
+    )
 
     def into_event(self, correlation_id: str) -> "HookCreatedEvent":
         return HookCreatedEvent(correlation_id=correlation_id, event_data=self)

--- a/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
@@ -1176,7 +1176,7 @@ class LocalWorld(w.World):
                 created_at=now,
                 spec_version=data.spec_version,
                 is_webhook=False,
-                is_system=False,
+                is_system=bool(hook_data.is_system),
             )
             hook_path = self.data_dir / "hooks" / f"{data.correlation_id}.json"
             write_json(hook_path, hook)


### PR DESCRIPTION
Enable with `@workflows.step(cancellable=True)`.

When `cancel()` is called on a cancellable step, we send a message on
a stream that the step will listen for. If it gets a message, it will
exit. It gets recorded in the event log as a hook read. (This makes
more sense implementing JS AbortController than it does here, but we
need to record it somehow.)

Note that like regular asyncio tasks, `cancel()` does not cause the
step to immediately become "cancelled". Waiting on it will still wait
for the step to actually terminate.

If there are still cancellable steps running when a workflow function
completes, they will be cancelled and the workflow will wait for them
to finish before terminating.

I am unsure about that particular part of the design. It could be
potentially useful sometimes to leave them running, also.  This
approach best leverages what `asyncio.run` does naturally with tasks,
which is how everything else gets run here.