### PR TITLE
workflow: harden readable stream parity

### DIFF
--- a/changes/vercel-workflow/readable-stream-hardening.feature.md
+++ b/changes/vercel-workflow/readable-stream-hardening.feature.md
@@ -1,0 +1,2 @@
+Complete readable-stream route parity with byte-mode lifecycle, reconnect,
+backpressure, and static typing coverage.

--- a/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_readable_stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Sequence
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import anyio
 import pytest
@@ -13,6 +13,32 @@ from vercel.workflow._internal import core, runtime, serialization as ser, strea
 from vercel.workflow._internal.worlds.local import LocalWorld
 
 from ..world_stubs import NoStreams
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
+
+    async def _typed_objects() -> AsyncIterator[dict[str, str]]:
+        yield {"token": "value"}
+
+    async def _typed_buffers() -> AsyncIterator[Buffer]:
+        yield b"value"
+
+    async def _typed_non_buffers() -> AsyncIterator[str]:
+        yield "value"
+
+    assert_type(
+        readable_stream(_typed_objects()),
+        ReadableStream[dict[str, str]],
+    )
+    assert_type(
+        readable_stream(_typed_buffers(), mode="bytes"),
+        ReadableStream[bytes],
+    )
+    readable_stream(_typed_non_buffers(), mode="bytes")  # type: ignore[call-overload]
+
+    def _accepts_objects(stream: ReadableStream[object]) -> None: ...
+
+    _accepts_objects(readable_stream(_typed_objects()))
 
 RUN_ID = "wrun_readable"
 STEP_ID = "step_readable"
@@ -293,15 +319,20 @@ async def test_hook_resumer_can_own_an_object_stream() -> None:
     assert [item async for item in value] == ["resumed"]
 
 
