### PR TITLE
workflow: write compressed payloads

### DIFF
--- a/changes/vercel-workflow/compression-write.feature.md
+++ b/changes/vercel-workflow/compression-write.feature.md
@@ -1,0 +1,1 @@
+Write gzip- and zstd-compressed workflow payloads when the run supports them.

--- a/src/vercel-workflow/tests/integration/test_workflow_cli_interop.py
+++ b/src/vercel-workflow/tests/integration/test_workflow_cli_interop.py
@@ -13,9 +13,9 @@ so the run goes through the real queue and the real handlers -- the same path
 ``vercel dev`` takes -- and every file the CLI reads was written by the
 implementation under test.
 
-Metadata *and* payloads are asserted: Python writes a single ``devl``-prefixed
-devalue payload, so the CLI's hydration pipeline reads the values Python
-recorded rather than failing soft to ``{}``.
+Metadata *and* payloads are asserted: Python writes format-prefixed devalue
+payloads, compressed when worthwhile, so the CLI's hydration pipeline reads
+the values Python recorded rather than failing soft to ``{}``.
 
 The suite needs Node. Following the precedent in ``tests/integration/
 test_devalue.py`` it is optional locally and mandatory on CI, so a developer
@@ -344,7 +344,7 @@ async def test_cli_lists_the_run_python_wrote(workflow_cli, py_run) -> None:
     (run,) = page["data"]
     assert run["status"] == "completed"
     assert run["workflowName"] == checkout.workflow_id
-    assert run["specVersion"] == 2
+    assert run["specVersion"] == w.SPEC_VERSION_CURRENT
     # Materialized by py's own `attr_set` handling, and read back through the
     # TS schema: both writers (the body and a step), and the key the body
     # removed is gone rather than present-and-null.
@@ -366,7 +366,7 @@ async def test_cli_lists_the_steps_python_wrote(workflow_cli, py_run) -> None:
         assert step["runId"] == run_id
         assert step["status"] == "completed"
         assert step["attempt"] == 1
-        assert step["specVersion"] == 2
+        assert step["specVersion"] == w.SPEC_VERSION_CURRENT
 
 
 async def test_cli_lists_the_event_log_python_wrote(workflow_cli, py_run) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_arguments.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_arguments.py
@@ -283,6 +283,22 @@ async def test_start_normalizes_a_positional_call_on_a_named_parameter(
     assert positional.input == by_keyword.input == PLAIN_ENCODER.encode([{"value": 123}])
 
 
+async def test_start_compresses_large_inputs_for_new_runs(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    registry = _registry()
+
+    @registry.workflow
+    async def echo(value: str, /) -> str:
+        return value
+
+    value = "charged " * 256
+    stored = await _start(echo, value)
+
+    assert stored.spec_version == w.SPEC_VERSION_SUPPORTS_COMPRESSION
+    assert stored.input.startswith(ser.ZSTD)
+    assert ser.hydrate(stored.input, what="the input") == [value]
+
+
 async def test_start_refuses_a_call_that_does_not_fit_the_signature(tmp_path, monkeypatch) -> None:
     """And refuses it before a run row exists, rather than after."""
     monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))

