### PR TITLE
workflow: write encrypted payloads

### DIFF
--- a/changes/vercel-workflow/encryption-write.feature.md
+++ b/changes/vercel-workflow/encryption-write.feature.md
@@ -1,0 +1,1 @@
+Encrypt workflow payload writes and seal external hook resumes to the run's public key.

--- a/src/vercel-workflow/pyproject.toml
+++ b/src/vercel-workflow/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "anyio>=4.0.0,<5",
     "httpx>=0.27.0,<1",
     "pydantic>=2.12.0,<3",
+    "semver>=3,<4",
     "cbor2>=6.0,<7",
     "cryptography>=43.0.0",
     "zstandard>=0.23.0,<1 ; python_version < '3.14'",

--- a/src/vercel-workflow/tests/unit/test_workflow_compression.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_compression.py
@@ -5,7 +5,13 @@ import gzip
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from vercel.workflow._internal import compression, py_sandbox, serialization as ser, world as w
+from vercel.workflow._internal import (
+    compression,
+    encryption,
+    py_sandbox,
+    serialization as ser,
+    world as w,
+)
 
 # Produced by Node 24's node:zlib over b'devl["charged 42"]'.
 TS_GZIP = bytes.fromhex(
@@ -104,6 +110,18 @@ def test_compression_under_encryption_composes() -> None:
     payload = ser.ENCRYPTED + nonce + AESGCM(key).encrypt(nonce, compressed, None)
 
     assert ser.hydrate(payload, what="a payload", key=key) == "charged 42"
+
+
+def test_writes_compression_under_encryption() -> None:
+    key = bytes(range(32))
+    value = "charged " * 256
+
+    payload = ser.PayloadEncoder(compression=True, encryption_key=key).encode(value)
+
+    assert payload.startswith(ser.ENCRYPTED)
+    inner = encryption.open_envelope(key, payload[len(ser.ENCRYPTED) :])
+    assert inner.startswith(ser.ZSTD)
+    assert ser.hydrate(payload, what="a payload", key=key) == value
 
 
 @pytest.mark.parametrize("prefix", [ser.GZIP, ser.ZSTD])

--- a/src/vercel-workflow/tests/unit/test_workflow_encryption.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_encryption.py
@@ -40,6 +40,7 @@ from cryptography.hazmat.primitives.serialization import (
 from tests.payloads import PLAIN_ENCODER
 from vercel.oidc import VercelOidcTokenError
 from vercel.workflow._internal import (
+    core,
     encryption,
     py_sandbox,
     runtime,
@@ -255,6 +256,50 @@ def test_the_envelope_opens_what_webcrypto_sealed(size: int) -> None:
     assert encryption.open_envelope(key, nonce + sealed) == plaintext
 
 
+def test_the_envelope_writer_produces_webcrypto_compatible_bytes() -> None:
+    key = AESGCM.generate_key(bit_length=256)
+    plaintext = b'devl[["amount"],21]'
+
+    envelope = encryption.encrypt_envelope(key, plaintext)
+
+    assert len(envelope) == 12 + len(plaintext) + 16
+    assert AESGCM(key).decrypt(envelope[:12], envelope[12:], None) == plaintext
+
+
+def test_symmetric_payload_writes_are_randomized() -> None:
+    encoder = ser.PayloadEncoder(encryption_key=RUN_KEY)
+
+    first = encoder.encode({"amount": 21})
+    second = encoder.encode({"amount": 21})
+
+    assert first.startswith(ser.ENCRYPTED)
+    assert second.startswith(ser.ENCRYPTED)
+    assert first != second
+    assert ser.hydrate(first, what="a payload", key=RUN_KEY) == {"amount": 21}
+    assert ser.hydrate(second, what="a payload", key=RUN_KEY) == {"amount": 21}
+
+
+def test_random_nonces_do_not_make_a_step_call_nondeterministic() -> None:
+    encoder = ser.PayloadEncoder(encryption_key=RUN_KEY)
+
+    first = encoder.encode(ser.step_arguments((21,), {}))
+    replay = encoder.encode(ser.step_arguments((21,), {}))
+    changed = encoder.encode(ser.step_arguments((22,), {}))
+
+    assert first != replay
+    assert ser.payloads_equal(first, replay, key=RUN_KEY)
+    assert not ser.payloads_equal(first, changed, key=RUN_KEY)
+
+
+def test_encryption_works_inside_the_workflow_sandbox() -> None:
+    encoder = ser.PayloadEncoder(encryption_key=RUN_KEY)
+
+    with py_sandbox.Sandbox().enter():
+        payload = encoder.encode({"amount": 21})
+
+    assert ser.hydrate(payload, what="a payload", key=RUN_KEY) == {"amount": 21}
+
+
 def test_the_envelope_carries_no_additional_data() -> None:
     # `world-vercel` calls `aesGcmEncrypt(aesKey, data)` with `aad` omitted --
     # the AAD machinery in that module is for `encp`.
@@ -439,6 +484,27 @@ def test_the_sealed_box_opens_what_typescript_sealed() -> None:
     assert encryption.open_sealed_envelope(RUN_KEY, TS_SEALED) == b'devl[["amount"],21]'
 
 
+def test_the_sealed_box_writer_produces_typescript_compatible_bytes() -> None:
+    plaintext = b'devl[["amount"],21]'
+
+    sealed = encryption.seal_envelope(TS_PUBLIC_KEY, plaintext)
+
+    assert len(sealed) == 32 + 12 + len(plaintext) + 16
+    assert encryption.open_sealed_envelope(RUN_KEY, sealed) == plaintext
+
+
+def test_a_seal_only_payload_encoder_writes_encp() -> None:
+    payload = ser.PayloadEncoder(recipient_public_key=TS_PUBLIC_KEY).encode({"amount": 21})
+
+    assert payload.startswith(ser.SEALED)
+    assert ser.hydrate(payload, what="a payload", key=RUN_KEY) == {"amount": 21}
+
+
+def test_a_payload_encoder_cannot_mix_symmetric_and_seal_only_keys() -> None:
+    with pytest.raises(ValueError, match="cannot both encrypt and seal"):
+        ser.PayloadEncoder(encryption_key=RUN_KEY, recipient_public_key=TS_PUBLIC_KEY)
+
+
 def test_the_sealed_box_carries_no_additional_data() -> None:
     # `resumeHook` seals with `sealTo(runPublicKey)` and passes no AAD; the
     # construction binds the payload to its recipient through the content key's
@@ -606,13 +672,13 @@ async def test_a_run_of_this_deployment_derives_its_key_in_process(monkeypatch) 
     assert await world.run_key(RUN_ID, deployment_id="dpl_current") == key
 
 
-async def test_local_derivation_needs_a_project_id(monkeypatch) -> None:
-    # Getting it wrong yields a GCM failure rather than anything that names it.
+async def test_a_world_without_a_project_id_has_no_encryption_key(monkeypatch) -> None:
+    # JS omits getEncryptionKeyForRun entirely in this configuration, so a
+    # new run remains plaintext rather than making start() fail.
     _deployed(monkeypatch, VERCEL_PROJECT_ID=None)
     world = VercelWorld()
 
-    with pytest.raises(RuntimeError, match="no project id"):
-        await world.run_key(RUN_ID)
+    assert await world.run_key(RUN_ID) is None
 
 
 @respx.mock
@@ -766,6 +832,87 @@ async def test_a_world_that_does_not_encrypt_resolves_no_key() -> None:
     from vercel.workflow._internal.worlds.local import LocalWorld
 
     assert await LocalWorld().run_key(RUN_ID) is None
+
+
+async def test_start_encrypts_a_new_run_and_publishes_its_public_key(tmp_path, monkeypatch) -> None:
+    from vercel.workflow._internal.worlds.local import LocalWorld
+
+    class EncryptedLocalWorld(LocalWorld):
+        def __init__(self) -> None:
+            super().__init__()
+            self.queued: list[w.WorkflowInvokePayload] = []
+
+        async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+            return RUN_KEY
+
+        async def queue(self, queue_name, message, **kwargs) -> str:
+            assert isinstance(message, w.WorkflowInvokePayload)
+            self.queued.append(message)
+            return "msg_1"
+
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = EncryptedLocalWorld()
+    w.set_world(world)
+    registry = core.Workflows(as_vercel_job=False)
+
+    @registry.workflow
+    async def checkout(amount: int, /) -> int:
+        return amount
+
+    try:
+        public_run = await runtime.start(checkout, 21)
+        stored = await world.runs_get(public_run.run_id)
+    finally:
+        w.set_world(None)
+
+    expected_public_key = base64.b64encode(
+        encryption.derive_run_key_pair(RUN_KEY).public_key
+    ).decode()
+    assert isinstance(stored.input, bytes) and stored.input.startswith(ser.ENCRYPTED)
+    assert ser.hydrate(stored.input, what="the run input", key=RUN_KEY) == [21]
+    assert stored.encryption_public_key == expected_public_key
+    assert stored.execution_context is not None
+    assert stored.execution_context["workflowCoreVersion"] == w.WORKFLOW_CORE_COMPAT_VERSION
+    assert stored.execution_context["features"] == {"encryption": True}
+    (queued,) = world.queued
+    assert queued.run_id == stored.run_id
+    assert queued.run_input is not None
+    assert queued.run_input.encryption_public_key == expected_public_key
+    assert queued.run_input.input == stored.input
+
+
+async def test_start_stays_plaintext_without_a_project_id(monkeypatch) -> None:
+    _deployed(monkeypatch, VERCEL_PROJECT_ID=None)
+
+    class NoProjectVercelWorld(VercelWorld):
+        def __init__(self) -> None:
+            super().__init__()
+            self.created: w.RunCreatedEvent | None = None
+
+        async def events_create(self, run_id: str | None, data: w.Event) -> w.EventResult:
+            assert isinstance(data, w.RunCreatedEvent)
+            self.created = data
+            return w.EventResult()
+
+        async def queue(self, queue_name, message, **kwargs) -> str:
+            return "msg_1"
+
+    world = NoProjectVercelWorld()
+    w.set_world(world)
+    registry = core.Workflows(as_vercel_job=False)
+
+    @registry.workflow
+    async def checkout(amount: int, /) -> int:
+        return amount
+
+    try:
+        await runtime.start(checkout, 21)
+    finally:
+        w.set_world(None)
+
+    assert world.created is not None
+    assert world.created.event_data.input.startswith(ser.DEVALUE_V1)
+    assert world.created.event_data.encryption_public_key is None
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/vercel-workflow/tests/unit/test_workflow_health_check.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_health_check.py
@@ -13,6 +13,7 @@ deliberately omits are asserted as directly as the ones it sends.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from collections.abc import Sequence
@@ -21,7 +22,7 @@ from typing import Any
 import pydantic
 import pytest
 
-from vercel.workflow._internal import core, runtime, world as w
+from vercel.workflow._internal import core, encryption, runtime, world as w
 from vercel.workflow._internal.worlds import local as local_mod
 
 from ..world_stubs import NoStreams
@@ -147,17 +148,15 @@ async def test_the_answer_is_plain_json(registry) -> None:
     assert isinstance(body["timestamp"], int)
 
 
-async def test_the_answer_claims_no_capability_it_does_not_have(registry) -> None:
-    """The deliberate omissions -- see `_health_check_response`. Each is read as
-    a capability claim, and the consequence of a wrong one lands in the caller,
-    not here."""
+async def test_the_answer_claims_only_its_audited_core_compatibility(registry) -> None:
+    """The synthetic version is a wire capability claim, not our package version."""
     world = StreamsWorld()
     w.set_world(world)
 
     await _probe(registry)
 
     body = json.loads(world.writes[0][2])
-    assert "workflowCoreVersion" not in body
+    assert body["workflowCoreVersion"] == w.WORKFLOW_CORE_COMPAT_VERSION
     assert "encryptionPublicKey" not in body
 
 
@@ -186,9 +185,26 @@ async def test_a_probe_naming_a_run_is_still_a_probe(registry) -> None:
     world = StreamsWorld()
     w.set_world(world)
 
-    assert await _probe(registry, run_id="wrun_not_created_yet") is None
+    assert await _probe(registry, runId="wrun_not_created_yet") is None
 
     assert world.closes == [(RUN_ID, STREAM)]
+
+
+async def test_a_probe_naming_a_run_publishes_its_encryption_key(registry) -> None:
+    key = bytes(range(32))
+
+    class EncryptedWorld(StreamsWorld):
+        async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+            return key
+
+    world = EncryptedWorld()
+    w.set_world(world)
+
+    await _probe(registry, runId="wrun_not_created_yet")
+
+    body = json.loads(world.writes[0][2])
+    expected = base64.b64encode(encryption.derive_run_key_pair(key).public_key).decode()
+    assert body["encryptionPublicKey"] == expected
 
 
 async def test_a_message_without_the_discriminator_is_not_a_probe(registry) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_resume.py
@@ -9,6 +9,7 @@ way ``resume()`` in the runtime does it.
 
 from __future__ import annotations
 
+import base64
 import dataclasses
 import decimal
 from datetime import datetime, timezone
@@ -18,7 +19,7 @@ import pytest
 
 from tests.payloads import PLAIN_ENCODER
 from vercel.workflow import BaseHook
-from vercel.workflow._internal import runtime, serialization as ser, world as w
+from vercel.workflow._internal import encryption, runtime, serialization as ser, world as w
 from vercel.workflow._internal.worlds.local import LocalWorld
 
 TOKEN = "tok-abc"
@@ -63,14 +64,31 @@ class _RecordingLocalWorld(LocalWorld):
         return "msg_test"
 
 
+class _EncryptedRecordingLocalWorld(_RecordingLocalWorld):
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        return bytes(range(32))
+
+
 async def _run_with_hook(
-    world: _RecordingLocalWorld, *, spec_version: int = w.SPEC_VERSION_CURRENT
+    world: _RecordingLocalWorld,
+    *,
+    spec_version: int = w.SPEC_VERSION_CURRENT,
+    encryption_public_key: str | None = None,
+    workflow_core_version: str | None = None,
 ) -> str:
     result = await world.events_create(
         None,
         w.RunCreatedEvent(
             event_data=w.RunCreatedEventData(
-                deployment_id="dpl_1", workflow_name="test-wf", input=PLAIN_ENCODER.encode([])
+                deployment_id="dpl_1",
+                workflow_name="test-wf",
+                input=PLAIN_ENCODER.encode([]),
+                encryption_public_key=encryption_public_key,
+                execution_context=(
+                    {"workflowCoreVersion": workflow_core_version}
+                    if workflow_core_version is not None
+                    else None
+                ),
             ),
             spec_version=spec_version,
         ),
@@ -133,7 +151,7 @@ async def test_dataclass_hook_round_trips_through_resume(tmp_path, monkeypatch) 
 async def test_resume_compresses_large_payloads_for_current_runs(tmp_path, monkeypatch) -> None:
     world = _RecordingLocalWorld(tmp_path)
     monkeypatch.setattr(w, "the_world", world)
-    run_id = await _run_with_hook(world)
+    run_id = await _run_with_hook(world, workflow_core_version="5.0.0-beta.18")
 
     await Signoff(approved=True, reviewer="ada" * 512).resume(TOKEN)
 
@@ -144,12 +162,70 @@ async def test_resume_compresses_large_payloads_for_current_runs(tmp_path, monke
 async def test_resume_keeps_large_payloads_plain_for_old_runs(tmp_path, monkeypatch) -> None:
     world = _RecordingLocalWorld(tmp_path)
     monkeypatch.setattr(w, "the_world", world)
-    run_id = await _run_with_hook(world, spec_version=w.SPEC_VERSION_SUPPORTS_COMPRESSION - 1)
+    run_id = await _run_with_hook(
+        world,
+        spec_version=w.SPEC_VERSION_SUPPORTS_COMPRESSION - 1,
+        workflow_core_version="5.0.0-beta.18",
+    )
 
     await Signoff(approved=True, reviewer="ada" * 512).resume(TOKEN)
 
     payload = _received_payload((await world.events_list(run_id)).data)
     assert payload.startswith(ser.DEVALUE_V1)
+
+
+async def test_resume_keeps_large_payloads_plain_for_old_deployments(tmp_path, monkeypatch) -> None:
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world, workflow_core_version="5.0.0-beta.17")
+
+    await Signoff(approved=True, reviewer="ada" * 512).resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert payload.startswith(ser.DEVALUE_V1)
+
+
+async def test_resume_seals_to_the_run_public_key(tmp_path, monkeypatch) -> None:
+    key = bytes(range(32))
+    public_key = encryption.derive_run_key_pair(key).public_key
+    world = _RecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(
+        world, encryption_public_key=base64.b64encode(public_key).decode()
+    )
+
+    await Signoff(approved=True, reviewer="ada").resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert payload.startswith(ser.SEALED)
+    assert ser.hydrate(payload, what="the payload", key=key) == {
+        "approved": True,
+        "reviewer": "ada",
+    }
+
+
+@pytest.mark.parametrize(
+    ("workflow_core_version", "expected_prefix"),
+    [
+        (None, ser.DEVALUE_V1),
+        ("not-semver", ser.DEVALUE_V1),
+        ("4.2.0-beta.63", ser.DEVALUE_V1),
+        ("4.2.0-beta.64", ser.ENCRYPTED),
+        ("v4.2.0-beta.64", ser.ENCRYPTED),
+        (w.WORKFLOW_CORE_COMPAT_VERSION, ser.ENCRYPTED),
+    ],
+)
+async def test_symmetric_resume_fallback_respects_target_capabilities(
+    tmp_path, monkeypatch, workflow_core_version, expected_prefix
+) -> None:
+    world = _EncryptedRecordingLocalWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    run_id = await _run_with_hook(world, workflow_core_version=workflow_core_version)
+
+    await Signoff(approved=True, reviewer="ada").resume(TOKEN)
+
+    payload = _received_payload((await world.events_list(run_id)).data)
+    assert payload.startswith(expected_prefix)
 
 
 async def test_json_mode_is_the_way_back_to_json_shaped_values(tmp_path, monkeypatch) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_http_health.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_http_health.py
@@ -114,6 +114,7 @@ async def test_answers_a_probe_with_json(flow) -> None:
         "healthy": True,
         "endpoint": runtime.ENDPOINT_PATH,
         "specVersion": w.SPEC_VERSION_CURRENT,
+        "workflowCoreVersion": w.WORKFLOW_CORE_COMPAT_VERSION,
     }
     # A probe is not a message: nothing was handed to the queue handler.
     assert world.delivered == []
@@ -140,15 +141,13 @@ async def test_the_reported_path_is_the_one_that_was_probed(flow) -> None:
     assert json.loads(response.body)["endpoint"] == "/api/workflow"
 
 
-async def test_the_answer_claims_no_capability_it_does_not_have(flow) -> None:
-    """Omitted for the same reason as on the queue transport: it names a
-    JavaScript package's version, and the reader feeds it to that package's
-    capability tables."""
+async def test_the_answer_claims_its_audited_core_compatibility(flow) -> None:
+    """The version tells JavaScript which wire formats this runtime can read."""
     handler, _ = flow
 
     response = await handler(Request(f"{runtime.ENDPOINT_PATH}?__health"))
 
-    assert "workflowCoreVersion" not in json.loads(response.body)
+    assert json.loads(response.body)["workflowCoreVersion"] == w.WORKFLOW_CORE_COMPAT_VERSION
 
 
 async def test_a_preflight_gets_an_empty_204(flow) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_metadata.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_metadata.py
@@ -45,6 +45,11 @@ async def probe_workflow() -> dict[str, Any]:
     return {"workflow": body, "step": await probe_step()}
 
 
+@registry.workflow
+async def probe_workflow_only() -> dict[str, Any]:
+    return _as_dict(get_workflow_metadata())
+
+
 @registry.step
 async def large_step() -> str:
     return "charged " * 256
@@ -175,6 +180,44 @@ async def test_metadata_matches_between_body_and_step(tmp_path, monkeypatch) -> 
     # The step's context is cleared once the step body returns.
     with pytest.raises(RuntimeError, match="inside a workflow or a step"):
         get_workflow_metadata()
+
+
+async def test_encryption_feature_uses_the_resolved_key_not_the_public_key(
+    tmp_path, monkeypatch
+) -> None:
+    key = bytes(range(32))
+
+    class EncryptedWorld(_RecordingLocalWorld):
+        async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+            return key
+
+    world = EncryptedWorld(tmp_path)
+    monkeypatch.setattr(w, "the_world", world)
+    created = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deployment_id="dpl_1",
+            workflow_name=probe_workflow_only.workflow_id,
+            input=ser.PayloadEncoder(encryption_key=key).encode(ser.argument_array((), {})),
+            # Legacy encrypted runs have no published X25519 public key.
+            encryption_public_key=None,
+        ).into_event(),
+    )
+    assert created.run is not None
+    run_id = created.run.run_id
+
+    await runtime.workflow_handler(
+        w.WorkflowInvokePayload(run_id=run_id).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(probe_workflow_only.workflow_id),
+        message_id="msg_1",
+        registry=registry,
+    )
+
+    run = await world.runs_get(run_id)
+    assert run.output is not None
+    output = ser.hydrate(run.output, what="the run output", key=key)
+    assert output["encryption"] is True
 
 
 async def test_namespaced_queue_still_yields_the_workflow_name() -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_cancellation.py
@@ -535,8 +535,20 @@ async def test_uncancelled_cancellable_step_runs_normally(tmp_path, monkeypatch)
 
 
 class _AbortListenerWorld:
-    def __init__(self, reason: str, *, break_once: bool = False, split: bool = False) -> None:
-        payload = PLAIN_ENCODER.encode({"aborted": True, "reason": reason})
+    def __init__(
+        self,
+        reason: str,
+        *,
+        break_once: bool = False,
+        split: bool = False,
+        encryption_key: bytes | None = None,
+        serialized_payload: bytes | None = None,
+    ) -> None:
+        payload = serialized_payload
+        if payload is None:
+            payload = ser.PayloadEncoder(encryption_key=encryption_key).encode(
+                {"aborted": True, "reason": reason}
+            )
         self.wire = streams.encode_frame(payload)
         self.break_once = break_once
         self.split = split
@@ -562,7 +574,9 @@ class _AbortListenerWorld:
             yield self.wire
 
 
-async def _run_abort_listener(world: _AbortListenerWorld, reason: str) -> None:
+async def _run_abort_listener(
+    world: _AbortListenerWorld, reason: str, *, run_key: bytes | None = None
+) -> None:
     async def waits_forever() -> None:
         await asyncio.sleep(3600)
 
@@ -575,6 +589,7 @@ async def _run_abort_listener(world: _AbortListenerWorld, reason: str) -> None:
             world=world,  # type: ignore[arg-type]
             run_id="wrun_test",
             step_id="step_01M1329YCHWS235PHTPW377KZM",
+            run_key=run_key,
         )
 
 
