### PR TITLE
sandbox: Forward private parameters

### DIFF
--- a/changes/vercel-sandbox/private-parameters.feature.md
+++ b/changes/vercel-sandbox/private-parameters.feature.md
@@ -1,0 +1,1 @@
+Forward private ``__``-prefixed parameters to the Sandbox API.

--- a/src/vercel-sandbox/tests/test_sandbox_api_client.py
+++ b/src/vercel-sandbox/tests/test_sandbox_api_client.py
@@ -358,13 +358,13 @@ async def test_private_parameters_are_forwarded_to_sandbox_api() -> None:
 
     await client.fork_sandbox(
         source_sandbox="preview",
-        private_parameters={"__secureCompute": {"enabled": True}},
+        private_parameters={"__privateFeature": {"enabled": True}},
     )
 
     assert transport.request is not None
     body = transport.request[4]
     assert isinstance(body, JSONBody)
-    assert body.data["__secureCompute"] == {"enabled": True}
+    assert body.data["__privateFeature"] == {"enabled": True}
 
     await client.get_sandbox(
         name="preview",

--- a/src/vercel-sandbox/tests/test_sandbox_api_client.py
+++ b/src/vercel-sandbox/tests/test_sandbox_api_client.py
@@ -332,6 +332,55 @@ async def test_fork_sandbox_encodes_source_query_and_overrides() -> None:
     }
 
 
+async def test_private_parameters_are_forwarded_to_sandbox_api() -> None:
+    response = {
+        "sandbox": {
+            "name": "preview",
+            "currentSessionId": "sbx_123",
+            "status": "running",
+        },
+        "session": {
+            "id": "sbx_123",
+            "sourceSandboxName": "preview",
+            "projectId": "prj_123",
+            "status": "running",
+        },
+    }
+    transport = RecordingJsonTransport(response)
+    client = _sandbox_client(transport)
+
+    await client.create_sandbox(private_parameters={"__networkId": "network_123"})
+
+    assert transport.request is not None
+    body = transport.request[4]
+    assert isinstance(body, JSONBody)
+    assert body.data["__networkId"] == "network_123"
+
+    await client.fork_sandbox(
+        source_sandbox="preview",
+        private_parameters={"__secureCompute": {"enabled": True}},
+    )
+
+    assert transport.request is not None
+    body = transport.request[4]
+    assert isinstance(body, JSONBody)
+    assert body.data["__secureCompute"] == {"enabled": True}
+
+    await client.get_sandbox(
+        name="preview",
+        private_parameters={"__includeSystemRoutes": True},
+    )
+
+    assert transport.request is not None
+    params = transport.request[3]
+    assert params == {
+        "teamId": "team_123",
+        "projectId": "prj_123",
+        "resume": "false",
+        "__includeSystemRoutes": True,
+    }
+
+
 async def test_stop_runtime_session_retains_sparse_sandbox_metadata() -> None:
     client = _sandbox_client(
         JsonTransport(

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -111,15 +111,42 @@ def _sandbox_response(
 
 
 @respx.mock
-async def test_public_create_forwards_private_parameters(mock_env_clear: None) -> None:
-    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
-        return_value=httpx.Response(200, json=_sandbox_response())
+async def test_async_lifecycle_forwards_private_parameters_without_leaking_to_polls(
+    mock_env_clear: None,
+) -> None:
+    create_route = respx.post("https://sandbox.test/v3/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="created", status="pending"))
+    )
+    create_poll = respx.get("https://sandbox.test/v2/sandboxes/created").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="created"))
+    )
+    fork_route = respx.post("https://sandbox.test/v2/sandboxes/created/fork").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="forked", status="pending"))
+    )
+    fork_poll = respx.get("https://sandbox.test/v2/sandboxes/forked").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="forked"))
+    )
+    get_route = respx.get("https://sandbox.test/v2/sandboxes/fetched").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="fetched"))
+    )
+    resume_route = respx.get("https://sandbox.test/v2/sandboxes/resumed").mock(
+        return_value=httpx.Response(200, json=_sandbox_response(name="resumed"))
     )
 
     async with session(service_options=_session_options()):
-        await sandbox.create_sandbox(__networkId="network_123")
+        await sandbox.create_sandbox(name="created", __networkId="network_123")
+        await sandbox.fork_sandbox(
+            source_sandbox="created", name="forked", __networkId="network_123"
+        )
+        await sandbox.get_sandbox(name="fetched", __includeSystemRoutes=True)
+        await sandbox.resume_sandbox(name="resumed", __includeSystemRoutes=True)
 
-    assert json.loads(route.calls.last.request.content)["__networkId"] == "network_123"
+    assert json.loads(create_route.calls.last.request.content)["__networkId"] == "network_123"
+    assert "__networkId" not in create_poll.calls.last.request.url.params
+    assert json.loads(fork_route.calls.last.request.content)["__networkId"] == "network_123"
+    assert "__networkId" not in fork_poll.calls.last.request.url.params
+    assert get_route.calls.last.request.url.params["__includeSystemRoutes"] == "true"
+    assert resume_route.calls.last.request.url.params["__includeSystemRoutes"] == "true"
 
 
 @respx.mock
