### PR TITLE
workflow: order hook disposal before creation

### DIFF
--- a/changes/vercel-workflow/hook-disposal-order.bugfix.md
+++ b/changes/vercel-workflow/hook-disposal-order.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that caused reusing a hook token after disposing the previous hook to conflict with the same workflow run.

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+import pydantic
 import pytest
 
 from vercel.workflow import HookConflictError, WorkflowRunFailedError, sleep
@@ -40,7 +41,7 @@ TOKEN = "shared-token"
 registry = core.Workflows(as_vercel_job=False)
 
 
-class Claim(core.BaseHook):
+class Claim(core.BaseHook, pydantic.BaseModel):
     pass
 
 
@@ -48,6 +49,15 @@ class Claim(core.BaseHook):
 async def wait_for_claim() -> str:
     await Claim.wait(token=TOKEN)
     return "received"
+
+
+@registry.workflow
+async def reuse_claim_after_dispose() -> str:
+    first = Claim.wait(token=TOKEN)
+    await first
+    first.dispose()
+    conflict = await Claim.wait(token=TOKEN).get_conflict()
+    return "available" if conflict is None else "conflict"
 
 
 @registry.workflow
@@ -204,6 +214,37 @@ async def test_different_hook_same_token_conflicts(tmp_path, monkeypatch) -> Non
     assert isinstance(result.event, w.HookConflictEvent)
     assert result.event.event_data.token == TOKEN
     assert result.event.event_data.conflicting_run_id == RUN_ID
+
+
+async def test_disposal_is_flushed_before_reusing_a_hook_token(tmp_path, monkeypatch) -> None:
+    world = _world(tmp_path, monkeypatch)
+    w.set_world(world)
+    run_id = await _create_run(world, reuse_claim_after_dispose.workflow_id)
+
+    await _invoke(run_id, reuse_claim_after_dispose.workflow_id)
+    events = (await world.events_list(run_id)).data
+    first_hook = next(event for event in events if isinstance(event, w.HookCreatedEvent))
+    assert first_hook.correlation_id is not None
+    await world.events_create(
+        run_id,
+        w.HookReceivedEventData(payload=ser.dehydrate({}), token=TOKEN).into_event(
+            first_hook.correlation_id
+        ),
+    )
+
+    await _invoke(run_id, reuse_claim_after_dispose.workflow_id)
+
+    events = (await world.events_list(run_id)).data
+    assert [event.event_type for event in events] == [
+        "run_created",
+        "run_started",
+        "hook_created",
+        "hook_received",
+        "hook_disposed",
+        "hook_created",
+        "run_completed",
+    ]
+    assert await runtime.Run(run_id).return_value() == "available"
 
 
 def test_hook_conflict_owner_id_round_trips_on_the_wire() -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -1576,10 +1576,32 @@ async def _workflow_replay_pass(
             logger.warning(f"Workflow run {run_id} was already completed")
         return None
 
-    # Now that the workflow is fully suspended, we can create all pending events in parallel
     events_created = False
     immediate_replay_reasons: set[str] = set()
 
+    # A hook token is not released until its disposal event is durable. Flush
+    # disposals before creating new hooks so a workflow can reuse a token in the
+    # same suspension without conflicting with its own previous hook.
+    async with anyio.create_task_group() as tg:
+        for hook in context.hooks.values():
+            if hook.disposed and not hook.has_dispose_event:
+
+                async def dispose_hook(h=hook):
+                    try:
+                        await world.events_create(
+                            run_id,
+                            w.HookDisposedEvent(correlation_id=h.correlation_id),
+                        )
+                    except (w.EntityConflictError, w.HookNotFoundError):
+                        logger.debug(
+                            f"Workflow hook {h.correlation_id!r} has already been disposed"
+                        )
+
+                tg.start_soon(dispose_hook)
+                events_created = True
+
+    # Now that the workflow is fully suspended and old hook tokens have been
+    # released, create all pending events in parallel.
     async with anyio.create_task_group() as tg:
         for sus in context.suspensions.values():
             if sus.has_created_event:
@@ -1664,23 +1686,6 @@ async def _workflow_replay_pass(
                     immediate_replay_reasons.add("attr_set")
 
                 tg.start_soon(set_attr)
-                events_created = True
-
-        for hook in context.hooks.values():
-            if hook.disposed and not hook.has_dispose_event:
-
-                async def dispose_hook(h=hook):
-                    try:
-                        await world.events_create(
-                            run_id,
-                            w.HookDisposedEvent(correlation_id=h.correlation_id),
-                        )
-                    except (w.EntityConflictError, w.HookNotFoundError):
-                        logger.debug(
-                            f"Workflow hook {h.correlation_id!r} has already been disposed"
-                        )
-
-                tg.start_soon(dispose_hook)
                 events_created = True
 
     if not context.suspensions and events_created:


### PR DESCRIPTION
Flush pending hook disposals before creating new suspension events so a reused token cannot conflict with the same run's previous hook.