@@ -592,6 +607,20 @@ async def test_abort_listener_reassembles_transport_fragments() -> None:
     world = _AbortListenerWorld(reason, split=True)
 
     await _run_abort_listener(world, reason)
+
+
+async def test_abort_listener_hydrates_an_encrypted_signal() -> None:
+    reason = "encrypted cancellation"
+    run_key = bytes(range(32))
+    world = _AbortListenerWorld(reason, encryption_key=run_key)
+
+    await _run_abort_listener(world, reason, run_key=run_key)
+
+
+async def test_abort_listener_accepts_a_signal_with_an_unreadable_payload() -> None:
+    world = _AbortListenerWorld("unused", serialized_payload=b"invalid")
+
+    await _run_abort_listener(world, "step cancelled by its workflow")
 
 
 class _OpenAbortListenerWorld:

--- a/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_step_handler.py
@@ -85,13 +85,20 @@ class FakeWorld(NoStreams, w.World):
         started_step: w.WorkflowStep | None = None,
         start_error: Exception | None = None,
         run_spec_version: int | None = w.SPEC_VERSION_CURRENT,
+        run_key: bytes | None = None,
     ) -> None:
         self.step = step
         self.started_step = started_step
         self.start_error = start_error
         self.run = _running_run(spec_version=run_spec_version)
