### PR TITLE
queue: Force-cancel stuck dev server tasks

### DIFF
--- a/changes/vercel-queue/windows-devserver-shutdown.bugfix.md
+++ b/changes/vercel-queue/windows-devserver-shutdown.bugfix.md
@@ -1,0 +1,1 @@
+Force embedded development servers to exit when graceful shutdown stalls.

--- a/src/vercel-queue/tests/unit/test_queue_asgi.py
+++ b/src/vercel-queue/tests/unit/test_queue_asgi.py
@@ -4,9 +4,12 @@ from typing import cast
 
 import contextlib
 import logging
+import threading
 from collections.abc import AsyncIterable, Iterator
 from dataclasses import dataclass
+from types import SimpleNamespace
 
+import anyio
 import httpx
 import pytest
 
@@ -62,6 +65,66 @@ def test_devserver_main_defaults_to_random_port(
         }
     ]
     assert capsys.readouterr().out == '{"baseUrl": "http://127.0.0.1:54321"}\n'
+
+
+def test_devserver_shutdown_cancels_a_stuck_server() -> None:
+    class _Server:
+        should_exit = False
+        force_exit = False
+        cancelled = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    class _Thread(threading.Thread):
+        def __init__(self, server: _Server) -> None:
+            super().__init__()
+            self._server = server
+            self.join_timeouts: list[float] = []
+
+        def join(self, timeout: float | None = None) -> None:
+            assert timeout is not None
+            self.join_timeouts.append(timeout)
+
+        def is_alive(self) -> bool:
+            return not self._server.cancelled
+
+    server = _Server()
+    thread = _Thread(server)
+
+    queue_devserver_internal._stop_server(server, thread, "test server", timeout=2.5)
+
+    assert server.should_exit is True
+    assert server.force_exit is True
+    assert server.cancelled is True
+    assert thread.join_timeouts == [3.5, 2.5]
+
+
+def test_cancellable_devserver_stops_its_event_loop_task() -> None:
+    started = threading.Event()
+
+    class _Config:
+        def get_loop_factory(self) -> None:
+            return None
+
+    class _Server:
+        def __init__(self, config: object) -> None:
+            self.config = config
+
+        async def serve(self, sockets: list[object] | None = None) -> None:
+            started.set()
+            await anyio.sleep_forever()
+
+    uvicorn = SimpleNamespace(Server=_Server)
+    server = queue_devserver_internal._cancellable_server(uvicorn, _Config())
+    thread = threading.Thread(target=server.run)
+    thread.start()
+
+    assert started.wait(timeout=5)
+    server.cancel()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
 
 
 class _FakeClient:

--- a/src/vercel-queue/tests/unit/test_queue_lease.py
+++ b/src/vercel-queue/tests/unit/test_queue_lease.py
@@ -1850,7 +1850,7 @@ def _wait_for_sync_lease_deadline(
     condition: Callable[[], bool] | None = None,
 ) -> None:
     expected = server.state.now + timedelta(seconds=seconds)
-    deadline = time.monotonic() + 1
+    deadline = time.monotonic() + 5
     while server.state.by_id[message_id].lease_deadline_by_consumer[consumer] != expected or (
         condition is not None and not condition()
     ):

--- a/src/vercel-queue/vercel/queue/_internal/devserver.py
+++ b/src/vercel-queue/vercel/queue/_internal/devserver.py
@@ -15,6 +15,9 @@ import time
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 
+import anyio
+from anyio import from_thread
+
 from ..embedded import create_embedded_queue_app
 from .asgi import QueueClientAsgiApp, asgi_app
 from .client import QueueClient
@@ -22,6 +25,9 @@ from .config import CURRENT_DEPLOYMENT, BaseUrl, DeploymentOption
 from .embedded import EmbeddedQueueDevServer
 from .http import AsyncHttpClientFactory
 from .types import Duration
