### PR TITLE
workflow: add object readable streams

### DIFF
--- a/changes/vercel-internal-core/buffer-to-bytes.internal.md
+++ b/changes/vercel-internal-core/buffer-to-bytes.internal.md
@@ -1,0 +1,1 @@
+Add a shared helper for snapshotting arbitrary buffer-protocol values as bytes.

--- a/changes/vercel-workflow/readable-stream-object.feature.md
+++ b/changes/vercel-workflow/readable-stream-object.feature.md
@@ -1,0 +1,1 @@
+Add serializable generic readable streams and the step-to-caller object-stream path.

--- a/src/vercel-internal-core/tests/test_byte_stream.py
+++ b/src/vercel-internal-core/tests/test_byte_stream.py
@@ -8,6 +8,7 @@ from vercel._internal.core.byte_stream import (
     AsyncByteStreamRuntime,
     StagingFileRuntime,
     SyncByteStreamRuntime,
+    buffer_to_bytes,
 )
 from vercel._internal.core.iter_coroutine import iter_coroutine
 
@@ -26,6 +27,13 @@ class _AsyncReader:
 
     async def read(self, size: int = -1, /) -> bytes:
         return self._source.read(size)
+
+
+def test_buffer_to_bytes_returns_an_immutable_snapshot() -> None:
+    source = bytearray(b"before")
+    snapshot = buffer_to_bytes(memoryview(source))
+    source[:] = b"after!"
+    assert snapshot == b"before"
 
 
 async def _assert_bytes_like_readers(runtime: SyncByteStreamRuntime) -> None:

--- a/src/vercel-internal-core/vercel/_internal/core/byte_stream.py
+++ b/src/vercel-internal-core/vercel/_internal/core/byte_stream.py
@@ -41,6 +41,11 @@ AsyncByteSource: TypeAlias = AsyncByteReader
 RawByteSource: TypeAlias = SyncByteSource | AsyncByteSource
 
 
