### PR TITLE
workflow: create hooks on first suspend after `.wait()`

### DIFF
--- a/changes/vercel-workflow/hook-ooo.bugfix.md
+++ b/changes/vercel-workflow/hook-ooo.bugfix.md
@@ -1,0 +1,1 @@
+Properly handle hook resumes that arrive after calling `get_conflict()` but before waiting.

--- a/changes/vercel-workflow/hook-registration.bugfix.md
+++ b/changes/vercel-workflow/hook-registration.bugfix.md
@@ -1,0 +1,1 @@
+Fix `BaseHook.wait` to create the hook when the run next suspends rather then when it blocks on the hook. So that hooks are created before their tokens are published, make sure that steps are launched after any hooks are registered.

--- a/src/vercel-workflow/tests/unit/test_workflow_hook_registration.py
+++ b/src/vercel-workflow/tests/unit/test_workflow_hook_registration.py
@@ -1,0 +1,167 @@
+"""When a hook is registered, and what happens to a payload nobody awaits yet.
+
+A hook is registered (its ``hook_created`` written) at the run's next
+suspension, whatever the body is blocked on, not at the first ``await`` of the
+hook. That matches the JS SDK, and it means a token is claimed, and resumable
+from outside, as soon as the body has created the hook and yielded.
+
+Registering early means a payload can arrive while the body is doing something
+else. Such a ``hook_received`` must be held until the body awaits the hook, not
+dropped. The same hazard already existed via ``get_conflict()``, which left a
+registered hook with no awaiter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pydantic
+import pytest
+
+from tests.payloads import PLAIN_ENCODER
+from vercel.workflow._internal import core, runtime, serialization as ser, world as w
+from vercel.workflow._internal.worlds import local as local_mod
+
+TOKEN = "order:42"
+
+registry = core.Workflows(as_vercel_job=False)
+
+
+class Approval(core.BaseHook, pydantic.BaseModel):
+    approved: bool
+
+
+@registry.step
+async def pending_step() -> str:
+    return "done"
+
+
+@registry.workflow
+async def create_then_step_then_await() -> dict[str, object]:
+    approval = Approval.wait(token=TOKEN)
+    step_result = await pending_step()
+    return {"approved": (await approval).approved, "step_result": step_result}
+
+
+@registry.workflow
+async def confirm_then_step_then_await() -> dict[str, object]:
+    approval = Approval.wait(token=TOKEN)
+    assert await approval.get_conflict() is None
+    step_result = await pending_step()
+    return {"approved": (await approval).approved, "step_result": step_result}
+
+
+class RecordingLocalWorld(local_mod.LocalWorld):
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: object) -> str:
+        return "msg_test"
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch) -> Iterator[RecordingLocalWorld]:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = RecordingLocalWorld()
+    w.set_world(world)
+    yield world
+    w.set_world(None)
+
+
+async def _create_run(world: local_mod.LocalWorld, workflow_name: str) -> str:
+    result = await world.events_create(
+        None,
+        w.RunCreatedEventData(
+            deployment_id="",
+            workflow_name=workflow_name,
+            input=PLAIN_ENCODER.encode(ser.argument_array((), {})),
+        ).into_event(),
+    )
+    assert result.run is not None
+    return result.run.run_id
+
+
+async def _invoke(run_id: str, workflow_name: str) -> w.QueueContinuation | None:
+    return await runtime.workflow_handler(
+        w.WorkflowInvokePayload(run_id=run_id).model_dump(by_alias=True),
+        attempt=1,
+        queue_name=w.get_queue_name(workflow_name),
+        message_id="msg_1",
+        registry=registry,
+    )
+
+
+async def _correlation_id(world: local_mod.LocalWorld, run_id: str, event_type: type) -> str:
+    event = next(e for e in (await world.events_list(run_id)).data if isinstance(e, event_type))
+    assert event.correlation_id is not None
+    return event.correlation_id
+
+
+async def test_hook_is_registered_when_the_run_first_suspends(world) -> None:
+    run_id = await _create_run(world, create_then_step_then_await.workflow_id)
+
+    await _invoke(run_id, create_then_step_then_await.workflow_id)
+
+    events = (await world.events_list(run_id)).data
+    assert sorted(event.event_type for event in events) == sorted(
+        ["run_created", "run_started", "step_created", "hook_created"]
+    )
+    assert (await world.hooks_get_by_token(TOKEN)).run_id == run_id
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    [create_then_step_then_await, confirm_then_step_then_await],
+    ids=["awaited later", "confirmed with get_conflict"],
+)
+async def test_payload_received_before_the_body_awaits_is_kept(world, workflow) -> None:
+    run_id = await _create_run(world, workflow.workflow_id)
+    await _invoke(run_id, workflow.workflow_id)
+    hook_id = await _correlation_id(world, run_id, w.HookCreatedEvent)
+    step_id = await _correlation_id(world, run_id, w.StepCreatedEvent)
+
+    # The payload lands while the body is still blocked on the step.
+    await world.events_create(
+        run_id,
+        w.HookReceivedEventData(
+            payload=PLAIN_ENCODER.encode({"approved": True}), token=TOKEN
+        ).into_event(hook_id),
+    )
+    await _invoke(run_id, workflow.workflow_id)
+    assert (await world.runs_get(run_id)).status == "running"
+
+    await world.events_create(
+        run_id, w.StepCompletedEventData(result=PLAIN_ENCODER.encode("done")).into_event(step_id)
+    )
+    await _invoke(run_id, workflow.workflow_id)
+
+    assert (await world.runs_get(run_id)).status == "completed"
+    assert await runtime.Run(run_id).return_value() == {"approved": True, "step_result": "done"}
+
+
+class HookCheckingLocalWorld(RecordingLocalWorld):
+    """Records whether the run's hook already existed when each step was enqueued."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.hook_existed_at_enqueue: list[bool] = []
+
+    async def queue(self, queue_name: str, message: w.QueuePayload, **kwargs: object) -> str:
+        if isinstance(message, w.WorkflowInvokePayload) and message.step_id is not None:
+            try:
+                await self.hooks_get_by_token(TOKEN)
+            except w.HookNotFoundError:
+                self.hook_existed_at_enqueue.append(False)
+            else:
+                self.hook_existed_at_enqueue.append(True)
+        return "msg_test"
+
+
+async def test_hooks_are_created_before_steps_are_enqueued(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_LOCAL_DATA_DIR", str(tmp_path))
+    world = HookCheckingLocalWorld()
+    w.set_world(world)
+    try:
+        run_id = await _create_run(world, create_then_step_then_await.workflow_id)
+        await _invoke(run_id, create_then_step_then_await.workflow_id)
+    finally:
+        w.set_world(None)
+
+    assert world.hook_existed_at_enqueue == [True]

--- a/src/vercel-workflow/vercel/workflow/_internal/core.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/core.py
@@ -244,12 +244,7 @@ class HookEvent(Generic[T]):
         self.dispose()
 
     async def get_conflict(self) -> Run[Any] | None:
-        """Return the run already using this hook's token, if there is one.
-
-        Awaiting this method commits the hook registration without waiting for
-        payload data. A successful registration returns ``None``; a conflict
-        returns a handle for the run that owns the token.
-        """
+        """Return the run already using this hook's token, if there is one."""
         from . import runtime
 
         try:

--- a/src/vercel-workflow/vercel/workflow/_internal/runtime.py
+++ b/src/vercel-workflow/vercel/workflow/_internal/runtime.py
@@ -13,7 +13,15 @@ import random
 import sys
 import traceback
 from collections import deque
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Mapping, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Mapping,
+    Sequence,
+)
 from datetime import datetime
 from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast, overload
 from urllib.parse import parse_qsl, urlsplit
