### PR TITLE
workflow: typed streams

### DIFF
--- a/changes/vercel-workflow/typed-streams.feature.md
+++ b/changes/vercel-workflow/typed-streams.feature.md
@@ -1,0 +1,5 @@
+Streams can now carry typed data.
+
+`get_writable(type=Token)` returns a `WorkflowWritable[Token]` whose writes are dumped through pydantic the way typed step arguments are; then `run.readable(type=Token)` and `read_stream(run_id, name, type=Token)` validate each chunk on the way back, raising `TypeValidationError` on a mismatch.
+
+`WorkflowWritable` is now generic, defaulting to `Any`; a step parameter annotated `WorkflowWritable[Token]` becomes a handle the workflow passed in as a writer of that type, and `writable.with_type(Token)` gives a typed view of any writable.

--- a/src/vercel-workflow/README.md
+++ b/src/vercel-workflow/README.md
@@ -218,6 +218,26 @@ below) can be written, and a reader gets it back. A `bytes` chunk arrives on the
 TypeScript side as a `Uint8Array`, so a consumer there can pipe the stream
 straight into a `Response`.
 
+A stream can carry a type. `get_writable(type=Token)` returns a
+`WorkflowWritable[Token]`, and each write is dumped through pydantic the way a
+typed step argument is:
+
+```python
+class Token(pydantic.BaseModel):
+    text: str
+    index: int
+
+
+@app.step
+async def summarize(*, document: str) -> str:
+    writable = get_writable(type=Token)
+    index = 0
+    async for text in llm.stream(document):
+        await writable.write(Token(text=text, index=index))
+        index += 1
+    ...
+```
+
 Three things are worth knowing:
 
 - **Nothing closes a stream for you.** Not the end of a step, not the end of the
