### PR TITLE
workflow: rework py-sandboxing of asyncio

### DIFF
--- a/changes/vercel-workflow/asyncio-loop-restrictions.bugfix.md
+++ b/changes/vercel-workflow/asyncio-loop-restrictions.bugfix.md
@@ -1,0 +1,1 @@
+Add a bunch of incorrectly missing `asyncio` methods to the sandbox blacklist.

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -561,15 +561,29 @@ class TestAsyncioRestrictions:
 
     def test_asyncio_events_loop_escape_blocked(self):
         """asyncio.events cannot be used to escape or overwrite the event loop."""
+        _raises_in_sandbox("import asyncio; asyncio.events.new_event_loop()")
+        _raises_in_sandbox("import asyncio; asyncio.events.set_event_loop(None)")
         _raises_in_sandbox("import asyncio.events; asyncio.events.new_event_loop()")
         _raises_in_sandbox("import asyncio.events; asyncio.events.set_event_loop(None)")
         ns = _run_in_sandbox(
-            "import asyncio.events; "
+            "import asyncio; "
             "loop_cls = asyncio.events.AbstractEventLoop; "
             "getter = asyncio.events.get_running_loop"
         )
         assert ns["loop_cls"] is not None
         assert callable(ns["getter"])
+
+    @pytest.mark.parametrize(
+        ("module", "call"),
+        [
+            ("runners", "run(None)"),
+            ("subprocess", "create_subprocess_exec('echo')"),
+            ("threads", "to_thread(lambda: None)"),
+        ],
+    )
+    def test_asyncio_blocked_submodule_reexports(self, module, call):
+        """Blocked asyncio submodules cannot be reached through the package."""
+        _raises_in_sandbox(f"import asyncio; asyncio.{module}.{call}")
 
     def test_host_asyncio_unaffected(self):
         """Host asyncio functions should remain unblocked."""

--- a/src/vercel-workflow/tests/unit/test_py_sandbox.py
+++ b/src/vercel-workflow/tests/unit/test_py_sandbox.py
@@ -4,8 +4,8 @@ Covers:
 - _RESTRICTIONS: builtins, datetime, platform, os, time, socket, random, threading,
   asyncio, zstandard, io, _io
 - _BLOCKED: subprocess, ssl, ctypes, multiprocessing, signal, etc.