@@ -135,8 +162,10 @@ def test_sync_get_forwards_private_parameters(mock_env_clear: None) -> None:
 
 
 def test_public_sandbox_functions_reject_unknown_parameters() -> None:
-    with pytest.raises(TypeError, match="Unexpected sandbox parameter: 'typo'"):
-        sandbox.create_sandbox(typo=True)
+    with pytest.raises(TypeError, match="unexpected keyword argument 'network_id'"):
+        sandbox.create_sandbox(network_id="network_123")
+    with pytest.raises(TypeError, match="unexpected keyword argument 'network_id'"):
+        sandbox_sync.create_sandbox(network_id="network_123")
 
 
 def _image_sandbox_response(
@@ -1714,6 +1743,7 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
             "projectId": "prj_123",
             "name": "stale",
             "image": "stale-repository:latest",
+            "__networkId": "network_123",
         }
         return httpx.Response(
             200,
@@ -1724,7 +1754,9 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
 
     async with session(service_options=_session_options()):
         recreated, created = await sandbox.get_or_create_sandbox(
-            name="stale", image="stale-repository:latest"
+            name="stale",
+            image="stale-repository:latest",
+            __networkId="network_123",
         )
 
     assert recreated.name == "stale"
@@ -1732,6 +1764,8 @@ async def test_async_get_or_create_recreates_stale_snapshot(mock_env_clear: None
     assert recreated.image == "my-repository@sha256:resolved"
     assert not hasattr(recreated, "runtime")
     assert get_route.calls.last.request.url.params["resume"] == "true"
+    assert get_route.calls.last.request.url.params["__networkId"] == "network_123"
+    assert "__networkId" not in delete_route.calls.last.request.url.params
     assert delete_route.call_count == 1
     assert create_route.call_count == 1
 

--- a/src/vercel-sandbox/tests/test_sandbox_public_flow.py
+++ b/src/vercel-sandbox/tests/test_sandbox_public_flow.py
@@ -110,6 +110,35 @@ def _sandbox_response(
     }
 
 
+@respx.mock
+async def test_public_create_forwards_private_parameters(mock_env_clear: None) -> None:
+    route = respx.post("https://sandbox.test/v3/sandboxes").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    async with session(service_options=_session_options()):
+        await sandbox.create_sandbox(__networkId="network_123")
+
+    assert json.loads(route.calls.last.request.content)["__networkId"] == "network_123"
+
+
+@respx.mock
+def test_sync_get_forwards_private_parameters(mock_env_clear: None) -> None:
+    route = respx.get("https://sandbox.test/v2/sandboxes/preview").mock(
+        return_value=httpx.Response(200, json=_sandbox_response())
+    )
+
+    with session(service_options=_session_options()):
+        sandbox_sync.get_sandbox(name="preview", __includeSystemRoutes=True)
+
+    assert route.calls.last.request.url.params["__includeSystemRoutes"] == "true"
+
+
+def test_public_sandbox_functions_reject_unknown_parameters() -> None:
+    with pytest.raises(TypeError, match="Unexpected sandbox parameter: 'typo'"):
+        sandbox.create_sandbox(typo=True)
+
+
 def _image_sandbox_response(
     *,
     image: str = "my-repository@sha256:resolved",

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -53,6 +53,7 @@ from vercel.sandbox._internal.models import (
     DurationInput,
     FailoverRegionsInput,
     GitSource,
+    JSONValue,
     NetworkPolicy,
     NetworkPolicyKeyValueMatcher,
     NetworkPolicyMatcher,
@@ -75,6 +76,7 @@ from vercel.sandbox._internal.models import (
     SnapshotSource,
     TagFilter,
     TarballSource,
+    extract_private_parameters,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -110,6 +112,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    **private_parameters: JSONValue,
 ) -> CreateSandboxOperation:
     """Prepare an asynchronous sandbox creation operation.
 
@@ -165,6 +168,7 @@ def create_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -186,6 +190,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    **private_parameters: JSONValue,
 ) -> ForkSandboxOperation:
     """Prepare an asynchronous sandbox fork operation.
 
@@ -242,6 +247,7 @@ def fork_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -264,6 +270,7 @@ async def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
+    **private_parameters: JSONValue,
 ) -> tuple[Sandbox, bool]:
     """Get a named sandbox or create it when it does not exist.
 
@@ -319,6 +326,7 @@ async def get_or_create_sandbox(
         snapshot_retention=snapshot_retention,
         region=region,
         failover_regions=failover_regions,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -327,6 +335,7 @@ async def get_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    **private_parameters: JSONValue,
 ) -> Sandbox:
     """Fetch a sandbox by name without resuming it.
 
@@ -350,6 +359,7 @@ async def get_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -358,6 +368,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    **private_parameters: JSONValue,
 ) -> ResumeSandboxOperation:
     """Prepare an asynchronous sandbox resume operation.
 
@@ -381,6 +392,7 @@ def resume_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 

--- a/src/vercel-sandbox/vercel/sandbox/__init__.py
+++ b/src/vercel-sandbox/vercel/sandbox/__init__.py
@@ -53,7 +53,7 @@ from vercel.sandbox._internal.models import (
     DurationInput,
     FailoverRegionsInput,
     GitSource,
-    JSONValue,
+    JSONValue as _JSONValue,
     NetworkPolicy,
     NetworkPolicyKeyValueMatcher,
     NetworkPolicyMatcher,
@@ -76,7 +76,7 @@ from vercel.sandbox._internal.models import (
     SnapshotSource,
     TagFilter,
     TarballSource,
-    extract_private_parameters,
+    normalize_private_parameters as _normalize_private_parameters,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -112,7 +112,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> CreateSandboxOperation:
     """Prepare an asynchronous sandbox creation operation.
 
@@ -168,7 +168,7 @@ def create_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("create_sandbox", private_parameters),
     )
 
 
@@ -190,7 +190,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> ForkSandboxOperation:
     """Prepare an asynchronous sandbox fork operation.
 
@@ -247,7 +247,7 @@ def fork_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("fork_sandbox", private_parameters),
     )
 
 
@@ -270,7 +270,7 @@ async def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> tuple[Sandbox, bool]:
     """Get a named sandbox or create it when it does not exist.
 
@@ -326,7 +326,9 @@ async def get_or_create_sandbox(
         snapshot_retention=snapshot_retention,
         region=region,
         failover_regions=failover_regions,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters(
+            "get_or_create_sandbox", private_parameters
+        ),
     )
 
 
@@ -335,7 +337,7 @@ async def get_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> Sandbox:
     """Fetch a sandbox by name without resuming it.
 
@@ -359,7 +361,7 @@ async def get_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("get_sandbox", private_parameters),
     )
 
 
@@ -368,7 +370,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> ResumeSandboxOperation:
     """Prepare an asynchronous sandbox resume operation.
 
@@ -392,7 +394,7 @@ def resume_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("resume_sandbox", private_parameters),
     )
 
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -41,9 +41,11 @@ from vercel.sandbox._internal.errors import (
 )
 from vercel.sandbox._internal.models import (
     _OMITTED,
+    NO_PRIVATE_PARAMETERS,
     JSONObject,
     JSONValue,
     NetworkPolicy,
+    PrivateSandboxParameters,
     ProcessLog,
     ProcessLogStream,
     SandboxResources,
@@ -939,7 +941,7 @@ class SandboxApiClient:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _CreateSandboxRequest(
@@ -960,7 +962,7 @@ class SandboxApiClient:
             failover_regions=None if failover_regions is None else list(failover_regions),
         )
         body = request.to_api_dict()
-        body.update(private_parameters or {})
+        body.update(private_parameters)
         data = await self._request_json("POST", "v3/sandboxes", credentials=credentials, body=body)
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -982,7 +984,7 @@ class SandboxApiClient:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _ForkSandboxRequest(
@@ -1005,7 +1007,7 @@ class SandboxApiClient:
             format_url_path("v2/sandboxes/{source_sandbox}/fork", source_sandbox=source_sandbox),
             credentials=credentials,
             params={"projectId": project_id or credentials.project_id},
-            body={**request.to_api_dict(), **(private_parameters or {})},
+            body={**request.to_api_dict(), **(private_parameters)},
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -1016,7 +1018,7 @@ class SandboxApiClient:
         project_id: str | None = None,
         resume: bool = False,
         include_system_routes: bool | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _GetSandboxRequest(
@@ -1028,7 +1030,7 @@ class SandboxApiClient:
             "GET",
             format_url_path("v2/sandboxes/{name}", name=name),
             credentials=credentials,
-            params={**request.to_api_dict(), **(private_parameters or {})},
+            params={**request.to_api_dict(), **(private_parameters)},
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -1140,7 +1142,7 @@ class SandboxApiClient:
         name: str,
         project_id: str | None = None,
         include_system_routes: bool | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         return await self.get_sandbox(
             name=name,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/api_client.py
@@ -939,6 +939,7 @@ class SandboxApiClient:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _CreateSandboxRequest(
@@ -958,9 +959,9 @@ class SandboxApiClient:
             region=region,
             failover_regions=None if failover_regions is None else list(failover_regions),
         )
-        data = await self._request_json(
-            "POST", "v3/sandboxes", credentials=credentials, body=request.to_api_dict()
-        )
+        body = request.to_api_dict()
+        body.update(private_parameters or {})
+        data = await self._request_json("POST", "v3/sandboxes", credentials=credentials, body=body)
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
     async def fork_sandbox(
@@ -981,6 +982,7 @@ class SandboxApiClient:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _ForkSandboxRequest(
@@ -1003,7 +1005,7 @@ class SandboxApiClient:
             format_url_path("v2/sandboxes/{source_sandbox}/fork", source_sandbox=source_sandbox),
             credentials=credentials,
             params={"projectId": project_id or credentials.project_id},
-            body=request.to_api_dict(),
+            body={**request.to_api_dict(), **(private_parameters or {})},
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -1014,6 +1016,7 @@ class SandboxApiClient:
         project_id: str | None = None,
         resume: bool = False,
         include_system_routes: bool | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         credentials = await self._credentials_factory()
         request = _GetSandboxRequest(
@@ -1025,7 +1028,7 @@ class SandboxApiClient:
             "GET",
             format_url_path("v2/sandboxes/{name}", name=name),
             credentials=credentials,
-            params=request.to_api_dict(),
+            params={**request.to_api_dict(), **(private_parameters or {})},
         )
         return _validate_response(_SandboxResponse, data).to_sandbox()
 
@@ -1137,12 +1140,14 @@ class SandboxApiClient:
         name: str,
         project_id: str | None = None,
         include_system_routes: bool | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         return await self.get_sandbox(
             name=name,
             project_id=project_id,
             resume=True,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         )
 
     async def stop_runtime_session(self, *, session_id: str) -> RuntimeSessionStopState:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from types import TracebackType
 from typing import Any, Literal, TextIO, overload
@@ -1429,7 +1429,9 @@ class _CreateSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
-    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
+    private_parameters: PrivateSandboxParameters = field(
+        default_factory=lambda: NO_PRIVATE_PARAMETERS
+    )
 
 
 class CreateSandboxOperation:
@@ -1527,7 +1529,9 @@ class _ForkSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
-    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
+    private_parameters: PrivateSandboxParameters = field(
+        default_factory=lambda: NO_PRIVATE_PARAMETERS
+    )
 
 
 class ForkSandboxOperation:
@@ -1612,7 +1616,9 @@ class _ResumeSandboxParams:
     name: str
     project_id: str | None = None
     include_system_routes: bool | None = None
-    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
+    private_parameters: PrivateSandboxParameters = field(
+        default_factory=lambda: NO_PRIVATE_PARAMETERS
+    )
 
 
 class ResumeSandboxOperation:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -43,6 +43,7 @@ from vercel.sandbox._internal.models import (
     DirectoryEntry,
     DurationInput,
     FailoverRegionsInput,
+    JSONValue,
     NetworkPolicy,
     ProcessLog,
     SandboxQuery,
@@ -1427,6 +1428,7 @@ class _CreateSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
+    private_parameters: Mapping[str, JSONValue] | None = None
 
 
 class CreateSandboxOperation:
@@ -1475,6 +1477,7 @@ class CreateSandboxOperation:
             snapshot_retention=self._params.snapshot_retention,
             region=self._params.region,
             failover_regions=self._params.failover_regions,
+            private_parameters=self._params.private_parameters,
         )
 
     def __await__(self) -> Generator[Any, None, Sandbox]:
@@ -1523,6 +1526,7 @@ class _ForkSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
+    private_parameters: Mapping[str, JSONValue] | None = None
 
 
 class ForkSandboxOperation:
@@ -1570,6 +1574,7 @@ class ForkSandboxOperation:
             snapshot_retention=self._params.snapshot_retention,
             region=self._params.region,
             failover_regions=self._params.failover_regions,
+            private_parameters=self._params.private_parameters,
         )
 
     def __await__(self) -> Generator[Any, None, Sandbox]:
@@ -1606,6 +1611,7 @@ class _ResumeSandboxParams:
     name: str
     project_id: str | None = None
     include_system_routes: bool | None = None
+    private_parameters: Mapping[str, JSONValue] | None = None
 
 
 class ResumeSandboxOperation:
@@ -1635,6 +1641,7 @@ class ResumeSandboxOperation:
             name=self._params.name,
             project_id=self._params.project_id,
             include_system_routes=self._params.include_system_routes,
+            private_parameters=self._params.private_parameters,
         )
 
     def __await__(self) -> Generator[Any, None, Sandbox]:
@@ -1722,6 +1729,7 @@ def create_sandbox_operation(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> CreateSandboxOperation:
     return CreateSandboxOperation(
         service=service,
@@ -1741,6 +1749,7 @@ def create_sandbox_operation(
             snapshot_retention=snapshot_retention,
             region=region,
             failover_regions=normalize_failover_regions(failover_regions),
+            private_parameters=private_parameters,
         ),
         destroy=destroy,
     )
@@ -1765,6 +1774,7 @@ def fork_sandbox_operation(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> ForkSandboxOperation:
     return ForkSandboxOperation(
         service=service,
@@ -1784,6 +1794,7 @@ def fork_sandbox_operation(
             snapshot_retention=snapshot_retention,
             region=region,
             failover_regions=normalize_failover_regions(failover_regions),
+            private_parameters=private_parameters,
         ),
         destroy=destroy,
     )
@@ -1796,6 +1807,7 @@ async def get_sandbox(
     project_id: str | None = None,
     resume: bool = False,
     include_system_routes: bool | None = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> Sandbox:
     return Sandbox(
         payload=await service.get_sandbox(
@@ -1803,6 +1815,7 @@ async def get_sandbox(
             project_id=project_id,
             resume=resume,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         ),
         service=service,
         include_system_routes=include_system_routes,
@@ -1829,6 +1842,7 @@ async def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> tuple[Sandbox, bool]:
     try:
         state, created = await service.get_or_create_sandbox(
@@ -1849,6 +1863,7 @@ async def get_or_create_sandbox(
             snapshot_retention=snapshot_retention,
             region=region,
             failover_regions=normalize_failover_regions(failover_regions),
+            private_parameters=private_parameters,
         )
         return (
             Sandbox(
@@ -1875,12 +1890,14 @@ async def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> Sandbox:
     return Sandbox(
         payload=await service.resume_sandbox(
             name=name,
             project_id=project_id,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         ),
         service=service,
         include_system_routes=include_system_routes,
@@ -1893,6 +1910,7 @@ def resume_sandbox_operation(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> ResumeSandboxOperation:
     return ResumeSandboxOperation(
         service=service,
@@ -1900,6 +1918,7 @@ def resume_sandbox_operation(
             name=name,
             project_id=project_id,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         ),
     )
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/async_runtime.py
@@ -39,12 +39,13 @@ from vercel.sandbox._internal.filesystem_handle_core import (
 )
 from vercel.sandbox._internal.models import (
     _OMITTED,
+    NO_PRIVATE_PARAMETERS,
     CompletedProcess,
     DirectoryEntry,
     DurationInput,
     FailoverRegionsInput,
-    JSONValue,
     NetworkPolicy,
+    PrivateSandboxParameters,
     ProcessLog,
     SandboxQuery,
     SandboxResources,
@@ -1428,7 +1429,7 @@ class _CreateSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
-    private_parameters: Mapping[str, JSONValue] | None = None
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
 
 
 class CreateSandboxOperation:
@@ -1526,7 +1527,7 @@ class _ForkSandboxParams:
     snapshot_retention: SnapshotRetention | None = None
     region: str | None = None
     failover_regions: tuple[str, ...] | None = None
-    private_parameters: Mapping[str, JSONValue] | None = None
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
 
 
 class ForkSandboxOperation:
@@ -1611,7 +1612,7 @@ class _ResumeSandboxParams:
     name: str
     project_id: str | None = None
     include_system_routes: bool | None = None
-    private_parameters: Mapping[str, JSONValue] | None = None
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS
 
 
 class ResumeSandboxOperation:
@@ -1729,7 +1730,7 @@ def create_sandbox_operation(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> CreateSandboxOperation:
     return CreateSandboxOperation(
         service=service,
@@ -1774,7 +1775,7 @@ def fork_sandbox_operation(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> ForkSandboxOperation:
     return ForkSandboxOperation(
         service=service,
@@ -1807,7 +1808,7 @@ async def get_sandbox(
     project_id: str | None = None,
     resume: bool = False,
     include_system_routes: bool | None = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> Sandbox:
     return Sandbox(
         payload=await service.get_sandbox(
@@ -1842,7 +1843,7 @@ async def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> tuple[Sandbox, bool]:
     try:
         state, created = await service.get_or_create_sandbox(
@@ -1890,7 +1891,7 @@ async def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> Sandbox:
     return Sandbox(
         payload=await service.resume_sandbox(
@@ -1910,7 +1911,7 @@ def resume_sandbox_operation(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> ResumeSandboxOperation:
     return ResumeSandboxOperation(
         service=service,

--- a/src/vercel-sandbox/vercel/sandbox/_internal/models.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/models.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from subprocess import CalledProcessError
 from types import MappingProxyType
-from typing import Any, Literal, TypeAlias, cast
+from typing import Any, Final, Literal, TypeAlias, cast
 
 from pydantic import (
     BaseModel,
@@ -20,6 +20,8 @@ from vercel._internal.core.time import SECOND, coerce_duration, to_ms_int
 
 JSONValue: TypeAlias = PydanticJsonValue
 JSONObject: TypeAlias = dict[str, JSONValue]
+PrivateSandboxParameters: TypeAlias = Mapping[str, JSONValue]
+NO_PRIVATE_PARAMETERS: Final[PrivateSandboxParameters] = MappingProxyType({})
 DurationInput: TypeAlias = int | float | timedelta | None
 FailoverRegionsInput: TypeAlias = Iterable[str] | None
 _MIN_SNAPSHOT_EXPIRATION = timedelta(days=1)
@@ -27,11 +29,13 @@ _MAX_SNAPSHOT_EXPIRATION = timedelta(days=365 * 10)
 _ZERO_DELTA = timedelta(0)
 
 
-def extract_private_parameters(parameters: Mapping[str, JSONValue]) -> JSONObject:
+def normalize_private_parameters(
+    operation: str, parameters: PrivateSandboxParameters
+) -> JSONObject:
     """Validate and return private Sandbox API parameters."""
     for name in parameters:
         if not name.startswith("__"):
-            raise TypeError(f"Unexpected sandbox parameter: {name!r}")
+            raise TypeError(f"{operation}() got an unexpected keyword argument {name!r}")
     return dict(parameters)
 
 

--- a/src/vercel-sandbox/vercel/sandbox/_internal/models.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/models.py
@@ -27,6 +27,14 @@ _MAX_SNAPSHOT_EXPIRATION = timedelta(days=365 * 10)
 _ZERO_DELTA = timedelta(0)
 
 
+def extract_private_parameters(parameters: Mapping[str, JSONValue]) -> JSONObject:
+    """Validate and return private Sandbox API parameters."""
+    for name in parameters:
+        if not name.startswith("__"):
+            raise TypeError(f"Unexpected sandbox parameter: {name!r}")
+    return dict(parameters)
+
+
 def normalize_failover_regions(regions: FailoverRegionsInput) -> tuple[str, ...] | None:
     """Normalize sandbox failover regions while preserving explicit emptiness."""
     if regions is None:

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -22,9 +22,10 @@ from vercel.sandbox._internal.errors import (
 from vercel.sandbox._internal.log_stream import _parse_command_log_record
 from vercel.sandbox._internal.models import (
     _OMITTED,
+    NO_PRIVATE_PARAMETERS,
     DirectoryEntry,
-    JSONValue,
     NetworkPolicy,
+    PrivateSandboxParameters,
     ProcessLog,
     SandboxQuery,
     SandboxQueryByCreatedAt,
@@ -267,7 +268,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.create_sandbox(
@@ -308,7 +309,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.fork_sandbox(
@@ -338,7 +339,7 @@ class SandboxService:
         project_id: str | None = None,
         resume: bool = False,
         include_system_routes: bool | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         self._ensure_open()
         return await self._api_client.get_sandbox(
@@ -369,7 +370,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> tuple[SandboxState, bool]:
         """Return a named sandbox and whether it had to be created."""
         try:
@@ -480,7 +481,7 @@ class SandboxService:
         name: str,
         project_id: str | None = None,
         include_system_routes: bool | None = None,
-        private_parameters: Mapping[str, JSONValue] | None = None,
+        private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.resume_sandbox(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/service.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/service.py
@@ -23,6 +23,7 @@ from vercel.sandbox._internal.log_stream import _parse_command_log_record
 from vercel.sandbox._internal.models import (
     _OMITTED,
     DirectoryEntry,
+    JSONValue,
     NetworkPolicy,
     ProcessLog,
     SandboxQuery,
@@ -266,6 +267,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.create_sandbox(
@@ -284,6 +286,7 @@ class SandboxService:
             snapshot_retention=snapshot_retention,
             region=region or self._options.region,
             failover_regions=failover_regions,
+            private_parameters=private_parameters,
         )
         return await self._wait_for_ready_sandbox(sandbox, project_id=project_id)
 
@@ -305,6 +308,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.fork_sandbox(
@@ -323,6 +327,7 @@ class SandboxService:
             snapshot_retention=snapshot_retention,
             region=region or self._options.region,
             failover_regions=failover_regions,
+            private_parameters=private_parameters,
         )
         return await self._wait_for_ready_sandbox(sandbox, project_id=project_id)
 
@@ -333,6 +338,7 @@ class SandboxService:
         project_id: str | None = None,
         resume: bool = False,
         include_system_routes: bool | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         self._ensure_open()
         return await self._api_client.get_sandbox(
@@ -340,6 +346,7 @@ class SandboxService:
             project_id=project_id,
             resume=resume,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         )
 
     async def get_or_create_sandbox(
@@ -362,6 +369,7 @@ class SandboxService:
         snapshot_retention: SnapshotRetention | None = None,
         region: str | None = None,
         failover_regions: tuple[str, ...] | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> tuple[SandboxState, bool]:
         """Return a named sandbox and whether it had to be created."""
         try:
@@ -370,6 +378,7 @@ class SandboxService:
                 project_id=project_id,
                 resume=resume,
                 include_system_routes=include_system_routes,
+                private_parameters=private_parameters,
             )
         except SandboxApiError as error:
             if error.status_code == 404:
@@ -401,6 +410,7 @@ class SandboxService:
             snapshot_retention=snapshot_retention,
             region=region,
             failover_regions=failover_regions,
+            private_parameters=private_parameters,
         )
         return sandbox, True
 
@@ -470,12 +480,14 @@ class SandboxService:
         name: str,
         project_id: str | None = None,
         include_system_routes: bool | None = None,
+        private_parameters: Mapping[str, JSONValue] | None = None,
     ) -> SandboxState:
         self._ensure_open()
         sandbox = await self._api_client.resume_sandbox(
             name=name,
             project_id=project_id,
             include_system_routes=include_system_routes,
+            private_parameters=private_parameters,
         )
         if sandbox.current_session is None:
             raise SandboxResponseError(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -33,12 +33,13 @@ from vercel.sandbox._internal.filesystem_handle_core import (
 )
 from vercel.sandbox._internal.models import (
     _OMITTED,
+    NO_PRIVATE_PARAMETERS,
     CompletedProcess,
     DirectoryEntry,
     DurationInput,
     FailoverRegionsInput,
-    JSONValue,
     NetworkPolicy,
+    PrivateSandboxParameters,
     ProcessLog,
     SandboxQuery,
     SandboxResources,
@@ -1517,7 +1518,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> _ManagedSyncSandbox:
     try:
         state = iter_coroutine(
@@ -1568,7 +1569,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> _ManagedSyncSandbox:
     try:
         state = iter_coroutine(
@@ -1607,7 +1608,7 @@ def get_sandbox(
     project_id: str | None = None,
     resume: bool = False,
     include_system_routes: bool | None = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> SyncSandbox:
     return SyncSandbox(
         payload=iter_coroutine(
@@ -1644,7 +1645,7 @@ def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> tuple[SyncSandbox, bool]:
     try:
         state, created = iter_coroutine(
@@ -1694,7 +1695,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    private_parameters: Mapping[str, JSONValue] | None = None,
+    private_parameters: PrivateSandboxParameters = NO_PRIVATE_PARAMETERS,
 ) -> _ManagedSyncSandbox:
     return _ManagedSyncSandbox(
         payload=iter_coroutine(

--- a/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
+++ b/src/vercel-sandbox/vercel/sandbox/_internal/sync_runtime.py
@@ -37,6 +37,7 @@ from vercel.sandbox._internal.models import (
     DirectoryEntry,
     DurationInput,
     FailoverRegionsInput,
+    JSONValue,
     NetworkPolicy,
     ProcessLog,
     SandboxQuery,
@@ -1516,6 +1517,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> _ManagedSyncSandbox:
     try:
         state = iter_coroutine(
@@ -1535,6 +1537,7 @@ def create_sandbox(
                 snapshot_retention=snapshot_retention,
                 region=region,
                 failover_regions=normalize_failover_regions(failover_regions),
+                private_parameters=private_parameters,
             )
         )
         return _ManagedSyncSandbox(
@@ -1565,6 +1568,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> _ManagedSyncSandbox:
     try:
         state = iter_coroutine(
@@ -1584,6 +1588,7 @@ def fork_sandbox(
                 snapshot_retention=snapshot_retention,
                 region=region,
                 failover_regions=normalize_failover_regions(failover_regions),
+                private_parameters=private_parameters,
             )
         )
         return _ManagedSyncSandbox(
@@ -1602,6 +1607,7 @@ def get_sandbox(
     project_id: str | None = None,
     resume: bool = False,
     include_system_routes: bool | None = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> SyncSandbox:
     return SyncSandbox(
         payload=iter_coroutine(
@@ -1610,6 +1616,7 @@ def get_sandbox(
                 project_id=project_id,
                 resume=resume,
                 include_system_routes=include_system_routes,
+                private_parameters=private_parameters,
             )
         ),
         service=service,
@@ -1637,6 +1644,7 @@ def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> tuple[SyncSandbox, bool]:
     try:
         state, created = iter_coroutine(
@@ -1658,6 +1666,7 @@ def get_or_create_sandbox(
                 snapshot_retention=snapshot_retention,
                 region=region,
                 failover_regions=normalize_failover_regions(failover_regions),
+                private_parameters=private_parameters,
             )
         )
         return (
@@ -1685,6 +1694,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    private_parameters: Mapping[str, JSONValue] | None = None,
 ) -> _ManagedSyncSandbox:
     return _ManagedSyncSandbox(
         payload=iter_coroutine(
@@ -1692,6 +1702,7 @@ def resume_sandbox(
                 name=name,
                 project_id=project_id,
                 include_system_routes=include_system_routes,
+                private_parameters=private_parameters,
             )
         ),
         service=service,

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -26,7 +26,7 @@ from vercel.sandbox._internal.models import (
     DurationInput,
     FailoverRegionsInput,
     GitSource,
-    JSONValue,
+    JSONValue as _JSONValue,
     NetworkPolicy,
     NetworkPolicyKeyValueMatcher,
     NetworkPolicyMatcher,
@@ -49,7 +49,7 @@ from vercel.sandbox._internal.models import (
     SnapshotSource,
     TagFilter,
     TarballSource,
-    extract_private_parameters,
+    normalize_private_parameters as _normalize_private_parameters,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -107,7 +107,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> _ManagedSyncSandbox:
     """Create a sandbox and wait until it is ready.
 
@@ -162,7 +162,7 @@ def create_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("create_sandbox", private_parameters),
     )
 
 
@@ -184,7 +184,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> _ManagedSyncSandbox:
     """Fork a sandbox and wait until the fork is ready.
 
@@ -242,7 +242,7 @@ def fork_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("fork_sandbox", private_parameters),
     )
 
 
@@ -265,7 +265,7 @@ def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> tuple[SyncSandbox, bool]:
     """Get a named sandbox or create it when it does not exist.
 
@@ -321,7 +321,9 @@ def get_or_create_sandbox(
         snapshot_retention=snapshot_retention,
         region=region,
         failover_regions=failover_regions,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters(
+            "get_or_create_sandbox", private_parameters
+        ),
     )
 
 
@@ -330,7 +332,7 @@ def get_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> SyncSandbox:
     """Fetch a sandbox by name without resuming it.
 
@@ -354,7 +356,7 @@ def get_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("get_sandbox", private_parameters),
     )
 
 
@@ -363,7 +365,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
-    **private_parameters: JSONValue,
+    **private_parameters: _JSONValue,
 ) -> _ManagedSyncSandbox:
     """Resume a sandbox and return a managed handle.
 
@@ -387,7 +389,7 @@ def resume_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
-        private_parameters=extract_private_parameters(private_parameters),
+        private_parameters=_normalize_private_parameters("resume_sandbox", private_parameters),
     )
 
 

--- a/src/vercel-sandbox/vercel/sandbox/sync.py
+++ b/src/vercel-sandbox/vercel/sandbox/sync.py
@@ -26,6 +26,7 @@ from vercel.sandbox._internal.models import (
     DurationInput,
     FailoverRegionsInput,
     GitSource,
+    JSONValue,
     NetworkPolicy,
     NetworkPolicyKeyValueMatcher,
     NetworkPolicyMatcher,
@@ -48,6 +49,7 @@ from vercel.sandbox._internal.models import (
     SnapshotSource,
     TagFilter,
     TarballSource,
+    extract_private_parameters,
 )
 from vercel.sandbox._internal.options import (
     SandboxCredentials,
@@ -105,6 +107,7 @@ def create_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    **private_parameters: JSONValue,
 ) -> _ManagedSyncSandbox:
     """Create a sandbox and wait until it is ready.
 
@@ -159,6 +162,7 @@ def create_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -180,6 +184,7 @@ def fork_sandbox(
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
     destroy: bool = True,
+    **private_parameters: JSONValue,
 ) -> _ManagedSyncSandbox:
     """Fork a sandbox and wait until the fork is ready.
 
@@ -237,6 +242,7 @@ def fork_sandbox(
         region=region,
         failover_regions=failover_regions,
         destroy=destroy,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -259,6 +265,7 @@ def get_or_create_sandbox(
     snapshot_retention: SnapshotRetention | None = None,
     region: str | None = None,
     failover_regions: FailoverRegionsInput = None,
+    **private_parameters: JSONValue,
 ) -> tuple[SyncSandbox, bool]:
     """Get a named sandbox or create it when it does not exist.
 
@@ -314,6 +321,7 @@ def get_or_create_sandbox(
         snapshot_retention=snapshot_retention,
         region=region,
         failover_regions=failover_regions,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -322,6 +330,7 @@ def get_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    **private_parameters: JSONValue,
 ) -> SyncSandbox:
     """Fetch a sandbox by name without resuming it.
 
@@ -345,6 +354,7 @@ def get_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 
@@ -353,6 +363,7 @@ def resume_sandbox(
     name: str,
     project_id: str | None = None,
     include_system_routes: bool | None = None,
+    **private_parameters: JSONValue,
 ) -> _ManagedSyncSandbox:
     """Resume a sandbox and return a managed handle.
 
@@ -376,6 +387,7 @@ def resume_sandbox(
         name=name,
         project_id=project_id,
         include_system_routes=include_system_routes,
+        private_parameters=extract_private_parameters(private_parameters),
     )
 
 


### PR DESCRIPTION
The JavaScript Sandbox SDK forwards `__`-prefixed parameters so unreleased API features can be exercised before they have a stable public SDK option. This brings the Python SDK into alignment.

Python differs because lifecycle methods accept keyword arguments directly rather than an options object. The SDK therefore captures extra keyword arguments, forwards only `__`-prefixed names to the relevant API request, and raises Python-style `unexpected keyword argument` errors for ordinary typos.