@@ -250,6 +270,15 @@ async for chunk in run.readable():
     print(chunk)
 ```
 
+`run.readable(type=Token)` validates each chunk against the type on the way back, so
+what a step wrote as a model is a model again, and a chunk that does not match
+raises `TypeValidationError`:
+
+```python
+async for token in run.readable(type=Token):
+    print(token.text)
+```
+
 `run.readable_bytes()` is the same thing narrowed to `bytes`, which is what an
 HTTP body wants — hand it to a streaming response as-is.
 
@@ -269,7 +298,8 @@ duplicated or skipped.
 
 `run.stream_info()` gives the last chunk index and whether the stream is closed
 (`tail_index` is `-1` before anything is written), `run.list_streams()` lists
-every stream the run has, and `read_stream(run_id, name)` reads one by name.
+every stream the run has, and `read_stream(run_id, name)` reads one by name,
+taking a type the same way `run.readable()` does.
 
 The same stream is readable from the TypeScript SDK (`run.readable`), the
 dashboard, and `workflow inspect stream <id> --run=<run-id>`.

--- a/src/vercel-workflow/pyproject.toml
+++ b/src/vercel-workflow/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "cbor2>=6.0,<7",
     "cryptography>=43.0.0",
     "zstandard>=0.23.0,<1 ; python_version < '3.14'",
-    "typing-extensions>=4.0.0,<5 ; python_version < '3.11'",
+    "typing-extensions>=4.4.0,<5 ; python_version < '3.13'",
     "tomli>=2,<3 ; python_version < '3.11'",
 ]
 

--- a/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_get_writable.py
@@ -14,10 +14,12 @@ from datetime import datetime
 from typing import Any
 
 import anyio
+import pydantic
 import pytest
 
 from tests.payloads import PLAIN_ENCODER
 from vercel._internal.core.polyfills import UTC
+from vercel.workflow import TypeValidationError
 from vercel.workflow._internal import core, runtime, serialization as ser, streams, world as w
 
 from ..world_stubs import NoStreams
@@ -27,6 +29,11 @@ RUN_ID = "wrun_test"
 STEP_ID = "step_test"
 WORKFLOW_NAME = "workflow//tests.wf"
 STREAM = "strm_test_user"
+
+
+class Token(pydantic.BaseModel):
+    text: str
+    index: int
 
 
 class FakeWorld(NoStreams, w.World):
@@ -446,3 +453,217 @@ class TestHandOff:
             )
             handle = streams.WorkflowStreamHandle(RUN_ID, STREAM)
             assert PLAIN_ENCODER.encode(writer) == PLAIN_ENCODER.encode(handle)
+
+
+class TestTyped:
+    """A stream that carries a type, dumped on the way out like a step argument.
+
+    The type is a property of the writer, not of the stream on the wire: the
+    same `WritableStream` tag goes out, a reader that asks for the type gets
+    models, a reader that does not gets the dicts the format already carried.
+    """
+
+    async def test_a_typed_write_dumps_the_value_like_an_argument(self, registry) -> None:
+        @registry.step
+        async def emit() -> None:
+            writable: streams.WorkflowWritable[Token] = runtime.get_writable(type=Token)
+            await writable.write(Token(text="hi", index=0))
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        # A plain dict on the wire -- which is what a TypeScript reader, or an
+        # untyped Python one, would see -- rather than a serialized instance.
+        assert _chunk_values(fake) == [{"text": "hi", "index": 0}]
+
+    async def test_typed_and_untyped_writers_share_one_sink(self, registry) -> None:
+        """The ordering guarantee has to hold across types.
+
+        A typed writer is another object over the same buffer, so a step mixing
+        `get_writable()` and `get_writable(type=Token)` still writes in call order,
+        and the typed one is cached so a loop does not rebuild its adapter.
+        """
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit() -> None:
+            plain = runtime.get_writable()
+            typed = runtime.get_writable(type=Token)
+            seen.extend([plain, typed, runtime.get_writable(type=Token)])
+            await plain.write("first")
+            await typed.write(Token(text="second", index=1))
+            await plain.write("third")
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        plain, typed, again = seen
+        assert isinstance(typed, streams.WorkflowStreamWriter)
+        assert typed is not plain
+        assert typed is again
+        assert typed._sink is plain._sink
+        assert typed.type is Token
+        assert plain.type is None
+        assert _chunk_values(fake) == ["first", {"text": "second", "index": 1}, "third"]
+
+    async def test_with_type_gives_a_typed_view_over_the_same_stream(self, registry) -> None:
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit() -> None:
+            plain = runtime.get_writable()
+            typed: streams.WorkflowWritable[Token] = plain.with_type(Token)
+            seen.extend([plain, typed])
+            await plain.write("first")
+            await typed.write(Token(text="second", index=1))
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        plain, typed = seen
+        assert isinstance(typed, streams.WorkflowStreamWriter)
+        assert typed._sink is plain._sink
+        assert typed.type is Token
+        assert _chunk_values(fake) == ["first", {"text": "second", "index": 1}]
+
+    async def test_closing_through_a_typed_writer_closes_the_stream(self, registry) -> None:
+        @registry.step
+        async def finish() -> None:
+            await runtime.get_writable().write("last")
+            await runtime.get_writable(type=Token).close()
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        await _invoke(registry, finish.name)
+
+        assert _kinds(fake) == ["chunk", "close", "step_completed"]
+
+    async def test_a_type_pydantic_cannot_schematize_passes_through(self, registry) -> None:
+        class Opaque:
+            pass
+
+        @registry.step
+        async def emit() -> None:
+            writable: Any = runtime.get_writable(type=Opaque)
+            await writable.write("untouched")
+
+        fake = FakeWorld()
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        assert _chunk_values(fake) == ["untouched"]
+
+    async def test_a_workflow_body_gets_a_handle_for_a_typed_stream_too(self, registry) -> None:
+        ctx = runtime.WorkflowOrchestratorContext(
+            [], run_id=RUN_ID, seed=RUN_ID, started_at=0, registry=registry
+        )
+        token = ctx._ctx.set(ctx)
+        try:
+            handle = runtime.get_writable(type=Token)
+        finally:
+            ctx._ctx.reset(token)
+
+        assert isinstance(handle, streams.WorkflowStreamHandle)
+        # Same stream as the untyped handle: the type is not part of the name.
+        assert handle == ctx.stream_handle(None)
+
+    async def test_a_handle_arrives_typed_when_the_step_parameter_says_so(self, registry) -> None:
+        """The type crosses by annotation, since it is not on the wire.
+
+        `WorkflowWritable[Token]` on the step's parameter is what turns the
+        revived writer into a typed one, so the workflow can hand out a stream
+        and the step writes models to it without asking for the type again.
+        """
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit(*, out: streams.WorkflowWritable[Token]) -> None:
+            seen.append(out)
+            await out.write(Token(text="typed", index=0))
+
+        fake = FakeWorld(
+            step_input=PLAIN_ENCODER.encode(
+                ser.step_arguments((), {"out": streams.WorkflowStreamHandle(RUN_ID, STREAM)})
+            )
+        )
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        (out,) = seen
+        assert isinstance(out, streams.WorkflowStreamWriter)
+        assert out.type is Token
+        assert _chunk_values(fake) == [{"text": "typed", "index": 0}]
+        assert _kinds(fake)[-1] == "step_completed"
+
+    async def test_the_concrete_writer_class_types_a_handle_too(self, registry) -> None:
+        """`WorkflowStreamWriter[Token]` is what a step actually holds, so it
+        has to work as an annotation as well as the interface does.
+
+        The adapter builder swallows every schema-generation failure, so a hook
+        that broke on this shape would not raise -- the writer would quietly
+        arrive untyped and unchecked.
+        """
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit(*, out: streams.WorkflowStreamWriter[Token]) -> None:
+            seen.append(out)
+
+        fake = FakeWorld(
+            step_input=PLAIN_ENCODER.encode(
+                ser.step_arguments((), {"out": streams.WorkflowStreamHandle(RUN_ID, STREAM)})
+            )
+        )
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        (out,) = seen
+        assert isinstance(out, streams.WorkflowStreamWriter)
+        assert out.type is Token
+        with pytest.raises(TypeValidationError, match="argument 'out'"):
+            emit.codec.validate_arguments([], {"out": "not a stream"})
+
+    async def test_an_unparametrized_annotation_leaves_the_writer_untyped(self, registry) -> None:
+        seen: list[Any] = []
+
+        @registry.step
+        async def emit(*, out: streams.WorkflowWritable) -> None:
+            seen.append(out)
+
+        fake = FakeWorld(
+            step_input=PLAIN_ENCODER.encode(
+                ser.step_arguments((), {"out": streams.WorkflowStreamHandle(RUN_ID, STREAM)})
+            )
+        )
+        w.set_world(fake)
+        await _invoke(registry, emit.name)
+
+        (out,) = seen
+        assert isinstance(out, streams.WorkflowStreamWriter)
+        assert out.type is None
+
+    async def test_the_annotation_reaches_through_containers_and_unions(self, registry) -> None:
+        @registry.step
+        async def one(out: streams.WorkflowWritable[Token] | None) -> None: ...
+
+        @registry.step
+        async def many(outs: list[streams.WorkflowWritable[Token]]) -> None: ...
+
+        handle = streams.WorkflowStreamHandle(RUN_ID, STREAM)
+        # Dumping leaves the handle for the stream reducer, as before.
+        assert one.codec.dump("out", handle) is handle
+        assert many.codec.dump("outs", [handle])[0] is handle
+        # Validating a handle outside a step gives the handle back: there is
+        # no writer to type, and a handle carries no type.
+        _, kwargs = one.codec.validate_arguments([], {"out": handle})
+        assert kwargs["out"] is handle
+
+    async def test_something_that_is_not_a_stream_is_rejected(self, registry) -> None:
+        @registry.step
+        async def emit(out: streams.WorkflowWritable[Token]) -> None: ...
+
+        with pytest.raises(TypeValidationError, match="argument 'out'"):
+            emit.codec.validate_arguments([], {"out": "not a stream"})

--- a/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_stream_reader.py
@@ -12,14 +12,21 @@ import contextlib
 from collections.abc import AsyncGenerator, Sequence
 from typing import Any
 
+import pydantic
 import pytest
 
+from vercel.workflow import TypeValidationError
 from vercel.workflow._internal import runtime, serialization as ser, streams, world as w
 
 from ..world_stubs import NoStreams
 
 RUN_ID = "wrun_test"
 NAME = "strm_test_user"
+
+
+class Token(pydantic.BaseModel):
+    text: str
+    index: int
 
 
 class ReplayWorld(NoStreams, w.World):
@@ -295,3 +302,62 @@ class TestRunApi:
         w.set_world(world)
 
         assert [c async for c in runtime.read_stream(RUN_ID, "strm_someone_else")] == ["x"]
+
+
+class TestTypedReads:
+    """A type on the read side validates each chunk, as a step argument is."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_world(self):
+        yield
+        w.set_world(None)
+
+    async def test_a_typed_read_validates_each_chunk(self) -> None:
+        # What a typed writer put on the wire: plain dicts.
+        w.set_world(ReplayWorld([{"text": "a", "index": 0}, {"text": "b", "index": 1}]))
+
+        chunks = runtime.Run(RUN_ID).readable(type=Token)
+        tokens: list[Token] = [token async for token in chunks]
+
+        assert tokens == [Token(text="a", index=0), Token(text="b", index=1)]
+
+    async def test_an_untyped_read_of_the_same_stream_gets_the_dicts(self) -> None:
+        w.set_world(ReplayWorld([{"text": "a", "index": 0}]))
+
+        assert [c async for c in runtime.Run(RUN_ID).readable()] == [{"text": "a", "index": 0}]
+
+    async def test_a_chunk_that_does_not_match_names_its_index(self) -> None:
+        w.set_world(ReplayWorld([{"text": "a", "index": 0}, "not a token"]))
+
+        chunks = runtime.Run(RUN_ID).readable(type=Token)
+        async with contextlib.aclosing(chunks):
+            assert await chunks.__anext__() == Token(text="a", index=0)
+            with pytest.raises(TypeValidationError, match=f"chunk 1 of stream {NAME}"):
+                await chunks.__anext__()
+
+    async def test_the_index_in_the_error_is_absolute(self) -> None:
+        # Resumed at 5, so the first chunk seen is chunk 5, not chunk 0.
+        w.set_world(ReplayWorld([{}] * 5 + ["bad"]))
+
+        with pytest.raises(TypeValidationError, match="chunk 5 of stream"):
+            [c async for c in runtime.Run(RUN_ID).readable(type=Token, start_index=5)]
+
+    async def test_read_stream_takes_a_type_the_same_way(self) -> None:
+        w.set_world(ReplayWorld([{"text": "x", "index": 9}]))
+
+        chunks = runtime.read_stream(RUN_ID, "strm_someone_else", type=Token)
+        assert [c async for c in chunks] == [Token(text="x", index=9)]
+
+    async def test_a_generic_alias_validates_too(self) -> None:
+        w.set_world(ReplayWorld([[{"text": "a", "index": 0}]]))
+
+        chunks = runtime.Run(RUN_ID).readable(type=list[Token])
+        assert [c async for c in chunks] == [[Token(text="a", index=0)]]
+
+    async def test_a_union_validates_at_runtime(self) -> None:
+        # `Any` for the checker, since `type[T]` cannot name a union, but the
+        # adapter still runs.
+        w.set_world(ReplayWorld([[{"text": "a", "index": 0}], None]))
+
+        chunks = runtime.Run(RUN_ID).readable(type=list[Token] | None)
+        assert [c async for c in chunks] == [[Token(text="a", index=0)], None]

--- a/src/vercel-workflow/tests/unit/test_workflow_stream_writer.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_stream_writer.py
@@ -314,15 +314,16 @@ async def test_cancelling_the_dispatch_does_not_poison_the_writer() -> None:
         writer = streams.WorkflowStreamWriter(
             world=world, run_id=RUN_ID, name=NAME, task_group=task_group
         )
+        sink = writer._sink
         await writer.write("first")
         await _settle()  # the dispatch task is now blocked on the gate
-        assert writer._dispatching
+        assert sink._dispatching
         task_group.cancel_scope.cancel()
 
-    assert writer._sink_error is None
-    assert not writer._dispatching
+    assert sink._sink_error is None
+    assert not sink._dispatching
     assert world.batches == []
-    assert _values([writer._buffer]) == ["first"]
+    assert _values([sink._buffer]) == ["first"]
 
 
 async def test_drain_on_an_untouched_writer_is_a_no_op() -> None:

--- a/src/vercel-workflow/tests/unit/test_workflow_typed_arguments.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_typed_arguments.py
@@ -412,7 +412,7 @@ def test_a_name_that_never_resolves_passes_through_rather_than_erroring_late() -
     @registry.step
     async def nested(items: list[Order]) -> None: ...
 
-    assert dangling.codec._adapter("item") is None
+    assert dangling.codec._codec("item")._adapter is None
     assert dangling.codec.validate_arguments([], {"item": {"whatever": 1}}) == (
         [],
         {"item": {"whatever": 1}},
@@ -420,7 +420,7 @@ def test_a_name_that_never_resolves_passes_through_rather_than_erroring_late() -
 
     args, kwargs = nested.codec.validate_arguments([], {"items": [_ORDER_DICT]})
     assert args == []
-    if nested.codec._adapter("items") is None:
+    if nested.codec._codec("items")._adapter is None:
         assert kwargs == {"items": [_ORDER_DICT]}  # 3.10: unresolved, passed through
     else:
         assert kwargs == {"items": [Order.model_validate(_ORDER_DICT)]}
@@ -497,7 +497,7 @@ def test_a_dump_failure_propagates(monkeypatch) -> None:  # type: ignore[no-unty
     @registry.step
     async def fulfil(order: Order) -> None: ...
 
-    adapter = fulfil.codec._adapter("order")
+    adapter = fulfil.codec._codec("order")._adapter
     assert adapter is not None
 
     def fail(*args, **kwargs):  # type: ignore[no-untyped-def]
@@ -722,11 +722,11 @@ def test_adapters_are_built_once_per_instance_and_not_shared() -> None:
     @registry.step
     async def fulfil(order: Order) -> None: ...
 
-    first = fulfil.codec._adapter("order")
-    assert fulfil.codec._adapter("order") is first
+    first = fulfil.codec._codec("order")
+    assert fulfil.codec._codec("order") is first
 
     other = core.Step(fulfil.func)
-    assert other.codec._adapter("order") is not first
+    assert other.codec._codec("order") is not first
 
 
 def test_binding_without_a_codec_only_canonicalizes_the_call() -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -414,7 +414,10 @@ class _StepStreams:
             raise error
 
     def writer(
-        self, namespace: str | None, *, reentrant_ctx_on_err: bool = True
+        self,
+        namespace: str | None,
+        *,
+        reentrant_ctx_on_err: bool = True,
     ) -> streams.WorkflowStreamWriter:
         """The writer for this run's *namespace* stream."""
         return self.writer_for(
@@ -424,7 +427,11 @@ class _StepStreams:
         )
 
     def writer_for(
-        self, run_id: str, name: str, *, reentrant_ctx_on_err: bool = True
+        self,
+        run_id: str,
+        name: str,
+        *,
+        reentrant_ctx_on_err: bool = True,
     ) -> streams.WorkflowStreamWriter:
         """The writer for one stream, created on first use.
 
@@ -2499,7 +2506,10 @@ class Run(Generic[T]):
                 await asyncio.sleep(1)
 
     def readable(
-        self, *, namespace: str | None = None, start_index: int | None = None
+        self,
+        *,
+        namespace: str | None = None,
+        start_index: int | None = None,
     ) -> AsyncGenerator[Any, None]:
         """Read what the run's steps stream, as they stream it.
 

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -15,7 +15,7 @@ import traceback
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping, Sequence
 from datetime import datetime
-from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast
+from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast, overload
 from urllib.parse import parse_qsl, urlsplit
 
 import anyio
@@ -39,6 +39,7 @@ from .duration import DurationParam, parse_duration_to_date
 
 P = ParamSpec("P")
 T = TypeVar("T")
+Chunk = TypeVar("Chunk")
 logger = logging.getLogger("vercel.workflow")
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
@@ -366,8 +367,13 @@ class _StepStreams:
     """
 
     run_id: str
-    writers: dict[tuple[str, str], streams.WorkflowStreamWriter] = dataclasses.field(
+    writers: dict[tuple[str, str], streams.WorkflowStreamWriter[Any]] = dataclasses.field(
         default_factory=dict
+    )
+    # Typed views over the writers above, so a step asking for the same type
+    # in a loop does not build a pydantic adapter per call.
+    typed_writers: dict[tuple[str, str, Any], streams.WorkflowStreamWriter[Any]] = (
+        dataclasses.field(default_factory=dict)
     )
     _task_group: anyio.abc.TaskGroup | None = None
 
@@ -417,12 +423,14 @@ class _StepStreams:
         self,
         namespace: str | None,
         *,
+        type: Any = None,
         reentrant_ctx_on_err: bool = True,
-    ) -> streams.WorkflowStreamWriter:
+    ) -> streams.WorkflowStreamWriter[Any]:
         """The writer for this run's *namespace* stream."""
         return self.writer_for(
             self.run_id,
             streams.workflow_run_stream_id(self.run_id, namespace),
+            type=type,
             reentrant_ctx_on_err=reentrant_ctx_on_err,
         )
 
@@ -431,8 +439,9 @@ class _StepStreams:
         run_id: str,
         name: str,
         *,
+        type: Any = None,
         reentrant_ctx_on_err: bool = True,
-    ) -> streams.WorkflowStreamWriter:
+    ) -> streams.WorkflowStreamWriter[Any]:
         """The writer for one stream, created on first use.
 
         One writer per stream per step, deliberately. Handing out a fresh writer
@@ -443,6 +452,10 @@ class _StepStreams:
         that pattern correct instead of subtly wrong, and it is why a handle the
         workflow passed in resolves to the same writer the step would have got
         by asking for the stream itself.
+
+        A *type* gives a typed view over that same writer: another
+        object, the same buffer, so the ordering guarantee holds across
+        ``get_writable()`` and ``get_writable(type=Token)`` in one step.
         """
         if self._task_group is None:
             raise RuntimeError("stream writers are only available while a step is running")
@@ -457,7 +470,13 @@ class _StepStreams:
                 reentrant_ctx_on_err=reentrant_ctx_on_err,
             )
             self.writers[key] = writer
-        return writer
+        if type is None:
+            return writer
+        typed = self.typed_writers.get((run_id, name, type))
+        if typed is None:
+            typed = writer.with_type(type)
+            self.typed_writers[run_id, name, type] = typed
+        return typed
 
     async def drain(self) -> None:
         for writer in self.writers.values():
@@ -574,16 +593,50 @@ async def _write_attributes(pairs: list[tuple[str, str | None]], *, allow_reserv
     )
 
 
+@overload
 def get_writable(
     *,
     namespace: str | None = None,
     reentrant_ctx_on_err: bool = True,
-) -> streams.WorkflowWritable:
+) -> streams.WorkflowWritable[Any]: ...
+
+
+@overload
+def get_writable(
+    *,
+    type: type[T],
+    namespace: str | None = None,
+    reentrant_ctx_on_err: bool = True,
+) -> streams.WorkflowWritable[T]: ...
+
+
+@overload
+def get_writable(
+    *,
+    type: Any,
+    namespace: str | None = None,
+    reentrant_ctx_on_err: bool = True,
+) -> streams.WorkflowWritable[Any]: ...
+
+
+def get_writable(
+    *,
+    type: Any = None,
+    namespace: str | None = None,
+    reentrant_ctx_on_err: bool = True,
+) -> streams.WorkflowWritable[Any]:
     """The run's writable stream, for streaming output while the run works.
 
     Chunks are readable straight away, through :meth:`Run.readable`, the
     TypeScript SDK, the dashboard or ``workflow inspect stream`` -- no waiting
     for the step or the run to finish.
+
+    Pass *type* to say what the stream carries. Each write is dumped through
+    pydantic the way a typed step argument is, so a model crosses as the plain
+    dict the wire format carries, and :meth:`Run.readable` asked for the same
+    type hands the model back. Without it the stream is ``Any`` and values
+    travel as :mod:`.serialization` writes them. Any annotation pydantic can
+    build a schema for works.
 
     In a step this is a :class:`~.streams.WorkflowStreamWriter`, ready to write.
     In a workflow body it is a :class:`~.streams.WorkflowStreamHandle`, which
@@ -606,7 +659,7 @@ def get_writable(
     except LookupError:
         pass
     else:
-        return state.writer(namespace, reentrant_ctx_on_err=reentrant_ctx_on_err)
+        return state.writer(namespace, type=type, reentrant_ctx_on_err=reentrant_ctx_on_err)
 
     try:
         ctx = WorkflowOrchestratorContext.current()
@@ -617,7 +670,7 @@ def get_writable(
     return ctx.stream_handle(namespace)
 
 
-def open_writable(run_id: str | None, name: str) -> streams.WorkflowWritable:
+def open_writable(run_id: str | None, name: str) -> streams.WorkflowWritable[Any]:
     """Turn a serialized stream reference back into something writable.
 
     The reviving half of the ``WritableStream`` tag, so a handle a workflow put
@@ -960,7 +1013,7 @@ class WorkflowOrchestratorContext:
     def random(self) -> random.Random:
         return self._user_random
 
-    def stream_handle(self, namespace: str | None) -> streams.WorkflowStreamHandle:
+    def stream_handle(self, namespace: str | None) -> streams.WorkflowStreamHandle[Any]:
         """A reference to one of this run's streams, for a step to write to.
 
         Deterministic, so a replay of the body produces the same handle rather
@@ -2505,9 +2558,29 @@ class Run(Generic[T]):
             else:
                 await asyncio.sleep(1)
 
+    @overload
+    def readable(
+        self, *, namespace: str | None = None, start_index: int | None = None
+    ) -> AsyncGenerator[Any, None]: ...
+
+    @overload
     def readable(
         self,
         *,
+        type: type[Chunk],
+        namespace: str | None = None,
+        start_index: int | None = None,
+    ) -> AsyncGenerator[Chunk, None]: ...
+
+    @overload
+    def readable(
+        self, *, type: Any, namespace: str | None = None, start_index: int | None = None
+    ) -> AsyncGenerator[Any, None]: ...
+
+    def readable(
+        self,
+        *,
+        type: Any = None,
         namespace: str | None = None,
         start_index: int | None = None,
     ) -> AsyncGenerator[Any, None]:
@@ -2516,6 +2589,11 @@ class Run(Generic[T]):
         Yields one value per :meth:`~vercel.workflow.WorkflowStreamWriter.write`,
         in write order, and ends when a step closes the stream. A run that never
         closes its stream leaves this waiting until the run expires.
+
+        Pass *type* to validate each chunk against it, the way a typed
+        step argument is: a chunk a step wrote as a model comes back a model.
+        A chunk that does not match raises
+        :class:`~vercel.workflow.TypeValidationError` naming its index.
 
         *start_index* skips that many chunks; a negative value reads that many
         back from the end. Positive values resume exactly, which is what makes
@@ -2528,7 +2606,7 @@ class Run(Generic[T]):
         iterating a property twice would quietly start a second one.
         """
         name = streams.workflow_run_stream_id(self._run_id, namespace)
-        return _read_stream(self._world, self._run_id, name, start_index)
+        return _read_stream(self._world, self._run_id, name, type, start_index)
 
     def readable_bytes(
         self, *, namespace: str | None = None, start_index: int | None = None
@@ -2568,27 +2646,50 @@ class Run(Generic[T]):
         return await self._world.streams_list(self._run_id)
 
 
+@overload
 def read_stream(
     run_id: str, name: str, *, start_index: int | None = None
+) -> AsyncGenerator[Any, None]: ...
+
+
+@overload
+def read_stream(
+    run_id: str, name: str, *, type: type[Chunk], start_index: int | None = None
+) -> AsyncGenerator[Chunk, None]: ...
+
+
+@overload
+def read_stream(
+    run_id: str, name: str, *, type: Any, start_index: int | None = None
+) -> AsyncGenerator[Any, None]: ...
+
+
+def read_stream(
+    run_id: str, name: str, *, type: Any = None, start_index: int | None = None
 ) -> AsyncGenerator[Any, None]:
     """Read one of a run's streams by its full name.
 
     :meth:`Run.readable` derives the name from the run id and a namespace, so
     it only reaches streams that follow that scheme. This takes the name
     verbatim, which is what :meth:`Run.list_streams` returns and what another
-    SDK may have used.
+    SDK may have used. *type* means what it does there.
     """
-    return _read_stream(w.get_world(), run_id, name, start_index)
+    return _read_stream(w.get_world(), run_id, name, type, start_index)
 
 
 async def _read_stream(
-    world: w.World, run_id: str, name: str, start_index: int | None
+    world: w.World, run_id: str, name: str, type: Any, start_index: int | None
 ) -> AsyncGenerator[Any, None]:
+    codec = None if type is None else signature_codec.TypeCodec(type)
     frames = streams.reconnecting_frames(world, run_id, name, start_index)
     async with contextlib.aclosing(frames):
         index = start_index or 0
         async for payload in frames:
-            yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
+            what = f"chunk {index} of stream {name}"
+            value = ser.hydrate(payload, what=what)
+            if codec is not None:
+                value = codec.validate(value, what=what)
+            yield value
             index += 1
 
 

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -2527,17 +2527,8 @@ class Run(Generic[T]):
         A method rather than a property, because each call opens its own read:
         iterating a property twice would quietly start a second one.
         """
-
-        async def values() -> AsyncGenerator[Any, None]:
-            name = streams.workflow_run_stream_id(self._run_id, namespace)
-            frames = streams.reconnecting_frames(self._world, self._run_id, name, start_index)
-            async with contextlib.aclosing(frames):
-                index = start_index or 0
-                async for payload in frames:
-                    yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
-                    index += 1
-
-        return values()
+        name = streams.workflow_run_stream_id(self._run_id, namespace)
+        return _read_stream(self._world, self._run_id, name, start_index)
 
     def readable_bytes(
         self, *, namespace: str | None = None, start_index: int | None = None
@@ -2587,17 +2578,18 @@ def read_stream(
     verbatim, which is what :meth:`Run.list_streams` returns and what another
     SDK may have used.
     """
+    return _read_stream(w.get_world(), run_id, name, start_index)
 
-    async def values() -> AsyncGenerator[Any, None]:
-        world = w.get_world()
-        frames = streams.reconnecting_frames(world, run_id, name, start_index)
-        async with contextlib.aclosing(frames):
-            index = start_index or 0
-            async for payload in frames:
-                yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
-                index += 1
 
-    return values()
+async def _read_stream(
+    world: w.World, run_id: str, name: str, start_index: int | None
+) -> AsyncGenerator[Any, None]:
+    frames = streams.reconnecting_frames(world, run_id, name, start_index)
+    async with contextlib.aclosing(frames):
+        index = start_index or 0
+        async for payload in frames:
+            yield ser.hydrate(payload, what=f"chunk {index} of stream {name}")
+            index += 1
 
 
 async def start(wf: core.Workflow[P, T], *args: P.args, **kwargs: P.kwargs) -> Run[T]:

--- a/src/vercel-workflow/vercel/workflow/_internal/signature_codec.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/signature_codec.py
@@ -11,7 +11,8 @@ untouched.
 
 SignatureCodec is layered on top of the lower-level serialization done
 by the `serialization` module, which handles anything that has been
-passed through. TypeCodec is the per-annotation unit it is made of.
+passed through. TypeCodec is the per-annotation unit it is made of, and
+is also what a typed stream carries.
 
 ===========  ==========================================================
 outbound     caller -> SignatureCodec.dump -> PayloadEncoder.encode

--- a/src/vercel-workflow/vercel/workflow/_internal/signature_codec.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/signature_codec.py
@@ -11,7 +11,7 @@ untouched.
 
 SignatureCodec is layered on top of the lower-level serialization done
 by the `serialization` module, which handles anything that has been
-passed through.
+passed through. TypeCodec is the per-annotation unit it is made of.
 
 ===========  ==========================================================
 outbound     caller -> SignatureCodec.dump -> PayloadEncoder.encode
@@ -73,6 +73,39 @@ def _build_adapter(annotation: Any) -> pydantic.TypeAdapter[Any] | None:
     return adapter if adapter.pydantic_complete else None
 
 
+class TypeCodec:
+    """Dump and validate values against one annotation.
+
+    An annotation pydantic can build no schema for -- or `Any`, or one that
+    still needs resolving -- passes values through untouched in both
+    directions.
+    """
+
+    def __init__(self, annotation: Any) -> None:
+        self.annotation = annotation
+        self._adapter = _build_adapter(annotation)
+
+    def dump(self, value: Any) -> Any:
+        """*value*, as the annotation puts it on the wire."""
+        if self._adapter is None:
+            return value
+        # serialize_as_any so a subclass keeps the fields the annotation does
+        # not know about, rather than being silently truncated in transit.
+        # warnings=False because validation belongs to the receiving side; an
+        # actual serialization failure, however, must prevent writing bytes the
+        # receiver cannot reconstruct.
+        return self._adapter.dump_python(value, serialize_as_any=True, warnings=False)
+
+    def validate(self, value: Any, *, what: str) -> Any:
+        """*value* as the annotation reads it, or `TypeValidationError` naming *what*."""
+        if self._adapter is None:
+            return value
+        try:
+            return self._adapter.validate_python(value)
+        except pydantic.ValidationError as error:
+            raise TypeValidationError(f"{what} does not match: {error}") from error
+
+
 class SignatureCodec:
     """The adapters for one workflow's or step's signature.
 
@@ -87,7 +120,7 @@ class SignatureCodec:
         self._signature = signature
         self._qualname = qualname
         self._hints: Mapping[str, Any] | None = None
-        self._adapters: dict[str, pydantic.TypeAdapter[Any] | None] = {}
+        self._codecs: dict[str, TypeCodec] = {}
 
     def _resolved_hints(self) -> Mapping[str, Any]:
         if self._hints is None:
@@ -106,15 +139,15 @@ class SignatureCodec:
                 self._hints = {}
         return self._hints
 
-    def _adapter(self, name: str) -> pydantic.TypeAdapter[Any] | None:
+    def _codec(self, name: str) -> TypeCodec:
         try:
-            return self._adapters[name]
+            return self._codecs[name]
         except KeyError:
             pass
         annotation = self._resolved_hints().get(name, inspect.Parameter.empty)
-        adapter = _build_adapter(annotation)
-        self._adapters[name] = adapter
-        return adapter
+        codec = TypeCodec(annotation)
+        self._codecs[name] = codec
+        return codec
 
     # ═══════════════════════════════════════════════════════════════════════
     # outbound
@@ -122,15 +155,7 @@ class SignatureCodec:
 
     def dump(self, name: str, value: Any) -> Any:
         """*value*, as the parameter named *name* puts it on the wire."""
-        adapter = self._adapter(name)
-        if adapter is None:
-            return value
-        # serialize_as_any so a subclass keeps the fields the annotation does
-        # not know about, rather than being silently truncated in transit.
-        # warnings=False because validation belongs to the receiving side; an
-        # actual serialization failure, however, must prevent writing bytes the
-        # receiver cannot reconstruct.
-        return adapter.dump_python(value, serialize_as_any=True, warnings=False)
+        return self._codec(name).dump(value)
 
     def dump_arguments(
         self, args: tuple[Any, ...], kwargs: dict[str, Any]
@@ -150,15 +175,7 @@ class SignatureCodec:
     # ═══════════════════════════════════════════════════════════════════════
 
     def _validate(self, name: str, value: Any, *, what: str) -> Any:
-        adapter = self._adapter(name)
-        if adapter is None:
-            return value
-        try:
-            return adapter.validate_python(value)
-        except pydantic.ValidationError as error:
-            raise TypeValidationError(
-                f"{self._qualname}: {what} does not match: {error}"
-            ) from error
+        return self._codec(name).validate(value, what=f"{self._qualname}: {what}")
 
     def validate_return(self, value: Any) -> Any:
         return self._validate("return", value, what="the return value")

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -24,22 +24,37 @@ from __future__ import annotations
 
 import abc
 import base64
+import builtins
 import contextlib
+import copy
 import os
+import sys
 from collections.abc import AsyncGenerator, AsyncIterable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, get_args, overload
 
 import anyio
 import pydantic
+from pydantic_core import core_schema
 
-from . import serialization as ser
+from . import serialization as ser, signature_codec
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
 
 _PAYLOAD_ENCODER = ser.PayloadEncoder()
 
 if TYPE_CHECKING:
     from anyio.abc import TaskGroup
+    from pydantic import GetCoreSchemaHandler
 
     from . import world as w
+
+T = TypeVar("T", default=Any)
+"""What a stream carries. Defaults to ``Any``: an unparametrized stream is untyped."""
+
+S = TypeVar("S")
 
 FRAME_HEADER_SIZE = 4
 """Bytes of big-endian length prefix in front of every frame."""
@@ -273,7 +288,7 @@ MAX_BYTES_PER_BATCH = 1024 * 1024
 """Cumulative bytes in one write request, under platform body limits."""
 
 
-class WorkflowWritable(abc.ABC):
+class WorkflowWritable(abc.ABC, Generic[T]):
     """One of a run's streams, as :func:`vercel.workflow.get_writable` hands it out.
 
     Two classes implement it. In a step it is a :class:`WorkflowStreamWriter`
@@ -285,7 +300,46 @@ class WorkflowWritable(abc.ABC):
     pass it to a step without the type changing on the way, which is also how
     `@workflow/core` does it -- its workflow-side `getWritable()` returns
     something with `WritableStream`'s prototype whose methods throw.
+
+    The type parameter is what the stream carries. Left off, it is ``Any`` and
+    values travel exactly as :mod:`.serialization` writes them. Given --
+    ``get_writable(type=Token)`` -- each write is dumped through pydantic first, the
+    way a typed step argument is.
+
+    The type is not on the wire. A handle passed into a step arrives untyped
+    unless the step's parameter says otherwise: annotate it
+    ``WorkflowWritable[Token]`` and the argument is revived as a writer of
+    that type.
     """
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        """The schema pydantic uses when a signature names a stream.
+
+        Validation is an instance check, plus -- when the annotation is
+        parametrized -- retyping the value to carry that type, which is how a
+        handle a workflow passed in becomes a typed writer on the step side.
+        Serialization is the identity: the value is left for the lower layer's
+        ``WritableStream`` reducer, which is what puts it on the wire.
+        """
+        schema: Any = handler(cls)
+
+        # Serialize is just the identity function. The devalue layer is in charge
+        # of reducing stream references.
+        identity = core_schema.plain_serializer_function_ser_schema(lambda value: value)
+        schema["serialization"] = identity
+
+        args = get_args(source)
+        if args:
+            (type_,) = args
+            # If we have a type param, stamp it on the object
+            schema = core_schema.no_info_after_validator_function(
+                lambda value: value.with_type(type_),
+                schema,
+            )
+        return schema
 
     @property
     @abc.abstractmethod
@@ -297,12 +351,29 @@ class WorkflowWritable(abc.ABC):
     def name(self) -> str:
         """The stream this writes to."""
 
+    @overload
+    def with_type(self, type: type[S]) -> WorkflowWritable[S]: ...
+
+    @overload
+    def with_type(self, type: Any) -> WorkflowWritable[Any]: ...
+
     @abc.abstractmethod
-    async def write(self, value: Any) -> None:
+    def with_type(self, type: Any) -> WorkflowWritable[Any]:
+        """This same stream, carrying *type*.
+
+        A new view over the same stream rather than a change to this one: in a
+        step both share one buffer, so writes through either keep their order.
+        ``get_writable(type)`` is this applied to the run's stream; use this
+        when the writable arrived by other means, such as an untyped step
+        parameter.
+        """
+
+    @abc.abstractmethod
+    async def write(self, value: T) -> None:
         """Append *value* as one chunk."""
 
     @abc.abstractmethod
-    async def write_from(self, source: AsyncIterable[Any]) -> None:
+    async def write_from(self, source: AsyncIterable[T]) -> None:
         """Append every item *source* yields, in order."""
 
     @abc.abstractmethod
@@ -315,7 +386,7 @@ class WorkflowWritable(abc.ABC):
 
 
 @pydantic.dataclasses.dataclass(frozen=True)
-class WorkflowStreamHandle(WorkflowWritable):
+class WorkflowStreamHandle(WorkflowWritable[T]):
     """A reference to a stream, writable only once it reaches a step.
 
     A workflow body re-executes on every replay and its sandbox has no network,
@@ -328,6 +399,10 @@ class WorkflowStreamHandle(WorkflowWritable):
     Deterministic by construction: the stream name is derived from the run id
     and the namespace, so a replay produces the same handle rather than
     pointing a later attempt at a different stream.
+
+    Carries no type at runtime. Its type parameter is for the checker, and
+    for the step parameter it is passed to -- a handle is never written to,
+    so there is nothing here for a type to do.
     """
 
     # Underscored because the interface declares `run_id` and `name` as
@@ -337,11 +412,6 @@ class WorkflowStreamHandle(WorkflowWritable):
     _run_id: str
     _name: str
 
-    @pydantic.model_serializer(mode="plain")
-    def _identity(self) -> Any:
-        """Leave the handle for the lower layer's ``WritableStream`` reducer."""
-        return self
-
     @property
     def run_id(self) -> str:
         return self._run_id
@@ -350,6 +420,15 @@ class WorkflowStreamHandle(WorkflowWritable):
     def name(self) -> str:
         return self._name
 
+    @overload
+    def with_type(self, type: type[S]) -> WorkflowStreamHandle[S]: ...
+
+    @overload
+    def with_type(self, type: Any) -> WorkflowStreamHandle[Any]: ...
+
+    def with_type(self, type: Any) -> WorkflowStreamHandle[Any]:
+        return self
+
     def _refuse(self) -> RuntimeError:
         return RuntimeError(
             f"cannot write to stream {self._name!r} from here: a workflow body re-runs "
@@ -357,10 +436,10 @@ class WorkflowStreamHandle(WorkflowWritable):
             f"nothing to carry the sends. Pass this to a step and write to it there."
         )
 
-    async def write(self, value: Any) -> None:
+    async def write(self, value: T) -> None:
         raise self._refuse()
 
-    async def write_from(self, source: AsyncIterable[Any]) -> None:
+    async def write_from(self, source: AsyncIterable[T]) -> None:
         raise self._refuse()
 
     async def drain(self) -> None:
@@ -370,7 +449,7 @@ class WorkflowStreamHandle(WorkflowWritable):
         raise self._refuse()
 
 
-class WorkflowStreamWriter(WorkflowWritable):
+class WorkflowStreamWriter(WorkflowWritable[T]):
     """A stream that workflow steps can write to.
 
     Sending happens in a task of *task_group*, not in ``write()``, which is
@@ -378,8 +457,12 @@ class WorkflowStreamWriter(WorkflowWritable):
     The group therefore has to outlive every write and the final
     :meth:`drain` -- the step handler owns one for exactly that span.
 
-    The buffer and the dispatch live in a :class:`_StreamSink`, which deals in
-    encoded frames; this class is the part that knows what a frame means.
+    The buffer and the dispatch live in a :class:`_StreamSink`, and every
+    writer over one stream in one step shares it, whatever type each was asked
+    for. Two buffers over the same stream would flush independently and
+    interleave by whichever request wins, so the sink is what keeps
+    ``get_writable()`` and ``get_writable(type=Token)`` in one step writing in call
+    order.
 
     Not safe to use from more than one event loop; within one loop, concurrent
     writers are fine and their chunks land in call order.
@@ -392,9 +475,11 @@ class WorkflowStreamWriter(WorkflowWritable):
         run_id: str,
         name: str,
         task_group: TaskGroup,
+        type: Any = None,
         reentrant_ctx_on_err: bool = True,
     ) -> None:
         self._sink = _StreamSink(world=world, run_id=run_id, name=name, task_group=task_group)
+        self._codec = None if type is None else signature_codec.TypeCodec(type)
         self._reentrant_ctx_on_err = reentrant_ctx_on_err
 
     @property
@@ -407,16 +492,36 @@ class WorkflowStreamWriter(WorkflowWritable):
         """The run that owns the stream."""
         return self._sink.run_id
 
-    async def write(self, value: Any) -> None:
+    @property
+    def type(self) -> Any:
+        """The type this writer dumps values as, or ``None`` when untyped."""
+        return None if self._codec is None else self._codec.annotation
+
+    # `builtins.type` because the `type` property above shadows it here.
+    @overload
+    def with_type(self, type: builtins.type[S]) -> WorkflowStreamWriter[S]: ...
+
+    @overload
+    def with_type(self, type: Any) -> WorkflowStreamWriter[Any]: ...
+
+    def with_type(self, type: Any) -> WorkflowStreamWriter[Any]:
+        # A shallow copy shares the sink, which is the point.
+        writer = copy.copy(self)
+        writer._codec = signature_codec.TypeCodec(type)
+        return writer
+
+    async def write(self, value: T) -> None:
         """Append *value* as one chunk.
 
         Returns once the chunk is buffered and ordered, which is not yet
         durable; await :meth:`drain` or :meth:`close` for that. Blocks while
         the buffer is full, so a fast producer cannot grow it without bound.
         """
+        if self._codec is not None:
+            value = self._codec.dump(value)
         await self._sink.enqueue(encode_value(value))
 
-    async def write_from(self, source: AsyncIterable[Any]) -> None:
+    async def write_from(self, source: AsyncIterable[T]) -> None:
         """Append every item *source* yields, in order.
 
         This is simply a shortcut for a manual loop + :meth:`write` for
@@ -442,7 +547,7 @@ class WorkflowStreamWriter(WorkflowWritable):
         """
         await self._sink.close()
 
-    async def __aenter__(self) -> WorkflowStreamWriter:
+    async def __aenter__(self) -> WorkflowStreamWriter[T]:
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:

--- a/src/vercel-workflow/vercel/workflow/_internal/streams.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/streams.py
@@ -378,6 +378,9 @@ class WorkflowStreamWriter(WorkflowWritable):
     The group therefore has to outlive every write and the final
     :meth:`drain` -- the step handler owns one for exactly that span.
 
+    The buffer and the dispatch live in a :class:`_StreamSink`, which deals in
+    encoded frames; this class is the part that knows what a frame means.
+
     Not safe to use from more than one event loop; within one loop, concurrent
     writers are fine and their chunks land in call order.
     """
@@ -391,11 +394,74 @@ class WorkflowStreamWriter(WorkflowWritable):
         task_group: TaskGroup,
         reentrant_ctx_on_err: bool = True,
     ) -> None:
+        self._sink = _StreamSink(world=world, run_id=run_id, name=name, task_group=task_group)
+        self._reentrant_ctx_on_err = reentrant_ctx_on_err
+
+    @property
+    def name(self) -> str:
+        """The stream this writer appends to."""
+        return self._sink.name
+
+    @property
+    def run_id(self) -> str:
+        """The run that owns the stream."""
+        return self._sink.run_id
+
+    async def write(self, value: Any) -> None:
+        """Append *value* as one chunk.
+
+        Returns once the chunk is buffered and ordered, which is not yet
+        durable; await :meth:`drain` or :meth:`close` for that. Blocks while
+        the buffer is full, so a fast producer cannot grow it without bound.
+        """
+        await self._sink.enqueue(encode_value(value))
+
+    async def write_from(self, source: AsyncIterable[Any]) -> None:
+        """Append every item *source* yields, in order.
+
+        This is simply a shortcut for a manual loop + :meth:`write` for
+        forwarding an upstream async iterator (e.g. LLM tokens, HTTP body).
+        """
+        async for value in source:
+            await self.write(value)
+
+    async def drain(self) -> None:
+        """Wait until every accepted chunk is durably written.
+
+        Raises the sink's error if any request failed -- including one whose
+        ``write()`` had already returned.
+        """
+        await self._sink.drain()
+
+    async def close(self) -> None:
+        """Drain, then mark the stream complete so readers see the end.
+
+        Idempotent. Nothing closes a run's stream implicitly -- not the end of
+        a step, not the end of the run -- so a stream a workflow never closes
+        leaves its readers waiting until the run expires.
+        """
+        await self._sink.close()
+
+    async def __aenter__(self) -> WorkflowStreamWriter:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if exc_type is None or not self._reentrant_ctx_on_err:
+            await self.close()
+
+
+class _StreamSink:
+    """The buffer and dispatch behind every writer over one stream.
+
+    Deals in encoded frames only; what a frame means is the writer's business.
+    """
+
+    def __init__(self, *, world: w.World, run_id: str, name: str, task_group: TaskGroup) -> None:
         if not name:
             raise ValueError(f'"name" is required, got {name!r}')
         self._world = world
-        self._run_id = run_id
-        self._name = name
+        self.run_id = run_id
+        self.name = name
         self._task_group = task_group
 
         self._buffer: list[bytes] = []
@@ -432,37 +498,7 @@ class WorkflowStreamWriter(WorkflowWritable):
             "WORKFLOW_STREAM_MAX_BYTES_PER_BATCH", MAX_BYTES_PER_BATCH
         )
 
-        self._reentrant_ctx_on_err = reentrant_ctx_on_err
-
-    @property
-    def name(self) -> str:
-        """The stream this writer appends to."""
-        return self._name
-
-    @property
-    def run_id(self) -> str:
-        """The run that owns the stream."""
-        return self._run_id
-
-    async def write(self, value: Any) -> None:
-        """Append *value* as one chunk.
-
-        Returns once the chunk is buffered and ordered, which is not yet
-        durable; await :meth:`drain` or :meth:`close` for that. Blocks while
-        the buffer is full, so a fast producer cannot grow it without bound.
-        """
-        await self._enqueue(encode_value(value))
-
-    async def write_from(self, source: AsyncIterable[Any]) -> None:
-        """Append every item *source* yields, in order.
-
-        This is simply a shortcut for a manual loop + :meth:`write` for
-        forwarding an upstream async iterator (e.g. LLM tokens, HTTP body).
-        """
-        async for value in source:
-            await self.write(value)
-
-    async def _enqueue(self, frame: bytes) -> None:
+    async def enqueue(self, frame: bytes) -> None:
         async with self._condition:
             self._raise_if_unusable()
             while self._at_capacity():
@@ -476,7 +512,7 @@ class WorkflowStreamWriter(WorkflowWritable):
         if self._sink_error is not None:
             raise self._sink_error
         if self._closed:
-            raise ser.SerializationError(f"Stream {self._name!r} is closed")
+            raise ser.SerializationError(f"Stream {self.name!r} is closed")
 
     def _at_capacity(self) -> bool:
         chunks = len(self._buffer) + self._inflight_chunks
@@ -587,16 +623,11 @@ class WorkflowStreamWriter(WorkflowWritable):
 
     async def _send(self, group: Sequence[bytes]) -> None:
         if len(group) == 1:
-            await self._world.streams_write(self._run_id, self._name, group[0])
+            await self._world.streams_write(self.run_id, self.name, group[0])
         else:
-            await self._world.streams_write_multi(self._run_id, self._name, group)
+            await self._world.streams_write_multi(self.run_id, self.name, group)
 
     async def drain(self) -> None:
-        """Wait until every accepted chunk is durably written.
-
-        Raises the sink's error if any request failed -- including one whose
-        ``write()`` had already returned.
-        """
         async with self._condition:
             while True:
                 if self._sink_error is not None:
@@ -607,21 +638,8 @@ class WorkflowStreamWriter(WorkflowWritable):
                 await self._condition.wait()
 
     async def close(self) -> None:
-        """Drain, then mark the stream complete so readers see the end.
-
-        Idempotent. Nothing closes a run's stream implicitly -- not the end of
-        a step, not the end of the run -- so a stream a workflow never closes
-        leaves its readers waiting until the run expires.
-        """
         if self._closed and self._sink_error is None:
             return
         await self.drain()
-        await self._world.streams_close(self._run_id, self._name)
+        await self._world.streams_close(self.run_id, self.name)
         self._closed = True
-
-    async def __aenter__(self) -> WorkflowStreamWriter:
-        return self
-
-    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-        if exc_type is None or not self._reentrant_ctx_on_err:
-            await self.close()

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -732,7 +732,7 @@ name = "ggt"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/e5/b125686afaed90b803c91a4394d6fb3520df53734bcd1cea3410645c1265/ggt-1.6.0.tar.gz", hash = "sha256:c2bee3eeeb847da985bdf4a41a0c90220d76c69126c88ba0bcf6d5b6e9d57505", size = 206975, upload-time = "2026-08-31T21:54:03.482Z" }
 wheels = [
@@ -2839,7 +2839,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "vercel-headers" },
     { name = "vercel-internal-core" },
     { name = "vercel-oidc" },
@@ -2855,7 +2855,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1" },
     { name = "pydantic", specifier = ">=2.12.0,<3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.4.0,<5" },
     { name = "vercel-headers", editable = "src/vercel-headers" },
     { name = "vercel-internal-core", editable = "src/vercel-internal-core" },
     { name = "vercel-oidc", editable = "src/vercel-oidc" },


### PR DESCRIPTION
Add a type= argument to all the functions for getting streams.
This wraps a pydantic validator around the read or write.

WorkflowWritable also gets typed treatment when passed to a step.

The first three commits are pure refactors that support this.
I could split them off also.