### PR TITLE
workflow: add framed byte streams

### DIFF
--- a/changes/vercel-workflow/readable-stream-bytes.feature.md
+++ b/changes/vercel-workflow/readable-stream-bytes.feature.md
@@ -1,0 +1,1 @@
+Add framed byte readable streams and read compatibility for legacy raw-byte descriptors.

--- a/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
@@ -7,7 +7,7 @@ from typing import Any
 import anyio
 import pytest
 
-from vercel._internal.core.polyfills import UTC
+from vercel._internal.core.polyfills import UTC, Buffer
 from vercel.workflow import ReadableStream, readable_stream
 from vercel.workflow._internal import core, runtime, serialization as ser, streams, world as w
 from vercel.workflow._internal.worlds.local import LocalWorld
@@ -117,7 +117,7 @@ async def test_step_returned_object_stream_is_recorded_before_its_pump_runs() ->
     registry = core.Workflows(as_vercel_job=False)
     started = False
 
-    async def values() -> AsyncIterator[object]:
+    async def values() -> AsyncIterator[Any]:
         nonlocal started
         started = True
         yield {"token": "hello"}
@@ -355,3 +355,72 @@ async def test_aclose_cancels_a_locally_owned_pump(tmp_path, monkeypatch) -> Non
 
     info = await world.streams_get_info(RUN_ID, next(iter(await world.streams_list(RUN_ID))))
     assert info.done
+
+
+async def test_step_returned_framed_byte_stream_preserves_user_chunks() -> None:
+    registry = core.Workflows(as_vercel_job=False)
+    mutable = bytearray(b"mutable")
+
+    async def values() -> AsyncIterator[Buffer]:
+        yield mutable
+        mutable[:] = b"changed"
+        yield memoryview(b"view")
+        yield b""
+
+    @registry.step
+    async def produce() -> ReadableStream[bytes]:
+        return readable_stream(values(), mode="bytes")
+
+    world = ReadableWorld()
+    w.set_world(world)
+    background: list[Awaitable[object]] = []
+    with streams.readable_background_tasks(background.append):
+        await _invoke(registry, produce.name)
+
+    completed = [event for event in world.events if event.event_type == "step_completed"]
+    payload = completed[0].event_data.result
+    assert b'"type"' in payload and b'"bytes"' in payload
+    assert b'"framing"' in payload and b'"framed-v1"' in payload
+    await background[0]
+
+    stored = next(iter(world.chunks.values()))
+    assert stored == [
+        streams.encode_frame(b"mutable"),
+        streams.encode_frame(b"view"),
+        streams.encode_frame(b""),
+    ]
+    assert all(ser.DEVALUE_V1 not in frame for frame in stored)
+
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        reader = ser.hydrate(payload, what="byte stream")
+    assert [chunk async for chunk in reader] == [b"mutable", b"view", b""]
+
+
+async def test_byte_stream_rejects_a_non_buffer_chunk() -> None:
+    async def values() -> AsyncIterator[Any]:
+        yield "not bytes"
+
+    source = readable_stream(values(), mode="bytes")
+    world = ReadableWorld()
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        ser.dehydrate(source)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+
+    with pytest.raises(
+        TypeError,
+        match="byte stream chunks must implement the buffer protocol; got str",
+    ):
+        await background[0]
+
+
+async def test_legacy_raw_byte_descriptor_reads_transport_chunks_without_framing() -> None:
+    payload = ser.DEVALUE_V1 + (b'[["ReadableStream",1],{"name":2,"type":3},"legacy","bytes"]')
+    world = ReadableWorld()
+    world.chunks["legacy"] = [b"raw ", b"transport"]
+    world.closed.add("legacy")
+
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        reader = ser.hydrate(payload, what="legacy stream")
+    assert [chunk async for chunk in reader] == [b"raw ", b"transport"]

--- a/src/vercel-workflow/tests/unit/test_workflow_stream_framing.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_stream_framing.py
@@ -19,6 +19,14 @@ def test_frame_is_a_four_byte_big_endian_length_then_the_payload() -> None:
     assert streams.encode_frame(b"") == b"\x00\x00\x00\x00"
 
 
+def test_framed_byte_encoder_snapshots_any_buffer_without_a_format_prefix() -> None:
+    source = bytearray(b"hello")
+    frame = streams.encode_framed_bytes(memoryview(source))
+    source[:] = b"other"
+    assert frame == b"\x00\x00\x00\x05hello"
+    assert ser.DEVALUE_V1 not in frame
+
+
 def test_value_frame_carries_a_devl_payload() -> None:
     # The payload is exactly what the run/step payload boundary writes, which
     # is what lets `getDeserializeStream` on the TS side read it.

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 import anyio
 import pydantic
 
+from vercel._internal.core.byte_stream import buffer_to_bytes
 from vercel._internal.core.polyfills import Buffer
 
 from . import serialization as ser, ulid
