### PR TITLE
Keep multi-line news fragments as one changelog entry

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,8 +39,15 @@ Example:
 changes/vercel-cache/123.bugfix.md
 ```
 
-News fragment content should be one or more concise changelog bullets. The
-release script adds `- ` when a line does not already start with a bullet.
+A news fragment is one changelog entry. It may span several lines: a concise
+summary, optionally followed by blank-line-separated detail paragraphs, nested
+lists, or fenced code blocks. The release script renders the whole fragment as a
+single bullet, adding `- ` to the first line and indenting the rest so Markdown
+keeps them inside that bullet. Paragraph breaks and code blocks are preserved.
+
+To get more than one changelog entry from a single fragment, start each one with
+a `- ` in column zero. A list marker inside a fenced code block is sample text,
+not a new entry.
 
 Dependency-only cascade releases do not need handwritten news fragments. The
 release script writes `Update dependencies.` for those changelog entries.
@@ -77,7 +84,9 @@ uv run poe release
 News-fragment-backed changelog bullets include PR numbers when Git history for
 the news fragment contains GitHub squash subjects like
 `pkg: fix cache cleanup (#123)` or merge subjects like
-`Merge pull request #123 from user/branch`.
+`Merge pull request #123 from user/branch`. Each entry gets the number once, at
+the end of its summary, so a multi-line entry does not repeat the link on its
+detail paragraphs.
 Dependency-only cascade entries still render as `Update dependencies.` without a
 PR suffix.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,15 +39,14 @@ Example:
 changes/vercel-cache/123.bugfix.md
 ```
 
-A news fragment is one changelog entry. It may span several lines: a concise
-summary, optionally followed by blank-line-separated detail paragraphs, nested
-lists, or fenced code blocks. The release script renders the whole fragment as a
-single bullet, adding `- ` to the first line and indenting the rest so Markdown
-keeps them inside that bullet. Paragraph breaks and code blocks are preserved.
+One news fragment is exactly one changelog entry. It may span several lines: a
+concise summary, optionally followed by blank-line-separated detail paragraphs,
+nested lists, or fenced code blocks. All of it belongs to that one entry.
 
-To get more than one changelog entry from a single fragment, start each one with
-a `- ` in column zero. A list marker inside a fenced code block is sample text,
-not a new entry.
+The release script renders the fragment as a single bullet, adding `- ` to the
+first line and indenting the rest so Markdown keeps them inside that bullet.
+Paragraph breaks and code blocks are preserved. Nothing in the fragment splits
+it into more entries; write a second fragment for a second entry.
 
 Dependency-only cascade releases do not need handwritten news fragments. The
 release script writes `Update dependencies.` for those changelog entries.
@@ -84,8 +83,8 @@ uv run poe release
 News-fragment-backed changelog bullets include PR numbers when Git history for
 the news fragment contains GitHub squash subjects like
 `pkg: fix cache cleanup (#123)` or merge subjects like
-`Merge pull request #123 from user/branch`. Each entry gets the number once, at
-the end of its summary, so a multi-line entry does not repeat the link on its
+`Merge pull request #123 from user/branch`. Each fragment gets the number once,
+at the end of its summary, so a multi-line entry does not repeat the link on its
 detail paragraphs.
 Dependency-only cascade entries still render as `Update dependencies.` without a
 PR suffix.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,10 +48,21 @@ FRAGMENT_GUIDANCE = """
 
 # Write a concise news fragment for {package}.
 #
-# Each non-empty, non-comment line becomes changelog text.
-# The release script adds '- ' when a line does not already start with a bullet.
+# The whole fragment becomes one changelog entry: a summary, then any detail
+# paragraphs or code blocks. Blank lines and indentation are preserved.
+# The release script adds '- ' and appends the pull request number.
+# Start a line with '- ' to add a second entry. Comment lines outside code
+# blocks are ignored.
 {package_diff_section}
 """
+# A list marker in column zero, which is the only way to ask for a second
+# changelog entry from one news fragment.
+BULLET_RE = re.compile(r"[-*+]\s")
+# Up to three leading spaces then a run of at least three backticks or tildes,
+# per CommonMark fenced code blocks.
+FENCE_RE = re.compile(r" {0,3}(?P<marker>`{3,}|~{3,})")
+# Two spaces put a continuation line inside the Markdown list item it follows.
+CONTINUATION_INDENT = "  "
 
 
 @dataclass(frozen=True)
@@ -191,35 +202,120 @@ def _render_changelog_entry(release: Release, *, pr_numbers: dict[Path, int] | N
         if not fragments:
             continue
         lines.extend([f"### {title}", ""])
+        bullets: list[list[str]] = []
         for fragment in fragments:
             pr_number = pr_numbers.get(fragment.path) if pr_numbers is not None else None
-            for item in _fragment_changelog_items(fragment.text):
-                lines.append(_render_changelog_bullet(item, pr_number=pr_number))
+            bullets.extend(
+                _render_changelog_bullet(entry, pr_number=pr_number)
+                for entry in _fragment_changelog_entries(fragment.text)
+            )
+        lines.extend(_join_changelog_bullets(bullets))
         lines.append("")
     return "\n".join(lines)
 
 
-def _fragment_changelog_items(text: str) -> list[str]:
-    items: list[str] = []
+def _fragment_changelog_entries(text: str) -> list[list[str]]:
+    """Split news fragment text into changelog entries, as lists of lines.
+
+    A fragment is one changelog entry, even when it spans several lines: a
+    summary that may be hard wrapped, followed by detail paragraphs and code
+    blocks. Blank lines separate the parts of that one entry, so they must not
+    split it into separate bullets. Only an explicit list marker in column zero
+    starts another entry, and one inside a fenced code block is sample text.
+    """
+    lines = [line.rstrip() for line in text.splitlines()]
+    entries: list[list[str]] = []
     current: list[str] = []
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            if current:
-                items.append(" ".join(current))
-                current = []
+
+    def flush() -> None:
+        entry = _trim_blank_lines(current)
+        if entry:
+            entries.append(entry)
+        current.clear()
+
+    for line, in_fence in zip(lines, _fence_states(lines), strict=True):
+        if not in_fence and BULLET_RE.match(line):
+            flush()
+        current.append(line)
+    flush()
+    return entries
+
+
+def _fence_states(lines: Sequence[str]) -> list[bool]:
+    """Return, per line, whether it belongs to a fenced code block.
+
+    The delimiters count as part of the block, so nothing on a fence line is
+    mistaken for changelog markup either.
+    """
+    states: list[bool] = []
+    fence: str | None = None
+    for line in lines:
+        match = FENCE_RE.match(line)
+        marker = None if match is None else match.group("marker")
+        if fence is None:
+            states.append(marker is not None)
+            fence = marker
             continue
-        current.append(stripped)
-    if current:
-        items.append(" ".join(current))
-    return items
+        states.append(True)
+        if marker is not None and marker[0] == fence[0] and len(marker) >= len(fence):
+            fence = None
+    return states
 
 
-def _render_changelog_bullet(item: str, *, pr_number: int | None) -> str:
-    bullet = item if item.startswith("- ") else f"- {item}"
-    if pr_number is None or _mentions_pr(bullet, pr_number):
-        return bullet
-    return f"{bullet} (#{pr_number})"
+def _trim_blank_lines(lines: Sequence[str]) -> list[str]:
+    result = list(lines)
+    while result and not result[0]:
+        result.pop(0)
+    while result and not result[-1]:
+        result.pop()
+    return result
+
+
+def _render_changelog_bullet(entry: Sequence[str], *, pr_number: int | None) -> list[str]:
+    """Render one changelog entry as the lines of a single Markdown list item."""
+    lines = list(entry)
+    if pr_number is not None and not _mentions_pr("\n".join(lines), pr_number):
+        index = _pr_reference_index(lines)
+        lines[index] = f"{lines[index]} (#{pr_number})"
+    first, *rest = lines
+    bullet = first if BULLET_RE.match(first) else f"- {first}"
+    return [bullet, *(f"{CONTINUATION_INDENT}{line}" if line else "" for line in rest)]
+
+
+def _pr_reference_index(lines: Sequence[str]) -> int:
+    """Index of the line that should carry the ``(#123)`` reference.
+
+    The reference belongs at the end of the entry's summary, which may be hard
+    wrapped over several lines, rather than mid-sentence on the first one or
+    trailing the detail paragraphs. It never lands inside a fenced code block,
+    where Markdown would render it literally.
+    """
+    summary_end: int | None = None
+    for index, (line, in_fence) in enumerate(zip(lines, _fence_states(lines), strict=True)):
+        if in_fence:
+            continue
+        if not line:
+            if summary_end is not None:
+                return summary_end
+            continue
+        summary_end = index
+    return len(lines) - 1 if summary_end is None else summary_end
+
+
+def _join_changelog_bullets(bullets: Sequence[Sequence[str]]) -> list[str]:
+    """Concatenate rendered bullets, keeping multi-line ones visually separate.
+
+    A bullet that starts immediately after an indented detail paragraph is hard
+    to pick out, so multi-line bullets get a blank line on either side. Runs of
+    one-line bullets stay tight, leaving simple changelog sections unchanged.
+    """
+    lines: list[str] = []
+    for index, bullet in enumerate(bullets):
+        needs_gap = len(bullet) > 1 or (index > 0 and len(bullets[index - 1]) > 1)
+        if lines and needs_gap:
+            lines.append("")
+        lines.extend(bullet)
+    return lines
 
 
 def _mentions_pr(text: str, pr_number: int) -> bool:
@@ -683,13 +779,27 @@ def _select_editor() -> list[str]:
 
 
 def clean_news_fragment_text(text: str) -> str:
-    text = text.split(CUTOFF_MARKER, 1)[0]
-    lines = [
-        line.rstrip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    ]
-    return "\n".join(lines).strip()
+    """Turn editor buffer contents into the text stored in a news fragment.
+
+    Comment lines and everything below the cutoff marker are dropped. Blank
+    lines between paragraphs survive, because a fragment is one changelog entry
+    and those breaks are part of it; runs of them collapse to one. Code blocks
+    are kept verbatim, so a ``#`` comment in a sample is not read as a comment
+    on the fragment.
+    """
+    body = text.split(CUTOFF_MARKER, 1)[0]
+    lines = [line.rstrip() for line in body.splitlines()]
+    kept: list[str] = []
+    for line, in_fence in zip(lines, _fence_states(lines), strict=True):
+        if in_fence:
+            kept.append(line)
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        if not line and (not kept or not kept[-1]):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
 
 
 def validate_fragment_kind(kind: str) -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,13 +51,12 @@ FRAGMENT_GUIDANCE = """
 # The whole fragment becomes one changelog entry: a summary, then any detail
 # paragraphs or code blocks. Blank lines and indentation are preserved.
 # The release script adds '- ' and appends the pull request number.
-# Start a line with '- ' to add a second entry. Comment lines outside code
-# blocks are ignored.
+# Comment lines outside code blocks are ignored.
 {package_diff_section}
 """
-# A list marker in column zero, which is the only way to ask for a second
-# changelog entry from one news fragment.
-BULLET_RE = re.compile(r"[-*+]\s")
+# A list marker the fragment already opens with, so its entry is not given a
+# second one.
+LIST_MARKER_RE = re.compile(r"[-*+]\s")
 # Up to three leading spaces then a run of at least three backticks or tildes,
 # per CommonMark fenced code blocks.
 FENCE_RE = re.compile(r" {0,3}(?P<marker>`{3,}|~{3,})")
@@ -205,47 +204,17 @@ def _render_changelog_entry(release: Release, *, pr_numbers: dict[Path, int] | N
         bullets: list[list[str]] = []
         for fragment in fragments:
             pr_number = pr_numbers.get(fragment.path) if pr_numbers is not None else None
-            bullets.extend(
-                _render_changelog_bullet(entry, pr_number=pr_number)
-                for entry in _fragment_changelog_entries(fragment.text)
-            )
+            bullets.append(_render_changelog_bullet(fragment.text, pr_number=pr_number))
         lines.extend(_join_changelog_bullets(bullets))
         lines.append("")
     return "\n".join(lines)
 
 
-def _fragment_changelog_entries(text: str) -> list[list[str]]:
-    """Split news fragment text into changelog entries, as lists of lines.
-
-    A fragment is one changelog entry, even when it spans several lines: a
-    summary that may be hard wrapped, followed by detail paragraphs and code
-    blocks. Blank lines separate the parts of that one entry, so they must not
-    split it into separate bullets. Only an explicit list marker in column zero
-    starts another entry, and one inside a fenced code block is sample text.
-    """
-    lines = [line.rstrip() for line in text.splitlines()]
-    entries: list[list[str]] = []
-    current: list[str] = []
-
-    def flush() -> None:
-        entry = _trim_blank_lines(current)
-        if entry:
-            entries.append(entry)
-        current.clear()
-
-    for line, in_fence in zip(lines, _fence_states(lines), strict=True):
-        if not in_fence and BULLET_RE.match(line):
-            flush()
-        current.append(line)
-    flush()
-    return entries
-
-
 def _fence_states(lines: Sequence[str]) -> list[bool]:
     """Return, per line, whether it belongs to a fenced code block.
 
-    The delimiters count as part of the block, so nothing on a fence line is
-    mistaken for changelog markup either.
+    The delimiters count as part of the block, so a fence line is never treated
+    as prose that could take the pull request reference or a comment marker.
     """
     states: list[bool] = []
     fence: str | None = None
@@ -271,14 +240,22 @@ def _trim_blank_lines(lines: Sequence[str]) -> list[str]:
     return result
 
 
-def _render_changelog_bullet(entry: Sequence[str], *, pr_number: int | None) -> list[str]:
-    """Render one changelog entry as the lines of a single Markdown list item."""
-    lines = list(entry)
-    if pr_number is not None and not _mentions_pr("\n".join(lines), pr_number):
+def _render_changelog_bullet(text: str, *, pr_number: int | None) -> list[str]:
+    """Render one news fragment as the lines of a single Markdown list item.
+
+    A fragment is one changelog entry, however many lines it spans: a summary
+    that may be hard wrapped, followed by detail paragraphs, nested lists, and
+    code blocks. All of it belongs to that one entry, so the line structure is
+    kept and the continuation lines are indented to stay inside the bullet.
+    """
+    lines = _trim_blank_lines([line.rstrip() for line in text.splitlines()])
+    if not lines:
+        return []
+    if pr_number is not None and not _mentions_pr(text, pr_number):
         index = _pr_reference_index(lines)
         lines[index] = f"{lines[index]} (#{pr_number})"
     first, *rest = lines
-    bullet = first if BULLET_RE.match(first) else f"- {first}"
+    bullet = first if LIST_MARKER_RE.match(first) else f"- {first}"
     return [bullet, *(f"{CONTINUATION_INDENT}{line}" if line else "" for line in rest)]
 
 

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -486,19 +486,8 @@ def test_render_changelog_entry_does_not_duplicate_pr_number(tmp_path: Path) -> 
     assert entry.count("#42") == 1
 
 
-def test_render_changelog_entry_treats_paragraphs_as_items(tmp_path: Path) -> None:
-    fragment = release.Fragment(
-        package="pkg",
-        path=tmp_path / "123.bugfix.md",
-        kind="bugfix",
-        text=(
-            "Remember the last live Runtime Cache client process-wide and fall back to it\n"
-            "on threads that have no request context, and make strict=True raise\n"
-            "RuntimeCacheError when no cache is available.\n"
-            "\n"
-            "Prime the cache while request context is still visible.\n"
-        ),
-    )
+def _bugfix_changelog_entry(text: str, *, path: Path, pr_number: int | None = None) -> str:
+    fragment = release.Fragment(package="pkg", path=path, kind="bugfix", text=text)
     item = release.Release(
         package="pkg",
         old_version="0.6.0",
@@ -506,16 +495,108 @@ def test_render_changelog_entry_treats_paragraphs_as_items(tmp_path: Path) -> No
         bump="patch",
         fragments=(fragment,),
     )
+    return release._render_changelog_entry(
+        item, pr_numbers={} if pr_number is None else {path: pr_number}
+    )
 
-    entry = release._render_changelog_entry(item, pr_numbers={fragment.path: 178})
 
-    assert (
-        "- Remember the last live Runtime Cache client process-wide and fall back to it "
-        "on threads that have no request context, and make strict=True raise "
-        "RuntimeCacheError when no cache is available. (#178)"
-    ) in entry
-    assert "- Prime the cache while request context is still visible. (#178)" in entry
-    assert entry.count("#178") == 2
+def test_render_changelog_entry_keeps_a_multi_line_fragment_as_one_bullet(tmp_path: Path) -> None:
+    entry = _bugfix_changelog_entry(
+        "Remember the last live Runtime Cache client process-wide and fall back to it\n"
+        "on threads that have no request context, and make strict=True raise\n"
+        "RuntimeCacheError when no cache is available.\n"
+        "\n"
+        "Prime the cache while request context is still visible.\n",
+        path=tmp_path / "123.bugfix.md",
+        pr_number=178,
+    )
+
+    assert entry.endswith(
+        "- Remember the last live Runtime Cache client process-wide and fall back to it\n"
+        "  on threads that have no request context, and make strict=True raise\n"
+        "  RuntimeCacheError when no cache is available. (#178)\n"
+        "\n"
+        "  Prime the cache while request context is still visible.\n"
+    )
+    assert entry.count("#178") == 1
+
+
+def test_render_changelog_entry_preserves_fenced_code_blocks(tmp_path: Path) -> None:
+    entry = _bugfix_changelog_entry(
+        "Make `HookEvent` an async context manager.\n"
+        "\n"
+        "```python\n"
+        "# disposes the hook on block exit\n"
+        "async with SomeHook.wait(...) as hook:\n"
+        "    res = await hook\n"
+        "```\n",
+        path=tmp_path / "123.bugfix.md",
+        pr_number=42,
+    )
+
+    assert entry.endswith(
+        "- Make `HookEvent` an async context manager. (#42)\n"
+        "\n"
+        "  ```python\n"
+        "  # disposes the hook on block exit\n"
+        "  async with SomeHook.wait(...) as hook:\n"
+        "      res = await hook\n"
+        "  ```\n"
+    )
+
+
+def test_render_changelog_entry_ignores_bullets_inside_code_blocks(tmp_path: Path) -> None:
+    entry = _bugfix_changelog_entry(
+        "Reject manifests that repeat a step name.\n\n```yaml\n- name: build\n- name: build\n```\n",
+        path=tmp_path / "123.bugfix.md",
+        pr_number=42,
+    )
+
+    assert [line for line in entry.splitlines() if line.startswith("- ")] == [
+        "- Reject manifests that repeat a step name. (#42)"
+    ]
+    assert entry.count("  - name: build") == 2
+
+
+def test_render_changelog_entry_splits_on_explicit_bullets(tmp_path: Path) -> None:
+    entry = _bugfix_changelog_entry(
+        "- Drop the managed Redis backend.\n- Derive the scheduler id from the subscriber id.\n",
+        path=tmp_path / "123.bugfix.md",
+        pr_number=42,
+    )
+
+    assert entry.endswith(
+        "- Drop the managed Redis backend. (#42)\n"
+        "- Derive the scheduler id from the subscriber id. (#42)\n"
+    )
+
+
+def test_render_changelog_entry_pads_multi_line_bullets_only(tmp_path: Path) -> None:
+    texts = ["Fix the first thing.", "Fix the second thing.\n\nIt was subtle.", "Fix the third."]
+    item = release.Release(
+        package="pkg",
+        old_version="0.6.0",
+        new_version="0.6.1",
+        bump="patch",
+        fragments=tuple(
+            release.Fragment(
+                package="pkg", path=tmp_path / f"{index}.bugfix.md", kind="bugfix", text=text
+            )
+            for index, text in enumerate(texts)
+        ),
+    )
+
+    entry = release._render_changelog_entry(item, pr_numbers={})
+
+    assert entry.endswith(
+        "- Fix the first thing.\n"
+        "\n"
+        "- Fix the second thing.\n"
+        "\n"
+        "  It was subtle.\n"
+        "\n"
+        "- Fix the third.\n"
+    )
 
 
 def test_dependency_only_changelog_omits_pr_number() -> None:
@@ -576,6 +657,36 @@ def test_write_changelog_separates_prepended_entry(tmp_path: Path) -> None:
     content = changelog.read_text(encoding="utf-8")
     assert "- Fix cache cleanup.\n## 0.6.0" not in content
     assert "- Fix cache cleanup.\n\n## 0.6.0" in content
+
+
+def test_latest_changelog_entry_keeps_a_multi_line_bullet_whole(tmp_path: Path) -> None:
+    package_path = tmp_path / "pkg"
+    package_path.mkdir()
+    (package_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## 0.6.0 - 2026-01-01\n\n- Previous release.\n", encoding="utf-8"
+    )
+    item = release.Release(
+        package="pkg",
+        old_version="0.6.0",
+        new_version="0.6.1",
+        bump="patch",
+        fragments=(
+            release.Fragment(
+                package="pkg",
+                path=tmp_path / "123.bugfix.md",
+                kind="bugfix",
+                text="Fix cache cleanup.\n\n## Not a release heading\n\nIt leaked entries.",
+            ),
+        ),
+    )
+
+    release.write_changelog(package_path, item, pr_numbers={tmp_path / "123.bugfix.md": 42})
+    latest = release._latest_changelog_entry(package_path)
+
+    assert latest.endswith(
+        "- Fix cache cleanup. (#42)\n\n  ## Not a release heading\n\n  It leaked entries."
+    )
+    assert "Previous release" not in latest
 
 
 def test_release_commit_body_uses_latest_changelog_entries(tmp_path: Path) -> None:
@@ -1100,10 +1211,22 @@ def test_packages_for_paths_detects_package_code(tmp_path: Path) -> None:
     )
 
 
-def test_clean_news_fragment_text_strips_blank_and_comment_lines() -> None:
+def test_clean_news_fragment_text_strips_comment_and_edge_blank_lines() -> None:
     assert release.clean_news_fragment_text(
         "# template\n\nAdd thing.  \n  # ignored\n- Fix thing.\n"
     ) == ("Add thing.\n- Fix thing.")
+
+
+def test_clean_news_fragment_text_keeps_paragraph_breaks() -> None:
+    assert release.clean_news_fragment_text(
+        "# template\n\nAdd thing.\n\n\nIt replaces the old thing.\n\n"
+    ) == ("Add thing.\n\nIt replaces the old thing.")
+
+
+def test_clean_news_fragment_text_keeps_comments_inside_code_blocks() -> None:
+    assert release.clean_news_fragment_text(
+        "# template\nAdd thing.\n\n```python\n# not a comment on the fragment\n\nrun()\n```\n"
+    ) == ("Add thing.\n\n```python\n# not a comment on the fragment\n\nrun()\n```")
 
 
 def test_clean_news_fragment_text_ignores_cutoff_section() -> None:

--- a/tests/unit/test_release_system.py
+++ b/tests/unit/test_release_system.py
@@ -545,29 +545,30 @@ def test_render_changelog_entry_preserves_fenced_code_blocks(tmp_path: Path) -> 
     )
 
 
-def test_render_changelog_entry_ignores_bullets_inside_code_blocks(tmp_path: Path) -> None:
+def test_render_changelog_entry_keeps_the_pr_reference_out_of_code_blocks(tmp_path: Path) -> None:
     entry = _bugfix_changelog_entry(
-        "Reject manifests that repeat a step name.\n\n```yaml\n- name: build\n- name: build\n```\n",
-        path=tmp_path / "123.bugfix.md",
-        pr_number=42,
-    )
-
-    assert [line for line in entry.splitlines() if line.startswith("- ")] == [
-        "- Reject manifests that repeat a step name. (#42)"
-    ]
-    assert entry.count("  - name: build") == 2
-
-
-def test_render_changelog_entry_splits_on_explicit_bullets(tmp_path: Path) -> None:
-    entry = _bugfix_changelog_entry(
-        "- Drop the managed Redis backend.\n- Derive the scheduler id from the subscriber id.\n",
+        "```python\nrun()\n```\n\nCall `run()` directly instead of through the shim.\n",
         path=tmp_path / "123.bugfix.md",
         pr_number=42,
     )
 
     assert entry.endswith(
-        "- Drop the managed Redis backend. (#42)\n"
-        "- Derive the scheduler id from the subscriber id. (#42)\n"
+        "- ```python\n"
+        "  run()\n"
+        "  ```\n"
+        "\n"
+        "  Call `run()` directly instead of through the shim. (#42)\n"
+    )
+
+
+def test_render_changelog_entry_keeps_bullet_lines_inside_one_entry(tmp_path: Path) -> None:
+    entry = _bugfix_changelog_entry(
+        "- Drop the managed Redis backend.\n- Derive the scheduler id from the subscriber id.\n",
+        path=tmp_path / "123.bugfix.md",
+    )
+
+    assert entry.endswith(
+        "- Drop the managed Redis backend.\n  - Derive the scheduler id from the subscriber id.\n"
     )
 
 


### PR DESCRIPTION
## Problem

Multi-line news fragments were rendered as several separate list items in
package changelogs, each one getting its own bullet and its own PR link.

`_fragment_changelog_items` split fragment text on blank lines and joined each
resulting paragraph with spaces, so a fragment written the way we actually write
them — a summary, then detail paragraphs — became unrelated changelog entries.
Fenced code blocks were flattened onto one line.

This is visible in the generated changelogs on #333. For example
`changes/vercel-workflow/hook-await-disposed.breaking.md`:

```markdown
Make `await hook` never return `None`

Raises a new `HookDisposedError` instead of returning `None` when the hook has been disposed. ...
```

rendered as two entries:

```markdown
- Make `await hook` never return `None`
- Raises a new `HookDisposedError` instead of returning `None` when the hook has been disposed. ... (#353)
```

and `hook-context-manager.feature.md` had its code sample collapsed into prose:

```markdown
- This matches TS, which supports `using`. ``` # disposes the hook on block exit async with SomeHook.wait(...) as hook: res = await hook ```
```

## Fix

One news fragment is exactly one changelog entry. Nothing inside a fragment
splits it — a second entry needs a second fragment.

The renderer emits each fragment as a single Markdown list item: line structure
is preserved, continuation lines are indented two spaces so Markdown keeps them
inside the bullet, and the PR number is appended once at the end of the summary
rather than to every paragraph.

- Paragraph breaks, nested lists, and fenced code blocks are all ordinary
  content of that one entry and are kept as written.
- The PR reference goes at the end of the summary, so it does not land
  mid-sentence on a hard-wrapped first line or inside a code block.
- Multi-line bullets get a blank line on either side. Runs of one-line bullets
  stay tight, so sections built only from single-line fragments render exactly
  as before.
- `clean_news_fragment_text` (the `poe changelog` editor path) dropped blank
  lines, so a fragment authored through the TUI could not have paragraphs at
  all. It now keeps paragraph breaks, collapses runs of them to one, and treats
  code blocks as verbatim so a `#` line in a sample is not read as a comment.

Same fragments, after:

```markdown
### Breaking Changes

- Make `await hook` never return `None` (#353)

  Raises a new `HookDisposedError` instead of returning `None` when the hook has been disposed. It is now typed to return `T` instead of `T | None`. `async for` over a hook will stop iterating on disposal, still.

### Features

- Make `HookEvent` an async context manager (#354)

  This matches TS, which supports `using`.
  \```
  # disposes the hook on block exit
  async with SomeHook.wait(...) as hook:
      res = await hook
  \```
```

## Tests

`tests/unit/test_release_system.py`:

- `test_render_changelog_entry_treats_paragraphs_as_items` asserted the buggy
  behaviour (two bullets, `#178` twice) and is replaced by
  `test_render_changelog_entry_keeps_a_multi_line_fragment_as_one_bullet`.
- New: fenced code blocks preserved; column-zero bullet lines stay inside the
  one entry; the PR reference stays out of code blocks; blank-line padding
  applied only around multi-line bullets.
- New: `_latest_changelog_entry` still isolates one release when an entry's
  indented detail contains a `##` line — the PR/GitHub-release body path.
- New: `clean_news_fragment_text` keeps paragraph breaks and keeps `#` lines
  inside code blocks.

`RELEASING.md` and the editor guidance template are updated to state the
one-fragment-one-entry rule.

Verified: `uv run poe lint`, `uv run poe typecheck-root`, `uv run poe
lint-towncrier`, `uv run poe check-news-fragments`, and
`uv run pytest tests/unit` (165 passed). Every news fragment on #333's base
commit was rendered through the new code to confirm the output. No news
fragment is needed here — this touches release tooling, not package code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