--- a/src/vercel-workflow/tests/unit/test_workflow_compression.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_compression.py
@@ -5,7 +5,7 @@ import gzip
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from vercel.workflow._internal import serialization as ser
+from vercel.workflow._internal import compression, py_sandbox, serialization as ser, world as w
 
 # Produced by Node 24's node:zlib over b'devl["charged 42"]'.
 TS_GZIP = bytes.fromhex(
@@ -16,6 +16,7 @@ TS_GZIP = bytes.fromhex(
 TS_ZSTD_WITHOUT_CONTENT_SIZE = bytes.fromhex(
     "28b52ffd00009100006465766c5b2263686172676564203432225d"
 )
+COMPRESSING_ENCODER = ser.PayloadEncoder(compression=True)
 
 
 @pytest.mark.parametrize(
@@ -24,6 +25,68 @@ TS_ZSTD_WITHOUT_CONTENT_SIZE = bytes.fromhex(
 )
 def test_reads_a_typescript_compression_envelope(prefix: bytes, payload: bytes) -> None:
     assert ser.hydrate(prefix + payload, what="a payload") == "charged 42"
+
+
+def test_writes_zstd_by_default() -> None:
+    value = "charged " * 256
+
+    payload = COMPRESSING_ENCODER.encode(value)
+
+    assert payload.startswith(ser.ZSTD)
+    assert ser.hydrate(payload, what="a payload") == value
+
+
+def test_gzip_can_be_selected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOW_COMPRESSION_CODEC", "gzip")
+    value = "charged " * 256
+
+    payload = COMPRESSING_ENCODER.encode(value)
+
+    assert payload.startswith(ser.GZIP)
+    assert ser.hydrate(payload, what="a payload") == value
+
+
+def test_compression_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOW_DISABLE_COMPRESSION", "1")
+
+    payload = COMPRESSING_ENCODER.encode("charged " * 256)
+
+    assert payload.startswith(ser.DEVALUE_V1)
+
+
+def test_small_payloads_are_not_compressed() -> None:
+    assert compression.maybe_compress(b"x" * 1023, enabled=True) == b"x" * 1023
+
+
+def test_disabled_compression_leaves_large_payloads_alone() -> None:
+    data = b"x" * 2000
+
+    assert compression.maybe_compress(data, enabled=False) == data
+
+
+@pytest.mark.parametrize(
+    ("compressed_size", "prefix"),
+    [(1896, b"x"), (1895, ser.ZSTD)],
+)
+def test_compression_requires_five_percent_savings(
+    monkeypatch: pytest.MonkeyPatch, compressed_size: int, prefix: bytes
+) -> None:
+    monkeypatch.setattr(compression, "compress_zstd", lambda data: b"x" * compressed_size)
+
+    assert compression.maybe_compress(b"x" * 2000, enabled=True).startswith(prefix)
+
+
+def test_new_runs_advertise_compression_support() -> None:
+    assert w.SPEC_VERSION_CURRENT == w.SPEC_VERSION_SUPPORTS_COMPRESSION
+
+
+def test_compression_works_inside_the_workflow_sandbox() -> None:
+    value = "charged " * 256
+
+    with py_sandbox.Sandbox().enter():
+        payload = COMPRESSING_ENCODER.encode(value)
+
+    assert ser.hydrate(payload, what="a payload") == value
 
 
 def test_nested_compression_is_not_an_extra_protocol() -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
@@ -53,7 +53,16 @@ class FakeWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def runs_get(self, run_id: str) -> w.WorkflowRun:
-        raise NotImplementedError
+        assert run_id == RUN_ID
+        return w.NonFinalWorkflowRun(
+            run_id=RUN_ID,
+            status="running",
+            deployment_id="dpl_test",
+            workflow_name=WORKFLOW_NAME,
+            spec_version=w.SPEC_VERSION_CURRENT,
+            created_at=NOW,
+            updated_at=NOW,
+        )
 
     async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
         raise NotImplementedError

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_conflict.py
@@ -396,6 +396,7 @@ async def test_get_conflict_continues_while_a_parallel_step_runs(tmp_path, monke
     assert isinstance(queued, w.WorkflowInvokePayload)
     await runtime._execute_step(
         queued,
+        run=await world.runs_get(run_id),
         queue_name=w.get_queue_name(register_claim_with_step.workflow_id),
         registry=registry,
     )

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
@@ -63,17 +63,29 @@ class _RecordingLocalWorld(LocalWorld):
         return "msg_test"
 
 
-async def _run_with_hook(world: _RecordingLocalWorld) -> str:
+async def _run_with_hook(
+    world: _RecordingLocalWorld, *, spec_version: int = w.SPEC_VERSION_CURRENT
+) -> str:
     result = await world.events_create(
         None,
-        w.RunCreatedEventData(
-            deployment_id="dpl_1", workflow_name="test-wf", input=PLAIN_ENCODER.encode([])
-        ).into_event(),
+        w.RunCreatedEvent(
+            event_data=w.RunCreatedEventData(
+                deployment_id="dpl_1", workflow_name="test-wf", input=PLAIN_ENCODER.encode([])
+            ),
+            spec_version=spec_version,
+        ),
     )
     assert result.run is not None
     run_id = result.run.run_id
-    await world.events_create(run_id, w.RunStartedEvent())
-    await world.events_create(run_id, w.HookCreatedEventData(token=TOKEN).into_event("hook_0"))
+    await world.events_create(run_id, w.RunStartedEvent(spec_version=spec_version))
+    await world.events_create(
+        run_id,
+        w.HookCreatedEvent(
+            correlation_id="hook_0",
+            event_data=w.HookCreatedEventData(token=TOKEN),
+            spec_version=spec_version,
+        ),
+    )
     return run_id
 
 
@@ -116,6 +128,28 @@ async def test_dataclass_hook_round_trips_through_resume(tmp_path, monkeypatch) 
     hook.futures.append(future := _future())
     hook.set_result(ser.hydrate(payload, what="the payload"))
     assert future.result() == Signoff(approved=False, reviewer="grace")
+
+
+async def test_resume_compresses_large_payloads_for_current_runs(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world)
+
+    await Signoff(approved=True, reviewer="ada" * 512).resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert payload.startswith(ser.ZSTD)
+
+
+async def test_resume_keeps_large_payloads_plain_for_old_runs(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world, spec_version=w.SPEC_VERSION_SUPPORTS_COMPRESSION - 1)
+
+    await Signoff(approved=True, reviewer="ada" * 512).resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert payload.startswith(ser.DEVALUE_V1)
 
 
 async def test_json_mode_is_the_way_back_to_json_shaped_values(tmp_path, monkeypatch) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_metadata.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_metadata.py
@@ -45,6 +45,16 @@ async def probe_workflow() -> dict[str, Any]:
     return {"workflow": body, "step": await probe_step()}
 
 
+@registry.step
+async def large_step() -> str:
+    return "charged " * 256
+
+
+@registry.workflow
+async def workflow_with_large_step() -> str:
+    return await large_step()
+
+
 class _RecordingLocalWorld(LocalWorld):
     """Real LocalWorld for storage; only the outbound (networked) queue is stubbed."""
 
@@ -61,6 +71,49 @@ class _RecordingLocalWorld(LocalWorld):
 def test_get_workflow_metadata_outside_any_context_raises() -> None:
     with pytest.raises(RuntimeError, match="inside a workflow or a step"):
         get_workflow_metadata()
+
+
+async def test_a_new_step_in_an_old_run_uses_the_run_format_policy(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    old_version = w.SPEC_VERSION_SUPPORTS_COMPRESSION - 1
+    created = await world.events_create(
+        None,
+        w.RunCreatedEvent(
+            event_data=w.RunCreatedEventData(
+                deployment_id="dpl_1",
+                workflow_name=workflow_with_large_step.workflow_id,
+                input=PLAIN_ENCODER.encode(ser.argument_array((), {})),
+            ),
+            spec_version=old_version,
+        ),
+    )
+    assert created.run is not None
+    run_id = created.run.run_id
+    queue_name = w.get_queue_name(workflow_with_large_step.workflow_id)
+
+    async def deliver(payload: w.WorkflowInvokePayload) -> None:
+        await runtime.workflow_handler(
+            payload.model_dump(by_alias=True),
+            attempt=1,
+            queue_name=queue_name,
+            message_id="msg_1",
+            registry=registry,
+        )
+
+    await deliver(w.WorkflowInvokePayload(run_id=run_id))
+    (step_payload,) = [
+        payload
+        for _, payload in world.queued
+        if isinstance(payload, w.WorkflowInvokePayload) and payload.step_id is not None
+    ]
+    await deliver(step_payload)
+
+    assert step_payload.step_id is not None
+    step = await world.steps_get(run_id, step_payload.step_id)
+    assert step.spec_version == w.SPEC_VERSION_CURRENT
+    assert step.output is not None
+    assert step.output.startswith(ser.DEVALUE_V1)
 
 
 async def test_metadata_matches_between_body_and_step(tmp_path, monkeypatch) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_retryable_error.py
@@ -121,7 +121,16 @@ class FakeWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def runs_get(self, run_id: str) -> w.WorkflowRun:
-        raise NotImplementedError
+        assert run_id == RUN_ID
+        return w.NonFinalWorkflowRun(
+            run_id=RUN_ID,
+            status="running",
+            deployment_id="dpl_test",
+            workflow_name=WORKFLOW_NAME,
+            spec_version=w.SPEC_VERSION_CURRENT,
+            created_at=NOW,
+            updated_at=NOW,
+        )
 
     async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
         raise NotImplementedError

--- a/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
@@ -1,15 +1,13 @@
-"""Tests for the step path's start-first control flow and too-early/terminal paths.
+"""Tests for the step path's run context and too-early/terminal paths.
 
 Steps arrive on the workflow topic as a ``WorkflowInvokePayload`` carrying a
 ``stepId``, and ``workflow_handler`` dispatches those to its step path instead
-of replaying. That path issues ``step_started`` first and lets the world surface
-state as typed errors — ``TooEarlyError`` (retryAfter not reached, HTTP 425) and
-``EntityConflictError`` (terminal step, HTTP 409) — instead of pre-reading the
+of replaying. The handler reads the parent run for its format policy, then
+issues ``step_started`` and lets the world surface state as typed errors —
+``TooEarlyError`` (retryAfter not reached, HTTP 425) and
+``EntityConflictError`` (terminal step, HTTP 409) — without pre-reading the
 step. A too-early step defers via a queue timeout; a terminal step re-enqueues
 the parent workflow and acks.
-
-``FakeWorld.runs_get`` raises, which also pins down the dispatch order: the step
-path must be taken before the run is ever read.
 """
 
 from __future__ import annotations
@@ -40,7 +38,12 @@ STEP_ID = "step_test"
 WORKFLOW_NAME = "workflow//tests.wf"
 
 
-def _running_step(step_name: str, *, attempt: int, input: bytes | None = None) -> w.WorkflowStep:
+def _running_step(
+    step_name: str,
+    *,
+    attempt: int,
+    input: bytes | None = None,
+) -> w.WorkflowStep:
     return w.NonFinalWorkflowStep(
         run_id=RUN_ID,
         step_id=STEP_ID,
@@ -51,6 +54,18 @@ def _running_step(step_name: str, *, attempt: int, input: bytes | None = None) -
         updated_at=NOW,
         started_at=NOW,
         input=input if input is not None else PLAIN_ENCODER.encode(ser.step_arguments((), {})),
+    )
+
+
+def _running_run(*, spec_version: int | None = w.SPEC_VERSION_CURRENT) -> w.WorkflowRun:
+    return w.NonFinalWorkflowRun(
+        run_id=RUN_ID,
+        status="running",
+        deployment_id="dpl_test",
+        workflow_name=WORKFLOW_NAME,
+        spec_version=spec_version,
+        created_at=NOW,
+        updated_at=NOW,
     )
 
 
@@ -69,10 +84,12 @@ class FakeWorld(NoStreams, w.World):
         step: w.WorkflowStep | None = None,
         started_step: w.WorkflowStep | None = None,
         start_error: Exception | None = None,
+        run_spec_version: int | None = w.SPEC_VERSION_CURRENT,
     ) -> None:
         self.step = step
         self.started_step = started_step
         self.start_error = start_error
+        self.run = _running_run(spec_version=run_spec_version)
         self.queued: list[tuple[str, Any]] = []
         self.events: list[Any] = []
 
@@ -89,7 +106,8 @@ class FakeWorld(NoStreams, w.World):
         raise NotImplementedError
 
     async def runs_get(self, run_id: str) -> w.WorkflowRun:
-        raise NotImplementedError
+        assert run_id == RUN_ID
+        return self.run
 
     async def steps_get(self, run_id: str, step_id: str) -> w.WorkflowStep:
         assert self.step is not None, "test did not set a persisted step"
@@ -256,6 +274,33 @@ async def test_happy_path_completes_and_reenqueues(registry: core.Workflows) -> 
     assert result is None
     assert _event_types(fake) == ["step_completed"]
     assert len(_workflow_enqueues(fake)) == 1
+
+
+@pytest.mark.parametrize(
+    ("spec_version", "prefix"),
+    [
+        (w.SPEC_VERSION_SUPPORTS_COMPRESSION - 1, ser.DEVALUE_V1),
+        (w.SPEC_VERSION_SUPPORTS_COMPRESSION, ser.ZSTD),
+    ],
+)
+async def test_step_output_compression_follows_the_run_version(
+    registry: core.Workflows, spec_version: int, prefix: bytes
+) -> None:
+    @registry.step
+    async def my_step() -> str:
+        return "charged " * 256
+
+    fake = FakeWorld(
+        started_step=_running_step(my_step.name, attempt=1),
+        run_spec_version=spec_version,
+    )
+    w.set_world(fake)
+
+    await _invoke(registry, my_step.name)
+
+    (completed,) = fake.events
+    assert isinstance(completed, w.StepCompletedEvent)
+    assert completed.event_data.result.startswith(prefix)
 
 
 async def test_unregistered_step_fails_without_retrying(registry: core.Workflows) -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/compression.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/compression.py
@@ -1,8 +1,9 @@
-"""Readers for workflow payload compression envelopes."""
+"""Readers and writers for workflow payload compression envelopes."""
 
 from __future__ import annotations
 
 import gzip
+import os
 import sys
 import zlib
 
@@ -11,9 +12,44 @@ if sys.version_info >= (3, 14):
 else:
     import zstandard as _zstd
 
+COMPRESSION_MIN_BYTES = 1024
+COMPRESSION_MIN_SAVINGS_RATIO = 0.05
+ZSTD_LEVEL = 3
+
+GZIP = b"gzip"
+ZSTD = b"zstd"
+
 
 class DecompressionError(Exception):
     """A compressed payload is invalid."""
+
+
+def maybe_compress(data: bytes, *, enabled: bool) -> bytes:
+    """Compress *data* when the target run supports it and doing so pays off."""
+    if (
+        not enabled
+        or len(data) < COMPRESSION_MIN_BYTES
+        or os.getenv("WORKFLOW_DISABLE_COMPRESSION") == "1"
+    ):
+        return data
+
+    if os.getenv("WORKFLOW_COMPRESSION_CODEC") == "gzip":
+        prefix = GZIP
+        compressed = gzip.compress(data, compresslevel=6, mtime=0)
+    else:
+        prefix = ZSTD
+        compressed = compress_zstd(data)
+
+    wrapped = prefix + compressed
+    if len(wrapped) >= len(data) * (1 - COMPRESSION_MIN_SAVINGS_RATIO):
+        return data
+    return wrapped
+
+
+def compress_zstd(data: bytes) -> bytes:
+    if sys.version_info >= (3, 14):
+        return _zstd.compress(data, level=ZSTD_LEVEL)
+    return _zstd.ZstdCompressor(level=ZSTD_LEVEL).compress(data)
 
 
 def decompress_gzip(data: bytes) -> bytes:

--- a/src/vercel-workflow/vercel/workflow/_internal/encryption.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/encryption.py
@@ -1,7 +1,7 @@
 """The `encr` and `encp` payload formats, as `@workflow/world-vercel` writes them.
 
 Decryption only, for now: writing either is not implemented, so the payloads
-this SDK produces are plain `devl`.
+this SDK produces are unencrypted `devl`, `gzip`, or `zstd` envelopes.
 
 Both envelopes are two nested layers, and both descend from the same per-run
 key material :func:`derive_run_key` produces::

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -1498,7 +1498,13 @@ async def workflow_handler(
 
     req = w.WorkflowInvokePayload.from_wire(message)
     if req.step_id is not None:
-        return await _execute_step(req, queue_name=queue_name, registry=registry)
+        run = await world.runs_get(req.run_id)
+        return await _execute_step(
+            req,
+            run=run,
+            queue_name=queue_name,
+            registry=registry,
+        )
 
     run_id = req.run_id
     if refuse_cross_environment_delivery(world, req.run_input, run_id):
@@ -1716,7 +1722,7 @@ async def _workflow_replay_pass(
         started_at=workflow_started_at,
         registry=registry,
         run_key=await _resolve_run_key(world, workflow_run, events),
-        payload_encoder=ser.PayloadEncoder(),
+        payload_encoder=workflow_run.payload_encoder(),
         workflow_info=WorkflowInfo(
             run_id=run_id,
             workflow_name=workflow_run.workflow_name,
@@ -1991,6 +1997,7 @@ async def _run_cancellable_step(
 async def _execute_step(
     req: w.WorkflowInvokePayload,
     *,
+    run: w.WorkflowRun,
     queue_name: str,
     registry: core.Workflows,
 ) -> w.QueueContinuation | None:
@@ -2038,7 +2045,7 @@ async def _execute_step(
     if not start_result.step:
         raise RuntimeError(f"step_started event for '{req.step_id}' did not return step entity")
     step_run = start_result.step
-    payload_encoder = ser.PayloadEncoder()
+    payload_encoder = run.payload_encoder()
     current_attempt = step_run.attempt
     if not step_run.started_at:
         raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
@@ -2591,7 +2598,9 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
     namespace = wf._resolve_queue_namespace()
-    input_data = ser.PayloadEncoder().encode(ser.argument_array(dumped_args, dumped_kwargs))
+    input_data = ser.PayloadEncoder(compression=True).encode(
+        ser.argument_array(dumped_args, dumped_kwargs)
+    )
     execution_context: dict[str, Any] = {"hookResumeInputVersion": w.HOOK_RESUME_INPUT_VERSION}
     if namespace is not None:
         execution_context["queueNamespace"] = namespace
@@ -2651,7 +2660,7 @@ async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook
     else:
         hook = token_or_hook
         run = await world.runs_get(hook.run_id)
-    payload_encoder = ser.PayloadEncoder()
+    payload_encoder = run.payload_encoder()
     data = w.HookReceivedEventData(payload=payload_encoder.encode(payload))
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}

--- a/src/vercel-workflow/vercel/workflow/_internal/serialization.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/serialization.py
@@ -2,15 +2,16 @@
 
 The wire format is the one `@workflow/core` defines in
 `src/serialization-format.ts`: a 4-byte ASCII format tag followed by the
-payload. The only format this SDK writes is ``devl`` — UTF-8
-`devalue.stringify` output — so a payload written here parses with
-`devalue.parse` in JavaScript and vice versa.
+payload. Values begin as ``devl`` — UTF-8 `devalue.stringify` output — and
+large values may then be wrapped in ``gzip`` or ``zstd``. Both forms parse in
+JavaScript and Python.
 
 ``encr`` — an encrypted payload — and ``encp`` — one sealed to the run's public
 key — are read too.
 
-`gzip`/`zstd`, which wrap another prefixed payload, are decompressed before the
-inner format is decoded.
+`gzip`/`zstd` wrap another prefixed payload. Writes use them only for runs that
+advertise spec version 5 or newer; reads decompress them before decoding the
+inner format.
 """
 
 from __future__ import annotations
@@ -103,8 +104,10 @@ def _encode_devalue(value: Any) -> bytes:
 class PayloadEncoder:
     """Encode workflow payload values and errors."""
 
+    compression: bool = False
+
     def encode(self, value: Any) -> bytes:
-        return _encode_devalue(value)
+        return self._wrap(_encode_devalue(value))
 
     def encode_error(self, error: Exception) -> bytes:
         """Encode an error, falling back to a serializable summary."""
@@ -115,7 +118,10 @@ class PayloadEncoder:
             encoded = _encode_devalue(
                 errors.RemoteError(f"{name} could not be serialized: {encode_error}", name=name)
             )
-        return encoded
+        return self._wrap(encoded)
+
+    def _wrap(self, encoded: bytes) -> bytes:
+        return compression.maybe_compress(encoded, enabled=self.compression)
 
 
 def hydrate_error(data: Any, *, what: str, key: bytes | None = None) -> Exception:

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from datetime import datetime
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Generic,
@@ -29,6 +30,9 @@ from vercel._internal.core.polyfills import UTC, Self
 from vercel.queue import SanitizedName
 
 from . import ulid
+
+if TYPE_CHECKING:
+    from .serialization import PayloadEncoder
 
 T = TypeVar("T")
 QueuePrefix: TypeAlias = str
@@ -108,7 +112,8 @@ def get_physical_topic(queue_name: str) -> SanitizedName:
 #
 # `CURRENT` is what we stamp on rows we create; `MAX_SUPPORTED` is the highest
 # version we accept when reading, mirroring the same split in TS.
-SPEC_VERSION_CURRENT: Literal[2] = 2
+SPEC_VERSION_SUPPORTS_COMPRESSION = 5
+SPEC_VERSION_CURRENT: Literal[5] = 5
 SPEC_VERSION_MAX_SUPPORTED = 7
 
 # Which version of "lazy hook resume" this SDK's queue consumer implements.
@@ -304,6 +309,13 @@ class BaseWorkflowRun(BaseModel):
     completed_at: datetime | None = pydantic.Field(default=None, alias="completedAt")
     created_at: datetime = pydantic.Field(alias="createdAt")
     updated_at: datetime = pydantic.Field(alias="updatedAt")
+
+    def payload_encoder(self) -> "PayloadEncoder":
+        from .serialization import PayloadEncoder
+
+        return PayloadEncoder(
+            compression=(self.spec_version or 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+        )
 
 
 class NonFinalWorkflowRun(BaseWorkflowRun):


### PR DESCRIPTION
Write gzip- and zstd-compressed workflow payloads using the same compression thresholds and codec controls as the TypeScript SDK. This bumps the current specVersion to 5.