@@ -199,6 +207,11 @@ class Hook(BaseSuspension, Generic[T]):
     conflicting_run: "Run[Any] | None" = None
     hook_cls: type[T]
     metadata: bytes | None = None
+
+    @property
+    def awaited(self) -> bool:
+        """Whether the body is currently blocked on this hook."""
+        return any(not fut.done() for fut in self.futures)
 
     def fail(self, exc: Exception) -> None:
         while self.futures:
@@ -1035,6 +1048,7 @@ class WorkflowOrchestratorContext:
             metadata=None if metadata is None else self.payload_encoder.encode(metadata),
         )
         self.hooks[hook.correlation_id] = hook
+        self.suspensions[hook.correlation_id] = hook
         return core.HookEvent(correlation_id=hook.correlation_id, token=hook.token)
 
     def run_hook(self, *, correlation_id: str) -> asyncio.Future[T]:
@@ -1043,7 +1057,6 @@ class WorkflowOrchestratorContext:
             raise StopAsyncIteration
         if hook.conflict_error is not None:
             raise hook.conflict_error
-        self.suspensions[hook.correlation_id] = hook
         fut = asyncio.Future[T]()
         hook.futures.append(fut)
         return fut
@@ -1064,7 +1077,6 @@ class WorkflowOrchestratorContext:
             raise RuntimeError("cannot call get_conflict() on a disposed hook")
 
         hook.has_conflict_awaiter = True
-        self.suspensions[hook.correlation_id] = hook
         future = asyncio.Future[Run[Any] | None]()
         hook.conflict_futures.append(future)
         return future
@@ -1077,6 +1089,17 @@ class WorkflowOrchestratorContext:
             if not fut.done():
                 fut.set_exception(StopAsyncIteration)
         self.suspensions.pop(correlation_id, None)