+        self.run_key_material = run_key
+        if run_key is not None:
+            self.run = self.run.model_copy(update={"encryption_public_key": "enabled"})
         self.queued: list[tuple[str, Any]] = []
         self.events: list[Any] = []
+
+    async def run_key(self, run_id: str, *, deployment_id: str | None = None) -> bytes | None:
+        return self.run_key_material
 
     async def get_deployment_id(self) -> str:
         return ""
@@ -301,6 +308,30 @@ async def test_step_output_compression_follows_the_run_version(
     (completed,) = fake.events
     assert isinstance(completed, w.StepCompletedEvent)
     assert completed.event_data.result.startswith(prefix)
+
+
+async def test_step_output_is_encrypted_for_an_encrypted_run(
+    registry: core.Workflows,
+) -> None:
+    key = bytes(range(32))
+
+    @registry.step
+    async def my_step() -> str:
+        return "ok"
+
+    input_data = ser.PayloadEncoder(encryption_key=key).encode(ser.step_arguments((), {}))
+    fake = FakeWorld(
+        started_step=_running_step(my_step.name, attempt=1, input=input_data),
+        run_key=key,
+    )
+    w.set_world(fake)
+
+    await _invoke(registry, my_step.name)
+
+    (completed,) = fake.events
+    assert isinstance(completed, w.StepCompletedEvent)
+    assert completed.event_data.result.startswith(ser.ENCRYPTED)
+    assert ser.hydrate(completed.event_data.result, what="the result", key=key) == "ok"
 
 
 async def test_unregistered_step_fails_without_retrying(registry: core.Workflows) -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
@@ -303,6 +303,16 @@ class TestRunApi:
 
         assert [c async for c in runtime.read_stream(RUN_ID, "strm_someone_else")] == ["x"]
 
+    async def test_read_stream_exposes_payload_serialization_errors(self) -> None:
+        world = ReplayWorld([])
+        world.frames = [streams.encode_frame(b"invalid")]
+        w.set_world(world)
+
+        with pytest.raises(ser.SerializationError) as raised:
+            [c async for c in runtime.read_stream(RUN_ID, NAME)]
+
+        assert type(raised.value) is ser.SerializationError
+
 
 class TestTypedReads:
     """A type on the read side validates each chunk, as a step argument is."""

--- a/src/vercel-workflow/vercel/workflow/_internal/encryption.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/encryption.py
@@ -20,7 +20,7 @@ import base64
 import binascii
 import hashlib
 import hmac
-import os
+import secrets
 from typing import Any, NamedTuple
 
 from cryptography.exceptions import InvalidTag
@@ -59,7 +59,7 @@ def encrypt_envelope(key: bytes, plaintext: bytes) -> bytes:
     """Seal *plaintext* with AES-256-GCM, returning ``nonce + ciphertext + tag``."""
     if len(key) != KEY_LENGTH:
         raise ValueError(f"A run key is {KEY_LENGTH} bytes, got {len(key)}")
-    nonce = os.urandom(NONCE_LENGTH)
+    nonce = secrets.token_bytes(NONCE_LENGTH)
     return nonce + AESGCM(key).encrypt(nonce, plaintext, None)
 
 
@@ -252,7 +252,7 @@ def seal_envelope(recipient_public_key: bytes, plaintext: bytes) -> bytes:
     """
     if len(recipient_public_key) != KEY_LENGTH:
         raise ValueError(f"A run public key is {KEY_LENGTH} bytes, got {len(recipient_public_key)}")
-    ephemeral_scalar = os.urandom(KEY_LENGTH)
+    ephemeral_scalar = secrets.token_bytes(KEY_LENGTH)
     ephemeral_public_key = _x25519_public_key(ephemeral_scalar)
     shared = _x25519_exchange(ephemeral_scalar, recipient_public_key)
     if shared is None:

--- a/src/vercel-workflow/vercel/workflow/_internal/encryption.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/encryption.py
@@ -1,7 +1,4 @@
-"""The `encr` and `encp` payload formats, as `@workflow/world-vercel` writes them.
-
-Decryption only, for now: writing either is not implemented, so the payloads
-this SDK produces are unencrypted `devl`, `gzip`, or `zstd` envelopes.
+"""The `encr` and `encp` payload formats `@workflow/core` reads and writes.
 
 Both envelopes are two nested layers, and both descend from the same per-run
 key material :func:`derive_run_key` produces::
@@ -23,6 +20,7 @@ import base64
 import binascii
 import hashlib
 import hmac
+import os
 from typing import Any, NamedTuple
 
 from cryptography.exceptions import InvalidTag
@@ -55,6 +53,14 @@ def _aes_gcm_decrypt(key: bytes, nonce: bytes, sealed: bytes) -> bytes | None:
         return AESGCM(key).decrypt(nonce, sealed, None)
     except InvalidTag:
         return None
+
+
+def encrypt_envelope(key: bytes, plaintext: bytes) -> bytes:
+    """Seal *plaintext* with AES-256-GCM, returning ``nonce + ciphertext + tag``."""
+    if len(key) != KEY_LENGTH:
+        raise ValueError(f"A run key is {KEY_LENGTH} bytes, got {len(key)}")
+    nonce = os.urandom(NONCE_LENGTH)
+    return nonce + AESGCM(key).encrypt(nonce, plaintext, None)
 
 
 # Make `cryptography` do its internal imports now.
@@ -200,6 +206,11 @@ def derive_run_key_pair(run_key: bytes) -> RunKeyPair:
     return RunKeyPair(scalar, _x25519_public_key(scalar))
 
 
+def derive_run_public_key(run_key: bytes) -> str:
+    """Derive the Base64-encoded public key published for a run."""
+    return base64.b64encode(derive_run_key_pair(run_key).public_key).decode()
+
+
 def open_sealed_envelope(run_key: bytes, payload: bytes) -> bytes:
     """Open the X25519 sealed box an `encp` payload carries.
 
@@ -231,6 +242,28 @@ def open_sealed_envelope(run_key: bytes, payload: bytes) -> bytes:
         length=KEY_LENGTH,
     )
     return open_envelope(content_key, envelope)
