### PR TITLE
workflow: Improve portability

### DIFF
--- a/changes/vercel-workflow/linux-sandbox-platform.bugfix.md
+++ b/changes/vercel-workflow/linux-sandbox-platform.bugfix.md
@@ -1,0 +1,1 @@
+Prevent recursive workflow sandbox imports on Windows and decode Node CLI output as UTF-8.

--- a/src/vercel-workflow/tests/integration/test_devalue.py
+++ b/src/vercel-workflow/tests/integration/test_devalue.py
@@ -564,6 +564,7 @@ def interop(devalue_entry: Path) -> dict[str, _Outcome]:
         input=json.dumps(payload),
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=120,
         check=False,
         env={**os.environ, "DEVALUE_ENTRY": str(devalue_entry)},
@@ -775,7 +776,7 @@ def _load_upstream_cases(test_file: Path) -> list[_UpstreamCase]:
             )
         pending.clear()
 
-    for line in test_file.read_text().split("\n"):
+    for line in test_file.read_text(encoding="utf-8").split("\n"):
         match = field.match(line)
         if match is None:
             continue
@@ -862,6 +863,7 @@ def corpus_results(
         input=json.dumps(pairs),
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=120,
         check=False,
         env={**os.environ, "DEVALUE_ENTRY": str(devalue_entry)},

--- a/src/vercel-workflow/tests/integration/test_workflow_cli_interop.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_cli_interop.py
@@ -96,6 +96,7 @@ def _npm_install_into(prefix: Path) -> bool:
             str(prefix),
         ],
         capture_output=True,
+        encoding="utf-8",
         text=True,
         timeout=600,
         check=False,
