### PR TITLE
workflow: cover object stream routes

### DIFF
--- a/changes/vercel-workflow/readable-stream-object-routes.feature.md
+++ b/changes/vercel-workflow/readable-stream-object-routes.feature.md
@@ -1,0 +1,1 @@
+Support object readable streams across start, step-argument, and hook-resume routes with local cancellation and producer-error propagation.

--- a/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
@@ -4,11 +4,13 @@ from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Sequence
 from datetime import datetime
 from typing import Any
 
+import anyio
 import pytest
 
 from vercel._internal.core.polyfills import UTC
 from vercel.workflow import ReadableStream, readable_stream
 from vercel.workflow._internal import core, runtime, serialization as ser, streams, world as w
+from vercel.workflow._internal.worlds.local import LocalWorld
 
 from ..world_stubs import NoStreams
 
@@ -23,11 +25,14 @@ class ReadableWorld(NoStreams, w.World):
         self.events: list[w.Event] = []
         self.chunks: dict[str, list[bytes]] = {}
         self.closed: set[str] = set()
+        self.queues: list[w.QueuePayload] = []
+        self.run: w.WorkflowRun | None = None
 
     async def get_deployment_id(self) -> str:
         return "dpl_test"
 
     async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+        self.queues.append(message)
         return "msg_test"
 
     def create_queue_handler(
@@ -36,7 +41,9 @@ class ReadableWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def runs_get(self, run_id: str) -> w.WorkflowRun:
-        raise NotImplementedError
+        if self.run is None:
+            raise NotImplementedError
+        return self.run
 
     async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
         raise NotImplementedError
@@ -169,3 +176,182 @@ async def test_unknown_readable_descriptor_metadata_is_rejected() -> None:
     payload = ser.DEVALUE_V1 + b'[["ReadableStream",1],{"name":2,"type":3},"s","other"]'
     with pytest.raises(ser.SerializationError, match="unknown ReadableStream type"):
         ser.hydrate(payload, what="stream")
+
+
+async def test_object_stream_can_flow_from_step_a_into_step_b() -> None:
+    registry = core.Workflows(as_vercel_job=False)
+
+    async def values() -> AsyncIterator[str]:
+        yield "one"
+        yield "two"
+
+    @registry.step
+    async def consume(source: ReadableStream[str]) -> list[str]:
+        return [value async for value in source]
+
+    source = readable_stream(values())
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        reference = ser.dehydrate(source)
+
+    world = ReadableWorld(
+        step_input=ser.dehydrate(
+            ser.step_arguments((), {"source": ser.hydrate(reference, what="reference")})
+        )
+    )
+    w.set_world(world)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+    await background[0]
+
+    await _invoke(registry, consume.name)
+    completed = [event for event in world.events if event.event_type == "step_completed"]
+    assert ser.hydrate(completed[-1].event_data.result, what="result") == ["one", "two"]
+
+
+async def test_nested_references_preserve_identity_without_repumping() -> None:
+    async def values() -> AsyncIterator[int]:
+        yield 1
+
+    source = readable_stream(values())
+    with streams.collecting_readable_sources() as pending:
+        payload = ser.dehydrate({"direct": source, "nested": [source]})
+
+    with streams.reviving_readable_streams(RUN_ID):
+        revived = ser.hydrate(payload, what="nested stream")
+    assert revived["direct"] is revived["nested"][0]
+    assert len(pending.local_sources) == 1
+    await source.aclose()
+
+
+async def test_start_defers_binding_until_the_run_exists(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    registry = core.Workflows(as_vercel_job=False)
+
+    @registry.workflow
+    async def relay(source: ReadableStream[str]) -> ReadableStream[str]:
+        return source
+
+    async def values() -> AsyncIterator[str]:
+        yield "started"
+
+    class World(LocalWorld):
+        async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+            return "msg_start"
+
+    world = World()
+    w.set_world(world)
+    background: list[Awaitable[object]] = []
+    with streams.readable_background_tasks(background.append):
+        run = await runtime.start(relay, readable_stream(values()))
+
+    stored = await world.runs_get(run.run_id)
+    assert isinstance(stored.input, bytes)
+    assert b'"ReadableStream"' in stored.input
+    assert len(background) == 1
+    await background[0]
+
+    with streams.reviving_readable_streams(run.run_id, world=world, live=True):
+        _, kwargs = ser.call_arguments(
+            ser.hydrate(stored.input, what="run input"), what="run input"
+        )
+    assert [value async for value in kwargs["source"]] == ["started"]
+
+
+async def test_hook_resumer_can_own_an_object_stream() -> None:
+    async def values() -> AsyncIterator[str]:
+        yield "resumed"
+
+    world = ReadableWorld()
+    world.run = w.NonFinalWorkflowRun(
+        run_id=RUN_ID,
+        status="running",
+        deployment_id="dpl_test",
+        workflow_name="workflow//test",
+        created_at=NOW,
+        updated_at=NOW,
+        started_at=NOW,
+    )
+    w.set_world(world)
+    hook = core.Hook(
+        token="hook_token",
+        hook_id="hook_test",
+        run_id=RUN_ID,
+        created_at=NOW,
+    )
+    background: list[Awaitable[object]] = []
+    with streams.readable_background_tasks(background.append):
+        await runtime.resume_hook(hook, readable_stream(values()))
+
+    received = [event for event in world.events if event.event_type == "hook_received"]
+    assert len(received) == 1
+    assert b'"ReadableStream"' in received[0].event_data.payload
+    await background[0]
+
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        value = ser.hydrate(received[0].event_data.payload, what="hook payload")
+    assert [item async for item in value] == ["resumed"]
+
+
+async def test_producer_error_is_reported_by_a_local_reader(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+
+    async def values() -> AsyncIterator[str]:
+        yield "before"
+        raise RuntimeError("producer failed")
+
+    world = LocalWorld()
+    source = readable_stream(values())
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        payload = ser.dehydrate(source)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+
+    with pytest.raises(RuntimeError, match="producer failed"):
+        await background[0]
+
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        reader = ser.hydrate(payload, what="stream")
+    iterator = aiter(reader)
+    assert await anext(iterator) == "before"
+    with pytest.raises(RuntimeError, match="producer failed"):
+        await anext(iterator)
+
+
+async def test_aclose_cancels_a_locally_owned_pump(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    producing = anyio.Event()
+    source_closed = anyio.Event()
+
+    async def values() -> AsyncIterator[str]:
+        try:
+            yield "first"
+            producing.set()
+            await anyio.sleep_forever()
+        finally:
+            source_closed.set()
+
+    world = LocalWorld()
+    source = readable_stream(values())
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        payload = ser.dehydrate(source)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+
+    async def run_pump() -> None:
+        await background[0]
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(run_pump)
+        await producing.wait()
+        with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+            reader = ser.hydrate(payload, what="stream")
+        iterator = aiter(reader)
+        assert await anext(iterator) == "first"
+        await reader.aclose()
+        await source_closed.wait()
+
+    info = await world.streams_get_info(RUN_ID, next(iter(await world.streams_list(RUN_ID))))
+    assert info.done

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -126,6 +126,7 @@ class _LocalReadableStream(ReadableStream[T]):
         self.descriptor = _ReadableDescriptor(descriptor)
         self.bound_run_id: str | None = None
         self.pump_registered = False
+        self.owner: _ReadablePump | None = None
 
     def __aiter__(self) -> AsyncIterator[T]:
         if self.pump_registered:
@@ -133,6 +134,8 @@ class _LocalReadableStream(ReadableStream[T]):
         return aiter(self.source)
 
     async def aclose(self) -> None:
+        if self.owner is not None:
+            self.owner.cancel()
         close = getattr(self.source, "aclose", None)
         if close is not None:
             await close()
@@ -184,6 +187,10 @@ class _WorldReadableStream(ReadableStream[Any]):
                             what=f"chunk {index} of stream {self.descriptor.name}",
                         )
                     index += 1
+            owner = _readable_pump(self._world, self._run_id, self.descriptor.name)
+            if owner is not None and owner.error is not None:
+                _readable_pumps.pop((self._world, self._run_id, self.descriptor.name), None)
+                raise owner.error
 
         self._iterator = values()
         return self._iterator
@@ -191,6 +198,11 @@ class _WorldReadableStream(ReadableStream[Any]):
     async def aclose(self) -> None:
         if self._iterator is not None:
             await self._iterator.aclose()
+        owner = _readable_pumps.get((self._world, self._run_id, self.descriptor.name))
+        if owner is not None:
+            owner.cancel()
+            if owner.done:
+                _readable_pumps.pop((self._world, self._run_id, self.descriptor.name), None)
 
 
 @overload
@@ -306,6 +318,26 @@ _background_tasks_ctx: contextvars.ContextVar[Callable[[Awaitable[object]], None
 )
 
 
+@dataclasses.dataclass
+class _ReadablePump:
+    cancel_scope: anyio.CancelScope | None = None
+    cancel_requested: bool = False
+    done: bool = False
+    error: BaseException | None = None
+
+    def cancel(self) -> None:
+        self.cancel_requested = True
+        if self.cancel_scope is not None:
+            self.cancel_scope.cancel()
+
+
+_readable_pumps: dict[tuple[w.World, str, str], _ReadablePump] = {}
+
+
+def _readable_pump(world: w.World, run_id: str, name: str) -> _ReadablePump | None:
+    return _readable_pumps.get((world, run_id, name))
+
+
 @contextlib.contextmanager
 def readable_background_tasks(
     register: Callable[[Awaitable[object]], None],
@@ -342,28 +374,60 @@ def _background_task_registrar() -> Callable[[Awaitable[object]], None]:
 
 
 async def _pump_local_stream(
-    stream: _LocalReadableStream[Any], *, world: w.World, run_id: str
+    stream: _LocalReadableStream[Any],
+    *,
+    world: w.World,
+    run_id: str,
+    owner: _ReadablePump,
 ) -> None:
+    cancelled = False
     try:
-        async with anyio.create_task_group() as task_group:
-            writer = WorkflowStreamWriter(
-                world=world,
-                run_id=run_id,
-                name=stream.descriptor.name,
-                task_group=task_group,
-            )
-            if stream.mode != "objects":
-                raise ser.SerializationError("byte ReadableStream support is not available")
-            async for value in stream.source:
-                await writer.write(value)
-            await writer.close()
-    except BaseException:
+        with anyio.CancelScope() as cancel_scope:
+            owner.cancel_scope = cancel_scope
+            if owner.cancel_requested:
+                cancel_scope.cancel()
+            async with anyio.create_task_group() as task_group:
+                writer = WorkflowStreamWriter(
+                    world=world,
+                    run_id=run_id,
+                    name=stream.descriptor.name,
+                    task_group=task_group,
+                )
+                if stream.mode != "objects":
+                    raise ser.SerializationError("byte ReadableStream support is not available")
+                source_error: Exception | None = None
+                try:
+                    async for value in stream.source:
+                        await writer.write(value)
+                except Exception as error:
+                    source_error = error
+                    await writer.drain()
+                else:
+                    await writer.close()
+            if source_error is not None:
+                raise source_error
+        cancelled = cancel_scope.cancel_called
+    except BaseException as error:
+        owner.error = error
         # The World API has no failed-stream operation. Closing is the only way
         # to guarantee a reader is not left hanging; the background owner still
         # observes and reports the producer exception.
         with anyio.CancelScope(shield=True):
             await world.streams_close(run_id, stream.descriptor.name)
         raise
+    finally:
+        owner.done = True
+        owner.cancel_scope = None
+        close = getattr(stream.source, "aclose", None)
+        if close is not None:
+            with anyio.CancelScope(shield=True):
+                await close()
+
+    if cancelled:
+        with anyio.CancelScope(shield=True):
+            await world.streams_close(run_id, stream.descriptor.name)
+    if owner.error is None:
+        _readable_pumps.pop((world, run_id, stream.descriptor.name), None)
 
 
 def bind_readable_sources(state: _ReadableSerialization, *, world: w.World, run_id: str) -> None:
@@ -380,11 +444,17 @@ def bind_readable_sources(state: _ReadableSerialization, *, world: w.World, run_
         if stream.pump_registered:
             continue
         stream.bound_run_id = run_id
-        pump = _pump_local_stream(stream, world=world, run_id=run_id)
+        owner = _ReadablePump()
+        stream.owner = owner
+        key = (world, run_id, stream.descriptor.name)
+        _readable_pumps[key] = owner
+        pump = _pump_local_stream(stream, world=world, run_id=run_id, owner=owner)
         try:
             register(pump)
         except BaseException:
             pump.close()
+            _readable_pumps.pop(key, None)
+            stream.owner = None
             stream.bound_run_id = None
             raise
         stream.pump_registered = True


### PR DESCRIPTION
Stacked on #364.

Completes object-stream route coverage for step arguments, start inputs, hook resumes, nested references, replay identity, and local lifecycle behavior. Existing references retain their descriptor and are never repumped.

Validation:
- uv run poe qa vercel-workflow -q
- uv run poe check-news-fragments