+
+
+def seal_envelope(recipient_public_key: bytes, plaintext: bytes) -> bytes:
+    """Seal *plaintext* to a run's raw X25519 public key.
+
+    The returned bytes omit the outer ``encp`` prefix: they are the ephemeral
+    public key followed by a nonce-prefixed AES-GCM envelope.
+    """
+    if len(recipient_public_key) != KEY_LENGTH:
+        raise ValueError(f"A run public key is {KEY_LENGTH} bytes, got {len(recipient_public_key)}")
+    ephemeral_scalar = os.urandom(KEY_LENGTH)
+    ephemeral_public_key = _x25519_public_key(ephemeral_scalar)
+    shared = _x25519_exchange(ephemeral_scalar, recipient_public_key)
+    if shared is None:
+        raise ValueError("The run public key is not a valid curve point")
+    content_key = hkdf_sha256(
+        ikm=shared,
+        salt=bytes(32),
+        info=CONTENT_KEY_INFO + ephemeral_public_key + recipient_public_key,
+        length=KEY_LENGTH,
+    )
+    return ephemeral_public_key + encrypt_envelope(content_key, plaintext)
 
 
 def decode_key(encoded: str, *, what: str) -> bytes:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -2040,18 +2040,21 @@ async def _run_cancellable_step(
     async def listen() -> None:
         nonlocal cancelled, reason
         try:
-            async for chunk in streams.reconnecting_frames(world, run_id, stream_name):
-                cancelled = True
-                try:
-                    data = ser.hydrate(
-                        chunk, what=f"the cancellation of step {step_id}", key=run_key
-                    )
-                except ser.SerializationError:
-                    pass
-                else:
+            source = _read_stream(
+                world,
+                run_id,
+                stream_name,
+                None,
+                0,
+                key=run_key,
+                ignore_payload_errors=True,
+            )
+            async with contextlib.aclosing(source):
+                async for data in source:
+                    cancelled = True
                     if isinstance(data, dict) and data.get("reason") is not None:
                         reason = str(data["reason"])
-                break
+                    break
         except Exception as error:
             # A dead listener must not fail the step: without the signal
             # the step simply runs to completion.
@@ -2712,7 +2715,14 @@ def read_stream(
 
 
 async def _read_stream(
-    world: w.World, run_id: str, name: str, type: Any, start_index: int | None
+    world: w.World,
+    run_id: str,
+    name: str,
+    type: Any,
+    start_index: int | None,
+    *,
+    key: bytes | None = None,
+    ignore_payload_errors: bool = False,
 ) -> AsyncGenerator[Any, None]:
     codec = None if type is None else signature_codec.TypeCodec(type)
     frames = streams.reconnecting_frames(world, run_id, name, start_index)
@@ -2720,7 +2730,16 @@ async def _read_stream(
         index = start_index or 0
         async for payload in frames:
             what = f"chunk {index} of stream {name}"
-            value = ser.hydrate(payload, what=what)
+            try:
+                value = ser.hydrate(payload, what=what, key=key)
+            except ser.SerializationError:
+                if ignore_payload_errors:
+                    # This is only used by cancellation streams: the payload carries
+                    # an optional cancel reason; the cancel happens anyway even if
+                    # the reason cannot be read.
+                    value = None
+                else:
+                    raise
             if codec is not None:
                 value = codec.validate(value, what=what)
             yield value
@@ -2804,6 +2823,35 @@ async def get_hook_by_token(token: str) -> core.Hook:
     return await _public_hook(world, await world.hooks_get_by_token(token))
 
 
+async def _hook_resume_payload_encoder(world: w.World, run: w.WorkflowRun) -> ser.PayloadEncoder:
+    """Build an encoder for a hook payload written from outside its run.
+
+    Prefer sealing to the run's published X25519 public key, avoiding a
+    symmetric-key lookup. If no valid public key is stored, fall back to the
+    symmetric run key. ``check_target_core_version`` disables symmetric
+    encryption or compression when the target run's library version doesn't
+    support them.
+    """
+    recipient_public_key = None
+    if run.encryption_public_key is not None:
+        try:
+            recipient_public_key = encryption.decode_key(
+                run.encryption_public_key, what="the run encryption public key"
+            )
+        except ValueError:
+            pass
+
+    encryption_key = None
+    if recipient_public_key is None:
+        encryption_key = await world.run_key(run.run_id, deployment_id=run.deployment_id)
+
+    return run.payload_encoder(
+        encryption_key=encryption_key,
+        recipient_public_key=recipient_public_key,
+        check_target_core_version=True,
+    )
+
+
 async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook:
     world = w.get_world()
     if isinstance(token_or_hook, str):
@@ -2813,23 +2861,7 @@ async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook
     else:
         hook = token_or_hook
         run = await world.runs_get(hook.run_id)
-    recipient_public_key = None
-    if run.encryption_public_key is not None:
-        try:
-            recipient_public_key = encryption.decode_key(
-                run.encryption_public_key, what="the run encryption public key"
-            )
-        except ValueError:
-            # Older or corrupted rows must retain the symmetric fallback.
-            pass
-    encryption_key = None
-    if recipient_public_key is None:
-        encryption_key = await world.run_key(run.run_id, deployment_id=run.deployment_id)
-    payload_encoder = run.payload_encoder(
-        encryption_key=encryption_key,
-        recipient_public_key=recipient_public_key,
-        check_target_core_version=True,
-    )
+    payload_encoder = await _hook_resume_payload_encoder(world, run)
     data = w.HookReceivedEventData(payload=payload_encoder.encode(payload))
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -26,6 +26,7 @@ from vercel._internal.core.polyfills import UTC, Self
 from . import (
     attributes as attrs,
     core,
+    encryption,
     errors,
     loop,
     nanoid,
@@ -41,6 +42,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 logger = logging.getLogger("vercel.workflow")
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_generate_run_ulid = ulid.monotonic_factory()
 
 # Wait-continuation dispatch — mirrors @workflow/core's wait-continuation.ts.
 # The delayed re-enqueue that wakes a run when a pending wait elapses is keyed on
@@ -1138,7 +1140,9 @@ class WorkflowOrchestratorContext:
                 # The recorded step at this (positional) correlation ID must be
                 # the same call the body just issued; a mismatch means the body
                 # is non-deterministic.
-                if sus.step.name != name or sus.input != recorded_input:
+                if sus.step.name != name or not ser.payloads_equal(
+                    sus.input, recorded_input, key=self.run_key
+                ):
                     self._fail_nondeterminism(
                         sus,
                         NondeterminismError(
@@ -1369,9 +1373,11 @@ async def _write_attr_set(world: w.World, run_id: str, sus: Attributes) -> None:
 async def _resolve_run_key(
     world: w.World, run: w.WorkflowRun, events: list[w.Event]
 ) -> bytes | None:
-    """The key this run's payloads need, or ``None`` when none of them is encrypted."""
-    encrypted = ser.is_encrypted(run.input) or any(
-        ser.is_encrypted(payload) for event in events for payload in event.payloads()
+    """The key this run reads and writes with, or ``None`` when encryption is off."""
+    encrypted = (
+        run.encryption_public_key is not None
+        or ser.is_encrypted(run.input)
+        or any(ser.is_encrypted(payload) for event in events for payload in event.payloads())
     )
     if not encrypted:
         return None
@@ -1408,20 +1414,40 @@ def _parse_health_check(message: Any) -> w.HealthCheckPayload | None:
         return None
 
 
-def _health_check_response(correlation_id: str) -> dict[str, Any]:
-    return {
+def _health_check_response(
+    correlation_id: str, *, encryption_public_key: str | None = None
+) -> dict[str, Any]:
+    response: dict[str, Any] = {
         "healthy": True,
         "correlationId": correlation_id,
         "specVersion": w.SPEC_VERSION_CURRENT,
+        "workflowCoreVersion": w.WORKFLOW_CORE_COMPAT_VERSION,
         "hookResumeInputVersion": w.HOOK_RESUME_INPUT_VERSION,
         "timestamp": int(datetime.now(UTC).timestamp() * 1000),
     }
+    if encryption_public_key is not None:
+        response["encryptionPublicKey"] = encryption_public_key
+    return response
 
 
 async def _answer_health_check(world: w.World, health: w.HealthCheckPayload) -> None:
     run_id = _health_check_run_id(health.correlation_id)
     name = _health_check_stream_name(health.correlation_id)
-    body = json.dumps(_health_check_response(health.correlation_id)).encode()
+    encryption_public_key = None
+    if health.run_id is not None:
+        try:
+            run_key = await world.run_key(health.run_id)
+            if run_key is not None:
+                encryption_public_key = encryption.derive_run_public_key(run_key)
+        except Exception as error:
+            logger.warning(
+                "Health check %r could not derive a run public key: %s",
+                health.correlation_id,
+                error,
+            )
+    body = json.dumps(
+        _health_check_response(health.correlation_id, encryption_public_key=encryption_public_key)
+    ).encode()
     try:
         await world.streams_write(run_id, name, body)
         await world.streams_close(run_id, name)
@@ -1715,20 +1741,21 @@ async def _workflow_replay_pass(
         if _has_terminal_run_event(events, run_id):
             return None
 
+    run_key = await _resolve_run_key(world, workflow_run, events)
     context = WorkflowOrchestratorContext(
         events,
         run_id=run_id,
         seed=run_id,
         started_at=workflow_started_at,
         registry=registry,
-        run_key=await _resolve_run_key(world, workflow_run, events),
-        payload_encoder=workflow_run.payload_encoder(),
+        run_key=run_key,
+        payload_encoder=workflow_run.payload_encoder(encryption_key=run_key),
         workflow_info=WorkflowInfo(
             run_id=run_id,
             workflow_name=workflow_run.workflow_name,
             started_at=workflow_run.started_at,
             url=_workflow_url(),
-            features=WorkflowFeatures(encryption=workflow_run.encryption_public_key is not None),
+            features=WorkflowFeatures(encryption=run_key is not None),
         ),
     )
     try:
@@ -1936,6 +1963,7 @@ async def _run_cancellable_step(
     world: w.World,
     run_id: str,
     step_id: str,
+    run_key: bytes | None = None,
 ) -> T:
     """Run a cancellable step and a listener for cancellations.
 
@@ -1955,7 +1983,9 @@ async def _run_cancellable_step(
             async for chunk in streams.reconnecting_frames(world, run_id, stream_name):
                 cancelled = True
                 try:
-                    data = ser.hydrate(chunk, what=f"the cancellation of step {step_id}")
+                    data = ser.hydrate(
+                        chunk, what=f"the cancellation of step {step_id}", key=run_key
+                    )
                 except ser.SerializationError:
                     pass
                 else:
@@ -2045,7 +2075,10 @@ async def _execute_step(
     if not start_result.step:
         raise RuntimeError(f"step_started event for '{req.step_id}' did not return step entity")
     step_run = start_result.step
-    payload_encoder = run.payload_encoder()
+    run_key = None
+    if run.encryption_public_key is not None or ser.is_encrypted(step_run.input):
+        run_key = await world.run_key(req.run_id, deployment_id=run.deployment_id)
+    payload_encoder = run.payload_encoder(encryption_key=run_key)
     current_attempt = step_run.attempt
     if not step_run.started_at:
         raise RuntimeError(f"Step '{req.step_id}' has no 'startedAt' timestamp")
@@ -2131,9 +2164,7 @@ async def _execute_step(
                 # the run, which we don't want to have to do.
                 started_at=None,
                 url=_workflow_url(),
-                features=WorkflowFeatures(
-                    encryption=bool(step_run.input) and ser.is_encrypted(step_run.input)
-                ),
+                features=WorkflowFeatures(encryption=run_key is not None),
             ),
         )
     )
@@ -2146,7 +2177,6 @@ async def _execute_step(
             what = f"the input of step {req.step_id}"
             # No deployment id: the queue message routed this step to the deployment
             # that owns the run, so the key resolves against the current one.
-            run_key = await world.run_key(req.run_id) if ser.is_encrypted(step_run.input) else None
             args, kwargs = ser.step_call_arguments(
                 ser.hydrate(step_run.input, what=what, key=run_key), what=what
             )
@@ -2162,7 +2192,13 @@ async def _execute_step(
             # Execute the step function
             if step.cancellable:
                 result = await _run_cancellable_step(
-                    step, args, kwargs, world=world, run_id=req.run_id, step_id=req.step_id
+                    step,
+                    args,
+                    kwargs,
+                    world=world,
+                    run_id=req.run_id,
+                    step_id=req.step_id,
+                    run_key=run_key,
                 )
             else:
                 result = await step.func(*args, **kwargs)
@@ -2324,15 +2360,13 @@ def _with_health_check(handler: w.HTTPHandler) -> w.HTTPHandler:
             return await handler(request)
         if request.method == "OPTIONS":
             return w.HTTPResponse(204, b"", dict(_HEALTH_CHECK_CORS_HEADERS))
-        # Same omissions as `_health_check_response`, and `endpoint` in place of
-        # the correlation id: taken from the request, as `url.pathname` is
-        # upstream, so an app serving the route elsewhere reports where it
-        # actually answered.
+        # Match upstream: `endpoint` is the path of the HTTP health-check request.
         response = w.HTTPResponse.json(
             {
                 "healthy": True,
                 "endpoint": target.path,
                 "specVersion": w.SPEC_VERSION_CURRENT,
+                "workflowCoreVersion": w.WORKFLOW_CORE_COMPAT_VERSION,
             }
         )
         response.headers.update(_HEALTH_CHECK_CORS_HEADERS)
@@ -2598,10 +2632,20 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
     world = w.get_world()
     deployment_id = await world.get_deployment_id()
     namespace = wf._resolve_queue_namespace()
-    input_data = ser.PayloadEncoder(compression=True).encode(
+    # TODO: add and prefer world.create_run_id()
+    run_id = f"wrun_{_generate_run_ulid()}"
+    run_key = await world.run_key(run_id, deployment_id=deployment_id)
+    encryption_public_key = (
+        encryption.derive_run_public_key(run_key) if run_key is not None else None
+    )
+    input_data = ser.PayloadEncoder(compression=True, encryption_key=run_key).encode(
         ser.argument_array(dumped_args, dumped_kwargs)
     )
-    execution_context: dict[str, Any] = {"hookResumeInputVersion": w.HOOK_RESUME_INPUT_VERSION}
+    execution_context: dict[str, Any] = {
+        "workflowCoreVersion": w.WORKFLOW_CORE_COMPAT_VERSION,
+        "hookResumeInputVersion": w.HOOK_RESUME_INPUT_VERSION,
+        "features": {"encryption": run_key is not None},
+    }
     if namespace is not None:
         execution_context["queueNamespace"] = namespace
     data = w.RunCreatedEventData(
@@ -2609,17 +2653,23 @@ async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> R
         workflow_name=wf.workflow_id,
         input=input_data,
         execution_context=execution_context,
+        encryption_public_key=encryption_public_key,
     )
-    result = await world.events_create(None, data.into_event())
-
-    # Assert that the run was created
-    if not result.run:
-        raise RuntimeError("Missing 'run' in server response for 'run_created' event")
-
-    run_id = result.run.run_id
+    await world.events_create(run_id, data.into_event())
     await world.queue(
         w.get_queue_name(wf.workflow_id, namespace),
-        w.WorkflowInvokePayload(run_id=run_id),
+        w.WorkflowInvokePayload(
+            run_id=run_id,
+            run_input=w.RunInput(
+                input=input_data,
+                deployment_id=deployment_id,
+                workflow_name=wf.workflow_id,
+                spec_version=w.SPEC_VERSION_CURRENT,
+                execution_context=execution_context,
+                encryption_public_key=encryption_public_key,
+                environment=world.get_environment(),
+            ),
+        ),
         deployment_id=deployment_id,
     )
 
@@ -2660,7 +2710,23 @@ async def resume_hook(token_or_hook: str | core.Hook, payload: Any) -> core.Hook
     else:
         hook = token_or_hook
         run = await world.runs_get(hook.run_id)
-    payload_encoder = run.payload_encoder()
+    recipient_public_key = None
+    if run.encryption_public_key is not None:
+        try:
+            recipient_public_key = encryption.decode_key(
+                run.encryption_public_key, what="the run encryption public key"
+            )
+        except ValueError:
+            # Older or corrupted rows must retain the symmetric fallback.
+            pass
+    encryption_key = None
+    if recipient_public_key is None:
+        encryption_key = await world.run_key(run.run_id, deployment_id=run.deployment_id)
+    payload_encoder = run.payload_encoder(
+        encryption_key=encryption_key,
+        recipient_public_key=recipient_public_key,
+        check_target_core_version=True,
+    )
     data = w.HookReceivedEventData(payload=payload_encoder.encode(payload))
     await world.events_create(hook.run_id, data.into_event(hook.hook_id))
     execution_context = run.execution_context or {}

--- a/src/vercel-workflow/vercel/workflow/_internal/serialization.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/serialization.py
@@ -105,6 +105,12 @@ class PayloadEncoder:
     """Encode workflow payload values and errors."""
 
     compression: bool = False
+    encryption_key: bytes | None = None
+    recipient_public_key: bytes | None = None
+
+    def __post_init__(self) -> None:
+        if self.encryption_key is not None and self.recipient_public_key is not None:
+            raise ValueError("A payload encoder cannot both encrypt and seal")
 
     def encode(self, value: Any) -> bytes:
         return self._wrap(_encode_devalue(value))
@@ -121,7 +127,12 @@ class PayloadEncoder:
         return self._wrap(encoded)
 
     def _wrap(self, encoded: bytes) -> bytes:
-        return compression.maybe_compress(encoded, enabled=self.compression)
+        encoded = compression.maybe_compress(encoded, enabled=self.compression)
+        if self.recipient_public_key is not None:
+            return SEALED + encryption.seal_envelope(self.recipient_public_key, encoded)
+        if self.encryption_key is not None:
+            return ENCRYPTED + encryption.encrypt_envelope(self.encryption_key, encoded)
+        return encoded
 
 
 def hydrate_error(data: Any, *, what: str, key: bytes | None = None) -> Exception:
@@ -153,6 +164,27 @@ def is_encrypted(data: Any) -> bool:
     if not isinstance(data, bytes | bytearray | memoryview):
         return False
     return bytes(data[:FORMAT_PREFIX_LENGTH]) in ENCRYPTED_FORMATS
+
+
+def payloads_equal(left: Any, right: Any, *, key: bytes | None) -> bool:
+    """Compare serialized payloads without treating fresh encryption nonces as data."""
+    if left == right:
+        return True
+    if key is None or not isinstance(left, bytes) or not isinstance(right, bytes):
+        return False
+
+    def plaintext(data: bytes) -> bytes:
+        prefix, payload = _decode_format(data, what="a payload")
+        if prefix == ENCRYPTED:
+            return encryption.open_envelope(key, payload)
+        if prefix == SEALED:
+            return encryption.open_sealed_envelope(key, payload)
+        return data
+
+    try:
+        return plaintext(left) == plaintext(right)
+    except (encryption.DecryptionError, SerializationError, ValueError):
+        return False
 
 
 def _decode_format(data: bytes, *, what: str) -> tuple[bytes, bytes]:

--- a/src/vercel-workflow/vercel/workflow/_internal/world.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/world.py
@@ -25,6 +25,7 @@ else:
     from typing_extensions import Self
 
 import pydantic
+import semver
 
 from vercel._internal.core.polyfills import UTC, Self
 from vercel.queue import SanitizedName
@@ -115,6 +116,16 @@ def get_physical_topic(queue_name: str) -> SanitizedName:
 SPEC_VERSION_SUPPORTS_COMPRESSION = 5
 SPEC_VERSION_CURRENT: Literal[5] = 5
 SPEC_VERSION_MAX_SUPPORTED = 7
+
+# The highest synthetic `@workflow/core` version whose wire capabilities this
+# Python runtime has audited. This is deliberately not the Python package
+# version: upstream uses the field to choose formats for cross-deployment
+# writes, so advancing it is a protocol claim.
+WORKFLOW_CORE_COMPAT_VERSION = "4.2.0"
+
+# First upstream release that can read the symmetric `encr` payload format.
+_WORKFLOW_CORE_ENCRYPTION_MIN_VERSION = semver.Version.parse("4.2.0-beta.64")
+_WORKFLOW_CORE_COMPRESSION_MIN_VERSION = semver.Version.parse("5.0.0-beta.18")
 
 # Which version of "lazy hook resume" this SDK's queue consumer implements.
 #
@@ -310,11 +321,37 @@ class BaseWorkflowRun(BaseModel):
     created_at: datetime = pydantic.Field(alias="createdAt")
     updated_at: datetime = pydantic.Field(alias="updatedAt")
 
-    def payload_encoder(self) -> "PayloadEncoder":
+    def payload_encoder(
+        self,
+        *,
+        encryption_key: bytes | None = None,
+        recipient_public_key: bytes | None = None,
+        check_target_core_version: bool = False,
+    ) -> "PayloadEncoder":
         from .serialization import PayloadEncoder
 
+        if encryption_key is not None and recipient_public_key is not None:
+            raise ValueError("A payload encoder cannot both encrypt and seal")
+        compression = (self.spec_version or 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+        if check_target_core_version:
+            version_str = (self.execution_context or {}).get("workflowCoreVersion")
+            try:
+                if not isinstance(version_str, str):
+                    raise ValueError
+                version = semver.Version.parse(version_str.removeprefix("v"))
+            except ValueError:
+                encryption_key = None
+                compression = False
+            else:
+                if version < _WORKFLOW_CORE_ENCRYPTION_MIN_VERSION:
+                    encryption_key = None
+                if version < _WORKFLOW_CORE_COMPRESSION_MIN_VERSION:
+                    compression = False
+
         return PayloadEncoder(
-            compression=(self.spec_version or 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+            compression=compression,
+            encryption_key=encryption_key,
+            recipient_public_key=recipient_public_key,
         )
 
 
@@ -456,6 +493,9 @@ class RunCreatedEventData(BaseModel):
     input: bytes
     execution_context: dict[str, Any] | None = pydantic.Field(
         default=None, alias="executionContext", exclude_if=lambda e: e is None
+    )
+    encryption_public_key: str | None = pydantic.Field(
+        default=None, alias="encryptionPublicKey", exclude_if=lambda e: e is None
     )
 
     def into_event(self) -> "RunCreatedEvent":
@@ -1200,13 +1240,14 @@ class World(metaclass=abc.ABCMeta):
     async def hooks_get_by_token(self, token: str) -> Hook: ...
 
     @overload
-    async def events_create(self, run_id: None, data: RunCreatedEvent) -> EventResult:
+    async def events_create(self, run_id: str | None, data: RunCreatedEvent) -> EventResult:
         """
         Create a run_created event to start a new workflow run.
-        The run_id parameter must be None - the server generates and returns the runId.
+        When run_id is None the server generates it; callers may provide one
+        when key derivation needs the stable id before the event is encoded.
 
         Args:
-            run_id: Must be None for run_created events
+            run_id: Optional client-generated workflow run ID
             data: The run_created event data
         Returns:
             The created event and run entity

--- a/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/worlds/local.py
@@ -730,6 +730,7 @@ class LocalWorld(w.World):
                 workflow_name=run_data.workflow_name,
                 input=run_data.input,
                 execution_context=run_data.execution_context,
+                encryption_public_key=run_data.encryption_public_key,
             ),
             spec_version=data.spec_version,
         )
@@ -894,6 +895,7 @@ class LocalWorld(w.World):
                 spec_version=data.spec_version,
                 execution_context=run_data.execution_context,
                 input=run_data.input,
+                encryption_public_key=run_data.encryption_public_key,
                 created_at=now,
                 updated_at=now,
             )

--- a/src/vercel-workflow/vercel/workflow/_internal/worlds/vercel.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/worlds/vercel.py
@@ -457,10 +457,9 @@ class VercelWorld(w.World):
         # WORKFLOW_VERCEL_PROJECT and WORKFLOW_VERCEL_TEAM are both set.
         project_id = self._project_id or os.getenv("VERCEL_PROJECT_ID")
         if not project_id:
-            raise RuntimeError(
-                f"Cannot resolve the encryption key for run {run_id}: no project id. "
-                "Set VERCEL_PROJECT_ID, or pass one to the world."
-            )
+            # Matches world-vercel's optional getEncryptionKeyForRun: without
+            # a project id the World exposes no encryption-key capability.
+            return None
 
         current_deployment = os.getenv("VERCEL_DEPLOYMENT_ID")
         own_deployment = deployment_id is None or deployment_id == current_deployment

--- a/uv.lock
+++ b/uv.lock
@@ -2071,6 +2071,15 @@ wheels = [
 ]
 
 [[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2838,6 +2847,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "semver" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "vercel-headers" },
@@ -2854,6 +2864,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1" },
     { name = "pydantic", specifier = ">=2.12.0,<3" },
+    { name = "semver", specifier = ">=3,<4" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
     { name = "vercel-headers", editable = "src/vercel-headers" },


### PR DESCRIPTION
Encrypt workflow payload writes and seal external hook resumes to the run's public key.

Streamed data is not encrypted yet.

Also publishes a synthetic workflowCoreVersion, which is apparently used (improperly) as capability detection in the JS SDK.