-- _PASSTHROUGHS: stdlib modules that pass through unchanged
-- Loop proxy: allowlisted methods pass, everything else restricted
+- _PASSTHROUGHS: stdlib modules that pass through unchanged (including asyncio)
+- WorkflowLoop: allowlisted methods pass, restricted I/O/subprocess methods blocked
 - random: module-level functions blocked; explicit Random(seed) allowed
 - Module isolation: non-passthrough modules are freshly imported
 """
@@ -546,7 +546,7 @@ class TestIoRestrictions:
 
 
 # ═══════════════════════════════════════════════════════════════
-#  asyncio restrictions + loop proxy
+#  asyncio in sandbox
 # ═══════════════════════════════════════════════════════════════
 
 
@@ -555,76 +555,34 @@ class TestAsyncioRestrictions:
         """asyncio should be importable inside the sandbox."""
         _run_in_sandbox("import asyncio")
 
-    @pytest.mark.asyncio
-    async def test_loop_create_connection_blocked(self):
-        with workflow_sandbox():
-            import asyncio
+    def test_asyncio_run_blocked(self):
+        """asyncio.run cannot be used to escape the workflow loop."""
+        _raises_in_sandbox("import asyncio; asyncio.run(None)")
 
-            loop = asyncio.get_running_loop()
-            with pytest.raises(SandboxRestrictionError, match="loop.create_connection"):
-                loop.create_connection(None, "localhost", 80)  # type: ignore[call-overload]
+    def test_asyncio_events_loop_escape_blocked(self):
+        """asyncio.events cannot be used to escape or overwrite the event loop."""
+        _raises_in_sandbox("import asyncio.events; asyncio.events.new_event_loop()")
+        _raises_in_sandbox("import asyncio.events; asyncio.events.set_event_loop(None)")
+        ns = _run_in_sandbox(
+            "import asyncio.events; "
+            "loop_cls = asyncio.events.AbstractEventLoop; "
+            "getter = asyncio.events.get_running_loop"
+        )
+        assert ns["loop_cls"] is not None
+        assert callable(ns["getter"])
 
-    @pytest.mark.asyncio
-    async def test_loop_subprocess_exec_blocked(self):
-        with workflow_sandbox():
-            import asyncio
+    def test_host_asyncio_unaffected(self):
+        """Host asyncio functions should remain unblocked."""
+        import asyncio
 
-            loop = asyncio.get_running_loop()
-            with pytest.raises(SandboxRestrictionError, match="loop.subprocess_exec"):
-                loop.subprocess_exec(None, "echo")  # type: ignore[arg-type,unused-coroutine]
-
-    @pytest.mark.asyncio
-    async def test_loop_subprocess_shell_blocked(self):
-        with workflow_sandbox():
-            import asyncio
-
-            loop = asyncio.get_running_loop()
-            with pytest.raises(SandboxRestrictionError, match="loop.subprocess_shell"):
-                loop.subprocess_shell(None, "echo")  # type: ignore[arg-type,unused-coroutine]
-
-    @pytest.mark.asyncio
-    async def test_loop_call_soon_allowed(self):
-        with workflow_sandbox():
-            import asyncio
-
-            loop = asyncio.get_running_loop()
-            called: list[int] = []
-            loop.call_soon(called.append, 1)
-            await asyncio.sleep(0)  # yield to let call_soon fire
-            # call_soon should not raise — we can't easily assert it fired
-            # because asyncio.sleep is going through the real loop, but
-            # the important thing is call_soon didn't raise.
-
-    @pytest.mark.asyncio
-    async def test_loop_create_future_allowed(self):
-        with workflow_sandbox():
-            import asyncio
-
-            loop = asyncio.get_running_loop()
-            fut = loop.create_future()
-            assert not fut.done()
-
-    @pytest.mark.asyncio
-    async def test_loop_create_task_allowed(self):
-        with workflow_sandbox():
-            import asyncio
-
-            async def noop():
-                pass
-
-            loop = asyncio.get_running_loop()
-            task = loop.create_task(noop())
-            await task
+        assert callable(asyncio.run)
+        _raises_in_sandbox("import asyncio; asyncio.run(None)")
+        assert callable(asyncio.run)
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="TaskGroup requires Python 3.11+")
     async def test_taskgroup_works_in_sandbox(self):
-        """asyncio.TaskGroup must work inside the sandbox.
-
-        Regression: TaskGroup.__aenter__ calls current_task() which
-        returned None inside the sandbox, causing RuntimeError:
-        'TaskGroup cannot determine the parent task'.
-        """
+        """asyncio.TaskGroup must work inside the sandbox."""
         with workflow_sandbox():
             import asyncio
 
@@ -642,14 +600,7 @@ class TestAsyncioRestrictions:
     @pytest.mark.asyncio
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="TaskGroup requires Python 3.11+")
     async def test_taskgroup_cancels_siblings_on_error(self):
-        """TaskGroup must correctly cancel siblings when one task fails.
-
-        Regression: when asyncio was a plain passthrough (no restriction
-        proxy), CancelledError inside the sandbox was a different class
-        than the one used by the C _asyncio extension, so TaskGroup's
-        _on_task_done failed with:
-            AttributeError: 'NoneType' object has no attribute 'append'
-        """
+        """TaskGroup must correctly cancel siblings when one task fails."""
         with workflow_sandbox():
             import asyncio
 
@@ -676,112 +627,75 @@ class TestAsyncioRestrictions:
 
 
 # ═══════════════════════════════════════════════════════════════
-#  asyncio loop proxy with uvloop
+#  WorkflowLoop restrictions
 # ═══════════════════════════════════════════════════════════════
 
 
-class TestUvloopProxy:
-    """Loop proxy must work with uvloop (C-based event loop)."""
+class TestWorkflowLoopRestrictions:
+    """WorkflowLoop blocks I/O, subprocess, and non-deterministic methods."""
 
-    @pytest.fixture(autouse=True)
-    def _use_uvloop(self):
-        """Run every test in this class on uvloop."""
-        uvloop = pytest.importorskip("uvloop")
-        loop = uvloop.new_event_loop()
-        yield loop
+    @staticmethod
+    def _make_loop():
+        from vercel.workflow._internal.loop import WorkflowLoop
+
+        class DummyWorkflow:
+            def resume(self):
+                pass
+
+            def time(self):
+                return 0.0
+
+            def check_suspended(self):
+                pass
+
+            def run_wait(self, spec):
+                pass
+
+        return WorkflowLoop(workflow=DummyWorkflow())
+
+    def test_loop_create_connection_blocked(self):
+        loop = self._make_loop()
+        with pytest.raises(SandboxRestrictionError, match="loop.create_connection"):
+            loop.create_connection(None, "localhost", 80)
+
+    def test_loop_subprocess_exec_blocked(self):
+        loop = self._make_loop()
+        with pytest.raises(SandboxRestrictionError, match="loop.subprocess_exec"):
+            loop.subprocess_exec(None, "echo")
+
+    def test_loop_subprocess_shell_blocked(self):
+        loop = self._make_loop()
+        with pytest.raises(SandboxRestrictionError, match="loop.subprocess_shell"):
+            loop.subprocess_shell(None, "echo")
+
+    def test_loop_call_soon_allowed(self):
+        loop = self._make_loop()
+        called: list[int] = []
+        loop.call_soon(called.append, 1)
+        assert len(loop._ready) == 1
+
+    def test_loop_create_future_allowed(self):
+        loop = self._make_loop()
+        fut = loop.create_future()
+        assert not fut.done()
+
+    def test_loop_create_task_allowed(self):
+        import asyncio
+
+        loop = self._make_loop()
+
+        async def run():
+            task = loop.create_task(asyncio.sleep(0))
+            await task
+            assert task.done()
+
+        loop.run_until_complete(run())
         loop.close()
 
-    def _run_async(self, coro, loop):
-        return loop.run_until_complete(coro)
-
-    def test_uvloop_create_connection_blocked(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                with pytest.raises(SandboxRestrictionError, match="loop.create_connection"):
-                    proxy_loop.create_connection(  # type: ignore[call-overload]
-                        None, "localhost", 80
-                    )
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_subprocess_exec_blocked(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                with pytest.raises(SandboxRestrictionError, match="loop.subprocess_exec"):
-                    proxy_loop.subprocess_exec(  # type: ignore[arg-type,unused-coroutine]
-                        None,  # type: ignore[arg-type]
-                        "echo",
-                    )
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_call_soon_allowed(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                called: list[int] = []
-                proxy_loop.call_soon(called.append, 1)
-                await asyncio.sleep(0)
-                # call_soon should not raise
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_create_task_allowed(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                async def noop():
-                    pass
-
-                proxy_loop = asyncio.get_running_loop()
-                task = proxy_loop.create_task(noop())
-                await task
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_create_future_allowed(self, _use_uvloop):
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                fut = proxy_loop.create_future()
-                assert not fut.done()
-
-        self._run_async(go(), loop)
-
-    def test_uvloop_proxy_wraps_real_loop(self, _use_uvloop):
-        """Proxy loop should delegate allowed attrs to the real uvloop."""
-        loop = _use_uvloop
-
-        async def go():
-            with workflow_sandbox():
-                import asyncio
-
-                proxy_loop = asyncio.get_running_loop()
-                assert proxy_loop.is_running()
-                assert not proxy_loop.is_closed()
-
-        self._run_async(go(), loop)
+    def test_loop_nonexistent_attribute_raises_attribute_error(self):
+        loop = self._make_loop()
+        assert not hasattr(loop, "nonexistent_method")
+        assert getattr(loop, "nonexistent_method", None) is None
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/src/vercel-workflow/vercel/workflow/_internal/loop.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/loop.py
@@ -3,7 +3,7 @@ import contextvars
 import datetime
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 from vercel._internal.core.polyfills import UTC
 
@@ -116,3 +116,56 @@ class WorkflowLoop(asyncio.BaseEventLoop):
 
     def time(self) -> float:
         return self.workflow.time()
+
+
+_LOOP_ALLOWED: frozenset[str] = frozenset(
+    {
+        # Core event loop lifecycle
+        "run_forever",
+        "run_until_complete",
+        "stop",
+        "close",
+        "is_running",
+        "is_closed",
+        "shutdown_asyncgens",
+        "shutdown_default_executor",
+        # Deterministic scheduling
+        "call_soon",
+        # Sleep based scheduling (does a workflow sleep)
+        "call_at",
+        "call_later",
+        # Time (uses deterministic time)
+        "time",
+        # Task / future creation
+        "create_future",
+        "create_task",
+        "set_task_factory",
+        "get_task_factory",
+        # Exception handling
+        "get_exception_handler",
+        "set_exception_handler",
+        "default_exception_handler",
+        "call_exception_handler",
+        # Debug
+        "get_debug",
+        "set_debug",
+    }
+)
+
+
+def _make_restricted_method(name: str) -> Callable[..., NoReturn]:
+    def _restricted(*_args: Any, **_kwargs: Any) -> NoReturn:
+        from .py_sandbox import SandboxRestrictionError
+
+        raise SandboxRestrictionError(
+            f"Cannot call loop.{name}() inside a workflow. Workflows must be deterministic."
+        )
+
+    _restricted.__name__ = name
+    _restricted.__qualname__ = f"WorkflowLoop.{name}"
+    return _restricted
+
+
+for _name in dir(asyncio.AbstractEventLoop):
+    if not _name.startswith("_") and _name not in _LOOP_ALLOWED:
+        setattr(WorkflowLoop, _name, _make_restricted_method(_name))

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -13,7 +13,6 @@ import sys
 import threading
 import types
 import typing
-import weakref
 from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from importlib.abc import Loader, MetaPathFinder
@@ -181,114 +180,6 @@ class _RestrictedRandom(random.Random, metaclass=_RestrictedRandomMeta):
         super().seed(a, version=version)
 
 
-def _wrap_get_loop(real_fn: Callable[..., Any]) -> Callable[..., Any]:
-    cache: weakref.WeakKeyDictionary[Any, Any] = weakref.WeakKeyDictionary()
-
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        real_loop = real_fn(*args, **kwargs)
-        if real_loop in cache:
-            return cache[real_loop]
-
-        real_loop_cls = type(real_loop)
-
-        class _LoopProxyMeta(type):
-            def __instancecheck__(cls, instance: Any) -> bool:
-                return isinstance(instance, real_loop_cls)
-
-            def __subclasscheck__(cls, subclass: type) -> bool:
-                return issubclass(subclass, real_loop_cls)
-
-        _LOOP_ALLOWED: frozenset[str] = frozenset(
-            {
-                # Core event loop lifecycle
-                "run_forever",
-                "run_until_complete",
-                "stop",
-                "close",
-                "is_running",
-                "is_closed",
-                "shutdown_asyncgens",
-                "shutdown_default_executor",
-                # Deterministic scheduling
-                "call_soon",
-                # Sleep based scheduling (does a workflow sleep)
-                "call_at",
-                "call_later",
-                # Time (uses deterministic time)
-                "time",
-                # Task / future creation
-                "create_future",
-                "create_task",
-                "set_task_factory",
-                "get_task_factory",
-                # Exception handling
-                "get_exception_handler",
-                "set_exception_handler",
-                "default_exception_handler",
-                "call_exception_handler",
-                # Debug
-                "get_debug",
-                "set_debug",
-                # Timer handle cancellation (internal)
-                "_timer_handle_cancelled",
-            }
-        )
-
-        class _LoopProxy(metaclass=_LoopProxyMeta):
-            """Wraps an event loop; only allowlisted methods pass through."""
-
-            def __init__(self, real: Any) -> None:
-                self._real = real
-
-            def __getattr__(self, name: str) -> Any:
-                if name.startswith("__") and name.endswith("__"):
-                    return getattr(self._real, name)
-                if name in _LOOP_ALLOWED:
-                    return getattr(self._real, name)
-                return _restricted(f"loop.{name}")
-
-            def __hash__(self) -> int:
-                return hash(self._real)
-
-            def __eq__(self, other: object) -> bool:
-                real = self._real
-                if hasattr(other, "_real"):
-                    return real is other._real
-                return real is other
-
-            def __repr__(self) -> str:
-                return f"<proxy for {self._real!r}>"
-
-        rv = _LoopProxy(real_loop)
-        cache[real_loop] = rv
-        return rv
-
-    return wrapper
-
-
-class _RestrictedAsyncioPolicy(_ModulePolicy):
-    """Wraps get_running_loop/get_event_loop to return a _LoopProxy."""
-
-    def post_exec(self, *, proxy: _ProxyModule, module: types.ModuleType, **kwargs: Any) -> None:
-        for attr in ("get_running_loop", "get_event_loop"):
-            real_fn = getattr(module, attr, None)
-            if real_fn is not None:
-                proxy.__dict__[attr] = _wrap_get_loop(real_fn)
-
-        # Wrap current_task so that passing a _LoopProxy works.
-        # The C implementation uses internal identity-based lookup that
-        # does not honour __hash__/__eq__, so we unwrap the proxy first.
-        real_current_task = getattr(module, "current_task", None)
-        if real_current_task is not None:
-
-            def _current_task(loop: Any = None) -> Any:
-                if loop is not None and hasattr(loop, "_real"):
-                    loop = loop._real
-                return real_current_task(loop)
-
-            proxy.__dict__["current_task"] = _current_task
-
-
 def _host_system() -> str:
     return _host_import("platform").system()
 
@@ -355,8 +246,6 @@ _RESTRICTIONS: dict[str, _ModulePolicy] = {
         # all-caps constants (AF_*, SOCK_*, SOL_*, SO_*, IPPROTO_*, etc.)
         allow_if=str.isupper,
     ),
-    "asyncio": _RestrictedAsyncioPolicy("asyncio"),
-    "_asyncio": _RestrictedAsyncioPolicy("asyncio.events"),
     "threading": _blocklist(
         "threading",
         # thread creation
@@ -370,6 +259,40 @@ _RESTRICTIONS: dict[str, _ModulePolicy] = {
     ),
     "io": _blocklist("io", "open", "open_code", "FileIO"),
     "_io": _blocklist("_io", "open", "open_code", "FileIO"),
+    "asyncio": _blocklist(
+        "asyncio",
+        # Event loop creation and management escapes
+        "run",
+        "Runner",
+        "new_event_loop",
+        "set_event_loop",
+        "get_event_loop_policy",
+        "set_event_loop_policy",
+        "get_child_watcher",
+        "DefaultEventLoopPolicy",
+        # Threading / concurrency escapes
+        "to_thread",
+        "run_coroutine_threadsafe",
+        # Subprocesses
+        "create_subprocess_exec",
+        "create_subprocess_shell",
+        # Network / socket I/O
+        "open_connection",
+        "open_unix_connection",
+        "start_server",
+        "start_unix_server",
+        # Bridging external threaded futures
+        "wrap_future",
+    ),
+    "asyncio.events": _blocklist(
+        "asyncio.events",
+        "new_event_loop",
+        "set_event_loop",
+        "get_event_loop_policy",
+        "set_event_loop_policy",
+        "get_child_watcher",
+        "BaseDefaultEventLoopPolicy",
+    ),
     "zstandard": _blocklist("zstandard", "open"),
 }
 
@@ -389,6 +312,10 @@ _BLOCKED: set[str] = {
     "faulthandler",  # write to arbitrary fds
     "syslog",  # write to system log
     "readline",  # terminal input
+    # Asyncio submodules for subprocesses, threads, and runners
+    "asyncio.subprocess",
+    "asyncio.runners",
+    "asyncio.threads",
 }
 
 _PASSTHROUGHS: set[str] = {

--- a/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/py_sandbox.py
@@ -129,6 +129,18 @@ def _allowlist(
     )
 
 
+class _AsyncioPolicy(_ModulePolicy):
+    """Apply submodule policies to modules re-exported by ``asyncio``."""
+
+    def resolve_attr(self, name: str, real: types.ModuleType) -> Any:
+        value = super().resolve_attr(name, real)
+        if name == "events":
+            return _ProxyModule(value, _ASYNCIO_EVENTS_POLICY)
+        if name in {"runners", "subprocess", "threads"}:
+            return _StubModule(f"asyncio.{name}", value)
+        return value
+
+
 class _RestrictedDatetimeMeta(type):
     def __instancecheck__(cls, instance: Any) -> bool:
         return isinstance(instance, _dt.datetime)
@@ -182,6 +194,17 @@ class _RestrictedRandom(random.Random, metaclass=_RestrictedRandomMeta):
 
 def _host_system() -> str:
     return _host_import("platform").system()
+
+
+_ASYNCIO_EVENTS_POLICY = _blocklist(
+    "asyncio.events",
+    "new_event_loop",
+    "set_event_loop",
+    "get_event_loop_policy",
+    "set_event_loop_policy",
+    "get_child_watcher",
+    "BaseDefaultEventLoopPolicy",
+)
 
 
 _RESTRICTIONS: dict[str, _ModulePolicy] = {
@@ -259,40 +282,35 @@ _RESTRICTIONS: dict[str, _ModulePolicy] = {
     ),
     "io": _blocklist("io", "open", "open_code", "FileIO"),
     "_io": _blocklist("_io", "open", "open_code", "FileIO"),
-    "asyncio": _blocklist(
+    "asyncio": _AsyncioPolicy(
         "asyncio",
-        # Event loop creation and management escapes
-        "run",
-        "Runner",
-        "new_event_loop",
-        "set_event_loop",
-        "get_event_loop_policy",
-        "set_event_loop_policy",
-        "get_child_watcher",
-        "DefaultEventLoopPolicy",
-        # Threading / concurrency escapes
-        "to_thread",
-        "run_coroutine_threadsafe",
-        # Subprocesses
-        "create_subprocess_exec",
-        "create_subprocess_shell",
-        # Network / socket I/O
-        "open_connection",
-        "open_unix_connection",
-        "start_server",
-        "start_unix_server",
-        # Bridging external threaded futures
-        "wrap_future",
+        overrides=_blocklist(
+            "asyncio",
+            # Event loop creation and management escapes
+            "run",
+            "Runner",
+            "new_event_loop",
+            "set_event_loop",
+            "get_event_loop_policy",
+            "set_event_loop_policy",
+            "get_child_watcher",
+            "DefaultEventLoopPolicy",
+            # Threading / concurrency escapes
+            "to_thread",
+            "run_coroutine_threadsafe",
+            # Subprocesses
+            "create_subprocess_exec",
+            "create_subprocess_shell",
+            # Network / socket I/O
+            "open_connection",
+            "open_unix_connection",
+            "start_server",
+            "start_unix_server",
+            # Bridging external threaded futures
+            "wrap_future",
+        ).overrides,
     ),
-    "asyncio.events": _blocklist(
-        "asyncio.events",
-        "new_event_loop",
-        "set_event_loop",
-        "get_event_loop_policy",
-        "set_event_loop_policy",
-        "get_child_watcher",
-        "BaseDefaultEventLoopPolicy",
-    ),
+    "asyncio.events": _ASYNCIO_EVENTS_POLICY,
     "zstandard": _blocklist("zstandard", "open"),
 }
 


### PR DESCRIPTION
* The asyncio module was not having restrictions applied to it, so a bunch of state modification functions were allowed.
* We don't need to *proxy* the event loop any more, because we already are running an actually inherently restricted event loop.
* But move more principled blocking into the loop.