+
+    def _awaits_hook_payload(self, correlation_id: str) -> bool:
+        """Whether a stashed ``hook_received`` can be delivered now.
+
+        A step cancellation has no awaiter and always consumes its
+        ``hook_received``.
+        """
+        sus = self.suspensions.get(correlation_id)
+        if isinstance(sus, Hook):
+            return sus.awaited
+        return isinstance(sus, Cancellation)
 
     def _fail_nondeterminism(self, sus: BaseSuspension, exc: Exception) -> None:
         """Fail the run with a replay-divergence error the body cannot suppress.
@@ -1126,7 +1149,7 @@ class WorkflowOrchestratorContext:
         event: w.Event | None = None
         # Look for any out-of-order hooks that can be applied
         for event in self.ooo_hook_received_events:
-            if event.correlation_id in self.suspensions:
+            if self._awaits_hook_payload(event.correlation_id):
                 self.ooo_hook_received_events.remove(event)
                 break
         else:
@@ -1136,13 +1159,17 @@ class WorkflowOrchestratorContext:
             event = self.events[self.replay_index]
             if event.correlation_id not in self.suspensions:
                 match event:
-                    # A step's attribute write. It answers no call in
-                    # this body, so consume it and move on.
                     case (
+                        # A step's attribute write. It answers no call in
+                        # this body, so consume it and move on.
                         w.AttrSetEvent(correlation_id=None)
                         | w.AttrSetEvent(
                             event_data=w.AttrSetEventData(writer=w.StepAttributeWriter())
                         )
+                        # A hook received without being registered
+                        # means it has been disposed of. Nothing to do
+                        # but drop it.
+                        | w.HookReceivedEvent()
                     ):
                         self.replay_index += 1
                         return
@@ -1177,13 +1204,6 @@ class WorkflowOrchestratorContext:
                             f"workflow replay cannot deliver {slot_id!r}: "
                             "the workflow body has not registered its suspension"
                         )
-                    # HookReceivedEvent is not created from workflows, it may arrive
-                    # at any time out of order. At this momemnt we don't need one,
-                    # so we just stash it and continue with the event log.
-                    case w.HookReceivedEvent():
-                        self.ooo_hook_received_events.append(event)
-                        self.replay_index += 1
-                        return
             self.replay_index += 1
 
         # No events to process. Suspend.
@@ -1326,14 +1346,17 @@ class WorkflowOrchestratorContext:
                     return
 
                 assert isinstance(hook, Hook)
+                if not hook.awaited:
+                    # Nothing is blocked on the hook right now: hold the payload
+                    # for its next await rather than dropping it.
+                    self.ooo_hook_received_events.append(event)
+                    return
                 result = ser.hydrate(
                     data,
                     what=f"the payload of hook {event.correlation_id}",
                     key=self.run_key,
                 )
                 hook.set_result(result)
-                if not hook.futures:
-                    self.suspensions.pop(event.correlation_id)
 
             case w.HookDisposedEvent():
                 self.hooks[event.correlation_id].has_dispose_event = True
@@ -1873,7 +1896,10 @@ async def _workflow_replay_pass(
                 events_created = True
 
     # Now that the workflow is fully suspended and old hook tokens have been
-    # released, create all pending events in parallel.
+    # released, create all pending events in parallel. Steps are enqueued only
+    # once every event is durable: a step may hand a hook's token to whoever
+    # will resume it, so the hook has to exist by the time the step runs.
+    steps_to_queue: list[Callable[[], Awaitable[str]]] = []
     async with anyio.create_task_group() as tg:
         for sus in context.suspensions.values():
             if sus.has_created_event:
@@ -1894,15 +1920,18 @@ async def _workflow_replay_pass(
                     #
                     # Instead we use an idempotency_key to pervent
                     # duplicate queueing.
-                    await world.queue(
-                        w.get_queue_name(workflow_run.workflow_name, namespace),
-                        w.WorkflowInvokePayload(
-                            run_id=run_id,
-                            step_id=s.correlation_id,
-                            step_name=s.step.name,
-                            requested_at=datetime.now(UTC),
-                        ),
-                        idempotency_key=s.correlation_id,
+                    steps_to_queue.append(
+                        functools.partial(
+                            world.queue,
+                            w.get_queue_name(workflow_run.workflow_name, namespace),
+                            w.WorkflowInvokePayload(
+                                run_id=run_id,
+                                step_id=s.correlation_id,
+                                step_name=s.step.name,
+                                requested_at=datetime.now(UTC),
+                            ),
+                            idempotency_key=s.correlation_id,
+                        )
                     )
 
                 tg.start_soon(create_step)
@@ -1959,6 +1988,10 @@ async def _workflow_replay_pass(
 
                 tg.start_soon(set_attr)
                 events_created = True
+
+    async with anyio.create_task_group() as tg:
+        for queue_step in steps_to_queue:
+            tg.start_soon(queue_step)
 
     if not context.suspensions and events_created:
         # A disposed hook can clear the last suspension while its lifecycle


### PR DESCRIPTION
This is similar to how `dispose` operates, where it is triggered without its own await. It matches JS.

This is accomplished just by registering it in suspensions in `create_hook`.

We then never remove it until it is disposed, and we decide whether to put something in the ooo queue based on whether there are waiters, not based on its presence in suspensions. This fixes an existing bug where messages that come in between `get_conflict()` and an actual wait on the hook would get dropped.

Also, adjust even creation so that the actual step queueing is done *after* all events are created. This ensures that, if we create a hook and then publish its token with a step, the hook will be created before the step executes.