### PR TITLE
ci: Stabilize tests by using time machine some more

### DIFF
--- a/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
+++ b/integrations/vercel-apscheduler/tests/unit/test_apscheduler_cache.py
@@ -16,6 +16,7 @@ from types import ModuleType
 from unittest.mock import patch
 
 import pytest
+import time_machine
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.blocking import BlockingScheduler
 
@@ -523,10 +524,13 @@ def test_cache_pause_publishes_control_message_and_subscriber_applies_it() -> No
     scheduler, adapter, _payload = started_cache_scheduler()
     start_subscription = get_subscriptions()[0]
 
-    with patch(
-        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
-        return_value="msg_ctl",
-    ) as send:
+    with (
+        time_machine.travel(datetime.now(UTC), tick=False),
+        patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg_ctl",
+        ) as send,
+    ):
         scheduler.pause()
 
     send.assert_called_once()
@@ -553,9 +557,12 @@ def test_cache_pause_publishes_control_message_and_subscriber_applies_it() -> No
     # A resume elsewhere arrives as a start message minting generation 2; a
     # late redelivery of the generation-1 pause must not settle the chain
     # back to paused.
-    with patch(
-        "vercel.integrations.apscheduler._adapter.vqs_sync.send",
-        return_value="msg_wake_after_resume",
+    with (
+        time_machine.travel(control.issued_at + timedelta(seconds=1), tick=False),
+        patch(
+            "vercel.integrations.apscheduler._adapter.vqs_sync.send",
+            return_value="msg_wake_after_resume",
+        ),
     ):
         start_subscription.func(
             message(

--- a/integrations/vercel-django-tasks/tests/unit/test_django_tasks.py
+++ b/integrations/vercel-django-tasks/tests/unit/test_django_tasks.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from typing import Any, ClassVar, cast
 
 import pytest
+import time_machine
 
 from django.conf import settings
 
@@ -365,10 +366,11 @@ def test_enqueue_normalizes_transport_topic_but_preserves_logical_queue() -> Non
     assert sent["payload"]["queue"] == "emails.high"
 
 
+@time_machine.travel(datetime(2026, 1, 1, tzinfo=UTC), tick=False)
 def test_enqueue_maps_run_after_to_delay() -> None:
     add_one.using(run_after=datetime.now(UTC) + timedelta(seconds=90)).enqueue(1)
 
-    assert FakeSyncQueueClient.instances[0].sent[0]["kwargs"]["delay"] in {89, 90}
+    assert FakeSyncQueueClient.instances[0].sent[0]["kwargs"]["delay"] == 90
 
 
 def test_enqueue_reuses_sync_client_and_close_clears_both_clients() -> None:

--- a/src/vercel-oidc/tests/test_verify.py
+++ b/src/vercel-oidc/tests/test_verify.py
@@ -644,6 +644,7 @@ def test_refetch_throttle_engages_before_the_claim_is_released(
     """
     import threading
     from concurrent.futures import ThreadPoolExecutor
+    from contextvars import ContextVar
 
     from vercel.oidc import verify as oidc_verify
 
@@ -653,8 +654,12 @@ def test_refetch_throttle_engages_before_the_claim_is_released(
     assert route.call_count == 1
 
     original_select = oidc_verify._select_key
+    original_claim_fetch = oidc_verify._claim_fetch
     outcome_pending = threading.Event()
+    second_claim_checked = threading.Event()
     record_outcome = threading.Event()
+    caller_kid: ContextVar[str | None] = ContextVar("caller_kid", default=None)
+    second_claim_results: list[bool] = []
     first_kid_selections = 0
 
     def paused_select(document: Mapping[str, Any], kid: str) -> Any:
@@ -670,16 +675,30 @@ def test_refetch_throttle_engages_before_the_claim_is_released(
 
     monkeypatch.setattr(oidc_verify, "_select_key", paused_select)
 
+    def observed_claim_fetch(url: str) -> bool:
+        claimed = original_claim_fetch(url)
+        if caller_kid.get() == "forged-second":
+            second_claim_results.append(claimed)
+            second_claim_checked.set()
+        return claimed
+
+    monkeypatch.setattr(oidc_verify, "_claim_fetch", observed_claim_fetch)
+
     def attempt(kid: str) -> None:
-        with pytest.raises(VercelOidcVerificationError):
-            verify_vercel_oidc_token(sign(signing_key, kid=kid), **EXPECTATIONS)
+        token = caller_kid.set(kid)
+        try:
+            with pytest.raises(VercelOidcVerificationError):
+                verify_vercel_oidc_token(sign(signing_key, kid=kid), **EXPECTATIONS)
+        finally:
+            caller_kid.reset(token)
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         first = pool.submit(attempt, "forged-first")
         assert outcome_pending.wait(timeout=5)
         second = pool.submit(attempt, "forged-second")
-        time.sleep(0.25)  # let the second caller reach the fetch claim
+        assert second_claim_checked.wait(timeout=5)
         record_outcome.set()
+        assert second_claim_results == [False]
         first.result(timeout=10)
         second.result(timeout=10)
 

--- a/src/vercel-workflow/tests/unit/test_workflow_local_streamer.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_local_streamer.py
@@ -121,20 +121,33 @@ class TestLiveRead:
 
         assert await _drain(world) == [b"a", b"b"]
 
-    async def test_waits_for_chunks_that_have_not_been_written_yet(self, world) -> None:
+    async def test_waits_for_chunks_that_have_not_been_written_yet(
+        self, world, monkeypatch
+    ) -> None:
         """The defining property: a read tails, it does not stop at the tail."""
         received: list[bytes] = []
+        reader_started = asyncio.Event()
+        chunk_received = asyncio.Event()
+        real_chunk_files = world._chunk_files
+
+        def observed_chunk_files(name):
+            files = real_chunk_files(name)
+            reader_started.set()
+            return files
+
+        monkeypatch.setattr(world, "_chunk_files", observed_chunk_files)
 
         async def reader() -> None:
             async for chunk in world.streams_get(RUN_ID, NAME):
                 received.append(chunk)
+                chunk_received.set()
 
         task = asyncio.ensure_future(reader())
-        await asyncio.sleep(0.05)
+        await asyncio.wait_for(reader_started.wait(), timeout=5)
         assert received == [], "nothing written yet"
 
         await world.streams_write(RUN_ID, NAME, b"late")
-        await asyncio.sleep(0.3)
+        await asyncio.wait_for(chunk_received.wait(), timeout=5)
         assert received == [b"late"], "a chunk written after the read started"
 
         await world.streams_close(RUN_ID, NAME)
@@ -144,8 +157,14 @@ class TestLiveRead:
         # Nothing closes a stream implicitly, which is exactly why a workflow
         # that forgets to close leaves its readers hanging.
         await world.streams_write(RUN_ID, NAME, b"a")
-        task = asyncio.ensure_future(_drain(world))
-        await asyncio.sleep(0.3)
+        chunk_received = asyncio.Event()
+
+        async def reader() -> None:
+            async for _chunk in world.streams_get(RUN_ID, NAME):
+                chunk_received.set()
+
+        task = asyncio.ensure_future(reader())
+        await asyncio.wait_for(chunk_received.wait(), timeout=5)
         assert not task.done()
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -188,7 +207,9 @@ class TestLiveRead:
 
         assert await _drain(world, start_index=50) == []
 
-    async def test_skipped_chunks_are_not_re_delivered_by_the_poll(self, world) -> None:
+    async def test_skipped_chunks_are_not_re_delivered_by_the_poll(
+        self, world, monkeypatch
+    ) -> None:
         """A resumed read must not replay history once it starts polling.
 
         The poll re-lists the whole directory, so anything the caller asked to
@@ -198,15 +219,31 @@ class TestLiveRead:
             await world.streams_write(RUN_ID, NAME, str(i).encode())
 
         received: list[bytes] = []
+        polling = asyncio.Event()
+        new_chunk_received = asyncio.Event()
+        real_chunk_files = world._chunk_files
+        scans = 0
+
+        def observed_chunk_files(name):
+            nonlocal scans
+            files = real_chunk_files(name)
+            scans += 1
+            if scans == 2:
+                polling.set()
+            return files
+
+        monkeypatch.setattr(world, "_chunk_files", observed_chunk_files)
 
         async def reader() -> None:
             async for chunk in world.streams_get(RUN_ID, NAME, 2):
                 received.append(chunk)
+                if chunk == b"new":
+                    new_chunk_received.set()
 
         task = asyncio.ensure_future(reader())
-        await asyncio.sleep(0.3)
+        await asyncio.wait_for(polling.wait(), timeout=5)
         await world.streams_write(RUN_ID, NAME, b"new")
-        await asyncio.sleep(0.3)
+        await asyncio.wait_for(new_chunk_received.wait(), timeout=5)
         await world.streams_close(RUN_ID, NAME)
         await asyncio.wait_for(task, timeout=5)
 

--- a/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
+import time_machine
 
 from vercel._internal.core.polyfills import UTC
 from vercel.workflow import RetryableError
@@ -40,11 +41,11 @@ WORKFLOW_QUEUE = f"__wkf_workflow_{WORKFLOW_NAME}"
 # ── the error ──────────────────────────────────────────────────────────────
 
 
+@time_machine.travel(NOW, tick=False)
 def test_retry_after_defaults_to_a_second() -> None:
-    before = datetime.now(UTC)
     err = RetryableError("later")
 
-    assert timedelta(seconds=1) <= err.retry_at - before <= timedelta(seconds=2)
+    assert err.retry_at == NOW + timedelta(seconds=1)
 
 
 @pytest.mark.parametrize(
@@ -59,10 +60,10 @@ def test_retry_after_defaults_to_a_second() -> None:
 def test_retry_after_takes_the_durations_sleep_takes(
     retry_after: str | int | float | timedelta, expected: timedelta
 ) -> None:
-    before = datetime.now(UTC)
-    err = RetryableError("later", retry_after=retry_after)
+    with time_machine.travel(NOW, tick=False):
+        err = RetryableError("later", retry_after=retry_after)
 
-    assert expected <= err.retry_at - before <= expected + timedelta(seconds=1)
+    assert err.retry_at == NOW + expected
 
 
 def test_retry_after_takes_an_absolute_datetime() -> None:
@@ -159,6 +160,7 @@ async def _invoke(registry: core.Workflows, step_name: str) -> w.QueueContinuati
     )
 
 
+@time_machine.travel(NOW, tick=False)
 async def test_retryable_error_carries_its_deadline_to_the_event(
     registry: core.Workflows,
 ) -> None:
@@ -174,12 +176,10 @@ async def test_retryable_error_carries_its_deadline_to_the_event(
     assert [e.event_type for e in fake.events] == ["step_retrying"]
     retry_after = fake.events[0].event_data.retry_after
     assert retry_after is not None
-    assert timedelta(seconds=9) <= retry_after - datetime.now(UTC) <= timedelta(seconds=10)
-    # The continuation asks the queue for the same wait, rounded up. Bounded
-    # rather than exact because it is measured against the clock: the second
-    # spent getting here counts against the ten.
+    assert retry_after == NOW + timedelta(seconds=10)
+    # The continuation asks the queue for the same wait, rounded up.
     assert result is not None
-    assert 9 <= result.delay_seconds <= 10
+    assert result.delay_seconds == 10
 
 
 async def test_a_plain_error_keeps_the_one_second_retry(registry: core.Workflows) -> None:


### PR DESCRIPTION
Use `time_machine.travel` in more places to reduce test flakiness.