@@ -168,25 +169,43 @@ class _WorldReadableStream(ReadableStream[Any]):
     def __aiter__(self) -> AsyncIterator[Any]:
         if self._iterator is not None:
             raise RuntimeError("a ReadableStream can only be iterated once")
-        if self.descriptor.data.get("type") == "bytes":
-            raise ser.SerializationError("byte ReadableStream support is not available")
 
         async def values() -> AsyncGenerator[Any, None]:
-            frames = reconnecting_frames(
-                self._world,
-                self._run_id,
-                self.descriptor.name,
-                self.descriptor.start_index,
-            )
-            async with contextlib.aclosing(frames):
-                index = self.descriptor.start_index or 0
-                async for payload in frames:
-                    with reviving_readable_streams(self._run_id, world=self._world, live=True):
-                        yield ser.hydrate(
-                            payload,
-                            what=f"chunk {index} of stream {self.descriptor.name}",
-                        )
-                    index += 1
+            stream_type = self.descriptor.data.get("type")
+            framing = self.descriptor.data.get("framing")
+            if stream_type == "bytes" and framing is None:
+                # Legacy descriptors name an unframed raw byte stream. The
+                # transport's reads are the only boundaries available, and a
+                # frame-index reconnect would be unsafe.
+                source = self._world.streams_get(
+                    self._run_id,
+                    self.descriptor.name,
+                    self.descriptor.start_index,
+                )
+                async with contextlib.aclosing(source):
+                    async for chunk in source:
+                        yield bytes(chunk)
+            else:
+                frames = reconnecting_frames(
+                    self._world,
+                    self._run_id,
+                    self.descriptor.name,
+                    self.descriptor.start_index,
+                )
+                async with contextlib.aclosing(frames):
+                    index = self.descriptor.start_index or 0
+                    async for payload in frames:
+                        if stream_type == "bytes":
+                            yield payload
+                        else:
+                            with reviving_readable_streams(
+                                self._run_id, world=self._world, live=True
+                            ):
+                                yield ser.hydrate(
+                                    payload,
+                                    what=f"chunk {index} of stream {self.descriptor.name}",
+                                )
+                        index += 1
             owner = _readable_pump(self._world, self._run_id, self.descriptor.name)
             if owner is not None and owner.error is not None:
                 _readable_pumps.pop((self._world, self._run_id, self.descriptor.name), None)
@@ -393,12 +412,20 @@ async def _pump_local_stream(
                     name=stream.descriptor.name,
                     task_group=task_group,
                 )
-                if stream.mode != "objects":
-                    raise ser.SerializationError("byte ReadableStream support is not available")
                 source_error: Exception | None = None
                 try:
                     async for value in stream.source:
-                        await writer.write(value)
+                        if stream.mode == "objects":
+                            await writer.write(value)
+                        else:
+                            try:
+                                frame = encode_framed_bytes(value)
+                            except TypeError:
+                                raise TypeError(
+                                    "byte stream chunks must implement the buffer protocol; "
+                                    f"got {type(value).__name__}"
+                                ) from None
+                            await writer.write_encoded(frame)
                 except Exception as error:
                     source_error = error
                     await writer.drain()
@@ -506,6 +533,11 @@ def encode_frame(payload: bytes) -> bytes:
             f"({MAX_FRAME_SIZE}); split the data into smaller chunks before writing"
         )
     return len(payload).to_bytes(FRAME_HEADER_SIZE, "big") + payload
+
+
+def encode_framed_bytes(value: Buffer, /) -> bytes:
+    """Snapshot and frame one user-provided byte-stream chunk."""
+    return encode_frame(buffer_to_bytes(value))
 
 
 def encode_value(value: Any) -> bytes:
@@ -859,6 +891,10 @@ class WorkflowStreamWriter(WorkflowWritable):
         the buffer is full, so a fast producer cannot grow it without bound.
         """
         await self._enqueue(encode_value(value))
+
+    async def write_encoded(self, frame: bytes) -> None:
+        """Enqueue one already encoded frame through the shared batching sink."""
+        await self._enqueue(frame)
 
     async def write_from(self, source: AsyncIterable[Any]) -> None:
         """Append every item *source* yields, in order.


### PR DESCRIPTION
Stacked on #365.

Adds framed-v1 byte-stream descriptors, raw-buffer snapshotting, shared writer enqueueing, framed live reads with reconnect support, and legacy raw-byte descriptor compatibility. User yield boundaries remain one frame and one World chunk.

The current World protocol has no failed-stream operation, so a remote producer failure is represented by closing the stream while the invocation background owner reports the original exception; an in-process owned reader also receives that exception.

Validation:
- uv run poe qa vercel-workflow -q
- byte framing and descriptor conformance assertions
- uv run poe check-news-fragments