### PR TITLE
workflow: make zstandard passthrough (and restricted) to make httpx work

### DIFF
--- a/changes/vercel-workflow/zstandard-sandbox-passthrough.bugfix.md
+++ b/changes/vercel-workflow/zstandard-sandbox-passthrough.bugfix.md
@@ -1,0 +1,1 @@
+Make `zstandard` a sandbox passthrough while blocking `zstandard.open` to allow importing packages like `httpx`.

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -2,7 +2,7 @@
 
 Covers:
 - _RESTRICTIONS: builtins, datetime, platform, os, time, socket, random, threading,
-  asyncio
+  asyncio, zstandard
 - _BLOCKED: subprocess, ssl, ctypes, multiprocessing, signal, etc.
 - _PASSTHROUGHS: stdlib modules that pass through unchanged
 - Loop proxy: allowlisted methods pass, everything else restricted
@@ -453,6 +453,68 @@ class TestThreadingRestrictions:
 
     def test_current_thread_allowed(self):
         _run_in_sandbox("import threading; threading.current_thread()")
+
+
+# ═══════════════════════════════════════════════════════════════
+#  zstandard restrictions
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestZstandardRestrictions:
+    @pytest.fixture(autouse=True)
+    def _require_zstandard(self):
+        pytest.importorskip("zstandard")
+
+    def test_zstandard_imports(self):
+        """zstandard should be importable inside the sandbox."""
+        _run_in_sandbox("import zstandard")
+
+    def test_zstandard_open_blocked(self):
+        """zstandard.open should be blocked inside the sandbox."""
+        _raises_in_sandbox("import zstandard; zstandard.open('file.zst')")
+
+    def test_from_zstandard_open_blocked(self):
+        """from zstandard import open should also be blocked inside the sandbox."""
+        _raises_in_sandbox("from zstandard import open; open('file.zst')")
+
+    def test_zstandard_compress_allowed(self):
+        """zstandard compression and decompression should work inside the sandbox."""
+        ns = _run_in_sandbox(
+            "import zstandard; "
+            "data = zstandard.compress(b'deterministic payload'); "
+            "result = zstandard.decompress(data)"
+        )
+        assert ns["result"] == b"deterministic payload"
+
+    def test_zstandard_classes_allowed(self):
+        """ZstdCompressor and ZstdDecompressor should work inside the sandbox."""
+        ns = _run_in_sandbox(
+            "import zstandard; "
+            "cctx = zstandard.ZstdCompressor(); "
+            "dctx = zstandard.ZstdDecompressor(); "
+            "result = dctx.decompress(cctx.compress(b'streaming payload'))"
+        )
+        assert ns["result"] == b"streaming payload"
+
+    def test_host_zstandard_open_unaffected(self):
+        """zstandard.open on the host should remain unblocked."""
+        import zstandard
+
+        assert callable(zstandard.open)
+        _raises_in_sandbox("import zstandard; zstandard.open('file.zst')")
+        assert callable(zstandard.open)
+
+    def test_httpx_import_succeeds_with_zstandard(self, monkeypatch: pytest.MonkeyPatch):
+        """httpx importing zstandard inside the sandbox should succeed."""
+
+        class _HideDevDeps:
+            def find_spec(self, fullname, path, target=None):
+                if fullname.split(".")[0] in ("rich", "pygments", "click"):
+                    raise ModuleNotFoundError(f"No module named {fullname}")
+
+        monkeypatch.setattr(sys, "meta_path", [_HideDevDeps(), *sys.meta_path])
+        ns = _run_in_sandbox("import httpx; result = httpx.__name__")
+        assert ns["result"] == "httpx"
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -368,6 +368,7 @@ _RESTRICTIONS: dict[str, _ModulePolicy] = {
         "setprofile",
         "setprofile_all_threads",
     ),
+    "zstandard": _blocklist("zstandard", "open"),
 }
 
 _BLOCKED: set[str] = {
@@ -460,6 +461,12 @@ _PASSTHROUGHS: set[str] = {
     "sniffio",
     "typing_extensions",
     "annotated_types",
+    # Supporting zstandard here is a little ad-hoc, but it is a
+    # dependency of vercel-workflow itself, and httpx has an optional
+    # dependency on it and will try to import it. So importing httpx
+    # would fail unless we allow zstandard. (Actually *using* httpx
+    # will still actually fail, of course.)
+    "zstandard",
 }
 
 
@@ -622,15 +629,17 @@ class _SandboxFinder(MetaPathFinder):
             )
         if fullname in self._restrictions:
             policy = self._restrictions[fullname]
-            # If the module is also in the passthrough set and already
-            # loaded in the host, wrap the existing module with a proxy
-            # instead of re-importing (avoids issues with packages that
-            # have complex init like asyncio).
-            if fullname in self._host and self._is_passthrough(fullname):
-                proxy = _ProxyModule(self._host[fullname], policy)
+            # If the module is also in the passthrough set, wrap the host module
+            # with a proxy instead of re-importing (avoids issues with packages that
+            # have complex init like asyncio or platform checks).
+            if self._is_passthrough(fullname):
+                host_mod = self._host.get(fullname)
+                if host_mod is None:
+                    host_mod = _host_import(fullname)
+                proxy = _ProxyModule(host_mod, policy)
                 policy.post_exec(
                     proxy=proxy,
-                    module=self._host[fullname],
+                    module=host_mod,
                 )
                 return spec_from_loader(fullname, _PreloadedLoader(proxy), origin="sandbox")
             real_spec = self._find_real_spec(fullname, path, target)


### PR DESCRIPTION
zstandard is now a dep of vercel-workflow, which made importing httpx (and thus vercel's `ai`) fail in workflows. (*Using* httpx of course *should* fail, but importing it should be OK!)

zstandard does some harmless platform checking stuff. Add it to passthrough but blocklist its `open` method.