+def buffer_to_bytes(value: Buffer, /) -> bytes:
+    """Return an immutable snapshot of any buffer-protocol value."""
+    return memoryview(value).tobytes()
+
+
 class ReadableByteStream(Protocol):
     """Normalized readable stream consumed by shared internal workflows.
 
@@ -103,7 +108,7 @@ class _MemoryReader:
     """Give an immutable bytes snapshot a stateful, non-suspending read cursor."""
 
     def __init__(self, data: BytesLike) -> None:
-        self._data = memoryview(bytes(data))
+        self._data = memoryview(buffer_to_bytes(data))
         self._offset = 0
 
     async def read(self, size: int = -1, /) -> bytes:
@@ -243,6 +248,7 @@ __all__ = [
     "AsyncByteReader",
     "AsyncByteSource",
     "AsyncByteStreamRuntime",
+    "buffer_to_bytes",
     "BytesLike",
     "RawByteSource",
     "ReadableByteStream",

--- a/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Sequence
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from vercel._internal.core.polyfills import UTC
+from vercel.workflow import ReadableStream, readable_stream
+from vercel.workflow._internal import core, runtime, serialization as ser, streams, world as w
+
+from ..world_stubs import NoStreams
+
+RUN_ID = "wrun_readable"
+STEP_ID = "step_readable"
+NOW = datetime(2026, 9, 2, tzinfo=UTC)
+
+
+class ReadableWorld(NoStreams, w.World):
+    def __init__(self, *, step_input: bytes | None = None) -> None:
+        self.step_input = step_input or ser.dehydrate(ser.step_arguments((), {}))
+        self.events: list[w.Event] = []
+        self.chunks: dict[str, list[bytes]] = {}
+        self.closed: set[str] = set()
+
+    async def get_deployment_id(self) -> str:
+        return "dpl_test"
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        return "msg_test"
+
+    def create_queue_handler(
+        self, queue_name_prefix: w.QueuePrefix, handler: w.QueueHandler
+    ) -> w.HTTPHandler:
+        raise NotImplementedError
+
+    async def runs_get(self, run_id: str) -> w.WorkflowRun:
+        raise NotImplementedError
+
+    async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
+        raise NotImplementedError
+
+    async def hooks_get_by_token(self, token: str) -> w.Hook:
+        raise NotImplementedError
+
+    async def events_list(self, run_id: str, *, pagination: Any = None) -> Any:
+        raise NotImplementedError
+
+    async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+        if data.event_type == "step_started":
+            return w.EventResult(
+                step=w.NonFinalWorkflowStep(
+                    run_id=RUN_ID,
+                    step_id=STEP_ID,
+                    step_name=data.correlation_id or "",
+                    status="running",
+                    attempt=1,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    started_at=NOW,
+                    input=self.step_input,
+                )
+            )
+        self.events.append(data)
+        return w.EventResult()
+
+    async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+        self.chunks.setdefault(name, []).append(chunk)
+
+    async def streams_write_multi(self, run_id: str, name: str, chunks: Sequence[bytes]) -> None:
+        self.chunks.setdefault(name, []).extend(chunks)
+
+    async def streams_close(self, run_id: str, name: str) -> None:
+        self.closed.add(name)
+
+    def streams_get(
+        self, run_id: str, name: str, start_index: int | None = None
+    ) -> AsyncGenerator[bytes, None]:
+        async def read() -> AsyncGenerator[bytes, None]:
+            start = start_index or 0
+            for chunk in self.chunks.get(name, [])[start:]:
+                yield chunk
+
+        return read()
+
+
+@pytest.fixture(autouse=True)
+def _reset_world():
+    yield
+    w.set_world(None)
+
+
+async def _invoke(registry: core.Workflows, step_name: str) -> None:
+    payload = w.WorkflowInvokePayload(
+        run_id=RUN_ID,
+        step_id=STEP_ID,
+        step_name=step_name,
+    )
+    await runtime.workflow_handler(
+        payload.model_dump(by_alias=True),
+        attempt=1,
+        queue_name="__wkf_workflow_test",
+        message_id="msg_test",
+        registry=registry,
+    )
+
+
+async def test_step_returned_object_stream_is_recorded_before_its_pump_runs() -> None:
+    registry = core.Workflows(as_vercel_job=False)
+    started = False
+
+    async def values() -> AsyncIterator[object]:
+        nonlocal started
+        started = True
+        yield {"token": "hello"}
+        yield b"world"
+
+    @registry.step
+    async def produce() -> ReadableStream[object]:
+        return readable_stream(values())
+
+    world = ReadableWorld()
+    w.set_world(world)
+    background: list[Awaitable[object]] = []
+
+    with streams.readable_background_tasks(background.append):
+        await _invoke(registry, produce.name)
+
+    assert not started
+    completed = [event for event in world.events if event.event_type == "step_completed"]
+    assert len(completed) == 1
+    payload = completed[0].event_data.result
+    assert b'"ReadableStream"' in payload
+
+    with streams.reviving_readable_streams(RUN_ID):
+        workflow_value = ser.hydrate(payload, what="step result")
+    assert isinstance(workflow_value, ReadableStream)
+    with pytest.raises(RuntimeError, match="inside a workflow"):
+        workflow_value.__aiter__()
+
+    # Forwarding an existing reference preserves its descriptor and does not
+    # register a second source pump.
+    assert ser.dehydrate(workflow_value) == payload
+    assert len(background) == 1
+
+    await background[0]
+    assert world.closed == set(world.chunks)
+
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        caller_value = ser.hydrate(payload, what="run output")
+    assert [item async for item in caller_value] == [
+        {"token": "hello"},
+        b"world",
+    ]
+
+
+async def test_local_sources_need_an_execution_boundary_owner() -> None:
+    async def values() -> AsyncIterator[int]:
+        yield 1
+
+    stream = readable_stream(values())
+    with pytest.raises(RuntimeError, match="execution boundary"):
+        ser.dehydrate(stream)
+    await stream.aclose()
+
+
+async def test_unknown_readable_descriptor_metadata_is_rejected() -> None:
+    payload = ser.DEVALUE_V1 + b'[["ReadableStream",1],{"name":2,"type":3},"s","other"]'
+    with pytest.raises(ser.SerializationError, match="unknown ReadableStream type"):
+        ser.hydrate(payload, what="stream")

--- a/src/vercel-workflow/vercel/workflow/__init__.py
+++ b/src/vercel-workflow/vercel/workflow/__init__.py
@@ -26,9 +26,11 @@ from vercel.workflow._internal.runtime import (
 )
 from vercel.workflow._internal.serde import register_serializable, serializable
 from vercel.workflow._internal.streams import (
+    ReadableStream,
     WorkflowStreamHandle,
     WorkflowStreamWriter,
     WorkflowWritable,
+    readable_stream,
 )
 from vercel.workflow._internal.world import HTTPHandler, HTTPRequest, HTTPResponse
 
@@ -75,6 +77,8 @@ __all__ = [
     "get_workflow_metadata",
     "get_writable",
     "read_stream",
+    "readable_stream",
+    "ReadableStream",
     "WorkflowWritable",
     "WorkflowStreamWriter",
     "WorkflowStreamHandle",

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -812,6 +812,8 @@ class WorkflowOrchestratorContext:
         with (
             self.registry._get_sandbox() as sandbox,
             sandbox.enter(),
+            streams.reviving_readable_streams(workflow_run.run_id),
+            streams.collecting_readable_sources(allow_local=False),
         ):
             # Hold a lock over the import, to avoid weird init races
             with sandbox.import_lock:
@@ -2115,9 +2117,10 @@ async def _execute_step(
             # No deployment id: the queue message routed this step to the deployment
             # that owns the run, so the key resolves against the current one.
             run_key = await world.run_key(req.run_id) if ser.is_encrypted(step_run.input) else None
-            args, kwargs = ser.step_call_arguments(
-                ser.hydrate(step_run.input, what=what, key=run_key), what=what
-            )
+            with streams.reviving_readable_streams(req.run_id, world=world, live=True):
+                args, kwargs = ser.step_call_arguments(
+                    ser.hydrate(step_run.input, what=what, key=run_key), what=what
+                )
             args, kwargs = step.codec.validate_arguments(args, kwargs)
 
             logger.debug(
@@ -2152,8 +2155,12 @@ async def _execute_step(
             # escape hatch.
             await step_streams.drain()
 
-        # Serialize the result
-        output = ser.dehydrate(step.codec.dump_return(result))
+        # Serialize the result and hand any local readable sources to the
+        # invocation's post-response background owner. The descriptor is
+        # recorded immediately; its pump is allowed to outlive this step.
+        with streams.collecting_readable_sources() as readable_sources:
+            output = ser.dehydrate(step.codec.dump_return(result))
+        streams.bind_readable_sources(readable_sources, world=world, run_id=req.run_id)
 
         # Complete the step via event
         await world.events_create(
@@ -2446,7 +2453,12 @@ class Run(Generic[T]):
                 key = None
                 if ser.is_encrypted(run.output):
                     key = await self._world.run_key(run.run_id, deployment_id=run.deployment_id)
-                output = ser.hydrate(run.output, what=f"the output of run {run.run_id}", key=key)
+                with streams.reviving_readable_streams(run.run_id, world=self._world, live=True):
+                    output = ser.hydrate(
+                        run.output,
+                        what=f"the output of run {run.run_id}",
+                        key=key,
+                    )
                 if self._codec is None:
                     return cast("T", output)
                 return cast("T", self._codec.validate_return(output))
@@ -2564,7 +2576,8 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
     namespace = wf._resolve_queue_namespace()
-    input_data = ser.dehydrate(ser.argument_array(dumped_args, dumped_kwargs))
+    with streams.collecting_readable_sources() as readable_sources:
+        input_data = ser.dehydrate(ser.argument_array(dumped_args, dumped_kwargs))
     execution_context: dict[str, Any] = {"hookResumeInputVersion": w.HOOK_RESUME_INPUT_VERSION}
     if namespace is not None:
         execution_context["queueNamespace"] = namespace
@@ -2581,6 +2594,7 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
         raise RuntimeError("Missing 'run' in server response for 'run_created' event")
 
     run_id = result.run.run_id
+    streams.bind_readable_sources(readable_sources, world=world, run_id=run_id)
     await world.queue(
         w.get_queue_name(wf.workflow_id, namespace),
         w.WorkflowInvokePayload(run_id=run_id),
@@ -2624,7 +2638,10 @@ async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook
     else:
         hook = token_or_hook
         run = await world.runs_get(hook.run_id)
-    data = w.HookReceivedEventData(payload=ser.dehydrate(payload))
+    with streams.collecting_readable_sources() as readable_sources:
+        encoded_payload = ser.dehydrate(payload)
+    streams.bind_readable_sources(readable_sources, world=world, run_id=hook.run_id)
+    data = w.HookReceivedEventData(payload=encoded_payload)
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}
     namespace = execution_context.get("queueNamespace")

--- a/src/vercel-workflow/vercel/workflow/_internal/serialization.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/serialization.py
@@ -73,17 +73,31 @@ def _revive_writable_stream(value: Any) -> Any:
     return runtime.open_writable(run_id if isinstance(run_id, str) else None, value["name"])
 
 
+def _reduce_readable_stream(value: Any) -> Any:
+    from . import streams
+
+    return streams.reduce_readable_stream(value)
+
+
+def _revive_readable_stream(value: Any) -> Any:
+    from . import streams
+
+    return streams.revive_readable_stream(value)
+
+
 # Instance must precede the error reducers so registered exception classes keep
 # their custom serialization. Streams do not overlap either group.
 REDUCERS: dict[str, Any] = {
     **serde.REDUCERS,
     **error_serde.REDUCERS,
     "WritableStream": _reduce_writable_stream,
+    "ReadableStream": _reduce_readable_stream,
 }
 REVIVERS: dict[str, Any] = {
     **serde.REVIVERS,
     **error_serde.REVIVERS,
     "WritableStream": _revive_writable_stream,
+    "ReadableStream": _revive_readable_stream,
 }
 
 

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -25,14 +25,26 @@ from __future__ import annotations
 import abc
 import base64
 import contextlib
+import contextvars
+import dataclasses
 import os
-from collections.abc import AsyncGenerator, AsyncIterable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    Sequence,
+)
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 
 import anyio
 import pydantic
 
-from . import serialization as ser
+from vercel._internal.core.polyfills import Buffer
+
+from . import serialization as ser, ulid
 
 if TYPE_CHECKING:
     from anyio.abc import TaskGroup
@@ -49,6 +61,333 @@ A length header advertising more than this is refused rather than allocated:
 past a certain size the far more likely explanation is a misframed wire than a
 100 MB chunk.
 """
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+
+class ReadableStream(AsyncIterable[T_co], Generic[T_co], abc.ABC):
+    """A serializable asynchronous stream of values.
+
+    The same public type represents a local source, an opaque workflow-side
+    reference and a live World-backed reader.  Execution context determines
+    which operations are available after a descriptor is revived.
+    """
+
+    @abc.abstractmethod
+    def __aiter__(self) -> AsyncIterator[T_co]: ...
+
+    @abc.abstractmethod
+    async def aclose(self) -> None:
+        """Stop this reader and cancel its locally owned producer when possible."""
+
+
+ReadableMode = Literal["objects", "bytes"]
+_new_stream_ulid = ulid.monotonic_factory()
+
+
+@dataclasses.dataclass(frozen=True)
+class _ReadableDescriptor:
+    data: dict[str, Any]
+
+    @classmethod
+    def parse(cls, value: Any) -> _ReadableDescriptor:
+        if not isinstance(value, dict) or not isinstance(value.get("name"), str):
+            raise ValueError(f"malformed ReadableStream payload: {value!r}")
+        stream_type = value.get("type")
+        framing = value.get("framing")
+        if stream_type is not None and stream_type != "bytes":
+            raise ValueError(f"unknown ReadableStream type: {stream_type!r}")
+        if framing is not None and framing != "framed-v1":
+            raise ValueError(f"unknown ReadableStream framing: {framing!r}")
+        if framing is not None and stream_type != "bytes":
+            raise ValueError("ReadableStream framing requires type='bytes'")
+        return cls(dict(value))
+
+    @property
+    def name(self) -> str:
+        return cast(str, self.data["name"])
+
+    @property
+    def start_index(self) -> int | None:
+        value = self.data.get("startIndex")
+        if value is not None and not isinstance(value, int):
+            raise ValueError(f"malformed ReadableStream startIndex: {value!r}")
+        return value
+
+
+class _LocalReadableStream(ReadableStream[T]):
+    def __init__(self, source: AsyncIterable[T], mode: ReadableMode) -> None:
+        self.source = source
+        self.mode = mode
+        descriptor: dict[str, Any] = {"name": f"strm_{_new_stream_ulid()}"}
+        if mode == "bytes":
+            descriptor.update(type="bytes", framing="framed-v1")
+        self.descriptor = _ReadableDescriptor(descriptor)
+        self.bound_run_id: str | None = None
+        self.pump_registered = False
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        if self.pump_registered:
+            raise RuntimeError("cannot consume a readable stream after its World pump has started")
+        return aiter(self.source)
+
+    async def aclose(self) -> None:
+        close = getattr(self.source, "aclose", None)
+        if close is not None:
+            await close()
+
+
+class _OpaqueReadableStream(ReadableStream[Any]):
+    def __init__(self, descriptor: _ReadableDescriptor) -> None:
+        self.descriptor = descriptor
+
+    def _refuse(self) -> RuntimeError:
+        return RuntimeError(
+            f"cannot consume stream {self.descriptor.name!r} inside a workflow: "
+            "workflow bodies replay in an I/O-free sandbox; forward or return the stream instead"
+        )
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        raise self._refuse()
+
+    async def aclose(self) -> None:
+        raise self._refuse()
+
+
+class _WorldReadableStream(ReadableStream[Any]):
+    def __init__(self, *, world: w.World, run_id: str, descriptor: _ReadableDescriptor) -> None:
+        self._world = world
+        self._run_id = run_id
+        self.descriptor = descriptor
+        self._iterator: AsyncGenerator[Any, None] | None = None
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        if self._iterator is not None:
+            raise RuntimeError("a ReadableStream can only be iterated once")
+        if self.descriptor.data.get("type") == "bytes":
+            raise ser.SerializationError("byte ReadableStream support is not available")
+
+        async def values() -> AsyncGenerator[Any, None]:
+            frames = reconnecting_frames(
+                self._world,
+                self._run_id,
+                self.descriptor.name,
+                self.descriptor.start_index,
+            )
+            async with contextlib.aclosing(frames):
+                index = self.descriptor.start_index or 0
+                async for payload in frames:
+                    with reviving_readable_streams(self._run_id, world=self._world, live=True):
+                        yield ser.hydrate(
+                            payload,
+                            what=f"chunk {index} of stream {self.descriptor.name}",
+                        )
+                    index += 1
+
+        self._iterator = values()
+        return self._iterator
+
+    async def aclose(self) -> None:
+        if self._iterator is not None:
+            await self._iterator.aclose()
+
+
+@overload
+def readable_stream(
+    source: AsyncIterable[T], *, mode: Literal["objects"] = "objects"
+) -> ReadableStream[T]: ...
+
+
+@overload
+def readable_stream(
+    source: AsyncIterable[Buffer], *, mode: Literal["bytes"]
+) -> ReadableStream[bytes]: ...
+
+
+def readable_stream(
+    source: AsyncIterable[Any], *, mode: ReadableMode = "objects"
+) -> ReadableStream[Any]:
+    """Make an asynchronous source serializable as a native ReadableStream."""
+    if mode not in ("objects", "bytes"):
+        raise ValueError(f"unknown readable stream mode: {mode!r}")
+    if not isinstance(source, AsyncIterable):
+        raise TypeError(
+            f"readable stream source must be an AsyncIterable, got {type(source).__name__}"
+        )
+    return _LocalReadableStream(source, mode)
+
+
+@dataclasses.dataclass
+class _ReadableSerialization:
+    allow_local: bool
+    local_sources: list[_LocalReadableStream[Any]] = dataclasses.field(default_factory=list)
+    _seen: set[int] = dataclasses.field(default_factory=set)
+
+    def add(self, stream: _LocalReadableStream[Any]) -> None:
+        if not self.allow_local:
+            raise RuntimeError(
+                "cannot create a readable stream inside a workflow: local sources need I/O; "
+                "create it in a caller, step, or hook resumer and forward its handle"
+            )
+        if id(stream) not in self._seen:
+            self._seen.add(id(stream))
+            self.local_sources.append(stream)
+
+
+_serialization_ctx: contextvars.ContextVar[_ReadableSerialization | None] = contextvars.ContextVar(
+    "WorkflowReadableSerialization", default=None
+)
+
+
+@contextlib.contextmanager
+def collecting_readable_sources(*, allow_local: bool = True) -> Iterator[_ReadableSerialization]:
+    state = _ReadableSerialization(allow_local=allow_local)
+    token = _serialization_ctx.set(state)
+    try:
+        yield state
+    finally:
+        _serialization_ctx.reset(token)
+
+
+@dataclasses.dataclass(frozen=True)
+class _ReadableRevival:
+    run_id: str
+    world: w.World | None = None
+    live: bool = False
+
+
+_revival_ctx: contextvars.ContextVar[_ReadableRevival | None] = contextvars.ContextVar(
+    "WorkflowReadableRevival", default=None
+)
+
+
+@contextlib.contextmanager
+def reviving_readable_streams(
+    run_id: str, *, world: w.World | None = None, live: bool = False
+) -> Iterator[None]:
+    token = _revival_ctx.set(_ReadableRevival(run_id=run_id, world=world, live=live))
+    try:
+        yield
+    finally:
+        _revival_ctx.reset(token)
+
+
+def reduce_readable_stream(value: Any) -> Any:
+    if isinstance(value, _LocalReadableStream):
+        state = _serialization_ctx.get()
+        if state is None:
+            raise RuntimeError(
+                "a local readable stream can only be serialized at a workflow execution boundary"
+            )
+        state.add(value)
+        return value.descriptor.data
+    if isinstance(value, _OpaqueReadableStream | _WorldReadableStream):
+        return value.descriptor.data
+    return False
+
+
+def revive_readable_stream(value: Any) -> ReadableStream[Any]:
+    descriptor = _ReadableDescriptor.parse(value)
+    context = _revival_ctx.get()
+    if context is not None and context.live:
+        if context.world is None:
+            raise RuntimeError("a live ReadableStream revival requires a World")
+        return _WorldReadableStream(
+            world=context.world,
+            run_id=context.run_id,
+            descriptor=descriptor,
+        )
+    return _OpaqueReadableStream(descriptor)
+
+
+_background_tasks_ctx: contextvars.ContextVar[Callable[[Awaitable[object]], None] | None] = (
+    contextvars.ContextVar("WorkflowReadableBackgroundTasks", default=None)
+)
+
+
+@contextlib.contextmanager
+def readable_background_tasks(
+    register: Callable[[Awaitable[object]], None],
+) -> Iterator[None]:
+    """Override invocation-owned background registration, primarily for hosts."""
+    token = _background_tasks_ctx.set(register)
+    try:
+        yield
+    finally:
+        _background_tasks_ctx.reset(token)
+
+
+def _background_task_registrar() -> Callable[[Awaitable[object]], None]:
+    register = _background_tasks_ctx.get()
+    if register is not None:
+        return register
+
+    # Vercel's Python Functions runtime installs this callback for the active
+    # invocation. Import lazily so `vercel-workflow` can still be imported as a
+    # standalone namespace package when the umbrella SDK is not installed.
+    try:
+        from vercel.cache.context import get_context
+    except ImportError:
+        pass
+    else:
+        register = get_context().wait_until
+        if register is not None:
+            return register
+
+    raise RuntimeError(
+        "serializing a local readable stream requires an invocation-owned background-task "
+        "facility (Vercel Functions wait_until is not available in this context)"
+    )
+
+
+async def _pump_local_stream(
+    stream: _LocalReadableStream[Any], *, world: w.World, run_id: str
+) -> None:
+    try:
+        async with anyio.create_task_group() as task_group:
+            writer = WorkflowStreamWriter(
+                world=world,
+                run_id=run_id,
+                name=stream.descriptor.name,
+                task_group=task_group,
+            )
+            if stream.mode != "objects":
+                raise ser.SerializationError("byte ReadableStream support is not available")
+            async for value in stream.source:
+                await writer.write(value)
+            await writer.close()
+    except BaseException:
+        # The World API has no failed-stream operation. Closing is the only way
+        # to guarantee a reader is not left hanging; the background owner still
+        # observes and reports the producer exception.
+        with anyio.CancelScope(shield=True):
+            await world.streams_close(run_id, stream.descriptor.name)
+        raise
+
+
+def bind_readable_sources(state: _ReadableSerialization, *, world: w.World, run_id: str) -> None:
+    """Bind newly serialized local sources to *run_id* and register their pumps."""
+    if not state.local_sources:
+        return
+    register = _background_task_registrar()
+    for stream in state.local_sources:
+        if stream.bound_run_id is not None and stream.bound_run_id != run_id:
+            raise RuntimeError(
+                f"readable stream {stream.descriptor.name!r} is already bound to "
+                f"run {stream.bound_run_id!r}"
+            )
+        if stream.pump_registered:
+            continue
+        stream.bound_run_id = run_id
+        pump = _pump_local_stream(stream, world=world, run_id=run_id)
+        try:
+            register(pump)
+        except BaseException:
+            pump.close()
+            stream.bound_run_id = None
+            raise
+        stream.pump_registered = True
 
 
 def _env_int(name: str, default: int, *, minimum: int = 1) -> int:


### PR DESCRIPTION
Stacked on #363.

Adds the public generic ReadableStream API, native devalue references, execution-boundary-aware source pumps, live World readers, and the first step-returned object-stream vertical slice. It also centralizes Buffer conversion in internal-core.

Validation:
- uv run poe qa vercel-internal-core vercel-workflow -q
- readable-stream tests on Python 3.10 and 3.14
- uv run poe check-news-fragments