+
+_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+_SERVER_STOP_TIMEOUT_MARGIN_SECONDS = 1.0
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -55,8 +61,9 @@ def embedded_queue_dev_server(
         log_level="warning",
         lifespan="off",
         ws="none",
+        timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
     )
-    server = uvicorn.Server(config)
+    server = _cancellable_server(uvicorn, config)
     thread = threading.Thread(target=_profiled_server_run(server, profile), daemon=True)
     thread.start()
     _wait_for_server(server)
@@ -69,11 +76,15 @@ def embedded_queue_dev_server(
             _thread=thread,
         )
     finally:
-        server.should_exit = True
-        thread.join(timeout=5)
-        if thread.is_alive():
-            raise RuntimeError("embedded queue dev server did not stop")
-        app.state.close()
+        try:
+            _stop_server(
+                server,
+                thread,
+                "embedded queue dev server",
+                timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
+            )
+        finally:
+            app.state.close()
 
 
 @contextlib.contextmanager
@@ -110,8 +121,9 @@ def queue_client_asgi_dev_server(  # noqa: PLR0913
         log_level="warning",
         lifespan="on",
         ws="none",
+        timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
     )
-    server = uvicorn.Server(config)
+    server = _cancellable_server(uvicorn, config)
     thread = threading.Thread(target=_profiled_server_run(server, profile), daemon=True)
     thread.start()
     _wait_for_server(server, "queue client ASGI dev server")
@@ -123,10 +135,12 @@ def queue_client_asgi_dev_server(  # noqa: PLR0913
             _thread=thread,
         )
     finally:
-        server.should_exit = True
-        thread.join(timeout=5)
-        if thread.is_alive():
-            raise RuntimeError("queue client ASGI dev server did not stop")
+        _stop_server(
+            server,
+            thread,
+            "queue client ASGI dev server",
+            timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -179,6 +193,52 @@ def _wait_for_server(server: Any, name: str = "embedded queue dev server") -> No
             time.sleep(0.01)
             continue
         raise RuntimeError(f"{name} did not start")
+
+
+def _stop_server(
+    server: Any,
+    thread: threading.Thread,
+    name: str,
+    *,
+    timeout: float,
+) -> None:
+    server.should_exit = True
+    thread.join(timeout=timeout + _SERVER_STOP_TIMEOUT_MARGIN_SECONDS)
+    if thread.is_alive():
+        server.force_exit = True
+        server.cancel()
+        thread.join(timeout=timeout)
+    if thread.is_alive():
+        raise RuntimeError(f"{name} did not stop")
+
+
+def _cancellable_server(uvicorn: Any, config: Any) -> Any:
+    class CancellableServer(uvicorn.Server):
+        _cancel_scope: anyio.CancelScope | None = None
+        _portal: from_thread.BlockingPortal | None = None
+
+        def run(self, sockets: list[Any] | None = None) -> None:
+            backend_options: dict[str, Any] = {}
+            get_loop_factory = getattr(self.config, "get_loop_factory", None)
+            if get_loop_factory is not None:
+                backend_options["loop_factory"] = get_loop_factory()
+            else:
+                self.config.setup_event_loop()
+            anyio.run(self._run, sockets, backend_options=backend_options)
+
+        async def _run(self, sockets: list[Any] | None) -> None:
+            async with from_thread.BlockingPortal() as self._portal:
+                with anyio.CancelScope() as self._cancel_scope:
+                    await self.serve(sockets=sockets)
+
+        def cancel(self) -> None:
+            if self._portal is not None and self._cancel_scope is not None:
+                try:
+                    self._portal.start_task_soon(self._cancel_scope.cancel)
+                except RuntimeError:
+                    pass
+
+    return CancellableServer(config)
 
 
 def _server_port(server: Any) -> int:


### PR DESCRIPTION
Calling force_exit does not wake a Windows server loop that is blocked in
I/O.  After a bounded graceful shutdown, cancel the actual AnyIO serve task
so its thread and event loop unwind deterministically.
