### PR TITLE
workflow: tolerate closed cancellation streams

### DIFF
--- a/changes/vercel-workflow/362.bugfix.md
+++ b/changes/vercel-workflow/362.bugfix.md
@@ -1,0 +1,1 @@
+Treat an already-closed cancellation stream as a successful cancellation signal.

--- a/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
@@ -340,6 +340,22 @@ async def test_throttled_cancellation_signal_is_not_recorded(tmp_path, monkeypat
     assert len(_of_type(await _events(world, run_id), w.HookReceivedEvent)) == 1
 
 
+async def test_closed_cancellation_stream_is_still_recorded(tmp_path, monkeypatch) -> None:
+    """Concurrent Vercel replays can find the abort stream already closed."""
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = _FlakyStreamWorld()
+    w.set_world(world)
+    run_id = await _create_run(world, cancel_and_wait.workflow_id)
+
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
+
+    world.fail_stream_writes = 1
+    world.stream_write_status = 409
+    await _invoke(run_id, cancel_and_wait.workflow_id)
+    assert len(_of_type(await _events(world, run_id), w.HookReceivedEvent)) == 1
+
+
 @pytest.mark.skipif(
     sys.version_info[:2] == (3, 10),
     reason="Python 3.10 drops CancelledError messages propagated through tasks",

--- a/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
@@ -288,8 +288,9 @@ class _FlakyStreamWorld(RecordingLocalWorld):
         await super().streams_write(run_id, name, chunk)
 
 
+@pytest.mark.parametrize("status", [400, 503])
 async def test_lost_cancellation_signal_fails_the_pass_and_is_retried(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, status
 ) -> None:
     """The stream packet is the only way a running step learns of the
     cancellation, so losing it must fail the pass -- and, since nothing
@@ -303,6 +304,7 @@ async def test_lost_cancellation_signal_fails_the_pass_and_is_retried(
     await _invoke_step(_queued_step(world, quick_step.name), cancel_and_wait.workflow_id)
 
     world.fail_stream_writes = 1
+    world.stream_write_status = status
     with pytest.raises(Exception) as excinfo:
         await _invoke(run_id, cancel_and_wait.workflow_id)
     assert "stream write lost" in repr(excinfo.value)

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -1560,7 +1560,10 @@ async def _send_cancellation(world: w.World, run_id: str, cancellation: Cancella
         await world.streams_write(run_id, stream_name, streams.encode_frame(payload))
         await world.streams_close(run_id, stream_name)
     except w.WorkflowWorldError as error:
-        if error.status not in (400, 409):
+        # Concurrent replays can both try to send the same cancellation. Once
+        # one replay closes the stream, Vercel rejects the other's write with
+        # 409; the signal was already delivered, so still record the events.
+        if error.status != 409:
             raise
         logger.debug(f"Cancellation stream {stream_name!r} rejected the signal: {error}")
 

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -1560,7 +1560,7 @@ async def _send_cancellation(world: w.World, run_id: str, cancellation: Cancella
         await world.streams_write(run_id, stream_name, streams.encode_frame(payload))
         await world.streams_close(run_id, stream_name)
     except w.WorkflowWorldError as error:
-        if error.status != 400:
+        if error.status not in (400, 409):
             raise
         logger.debug(f"Cancellation stream {stream_name!r} rejected the signal: {error}")
 


### PR DESCRIPTION
On `VercelWorld`, concurrent workflow replays may try to cancel the same step at the same time. Once one replay sends the cancellation and closes the abort stream, the other gets HTTP 409. It should ignore that response and continue recording the cancellation events.

This was caught by the E2E test added in vercel/workflow#3930.
Refs #348.