@@ -191,6 +192,7 @@ def _inspect_raw(cli: Path, data_dir: Path, *args: str) -> str:
     result = subprocess.run(
         ["node", str(cli), "inspect", *args, "--backend", "local", "--json"],
         capture_output=True,
+        encoding="utf-8",
         text=True,
         timeout=120,
         cwd=data_dir,

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -12,12 +12,16 @@ Covers:
 
 from __future__ import annotations
 
+import os
 import platform
+import struct
 import sys
+import time
 from contextlib import contextmanager
 
 import pytest
 
+from vercel.workflow._internal import py_sandbox
 from vercel.workflow._internal.py_sandbox import Sandbox, SandboxRestrictionError
 from vercel.workflow.sandbox import (
     ALL_CLEANUPS,
@@ -133,15 +137,20 @@ class TestDatetimeRestrictions:
 class TestOsRestrictions:
     def test_os_path_allowed(self):
         ns = _run_in_sandbox("import os; result = os.path.join('a', 'b')")
-        assert ns["result"] == "a/b"
+        assert ns["result"] == os.path.join("a", "b")
+
+    def test_os_path_alias_allowed(self):
+        path = os.path.join("a", "b")
+        ns = _run_in_sandbox(f"from os.path import dirname; result = dirname({path!r})")
+        assert ns["result"] == os.path.dirname(path)
 
     def test_os_sep_allowed(self):
         ns = _run_in_sandbox("import os; result = os.sep")
-        assert ns["result"] == "/"
+        assert ns["result"] == os.sep
 
     def test_os_name_allowed(self):
         ns = _run_in_sandbox("import os; result = os.name")
-        assert isinstance(ns["result"], str)
+        assert ns["result"] == os.name
 
     def test_os_fspath_allowed(self):
         ns = _run_in_sandbox("import os; result = os.fspath('/tmp')")
@@ -277,7 +286,16 @@ class TestTimeRestrictions:
         _run_in_sandbox("import time; _ = time.struct_time")
 
     def test_time_constants_allowed(self):
-        _run_in_sandbox("import time; _ = time.CLOCK_MONOTONIC")
+        for name in (
+            "CLOCK_REALTIME",
+            "CLOCK_MONOTONIC",
+            "CLOCK_PROCESS_CPUTIME_ID",
+            "CLOCK_THREAD_CPUTIME_ID",
+        ):
+            ns = _run_in_sandbox(
+                f"import time; result = (hasattr(time, {name!r}), getattr(time, {name!r}, None))"
+            )
+            assert ns["result"] == (hasattr(time, name), getattr(time, name, None))
 
     @pytest.mark.asyncio
     async def test_concurrent_coroutine_not_affected_by_sandbox(self):
@@ -768,8 +786,41 @@ class TestPassthroughModules:
         ns = _run_in_sandbox("import math; result = math.sqrt(16)")
         assert ns["result"] == 4.0
 
+    def test_zipimport_bootstrap_module_bypasses_finders(self, monkeypatch: pytest.MonkeyPatch):
+        sandbox = Sandbox()
+        assert sandbox.table["struct"] is struct
+
+        def unexpected_import(*args, **kwargs):
+            pytest.fail(f"preloaded module reached importlib: {args!r} {kwargs!r}")
+
+        monkeypatch.setattr(py_sandbox.importlib, "__import__", unexpected_import)
+        with sandbox.enter():
+            assert __import__("struct") is struct
+
+    def test_real_spec_finders_run_against_host_modules(self, monkeypatch: pytest.MonkeyPatch):
+        sandbox = Sandbox()
+        sandbox.table.pop("struct")
+        finder = next(f for f in sys.meta_path if isinstance(f, py_sandbox._SandboxFinder))
+        seen: list[object] = []
+
+        class RecordingFinder:
+            @staticmethod
+            def find_spec(fullname, path, target):
+                import struct as finder_struct
+
+                assert not py_sandbox.in_sandbox()
+                seen.append(finder_struct)
+                return None
+
+        index = sys.meta_path.index(finder)
+        monkeypatch.setattr(sys, "meta_path", [*sys.meta_path[: index + 1], RecordingFinder()])
+        with sandbox.enter():
+            assert finder._find_real_spec("missing", None, None) is None
+
+        assert seen == [struct]
+        assert "struct" not in sandbox.table
+
     def test_shutil_works(self):
-        _run_in_sandbox("import os; lurr = os.supports_dir_fd")
         _run_in_sandbox("import shutil")
 
     def test_pathlib_works(self):

--- a/src/vercel-workflow/tests/unit/test_workflow_manifest_command.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_manifest_command.py
@@ -19,6 +19,7 @@ project that deploys needs no arguments here.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -232,7 +233,7 @@ def test_the_command_line_works_as_a_command_line(tmp_path) -> None:
         text=True,
         timeout=120,
         env={
-            "PATH": "/usr/bin:/bin",
+            **os.environ,
             "WORKFLOW_TARGET_WORLD": "local",
             "PYTHONPATH": str(tmp_path),
         },

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -8,6 +8,7 @@ import importlib
 import logging
 import os
 import random
+import struct
 import sys
 import threading
 import types
@@ -426,6 +427,10 @@ _PASSTHROUGHS: set[str] = {
     "math",
     "numbers",
     "operator",
+    # Wrap the initialized host module with the restrictions above. Re-running
+    # os.py would duplicate its platform-specific initialization in every
+    # sandbox and can expose a different ``os.path`` module object.
+    "os",
     "posixpath",
     "pprint",
     "quopri",
@@ -571,11 +576,11 @@ class _SandboxFinder(MetaPathFinder):
 
     For every ``import X`` inside the sandbox:
 
-    1. If ``X`` **has restrictions** — return a ``_ProxyModule`` that
+    1. If ``X`` **has restrictions**, return a ``_ProxyModule`` that
        intercepts the restricted attributes.
-    2. If ``X`` **matches the passthrough set** — return the host module
+    2. If ``X`` **matches the passthrough set**, return the host module
        as-is (importing it into the host first if needed).
-    3. Otherwise — return ``None`` for a fresh re-import.
+    3. Otherwise, return ``None`` for a fresh re-import.
     """
 
     def __init__(
@@ -655,12 +660,27 @@ class _SandboxFinder(MetaPathFinder):
         path: Sequence[str] | None,
         target: types.ModuleType | None,
     ) -> ModuleSpec | None:
-        if self in sys.meta_path:
-            for finder in sys.meta_path[sys.meta_path.index(self) + 1 :]:
-                if hasattr(finder, "find_spec"):
-                    spec = finder.find_spec(fullname, path, target)
-                    if spec is not None:
-                        return spec
+        """Ask the remaining finders for a spec in the host import context.
+
+        Third-party finders may import their own support modules during spec
+        discovery. If those imports saw the sandbox module table, they could
+        re-enter this finder recursively. Only discovery runs against the host:
+        after the context variables are restored, ``_RestrictedLoader`` uses
+        the returned loader to execute the module inside the sandbox and then
+        applies its restrictions.
+        """
+        table_token = _sandbox_sys_modules.set(None)
+        sandbox_token = _in_sandbox.set(False)
+        try:
+            if self in sys.meta_path:
+                for finder in sys.meta_path[sys.meta_path.index(self) + 1 :]:
+                    if hasattr(finder, "find_spec"):
+                        spec = finder.find_spec(fullname, path, target)
+                        if spec is not None:
+                            return spec
+        finally:
+            _in_sandbox.reset(sandbox_token)
+            _sandbox_sys_modules.reset(table_token)
         return None
 
 
@@ -816,6 +836,15 @@ def _install_import_hook() -> None:
     ) -> types.ModuleType:
         if not _in_sandbox.get(False):
             return real_import(name, globals, locals, fromlist or (), level)
+        table = _sandbox_sys_modules.get()
+        if level == 0 and table is not None and name in table:
+            module = table[name]
+            if fromlist and all(item == "*" or hasattr(module, item) for item in fromlist):
+                return module
+            if not fromlist:
+                top_level = table.get(name.partition(".")[0])
+                if top_level is not None:
+                    return top_level
         return importlib.__import__(name, globals, locals, fromlist or (), level)
 
     builtins.__import__ = _sandbox_import
@@ -858,7 +887,18 @@ def _new_sandbox_table() -> dict[str, types.ModuleType]:
     """
     _ensure_installed()
 
-    table: dict[str, types.ModuleType] = {"sys": sys}
+    table: dict[str, types.ModuleType] = {
+        "sys": sys,
+        # Python 3.13+'s frozen zipimport imports struct lazily while probing
+        # ZIP64 entries. Windows console-script executables are zip candidates,
+        # so resolving struct through the sandbox finder can recursively probe
+        # the same executable before zipimport has cached its directory.
+        "struct": struct,
+        # os.py normally installs this alias while it initializes. The sandbox
+        # wraps the initialized host module, so copy its host-native path alias
+        # into every fresh module table.
+        "os.path": os.path,
+    }
     # Snapshot atomically (list() over the view is a single C op) so a
     # concurrent import in another thread can't trip "dict changed size".
     for key, mod in list(_real_sys_modules.items()):


### PR DESCRIPTION
Avoid import finder recursion by returning already-loaded sandbox
imports directly and performing third-party spec discovery in the host
import context.

Keep platform behavior host-native and decode Node CLI output as UTF-8
so the Windows test matrix passes.