-async def test_producer_error_is_reported_by_a_local_reader(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("mode", ["objects", "bytes"])
+async def test_producer_error_is_reported_by_a_local_reader(
+    tmp_path, monkeypatch, mode: str
+) -> None:
     monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
 
-    async def values() -> AsyncIterator[str]:
-        yield "before"
+    async def values() -> AsyncIterator[bytes]:
+        yield b"before"
         raise RuntimeError("producer failed")
 
     world = LocalWorld()
-    source = readable_stream(values())
+    source = (
+        readable_stream(values(), mode="bytes") if mode == "bytes" else readable_stream(values())
+    )
     background: list[Awaitable[object]] = []
     with streams.collecting_readable_sources() as pending:
         payload = ser.dehydrate(source)
@@ -314,26 +345,29 @@ async def test_producer_error_is_reported_by_a_local_reader(tmp_path, monkeypatc
     with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
         reader = ser.hydrate(payload, what="stream")
     iterator = aiter(reader)
-    assert await anext(iterator) == "before"
+    assert await anext(iterator) == b"before"
     with pytest.raises(RuntimeError, match="producer failed"):
         await anext(iterator)
 
 
-async def test_aclose_cancels_a_locally_owned_pump(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("mode", ["objects", "bytes"])
+async def test_aclose_cancels_a_locally_owned_pump(tmp_path, monkeypatch, mode: str) -> None:
     monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
     producing = anyio.Event()
     source_closed = anyio.Event()
 
-    async def values() -> AsyncIterator[str]:
+    async def values() -> AsyncIterator[bytes]:
         try:
-            yield "first"
+            yield b"first"
             producing.set()
             await anyio.sleep_forever()
         finally:
             source_closed.set()
 
     world = LocalWorld()
-    source = readable_stream(values())
+    source = (
+        readable_stream(values(), mode="bytes") if mode == "bytes" else readable_stream(values())
+    )
     background: list[Awaitable[object]] = []
     with streams.collecting_readable_sources() as pending:
         payload = ser.dehydrate(source)
@@ -349,12 +383,59 @@ async def test_aclose_cancels_a_locally_owned_pump(tmp_path, monkeypatch) -> Non
         with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
             reader = ser.hydrate(payload, what="stream")
         iterator = aiter(reader)
-        assert await anext(iterator) == "first"
+        assert await anext(iterator) == b"first"
         await reader.aclose()
         await source_closed.wait()
 
     info = await world.streams_get_info(RUN_ID, next(iter(await world.streams_list(RUN_ID))))
     assert info.done
+
+    # Cancellation closes the producer, but a second reader can still consume
+    # every chunk that was already durable.
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        second_reader = ser.hydrate(payload, what="stream")
+    assert [item async for item in second_reader] == [b"first"]
+
+
+@pytest.mark.parametrize("mode", ["objects", "bytes"])
+async def test_fast_local_producer_obeys_writer_backpressure(monkeypatch, mode: str) -> None:
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS", "2")
+    monkeypatch.setenv("WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH", "1")
+    entered_write = anyio.Event()
+    release_write = anyio.Event()
+    produced = 0
+
+    class BlockingWorld(ReadableWorld):
+        async def streams_write(self, run_id: str, name: str, chunk: bytes) -> None:
+            entered_write.set()
+            await release_write.wait()
+            await super().streams_write(run_id, name, chunk)
+
+    async def values() -> AsyncIterator[bytes]:
+        nonlocal produced
+        for value in range(20):
+            produced += 1
+            yield str(value).encode()
+
+    source = (
+        readable_stream(values(), mode="bytes") if mode == "bytes" else readable_stream(values())
+    )
+    world = BlockingWorld()
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        ser.dehydrate(source)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(lambda: background[0])
+        await entered_write.wait()
+        for _ in range(10):
+            await anyio.sleep(0)
+        assert produced <= 3
+        release_write.set()
+
+    assert produced == 20
 
 
 async def test_step_returned_framed_byte_stream_preserves_user_chunks() -> None:
@@ -424,3 +505,125 @@ async def test_legacy_raw_byte_descriptor_reads_transport_chunks_without_framing
     with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
         reader = ser.hydrate(payload, what="legacy stream")
     assert [chunk async for chunk in reader] == [b"raw ", b"transport"]
+
+
+async def test_framed_byte_stream_can_flow_from_step_a_into_step_b() -> None:
+    registry = core.Workflows(as_vercel_job=False)
+
+    async def values() -> AsyncIterator[Buffer]:
+        yield b"one"
+        yield bytearray(b"two")
+
+    @registry.step
+    async def consume(source: ReadableStream[bytes]) -> bytes:
+        return b"".join([value async for value in source])
+
+    source = readable_stream(values(), mode="bytes")
+    background: list[Awaitable[object]] = []
+    with streams.collecting_readable_sources() as pending:
+        reference = ser.dehydrate(source)
+
+    world = ReadableWorld(
+        step_input=ser.dehydrate(
+            ser.step_arguments((), {"source": ser.hydrate(reference, what="reference")})
+        )
+    )
+    w.set_world(world)
+    with streams.readable_background_tasks(background.append):
+        streams.bind_readable_sources(pending, world=world, run_id=RUN_ID)
+    await background[0]
+    await _invoke(registry, consume.name)
+
+    completed = [event for event in world.events if event.event_type == "step_completed"]
+    assert ser.hydrate(completed[-1].event_data.result, what="result") == b"onetwo"
+
+
+async def test_start_accepts_a_framed_byte_source(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    registry = core.Workflows(as_vercel_job=False)
+
+    @registry.workflow
+    async def relay(source: ReadableStream[bytes]) -> ReadableStream[bytes]:
+        return source
+
+    async def values() -> AsyncIterator[Buffer]:
+        yield b"from start"
+
+    class World(LocalWorld):
+        async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: Any) -> str:
+            return "msg_start_bytes"
+
+    world = World()
+    w.set_world(world)
+    background: list[Awaitable[object]] = []
+    with streams.readable_background_tasks(background.append):
+        run = await runtime.start(relay, readable_stream(values(), mode="bytes"))
+    await background[0]
+
+    stored = await world.runs_get(run.run_id)
+    assert isinstance(stored.input, bytes)
+    with streams.reviving_readable_streams(run.run_id, world=world, live=True):
+        _, kwargs = ser.call_arguments(
+            ser.hydrate(stored.input, what="run input"), what="run input"
+        )
+    assert [value async for value in kwargs["source"]] == [b"from start"]
+
+
+async def test_hook_resumer_accepts_a_framed_byte_source() -> None:
+    async def values() -> AsyncIterator[Buffer]:
+        yield b"from hook"
+
+    world = ReadableWorld()
+    world.run = w.NonFinalWorkflowRun(
+        run_id=RUN_ID,
+        status="running",
+        deployment_id="dpl_test",
+        workflow_name="workflow//test",
+        created_at=NOW,
+        updated_at=NOW,
+        started_at=NOW,
+    )
+    w.set_world(world)
+    hook = core.Hook("hook_token", "hook_test", RUN_ID, NOW)
+    background: list[Awaitable[object]] = []
+    with streams.readable_background_tasks(background.append):
+        await runtime.resume_hook(hook, readable_stream(values(), mode="bytes"))
+    await background[0]
+
+    received = [event for event in world.events if event.event_type == "hook_received"]
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        reader = ser.hydrate(received[0].event_data.payload, what="hook payload")
+    assert [value async for value in reader] == [b"from hook"]
+
+
+async def test_framed_byte_reader_reconnects_after_a_partial_frame() -> None:
+    first = streams.encode_frame(b"one")
+    second = streams.encode_frame(b"two")
+
+    class ReconnectingWorld(ReadableWorld):
+        def __init__(self) -> None:
+            super().__init__()
+            self.starts: list[int | None] = []
+
+        def streams_get(
+            self, run_id: str, name: str, start_index: int | None = None
+        ) -> AsyncGenerator[bytes, None]:
+            self.starts.append(start_index)
+
+            async def read() -> AsyncGenerator[bytes, None]:
+                if len(self.starts) == 1:
+                    yield first + second[:2]
+                    raise OSError("connection reset")
+                yield second
+
+            return read()
+
+    payload = ser.DEVALUE_V1 + (
+        b'[["ReadableStream",1],{"name":2,"type":3,"framing":4},"framed","bytes","framed-v1"]'
+    )
+    world = ReconnectingWorld()
+    with streams.reviving_readable_streams(RUN_ID, world=world, live=True):
+        reader = ser.hydrate(payload, what="framed stream")
+
+    assert [chunk async for chunk in reader] == [b"one", b"two"]
+    assert world.starts == [0, 1]

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -137,6 +137,10 @@ class _LocalReadableStream(ReadableStream[T]):
     async def aclose(self) -> None:
         if self.owner is not None:
             self.owner.cancel()
+            # The pump owns the active iteration and closes the source from
+            # its ``finally`` block. Calling ``aclose`` here as well can race
+            # an async generator that is currently suspended in ``__anext__``.
+            return
         close = getattr(self.source, "aclose", None)
         if close is not None:
             await close()
@@ -440,7 +444,8 @@ async def _pump_local_stream(
         # to guarantee a reader is not left hanging; the background owner still
         # observes and reports the producer exception.
         with anyio.CancelScope(shield=True):
-            await world.streams_close(run_id, stream.descriptor.name)
+            with contextlib.suppress(Exception):
+                await world.streams_close(run_id, stream.descriptor.name)
         raise
     finally:
         owner.done = True


### PR DESCRIPTION
Stacked on #366.

Completes framed-byte parity for step-to-step arguments, start inputs, and hook resumes. Hardens source cancellation, preserves durable chunks for other readers, proves bounded backpressure in both modes, covers late producer errors and partial-frame reconnects, and pins public overload behavior with static type checks.

Validation:
- uv run poe qa vercel-internal-core vercel-workflow -q (154 + 1329 tests)
- Python 3.10 and 3.14 matrix for the 40 readable-stream/framing tests
- uv run poe check-news-fragments