### PR TITLE
core: fix Buffer typing dependency

### DIFF
--- a/changes/vercel-internal-core/typing-extensions-buffer.bugfix.md
+++ b/changes/vercel-internal-core/typing-extensions-buffer.bugfix.md
@@ -1,0 +1,1 @@
+Buffer requires `typing-extensions` >=4.6 on Python <3.12.

--- a/src/vercel-internal-core/pyproject.toml
+++ b/src/vercel-internal-core/pyproject.toml
@@ -18,7 +18,7 @@ path = "hatch_build.py"
 dependencies = [
     "httpx>=0.27.0,<1",
     "anyio>=4.0.0,<5",
-    "typing-extensions>=4.0.0,<5 ; python_version < '3.11'",
+    "typing-extensions>=4.6.0,<5 ; python_version < '3.12'",
 ]
 
 [tool.hatch.version]

--- a/src/vercel-internal-core/vercel/_internal/core/byte_stream.py
+++ b/src/vercel-internal-core/vercel/_internal/core/byte_stream.py
@@ -9,7 +9,6 @@ appropriate.
 
 import inspect
 import io
-import sys
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -17,10 +16,7 @@ from typing import Protocol, TypeAlias, cast
 
 import anyio
 
-if sys.version_info >= (3, 12):
-    from collections.abc import Buffer
-else:
-    from typing_extensions import Buffer
+from vercel._internal.core.polyfills import Buffer
 
 
 class SyncByteReader(Protocol):

--- a/src/vercel-internal-core/vercel/_internal/core/polyfills/__init__.py
+++ b/src/vercel-internal-core/vercel/_internal/core/polyfills/__init__.py
@@ -4,6 +4,6 @@ Polyfills for modern Python features used by internal core.
 
 from ._datetime import UTC
 from ._strenum import StrEnum
-from ._typing import Self
+from ._typing import Buffer, Self
 
-__all__ = ("Self", "StrEnum", "UTC")
+__all__ = ("Buffer", "Self", "StrEnum", "UTC")

--- a/src/vercel-internal-core/vercel/_internal/core/polyfills/_typing.py
+++ b/src/vercel-internal-core/vercel/_internal/core/polyfills/_typing.py
@@ -1,8 +1,13 @@
 import sys
 
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
 
-__all__ = ("Self",)
+__all__ = ("Buffer", "Self")

--- a/uv.lock
+++ b/uv.lock
@@ -2721,14 +2721,14 @@ source = { editable = "src/vercel-internal-core" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5" },
     { name = "httpx", specifier = ">=0.27.0,<1" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0,<5" },
 ]
 
 [[package]]


### PR DESCRIPTION
`Buffer` added in #135 requires `typing-extensions` [4.6+](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-460-may-22-2023) on Python versions [before 3.12](https://docs.python.org/3/library/collections.abc.html#collections.abc.Buffer). This PR also exposes `Buffer` through the internal compatibility polyfills.